### PR TITLE
[DMS-1063] Implement View-based Authorization Strategy for GET-by-id, POST, PUT, and DELETE

### DIFF
--- a/reference/design/backend-redesign/design-docs/auth.md
+++ b/reference/design/backend-redesign/design-docs/auth.md
@@ -1595,7 +1595,9 @@ These indicate a misconfiguration in the security metadata and should not occur 
 | Resource has no security metadata | `No security metadata has been configured for this resource.` |
 | No authorization strategies defined for the matching claim | `No authorization strategies were defined for the requested action '{action}' against resource URIs ['{uri1}', '{uri2}'] matched by the caller's claim '{claimName}'.` |
 | Authorization strategy implementation not found | `Could not find authorization strategy implementations for the following strategy names: '{strategyName1}', '{strategyName2}'.` |
-| Custom view basis entity property not found on the target entity | `Unable to find a property on the authorization subject entity type '{targetEntityName}' corresponding to the '{propertyName}' property on the custom authorization view's basis entity type '{basisEntityName}' in order to perform authorization. Should a different authorization strategy be used?` |
+| No DocumentId join path from the subject resource to the custom view basis resource | `Relational {operation} authorization metadata is invalid for resource '{project}.{resource}'. Strategy '{strategyName}' uses custom auth view 'auth.{strategyName}'. No DocumentId join path could be resolved from subject resource '{project}.{subjectResource}' to custom view basis resource '{project}.{basisResource}'. Should a different authorization strategy be used?` |
+
+> ODS words this failure as a missing basis-entity *property* on the subject entity, because it joins custom views on natural keys. DMS joins on DocumentId, so there is no single missing property to name — the failure is that no reference path reaches the basis resource. The DMS wording states that, and keeps ODS's closing question. The diagnostic kind is `RelationshipAuthorization.NoCustomViewJoinPath`.
 
 ### Extensions
 

--- a/reference/design/backend-redesign/design-docs/auth.md
+++ b/reference/design/backend-redesign/design-docs/auth.md
@@ -377,6 +377,51 @@ DMS matches `auth.{StrategyName}` case-sensitively on both engines, emitting the
 CREATE OR REPLACE VIEW "auth"."StudentWithCTECourseEnrollments" AS ...
 ```
 
+#### Single-record operations
+
+GET-by-id, POST, PUT, and DELETE authorize against the same views as GET-many, but they check one document
+rather than filtering a page, so the check is a membership test on that document's DocumentId.
+
+For a regular resource the check rides the `AUTH1` abort device alongside the other strategies. Custom-view
+payloads use the `cv1|{index}|{kind}` prefix, an index space independent of the relationship (`1|`) and
+namespace (`ns1|`) families, so a failure is always mapped back to the request's own planned custom-view
+list and cannot be misread as another family's check. Indexes are request-wide, which lets several emitted
+checks share one command without colliding.
+
+Each operation checks the values it actually has:
+
+* GET-by-id and DELETE check the **stored** value — the document as it exists.
+* PUT checks the stored value and then the **proposed** value, in that order, so a client cannot move a
+  document out of its authorized set, nor edit one it could not read.
+* POST-create has no stored value, so it checks only the proposed value.
+
+When the basis resource *is* the resource being written, a create can never satisfy the view: the view
+returns DocumentIds of rows that already exist, and the row being created does not exist yet. A POST-create
+under a self-basis custom view is therefore always denied with the 2.4 ProblemDetails, even when the view
+would authorize the identity being created once it exists. This is a property of the strategy, not a
+defect — a self-basis custom view is only meaningful for operations on existing documents.
+
+Descriptors have no `AUTH1` statement to carry checks: descriptor GET-by-id reads the row and evaluates
+namespace in memory, and descriptor DELETE authorizes inside the locked-target boundary. Their custom-view
+checks therefore execute as their own membership query, sequenced in C# by CMS-configured index rather than
+by position within a statement. Two consequences follow from the locked boundary. The check must run on the
+**write session's** command executor, because a fresh connection would either block on the lock the session
+holds or read uncommitted state. And it runs ahead of the precondition outcome, so a request that both
+fails `If-Match` and fails the view reports the authorization denial, not the etag mismatch.
+
+Descriptor writes handle a self-basis proposed check fully. A proposed check whose basis is some other
+resource would require reading a reference value out of the descriptor body, which no shipped descriptor
+has — descriptors declare no document references — so rather than infer that from the ApiSchema, the write
+fails closed with a security-configuration 500 if one is ever planned.
+
+Validation keeps the GET-many contract and the GET-many attribution rule: only the views configured ahead of
+the failing terminal are validated, so an earlier missing or non-conforming view keeps its own 500 instead
+of being masked. On the write paths this happens lazily, after a provider failure has already aborted the
+write transaction, which is why validation always takes a fresh `IRelationalCommandExecutor` — those
+implementations open a new connection per command — rather than the aborted session. Only the views the
+failing command actually emitted are probed; a view that was planned but never emitted is not blamed for a
+failure it could not have caused.
+
 ### Relationship-based direct EdOrg claim match
 
 The relationship authorization plan must explicitly identify EdOrg-to-EdOrg subjects that allow direct claim match. A planner/check-spec flag such as `AllowDirectClaimMatch` should be set only when the subject is an EducationOrganization id relationship check that uses `auth.EducationOrganizationIdToEducationOrganizationId`.

--- a/reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md
@@ -183,6 +183,7 @@ row says otherwise, these estimates assume no request references.
 | Create, no collections, no authorization, no precondition | 4 | first-phase capture/lock plus vacuous hydration; `INSERT dms."Document" ... RETURNING`; root insert; `SELECT "ContentVersion" ... FOR UPDATE` |
 | Create, proposed relationship authorization | 4 | the `AUTH1` check remains prefixed onto the `dms.Document` insert by `RelationalWriteNoProfilePersister.BuildAuthorizedInsertDocumentCommand`; no extra command |
 | Create, proposed namespace authorization | 5 | `ProposedNamespaceAuthorizationOrchestrator` remains a later command |
+| Create, proposed custom-view authorization | 4 or 5 | the check is emitted before the `dms.Document` and resource DML; it joins the insert command when the provider shape and parameter budget permit, and takes its own earlier command otherwise |
 | Create, N collection tables with new rows | 4 + 2 x (row groups across all collection tables) | collection reservation and persistence are unchanged in this slice; five collections is roughly 14 |
 | Resolves to an existing document, no authorization | 1 + persist | first-phase capture/lock and hydration; per-table DML; `ContentVersion` |
 | Resolves to an existing document, stored authorization | 1 + persist when embeddable | stored namespace then stored relationship are logical statements in the first-phase command; a structured parameter or command-budget boundary selects ordered same-session segments |
@@ -198,6 +199,7 @@ reference lookup, and hydration into one command when the provider shape and par
 | Changed, no collections, no authorization, no precondition | 3 | first-phase capture/lock and hydration; root `UPDATE`; `SELECT "ContentVersion" ... FOR UPDATE` |
 | Changed, stored authorization | 3 when embeddable | stored namespace then stored relationship join the first phase; structured parameters or a command-budget boundary use ordered segments |
 | Changed, proposed authorization | +1 to +2 | proposed namespace and proposed relationship are each their own command; the POST-create inline path does not apply to PUT |
+| Changed, custom-view authorization | +0 to +2 | the stored check joins the first phase when embeddable; the proposed check follows the same rule as the other proposed families, and stored is always ordered before proposed |
 | Guarded no-op, no proposed authorization | 1 | first phase holds the capture lock; the exact same-session lock proof replaces the freshness query |
 | With collections | + 2 x row groups | the same N+1 shape as POST |
 | Missing target | 1 | the first-phase capture returns absent and the session rolls back |
@@ -218,6 +220,13 @@ DELETE Adoption"); the "Was" column is the pre-adoption estimate they replace.
 | Authorization that does not fit the command's parameter budget | 2 or 3 | n/a | the check that does not fit takes an ordered segment and the deletes wait for it |
 | Blocked by an inbound foreign key | 1 | 3 | the violation surfaces on the same command and is mapped by constraint name |
 
+Custom view-based authorization is not in the measured set above. Its stored `cv1` statement is emitted
+like the other stored families, so a regular-resource DELETE is expected to keep the counts in this table;
+a descriptor DELETE is structurally different, running its membership query on the write session inside the
+locked-target boundary rather than as an `AUTH1` statement. The regular-resource shape is covered functionally on
+both PostgreSQL and SQL Server, the descriptor locked-boundary shape on PostgreSQL, but neither has a
+recorded command count yet.
+
 ### GET-by-id
 
 | Variant | Commands |
@@ -225,6 +234,7 @@ DELETE Adoption"); the "Was" column is the pre-adoption estimate they replace.
 | No authorization | 2 — already at the draft target |
 | Namespace authorization only | 4 (adds the authorization command and `ShouldRetryPostHydrationReadBoundaryAsync`) |
 | Namespace and relationship authorization | 5 |
+| Custom-view authorization | unrecorded. A regular resource adds no command, because the `cv1` statement joins the authorization command. A descriptor GET-by-id has no authorization command to join — it evaluates namespace in memory — so its membership query is an added command |
 
 ### Descriptor Writes
 

--- a/reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md
@@ -220,12 +220,14 @@ DELETE Adoption"); the "Was" column is the pre-adoption estimate they replace.
 | Authorization that does not fit the command's parameter budget | 2 or 3 | n/a | the check that does not fit takes an ordered segment and the deletes wait for it |
 | Blocked by an inbound foreign key | 1 | 3 | the violation surfaces on the same command and is mapped by constraint name |
 
-Custom view-based authorization is not in the measured set above. Its stored `cv1` statement is emitted
-like the other stored families, so a regular-resource DELETE is expected to keep the counts in this table;
-a descriptor DELETE is structurally different, running its membership query on the write session inside the
-locked-target boundary rather than as an `AUTH1` statement. The regular-resource shape is covered functionally on
-both PostgreSQL and SQL Server, the descriptor locked-boundary shape on PostgreSQL, but neither has a
-recorded command count yet.
+Custom view-based authorization is not in the measured set above. Its stored `cv1` statement is emitted like the
+other stored families, so a regular-resource DELETE is expected to keep the counts in this table plus one command
+for the view-contract probe each membership run is preceded by — and one more when a custom view is configured
+after `NamespaceBased`, because that run takes an ordered segment so its view is validated only once the namespace
+check has passed. A descriptor DELETE is structurally different, running its membership query on the write session
+inside the locked-target boundary rather than as an `AUTH1` statement. The regular-resource shape is covered
+functionally on both PostgreSQL and SQL Server, the descriptor locked-boundary shape on PostgreSQL, but neither
+has a recorded command count yet.
 
 ### GET-by-id
 
@@ -234,7 +236,7 @@ recorded command count yet.
 | No authorization | 2 — already at the draft target |
 | Namespace authorization only | 4 (adds the authorization command and `ShouldRetryPostHydrationReadBoundaryAsync`) |
 | Namespace and relationship authorization | 5 |
-| Custom-view authorization | unrecorded. A regular resource adds no command, because the `cv1` statement joins the authorization command. A descriptor GET-by-id has no authorization command to join — it evaluates namespace in memory — so its membership query is an added command |
+| Custom-view authorization | unrecorded. A regular resource adds one command for the view-contract probe that precedes the membership run; the `cv1` statement itself joins the authorization command. A descriptor GET-by-id has no authorization command to join — it evaluates namespace in memory — so its membership query is an added command alongside that probe |
 
 ### Descriptor Writes
 

--- a/reference/design/backend-redesign/epics/14-authorization/20-configuration-problem-details.md
+++ b/reference/design/backend-redesign/epics/14-authorization/20-configuration-problem-details.md
@@ -26,11 +26,11 @@ Implement request-time 500 "Security Configuration Error" ProblemDetails respons
     - Title: Security Configuration Error
     - Detail: A security configuration problem was detected. The request cannot be authorized.
     - Error: Could not find authorization strategy implementations for the following strategy names: '{strategyName1}', '{strategyName2}'.
-- When a custom view-based strategy references a basis entity property that does not exist on the authorization subject entity, the system returns a 500 response with:
+- When a custom view-based strategy cannot be joined to its basis resource, the system returns a 500 response with:
     - Type: urn:ed-fi:api:system:configuration:security
     - Title: Security Configuration Error
     - Detail: A security configuration problem was detected. The request cannot be authorized.
-    - Error: Unable to find a property on the authorization subject entity type '{targetEntityName}' corresponding to the '{propertyName}' property on the custom authorization view's basis entity type '{basisEntityName}' in order to perform authorization. Should a different authorization strategy be used?
+    - Error: **Superseded.** This planning note carried ODS's natural-key wording ("Unable to find a property on the authorization subject entity type ... corresponding to the '{propertyName}' property ..."). DMS joins custom views on DocumentId, so no single missing property exists to name; the implemented wording and the reason it diverges are in the security-configuration table of [auth.md](../../design-docs/auth.md).
 - All scenarios include a correlationId in the response body for traceability, consistent with the ProblemDetails RFC 9457 structure used across DMS.
 - These checks run at request time during authorization resolution, not at startup. They are distinct from the startup validations in DMS-1091.
 - The error is logged with enough detail for an API host to diagnose and fix the misconfiguration.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/AuthSecurableElementContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/AuthSecurableElementContracts.cs
@@ -44,6 +44,33 @@ public sealed record ResolvedSecurableElementPath(
 );
 
 /// <summary>
+/// A resolved custom view-based basis resource path: the column path steps plus the JSON paths of the
+/// reference that terminates the path.
+/// </summary>
+/// <param name="Steps">
+/// The chain of column path steps ending at the basis resource's <c>DocumentId</c>. Empty when no path
+/// could be resolved.
+/// </param>
+/// <param name="TerminalReferenceJsonPaths">
+/// Canonical JSON paths of the terminal reference's identity values, in binding order — the document
+/// reference's identity paths (for example <c>$.studentReference.studentUniqueId</c>) or a descriptor's
+/// value path (for example <c>$.transportationTypeDescriptor</c>). These name the securable element that
+/// custom view-based authorization decided on, which is what the ProblemDetails wording reports.
+/// <para>
+/// Empty when the basis resource <em>is</em> the subject resource: that path terminates on the subject's
+/// own <c>DocumentId</c> rather than on a reference, so there is no reference path to report and callers
+/// must fall back to the basis resource's own identity property names.
+/// </para>
+/// </param>
+public sealed record ResolvedBasisResourcePath(
+    IReadOnlyList<ColumnPathStep> Steps,
+    IReadOnlyList<string> TerminalReferenceJsonPaths
+)
+{
+    public static ResolvedBasisResourcePath Unresolved { get; } = new([], []);
+}
+
+/// <summary>
 /// Securable element metadata for a single EducationOrganization path, carrying
 /// both the JSON path and the MetaEd identity property name.
 /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCustomViewAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCustomViewAuthorizationTests.cs
@@ -470,6 +470,86 @@ public class Given_A_Mssql_Relational_Query_Authorization_With_A_Custom_View_Str
         }
     }
 
+    [Test]
+    public async Task It_denies_delete_for_a_school_the_custom_view_excludes_and_leaves_the_row()
+    {
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[1].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            [CustomViewStrategyName]
+        );
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(CustomViewStrategyName);
+        // The check runs inside the locked-target boundary before the delete, so a denial must leave the row.
+        (await _context.CountDocumentRowsAsync(_schoolSeeds[1].DocumentUuid))
+            .Should()
+            .Be(1);
+    }
+
+    [Test]
+    public async Task It_denies_delete_with_if_match_for_a_school_the_custom_view_excludes()
+    {
+        // The If-Match delete authorizes through a different seam than the plain delete — the locked
+        // precondition path — so the denial has to hold there too, and ahead of the precondition outcome.
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[1].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            [CustomViewStrategyName],
+            ifMatch: "*"
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>();
+        (await _context.CountDocumentRowsAsync(_schoolSeeds[1].DocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_wraps_a_provider_error_when_the_configured_custom_view_does_not_exist_on_delete()
+    {
+        // GET-many already proves the view contract at the provider level; this proves the single-record
+        // DELETE path reaches it rather than reporting a generic delete failure.
+        await AssertCustomViewValidationFailure(async () =>
+            await _context.DeleteByIdAsync(
+                "ed-fi",
+                "School",
+                _schoolSeeds[0].DocumentUuid,
+                [ClaimEducationOrganizationId],
+                [MissingCustomViewStrategyName]
+            )
+        );
+
+        (await _context.CountDocumentRowsAsync(_schoolSeeds[0].DocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_reports_a_referencing_document_failure_after_the_custom_view_authorizes_the_delete()
+    {
+        // School 100 IS in the view, so authorization passes and the delete proceeds — and then fails because
+        // a ClassPeriod references it. A denial would stop before the delete and prove nothing, so this is the
+        // case that shows custom-view validation and error attribution do not swallow an ordinary failure.
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[0].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            [CustomViewStrategyName]
+        );
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureReference>()
+            .Which.ReferencingDocumentResourceNames.Should()
+            .NotBeEmpty();
+        (await _context.CountDocumentRowsAsync(_schoolSeeds[0].DocumentUuid)).Should().Be(1);
+    }
+
     private static async Task<SqlException> AssertCustomViewValidationFailure(Func<Task> action)
     {
         var assertion = await action.Should().ThrowAsync<CustomViewAuthorizationValidationException>();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCustomViewAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCustomViewAuthorizationTests.cs
@@ -529,6 +529,47 @@ public class Given_A_Mssql_Relational_Query_Authorization_With_A_Custom_View_Str
     }
 
     [Test]
+    public async Task It_throws_on_delete_when_the_custom_authorization_object_is_a_table_with_a_bigint_document_id()
+    {
+        // DELETE reaches the view through the co-batched stored run rather than a standalone query, and a table
+        // whose DocumentId is type-compatible answers that run's membership SQL without raising anything. Without
+        // validating the object the row would be deleted, or the caller denied, against something auth.md does
+        // not accept.
+        await _context.Database.ExecuteNonQueryAsync(
+            $"""
+            CREATE TABLE [auth].[{TableInsteadOfCustomViewStrategyName}] (
+                [DocumentId] bigint NOT NULL
+            );
+            """
+        );
+
+        try
+        {
+            var exception = await AssertCustomViewValidationFailure(async () =>
+                await _context.DeleteByIdAsync(
+                    "ed-fi",
+                    "School",
+                    _schoolSeeds[0].DocumentUuid,
+                    [ClaimEducationOrganizationId],
+                    [TableInsteadOfCustomViewStrategyName]
+                )
+            );
+
+            exception.Message.Should().Contain("Invalid custom authorization view DocumentId contract.");
+            (await _context.CountDocumentRowsAsync(_schoolSeeds[0].DocumentUuid)).Should().Be(1);
+        }
+        finally
+        {
+            await _context.Database.ExecuteNonQueryAsync(
+                $"""
+                IF OBJECT_ID(N'[auth].[{TableInsteadOfCustomViewStrategyName}]', N'U') IS NOT NULL
+                    DROP TABLE [auth].[{TableInsteadOfCustomViewStrategyName}];
+                """
+            );
+        }
+    }
+
+    [Test]
     public async Task It_reports_a_referencing_document_failure_after_the_custom_view_authorizes_the_delete()
     {
         // School 100 IS in the view, so authorization passes and the delete proceeds — and then fails because

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalGetByIdAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalGetByIdAuthorizationTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.External.Security;
 using FluentAssertions;
+using Microsoft.Data.SqlClient;
 using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
@@ -60,6 +61,11 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
     /// </summary>
     private const string CustomViewStrategyName = "SchoolWithGetByIdProviderTest";
     private static readonly IReadOnlyList<string> _customViewStrategy = [CustomViewStrategyName];
+
+    /// <summary>
+    /// A configured strategy whose <c>auth</c> object the masquerade test creates as a table rather than a view.
+    /// </summary>
+    private const string TableInsteadOfCustomViewStrategyName = "SchoolWithGetByIdTableProviderTest";
 
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
@@ -347,6 +353,49 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
             .BeOfType<GetResult.GetFailureCustomViewNotAuthorized>()
             .Subject.CustomViewFailure;
         failure.StrategyName.Should().Be(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task Given_A_Custom_Authorization_Object_That_Is_A_Table_It_Throws_On_Get_By_Id()
+    {
+        // A table whose DocumentId is type-compatible answers the membership query without raising anything, so
+        // the request would authorize or deny against an object auth.md does not accept. The run has to prove the
+        // object is a view first, and surface the documented urn:ed-fi:api:system 500 instead.
+        await _context.Database.ExecuteNonQueryAsync(
+            $"""
+            CREATE TABLE [auth].[{TableInsteadOfCustomViewStrategyName}] (
+                [DocumentId] bigint NOT NULL
+            );
+            """
+        );
+
+        try
+        {
+            Func<Task> act = () =>
+                _context.GetByIdAsync(
+                    "ed-fi",
+                    "School",
+                    _schoolSeeds[0].DocumentUuid,
+                    [ClaimEducationOrganizationId],
+                    [TableInsteadOfCustomViewStrategyName]
+                );
+
+            var assertion = await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+            assertion
+                .Which.InnerException.Should()
+                .BeOfType<SqlException>()
+                .Subject.Message.Should()
+                .Contain("Invalid custom authorization view DocumentId contract.");
+        }
+        finally
+        {
+            await _context.Database.ExecuteNonQueryAsync(
+                $"""
+                IF OBJECT_ID(N'[auth].[{TableInsteadOfCustomViewStrategyName}]', N'U') IS NOT NULL
+                    DROP TABLE [auth].[{TableInsteadOfCustomViewStrategyName}];
+                """
+            );
+        }
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalGetByIdAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalGetByIdAuthorizationTests.cs
@@ -54,6 +54,13 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
         AuthorizationStrategyNameConstants.OwnershipBased,
     ];
 
+    /// <summary>
+    /// A custom view over School authorizing School 100 only. School 200 is reachable through the claim's
+    /// edorg edges, so a denial on 200 can only come from the view's membership query.
+    /// </summary>
+    private const string CustomViewStrategyName = "SchoolWithGetByIdProviderTest";
+    private static readonly IReadOnlyList<string> _customViewStrategy = [CustomViewStrategyName];
+
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
         new(new DocumentUuid(Guid.Parse("22222222-0000-0000-0000-000000000001")), 100, "North School"),
@@ -289,6 +296,7 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
 
         await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, 100);
         await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, 200);
+        await _context.CreateSchoolCustomAuthViewAsync(CustomViewStrategyName, [100]);
         await _context.InsertAuthEdgeAsync(300, ClaimEducationOrganizationId);
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, ClaimEducationOrganizationId);
     }
@@ -298,6 +306,7 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
     {
         if (_context is not null)
         {
+            await _context.DropCustomAuthViewAsync(CustomViewStrategyName);
             await _context.DisposeAsync();
         }
     }
@@ -306,6 +315,38 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
     public void SetUp()
     {
         _context.ResetRecorder();
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Authorizes_A_School_The_View_Includes()
+    {
+        var result = await _context.GetByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[0].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Denies_A_School_The_View_Excludes()
+    {
+        var result = await _context.GetByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[1].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        var failure = result
+            .Should()
+            .BeOfType<GetResult.GetFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure;
+        failure.StrategyName.Should().Be(CustomViewStrategyName);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalPostAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalPostAuthorizationTests.cs
@@ -33,6 +33,13 @@ public class Given_A_Mssql_RelationalPost_Create_Authorization_With_A_Synthetic_
     private const string TermDescriptor = "uri://ed-fi.org/TermDescriptor#Fall Semester";
     private const string EntryGradeLevelDescriptor = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade";
 
+    /// <summary>
+    /// A custom view over School authorizing School 100 only. A create carries its School as a proposed
+    /// reference value and has no stored value at all, so the view alone decides the write.
+    /// </summary>
+    private const string CustomViewStrategyName = "SchoolWithPostProviderTest";
+    private static readonly IReadOnlyList<string> _customViewStrategy = [CustomViewStrategyName];
+
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
         new(new DocumentUuid(Guid.Parse("dddddddd-0000-0000-0000-000000000001")), 100, "North School"),
@@ -164,6 +171,8 @@ public class Given_A_Mssql_RelationalPost_Create_Authorization_With_A_Synthetic_
         await _context.InsertAuthEdgeAsync(300, ClaimEducationOrganizationId);
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, ClaimEducationOrganizationId);
         _context.ResetRecorder();
+
+        await _context.CreateSchoolCustomAuthViewAsync(CustomViewStrategyName, [100]);
     }
 
     [OneTimeTearDown]
@@ -171,8 +180,47 @@ public class Given_A_Mssql_RelationalPost_Create_Authorization_With_A_Synthetic_
     {
         if (_context is not null)
         {
+            await _context.DropCustomAuthViewAsync(CustomViewStrategyName);
             await _context.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Authorizes_A_Create_Whose_Proposed_School_The_View_Includes()
+    {
+        var seed = CreateRootChildSeed(
+            "cccccccc-0000-0000-0000-000000000601",
+            601,
+            "custom-view-authorized-create",
+            100,
+            []
+        );
+
+        var result = await PostRootChildAsync(seed, _customViewStrategy);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        await AssertPersistedRowsAsync(seed);
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Denies_A_Create_Whose_Proposed_School_The_View_Excludes()
+    {
+        var seed = CreateRootChildSeed(
+            "cccccccc-0000-0000-0000-000000000602",
+            602,
+            "custom-view-denied-create",
+            200,
+            []
+        );
+
+        var result = await PostRootChildAsync(seed, _customViewStrategy);
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(CustomViewStrategyName);
+        await AssertNoCreateSideEffectsAsync(seed);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalPutAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalPutAuthorizationTests.cs
@@ -107,6 +107,13 @@ public class Given_A_MssqlRelationalPutAuthorizationTests_With_A_Synthetic_EdOrg
     private const long ClaimEducationOrganizationId =
         RelationshipAuthorizationCrudTestSupport.ClaimEducationOrganizationId;
 
+    /// <summary>
+    /// A custom view over School authorizing School 100 only. An update is checked twice against it, once
+    /// for the stored School and once for the proposed School, so the two are covered separately below.
+    /// </summary>
+    private const string CustomViewStrategyName = "SchoolWithPutProviderTest";
+    private static readonly IReadOnlyList<string> _customViewStrategy = [CustomViewStrategyName];
+
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
         new(new DocumentUuid(Guid.Parse("eeeeeeee-1111-0000-0000-000000000001")), 100, "North School"),
@@ -170,6 +177,8 @@ public class Given_A_MssqlRelationalPutAuthorizationTests_With_A_Synthetic_EdOrg
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, 300);
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, ClaimEducationOrganizationId);
         _context.ResetRecorder();
+
+        await _context.CreateSchoolCustomAuthViewAsync(CustomViewStrategyName, [100]);
     }
 
     [OneTimeTearDown]
@@ -177,8 +186,99 @@ public class Given_A_MssqlRelationalPutAuthorizationTests_With_A_Synthetic_EdOrg
     {
         if (_context is not null)
         {
+            await _context.DropCustomAuthViewAsync(CustomViewStrategyName);
             await _context.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Authorizes_An_Update_Whose_Stored_And_Proposed_Schools_The_View_Includes()
+    {
+        var existingSeed = CreateRootChildSeed(
+            "cccccccc-1111-0000-0000-000000000601",
+            601,
+            "custom-view-authorized-existing",
+            100,
+            []
+        );
+        var proposedSeed = existingSeed with { Name = "custom-view-authorized-change" };
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationRootChildAsync(existingSeed)
+        );
+
+        var result = await _context.UpdateAuthorizationRootChildByIdAsync(
+            proposedSeed,
+            existingSeed.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        result.Should().BeOfType<UpdateResult.UpdateSuccess>();
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Denies_An_Update_Whose_Proposed_School_The_View_Excludes()
+    {
+        // The stored School is inside the view, so only the proposed School can produce this denial. Seeding
+        // the target row with an authorized School is what keeps the stored check from masking it.
+        var existingSeed = CreateRootChildSeed(
+            "cccccccc-1111-0000-0000-000000000602",
+            602,
+            "custom-view-proposed-denied-existing",
+            100,
+            []
+        );
+        var proposedSeed = existingSeed with { Name = "custom-view-proposed-denied-change", SchoolId = 200 };
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationRootChildAsync(existingSeed)
+        );
+
+        var result = await _context.UpdateAuthorizationRootChildByIdAsync(
+            proposedSeed,
+            existingSeed.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Denies_An_Update_Whose_Stored_School_The_View_Excludes()
+    {
+        // The mirror image: the proposed School is inside the view and the stored School is not, so this
+        // denial can only come from the stored check.
+        var existingSeed = CreateRootChildSeed(
+            "cccccccc-1111-0000-0000-000000000603",
+            603,
+            "custom-view-stored-denied-existing",
+            200,
+            []
+        );
+        var proposedSeed = existingSeed with { Name = "custom-view-stored-denied-change", SchoolId = 100 };
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationRootChildAsync(existingSeed)
+        );
+
+        var result = await _context.UpdateAuthorizationRootChildByIdAsync(
+            proposedSeed,
+            existingSeed.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(CustomViewStrategyName);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/CustomViewAuthorizationAuth1FailurePayloadTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/CustomViewAuthorizationAuth1FailurePayloadTests.cs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_CustomViewAuthorizationAuth1FailurePayloadCodec
+{
+    [Test]
+    public void It_should_reject_negative_emitted_auth1_indexes()
+    {
+        var act = () =>
+            new CustomViewAuthorizationAuth1FailurePayload(
+                -1,
+                CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+            );
+
+        act.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("emittedAuth1Index")
+            .WithMessage("Emitted AUTH1 index cannot be negative.*");
+    }
+
+    [Test]
+    public void It_should_encode_a_no_matching_row_payload_with_the_cv1_discriminator()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+        );
+
+        var encoded = CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(payload);
+
+        encoded.Should().Be("cv1|0|n");
+    }
+
+    [Test]
+    public void It_should_throw_for_unknown_failure_kinds_when_encoding()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            (CustomViewAuthorizationAuth1FailureKind)999
+        );
+
+        var act = () => CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(payload);
+
+        act.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("failureKind")
+            .WithMessage("Unsupported AUTH1 custom view failure kind.*");
+    }
+
+    [TestCase(0, CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow, "cv1|0|n")]
+    [TestCase(3, CustomViewAuthorizationAuth1FailureKind.StoredBasisValueNull, "cv1|3|u")]
+    [TestCase(5, CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing, "cv1|5|r")]
+    [TestCase(2, CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing, "cv1|2|s")]
+    public void It_should_round_trip_each_failure_kind(
+        int emittedIndex,
+        CustomViewAuthorizationAuth1FailureKind kind,
+        string expectedEncoding
+    )
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(emittedIndex, kind);
+
+        var encoded = CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(payload);
+        var parsed = CustomViewAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+            encoded,
+            out var parsedPayload
+        );
+
+        encoded.Should().Be(expectedEncoding);
+        parsed.Should().BeTrue();
+        parsedPayload.Should().BeEquivalentTo(payload);
+    }
+
+    [Test]
+    public void It_should_dispatch_postgresql_and_sql_server_provider_failures_to_the_same_custom_view_payload()
+    {
+        var payloadText = "cv1|7|n";
+        var sqlServerMessage =
+            $"Conversion failed when converting the varchar value 'AUTH1 - {payloadText}' to data type int.";
+
+        var postgresqlDispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            CustomViewAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+            payloadText,
+            out var postgresqlResult
+        );
+        var sqlServerDispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Mssql,
+            null,
+            sqlServerMessage,
+            out var sqlServerResult
+        );
+
+        postgresqlDispatched.Should().BeTrue();
+        sqlServerDispatched.Should().BeTrue();
+        var postgresqlPayload = postgresqlResult
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.CustomView>()
+            .Subject.Payload;
+        var sqlServerPayload = sqlServerResult
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.CustomView>()
+            .Subject.Payload;
+        sqlServerPayload.Should().BeEquivalentTo(postgresqlPayload);
+        sqlServerPayload.EmittedAuth1Index.Should().Be(7);
+        sqlServerPayload
+            .FailureKind.Should()
+            .Be(CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow);
+    }
+
+    [TestCase("cv2|0|n")] // unknown discriminator version
+    [TestCase("1|0|n")] // relationship discriminator, must be rejected
+    [TestCase("ns1|0|n")] // namespace discriminator, must be rejected
+    [TestCase("cv1|0|x")] // unknown failure kind
+    [TestCase("cv1|0|m")] // namespace's mismatch code is not a custom-view kind
+    [TestCase("cv1|0|")] // missing failure kind
+    [TestCase("cv1|0")] // missing failure kind segment entirely
+    [TestCase("cv1||n")] // missing index
+    [TestCase("cv1|-1|n")] // negative index
+    [TestCase("cv1|0|n|extra")] // extra trailing segment
+    [TestCase("")] // empty
+    [TestCase("   ")] // whitespace
+    public void It_should_fail_closed_for_malformed_or_unknown_payloads(string payloadText)
+    {
+        var parsed = CustomViewAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+            payloadText,
+            out var payload
+        );
+
+        parsed.Should().BeFalse();
+        payload.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_not_dispatch_a_payload_when_postgresql_error_code_is_not_AUTH1()
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            "P0001",
+            "cv1|0|n",
+            out var result
+        );
+
+        dispatched.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_report_an_invalid_payload_for_a_malformed_custom_view_payload_on_the_auth1_transport()
+    {
+        // The AUTH1 transport was used, so the dispatcher must claim the failure, but the payload cannot be
+        // decoded into an authorization decision. Callers log and fall through to a generic security
+        // failure rather than inventing a 403.
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            CustomViewAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+            "cv1|0|x",
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.InvalidPayload>()
+            .Subject.RawPayload.Should()
+            .Be("cv1|0|x");
+    }
+
+    [Test]
+    public void It_should_keep_the_three_payload_families_independent()
+    {
+        // Same emitted index in all three families. Each must decode to its own result type, which is what
+        // lets the custom-view index space stay independent of the namespace and relationship spaces.
+        var customViewDispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            "AUTH1",
+            "cv1|0|n",
+            out var customViewResult
+        );
+        var namespaceDispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            "AUTH1",
+            "ns1|0|m",
+            out var namespaceResult
+        );
+        var relationshipDispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            "AUTH1",
+            "1|0|1|0:0:n",
+            out var relationshipResult
+        );
+
+        customViewDispatched.Should().BeTrue();
+        namespaceDispatched.Should().BeTrue();
+        relationshipDispatched.Should().BeTrue();
+        customViewResult.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.CustomView>();
+        namespaceResult.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.Namespace>();
+        relationshipResult.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.Relationship>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/CustomViewAuthorizationFailureMapperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/CustomViewAuthorizationFailureMapperTests.cs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Core.External.Backend;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_CustomViewAuthorizationFailureMapper
+{
+    private static readonly DbTableName AuthView = new(
+        new DbSchemaName("auth"),
+        "StudentWithCTECourseEnrollments"
+    );
+    private static readonly DbTableName RootTable = new(new DbSchemaName("edfi"), "CourseTranscript");
+    private static readonly DbColumnName DocumentIdColumn = new("DocumentId");
+
+    private static SingleRecordCustomViewAuthorizationCheckSpec Check(
+        int index,
+        CustomViewAuthorizationCheckValueSource valueSource,
+        string strategyName = "StudentWithCTECourseEnrollments",
+        IReadOnlyList<string>? readableSecurableElements = null
+    ) =>
+        new(
+            new ConfiguredAuthorizationStrategy(strategyName, 0),
+            index,
+            valueSource,
+            AuthView,
+            DocumentIdColumn,
+            [new ColumnPathStep(RootTable, new DbColumnName("Student_DocumentId"), null, null)],
+            valueSource is CustomViewAuthorizationCheckValueSource.Stored
+                ? new CustomViewAuthorizationCheckTarget.Stored(RootTable, DocumentIdColumn)
+                : new CustomViewAuthorizationCheckTarget.Proposed(
+                    RootTable,
+                    new CustomViewAuthorizationProposedValueBinding(
+                        RootTable,
+                        new DbColumnName("Student_DocumentId"),
+                        "logical",
+                        "seed"
+                    )
+                ),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            readableSecurableElements ?? ["StudentUniqueId"],
+            CustomViewAuthorizationHintFormatter.Format(strategyName)
+        );
+
+    [Test]
+    public void It_should_map_a_stored_no_matching_row_payload_to_the_2_4_failure()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [Check(0, CustomViewAuthorizationCheckValueSource.Stored)],
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure.Should().NotBeNull();
+        failure!.FailureKind.Should().Be(CustomViewAuthorizationFailureKind.NoMatchingRow);
+        failure.ValueSource.Should().Be(CustomViewAuthorizationFailureValueSource.Stored);
+        failure.EmittedAuth1Index.Should().Be(0);
+        failure.StrategyName.Should().Be("StudentWithCTECourseEnrollments");
+        failure.ReadableSecurableElements.Should().Equal("StudentUniqueId");
+        failure.Hint.Should().Be("You may need a Student with CTE Course Enrollments.");
+    }
+
+    [Test]
+    public void It_should_map_a_stored_null_basis_payload_to_the_2_7_failure()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.StoredBasisValueNull
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [Check(0, CustomViewAuthorizationCheckValueSource.Stored)],
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure!.FailureKind.Should().Be(CustomViewAuthorizationFailureKind.StoredValueUninitialized);
+        failure.ValueSource.Should().Be(CustomViewAuthorizationFailureValueSource.Stored);
+    }
+
+    [Test]
+    public void It_should_map_a_proposed_missing_basis_payload_to_the_2_8_failure()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [Check(0, CustomViewAuthorizationCheckValueSource.Proposed)],
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure!.FailureKind.Should().Be(CustomViewAuthorizationFailureKind.ProposedValueMissing);
+        failure.ValueSource.Should().Be(CustomViewAuthorizationFailureValueSource.Proposed);
+    }
+
+    [Test]
+    public void It_should_select_the_check_the_payload_index_addresses_in_a_stored_then_proposed_pair()
+    {
+        // Update plans stored checks first, then proposed. The index is the only thing distinguishing them,
+        // so mapping index 1 must report the proposed check's value source and strategy.
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks =
+        [
+            Check(0, CustomViewAuthorizationCheckValueSource.Stored, "StudentWithCTECourseEnrollments"),
+            Check(1, CustomViewAuthorizationCheckValueSource.Proposed, "StudentWithCTECourseEnrollments"),
+        ];
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            1,
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            plannedChecks,
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure!.ValueSource.Should().Be(CustomViewAuthorizationFailureValueSource.Proposed);
+        failure.EmittedAuth1Index.Should().Be(1);
+    }
+
+    [Test]
+    public void It_should_report_every_readable_securable_element_of_a_composite_identity_basis()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    readableSecurableElements: ["CourseCode", "EducationOrganizationId"]
+                ),
+            ],
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure!.ReadableSecurableElements.Should().Equal("CourseCode", "EducationOrganizationId");
+    }
+
+    [Test]
+    public void It_should_not_map_a_payload_whose_index_is_out_of_range()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            5,
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [Check(0, CustomViewAuthorizationCheckValueSource.Stored)],
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_not_map_a_payload_against_an_empty_planned_check_list()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(payload, [], out var failure);
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_not_map_a_stored_only_kind_against_a_proposed_check()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.StoredBasisValueNull
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [Check(0, CustomViewAuthorizationCheckValueSource.Proposed)],
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_not_map_a_proposed_only_kind_against_a_stored_check()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [Check(0, CustomViewAuthorizationCheckValueSource.Stored)],
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_not_map_the_stale_target_kind_to_a_response_failure()
+    {
+        // Stale target is a retry signal that resolves to a 404, never a 403 body, so it must not produce a
+        // cross-boundary failure at all.
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing
+        );
+
+        var mapped = CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [Check(0, CustomViewAuthorizationCheckValueSource.Stored)],
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_recognize_a_stale_stored_target_payload_against_a_stored_check()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing
+        );
+
+        CustomViewAuthorizationFailureMapper
+            .IsStaleStoredTargetFailure(payload, [Check(0, CustomViewAuthorizationCheckValueSource.Stored)])
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    public void It_should_not_recognize_a_stale_payload_paired_with_a_proposed_check()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing
+        );
+
+        CustomViewAuthorizationFailureMapper
+            .IsStaleStoredTargetFailure(payload, [Check(0, CustomViewAuthorizationCheckValueSource.Proposed)])
+            .Should()
+            .BeFalse();
+    }
+
+    [Test]
+    public void It_should_not_recognize_a_stale_payload_whose_index_is_out_of_range()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            3,
+            CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing
+        );
+
+        CustomViewAuthorizationFailureMapper
+            .IsStaleStoredTargetFailure(payload, [Check(0, CustomViewAuthorizationCheckValueSource.Stored)])
+            .Should()
+            .BeFalse();
+    }
+
+    [Test]
+    public void It_should_not_recognize_a_non_stale_kind_as_a_stale_target()
+    {
+        var payload = new CustomViewAuthorizationAuth1FailurePayload(
+            0,
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+        );
+
+        CustomViewAuthorizationFailureMapper
+            .IsStaleStoredTargetFailure(payload, [Check(0, CustomViewAuthorizationCheckValueSource.Stored)])
+            .Should()
+            .BeFalse();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/CustomViewAuthorizationHintFormatterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/CustomViewAuthorizationHintFormatterTests.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_CustomViewAuthorizationHintFormatter
+{
+    [Test]
+    public void It_should_format_the_hint_documented_in_auth_md()
+    {
+        // auth.md §"Authorization Failure Hints" gives this exact pairing as the worked example.
+        CustomViewAuthorizationHintFormatter
+            .Format("StudentWithCTECourseEnrollments")
+            .Should()
+            .Be("You may need a Student with CTE Course Enrollments.");
+    }
+
+    [TestCase("StudentWithCTECourseEnrollments", "Student with CTE Course Enrollments")]
+    [TestCase("TransportationTypeDescriptorWithABus", "Transportation Type Descriptor with A Bus")]
+    [TestCase(
+        "EducationOrganizationWithACategoryContainingAnSWord",
+        "Education Organization with A Category Containing An S Word"
+    )]
+    [TestCase("SchoolContainingAnSWord", "School Containing An S Word")]
+    [TestCase("StudentWithGrade3Courses", "Student with Grade3 Courses")]
+    public void It_should_split_camel_case_while_keeping_acronym_runs_intact(
+        string strategyName,
+        string expectedDisplayText
+    )
+    {
+        CustomViewAuthorizationHintFormatter.FormatDisplayText(strategyName).Should().Be(expectedDisplayText);
+    }
+
+    [Test]
+    public void It_should_lowercase_every_With_token_so_a_description_containing_With_still_reads_as_prose()
+    {
+        CustomViewAuthorizationHintFormatter
+            .FormatDisplayText("StudentWithCoursesWithGrades")
+            .Should()
+            .Be("Student with Courses with Grades");
+    }
+
+    [TestCase("StudentWithCTECourseEnrollments", "a")]
+    [TestCase("SchoolContainingAnSWord", "a")]
+    [TestCase("EducationOrganizationWithACategory", "an")]
+    [TestCase("InterventionWithABudget", "an")]
+    [TestCase("ObjectiveAssessmentWithAScore", "an")]
+    [TestCase("AssessmentWithAnItem", "an")]
+    [TestCase("UniversityWithAProgram", "an")]
+    public void It_should_select_the_article_from_the_display_texts_leading_vowel(
+        string strategyName,
+        string expectedArticle
+    )
+    {
+        CustomViewAuthorizationHintFormatter
+            .Format(strategyName)
+            .Should()
+            .StartWith($"You may need {expectedArticle} ");
+    }
+
+    [Test]
+    public void It_should_keep_a_leading_acronym_run_as_one_word()
+    {
+        CustomViewAuthorizationHintFormatter
+            .FormatDisplayText("CTEProgramWithAnEnrollment")
+            .Should()
+            .Be("CTE Program with An Enrollment");
+    }
+
+    [Test]
+    public void It_should_format_a_name_that_does_not_carry_the_With_separator()
+    {
+        // Not reachable for a resolved custom view — the convention requires 'With' — but the formatter
+        // must not fail on one, because the strategy name is CMS-supplied text.
+        CustomViewAuthorizationHintFormatter
+            .FormatDisplayText("StudentEnrollments")
+            .Should()
+            .Be("Student Enrollments");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void It_should_reject_a_missing_strategy_name(string? strategyName)
+    {
+        var act = () => CustomViewAuthorizationHintFormatter.Format(strategyName!);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("strategyName");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -381,46 +381,12 @@ public class Given_RelationalAuthorizationPlanner
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
     }
 
-    [TestCase(NamespaceAuthorizationOperation.Update, false)]
-    [TestCase(NamespaceAuthorizationOperation.Update, true)]
-    public void It_returns_still_unsupported_for_custom_views_on_operations_that_do_not_execute_them(
-        NamespaceAuthorizationOperation operation,
-        bool hasEducationOrganizationClaims
-    )
-    {
-        // Dropping the checks and serving the request would ignore a configured restriction, so a caller
-        // that cannot execute them fails closed instead.
-        var outcome = RelationalAuthorizationPlanner.Plan(
-            EmptyMappingSet(ResourceKey(2, "PlainResource"), ResourceKey(3, "Student")),
-            ResourceWithoutSecurableElements(),
-            operation,
-            [Strategy("StudentWithCTECourseEnrollments", 0)],
-            new RelationalAuthorizationContext(hasEducationOrganizationClaims ? [255901L] : [])
-        );
-
-        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
-    }
-
-    [Test]
-    public void It_does_not_yet_plan_custom_views_for_a_single_record_update()
-    {
-        // The proposed value source is wired but the repository does not plan it yet, so Update stays behind
-        // the enforcement gate: a configured custom view keeps its 501 rather than being silently dropped.
-        var outcome = RelationalAuthorizationPlanner.Plan(
-            EmptyMappingSet(ResourceKey(2, "PlainResource"), ResourceKey(3, "Student")),
-            ResourceWithoutSecurableElements(),
-            NamespaceAuthorizationOperation.Update,
-            [Strategy("StudentWithCTECourseEnrollments", 0)],
-            new RelationalAuthorizationContext([])
-        );
-
-        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
-    }
-
     [TestCase(NamespaceAuthorizationOperation.ReadSingle, false)]
     [TestCase(NamespaceAuthorizationOperation.ReadSingle, true)]
     [TestCase(NamespaceAuthorizationOperation.Delete, false)]
     [TestCase(NamespaceAuthorizationOperation.Delete, true)]
+    [TestCase(NamespaceAuthorizationOperation.Update, false)]
+    [TestCase(NamespaceAuthorizationOperation.Update, true)]
     public void It_plans_custom_views_for_a_regular_resource_single_record_operation(
         NamespaceAuthorizationOperation operation,
         bool hasEducationOrganizationClaims
@@ -446,6 +412,7 @@ public class Given_RelationalAuthorizationPlanner
 
     [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
     [TestCase(NamespaceAuthorizationOperation.Delete)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
     public void It_returns_still_unsupported_for_custom_views_on_a_descriptor_single_record_operation(
         NamespaceAuthorizationOperation operation
     )

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -410,15 +410,14 @@ public class Given_RelationalAuthorizationPlanner
         plan.NonNamespaceConfiguredStrategies.Should().BeEmpty();
     }
 
-    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
     [TestCase(NamespaceAuthorizationOperation.Delete)]
     [TestCase(NamespaceAuthorizationOperation.Update)]
     public void It_returns_still_unsupported_for_custom_views_on_a_descriptor_single_record_operation(
         NamespaceAuthorizationOperation operation
     )
     {
-        // The descriptor single-record paths do not execute custom-view checks yet, so they must keep failing
-        // closed even though the regular-resource paths for the same operations now enforce them.
+        // The descriptor DELETE and write paths do not execute custom-view checks yet, so they must keep
+        // failing closed even though the regular-resource paths for the same operations now enforce them.
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
             DescriptorResource(),
@@ -430,14 +429,15 @@ public class Given_RelationalAuthorizationPlanner
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
     }
 
-    [Test]
-    public void It_plans_custom_views_for_a_descriptor_read_many()
+    [TestCase(NamespaceAuthorizationOperation.ReadMany)]
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    public void It_plans_custom_views_for_a_descriptor_read(NamespaceAuthorizationOperation operation)
     {
-        // Descriptor GET-many was wired with the rest of GET-many, so storage kind only gates ReadSingle.
+        // Both descriptor read paths execute custom-view checks, so storage kind no longer gates either.
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
             DescriptorResource(),
-            NamespaceAuthorizationOperation.ReadMany,
+            operation,
             [Strategy("StudentWithCTECourseEnrollments", 0)],
             TwoPrefixContext()
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -81,6 +81,29 @@ public class Given_RelationalAuthorizationPlanner
         );
     }
 
+    /// <summary>
+    /// A descriptor-storage resource. The descriptor GET-by-id path is wired independently of the
+    /// regular-resource one, so the planner distinguishes them by storage kind.
+    /// </summary>
+    private static ConcreteResourceModel DescriptorResource()
+    {
+        var root = RootTable("SchoolTypeDescriptor", []);
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "SchoolTypeDescriptor"),
+            _edfiSchema,
+            ResourceStorageKind.SharedDescriptorTable,
+            root,
+            [root],
+            [],
+            []
+        );
+        return new ConcreteResourceModel(
+            ResourceKey(4, "SchoolTypeDescriptor"),
+            ResourceStorageKind.SharedDescriptorTable,
+            model
+        );
+    }
+
     private static MappingSet EmptyMappingSet(params ResourceKeyEntry[] resourceKeysInIdOrder) =>
         new(
             Key: new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
@@ -358,17 +381,17 @@ public class Given_RelationalAuthorizationPlanner
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
     }
 
-    [TestCase(NamespaceAuthorizationOperation.ReadSingle, false)]
-    [TestCase(NamespaceAuthorizationOperation.ReadSingle, true)]
     [TestCase(NamespaceAuthorizationOperation.Update, false)]
     [TestCase(NamespaceAuthorizationOperation.Update, true)]
     [TestCase(NamespaceAuthorizationOperation.Delete, false)]
     [TestCase(NamespaceAuthorizationOperation.Delete, true)]
-    public void It_returns_still_unsupported_for_custom_views_on_non_ReadMany_operations(
+    public void It_returns_still_unsupported_for_custom_views_on_operations_that_do_not_execute_them(
         NamespaceAuthorizationOperation operation,
         bool hasEducationOrganizationClaims
     )
     {
+        // Dropping the checks and serving the request would ignore a configured restriction, so a caller
+        // that cannot execute them fails closed instead.
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(2, "PlainResource"), ResourceKey(3, "Student")),
             ResourceWithoutSecurableElements(),
@@ -380,12 +403,69 @@ public class Given_RelationalAuthorizationPlanner
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
     }
 
-    [Test]
-    public void It_returns_no_prefixes_for_non_ReadMany_ahead_of_an_unsupported_custom_view()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void It_plans_custom_views_for_a_regular_resource_read_single(bool hasEducationOrganizationClaims)
     {
-        // Custom views are implemented for ReadMany only, so for other operations they fail closed
-        // with 501 — but like OwnershipBased they rank after the namespace terminals, so the
-        // no-prefixes 403 is still the reported outcome.
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(2, "PlainResource"), ResourceKey(3, "Student")),
+            ResourceWithoutSecurableElements(),
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy("StudentWithCTECourseEnrollments", 0)],
+            new RelationalAuthorizationContext(hasEducationOrganizationClaims ? [255901L] : [])
+        );
+
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.CustomViewStrategies.Should().ContainSingle();
+        plan.CustomViewStrategies[0]
+            .ConfiguredStrategy.StrategyName.Should()
+            .Be("StudentWithCTECourseEnrollments");
+        // Excluded from the relationship bucket so the relationship planner never re-classifies it and
+        // downgrades it back to unsupported.
+        plan.NonNamespaceConfiguredStrategies.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_returns_still_unsupported_for_custom_views_on_a_descriptor_read_single()
+    {
+        // The descriptor GET-by-id path does not execute custom-view checks yet, so it must keep failing
+        // closed even though the regular-resource path for the same operation now enforces them.
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
+            DescriptorResource(),
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy("StudentWithCTECourseEnrollments", 0)],
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
+    [Test]
+    public void It_plans_custom_views_for_a_descriptor_read_many()
+    {
+        // Descriptor GET-many was wired with the rest of GET-many, so storage kind only gates ReadSingle.
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
+            DescriptorResource(),
+            NamespaceAuthorizationOperation.ReadMany,
+            [Strategy("StudentWithCTECourseEnrollments", 0)],
+            TwoPrefixContext()
+        );
+
+        outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.Plan>()
+            .Subject.CustomViewStrategies.Should()
+            .ContainSingle();
+    }
+
+    [Test]
+    public void It_returns_no_prefixes_for_read_single_ahead_of_a_later_configured_custom_view()
+    {
+        // Namespace terminals rank ahead of custom-view handling, so the no-prefixes 403 is still the
+        // reported outcome. The resolved views are carried on it so a caller can validate the ones
+        // configured before the terminal; here the view is configured after it, so none qualify.
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(1, "AcademicWeek"), ResourceKey(3, "Student")),
             RootNamespaceResource(),
@@ -402,11 +482,19 @@ public class Given_RelationalAuthorizationPlanner
             .BeOfType<RelationalAuthorizationPlanOutcome.NoPrefixesConfigured>()
             .Subject;
         noPrefixes.StrategyName.Should().Be(AuthorizationStrategyNameConstants.NamespaceBased);
-        noPrefixes.CustomViewStrategies.Should().BeEmpty();
+        noPrefixes.RawConfiguredIndex.Should().Be(0);
+        noPrefixes.CustomViewStrategies.Should().ContainSingle();
+        noPrefixes
+            .CustomViewStrategies.Should()
+            .AllSatisfy(strategy =>
+                strategy
+                    .ConfiguredStrategy.RawConfiguredIndex.Should()
+                    .BeGreaterThan(noPrefixes.RawConfiguredIndex)
+            );
     }
 
     [Test]
-    public void It_returns_no_usable_root_column_for_non_ReadMany_ahead_of_an_unsupported_custom_view()
+    public void It_returns_no_usable_root_column_for_read_single_ahead_of_a_later_configured_custom_view()
     {
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(2, "PlainResource"), ResourceKey(3, "Student")),
@@ -423,7 +511,8 @@ public class Given_RelationalAuthorizationPlanner
             .Should()
             .BeOfType<RelationalAuthorizationPlanOutcome.NoUsableRootColumn>()
             .Subject;
-        noUsableRootColumn.CustomViewStrategies.Should().BeEmpty();
+        noUsableRootColumn.RawConfiguredIndex.Should().Be(0);
+        noUsableRootColumn.CustomViewStrategies.Should().ContainSingle();
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -410,18 +410,15 @@ public class Given_RelationalAuthorizationPlanner
         plan.NonNamespaceConfiguredStrategies.Should().BeEmpty();
     }
 
-    [TestCase(NamespaceAuthorizationOperation.Delete)]
-    [TestCase(NamespaceAuthorizationOperation.Update)]
-    public void It_returns_still_unsupported_for_custom_views_on_a_descriptor_single_record_operation(
-        NamespaceAuthorizationOperation operation
-    )
+    [Test]
+    public void It_returns_still_unsupported_for_custom_views_on_a_descriptor_update()
     {
-        // The descriptor DELETE and write paths do not execute custom-view checks yet, so they must keep
-        // failing closed even though the regular-resource paths for the same operations now enforce them.
+        // The descriptor write path does not execute custom-view checks yet, so it must keep failing closed
+        // even though the regular-resource POST/PUT paths now enforce them.
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
             DescriptorResource(),
-            operation,
+            NamespaceAuthorizationOperation.Update,
             [Strategy("StudentWithCTECourseEnrollments", 0)],
             TwoPrefixContext()
         );
@@ -431,9 +428,11 @@ public class Given_RelationalAuthorizationPlanner
 
     [TestCase(NamespaceAuthorizationOperation.ReadMany)]
     [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
     public void It_plans_custom_views_for_a_descriptor_read(NamespaceAuthorizationOperation operation)
     {
-        // Both descriptor read paths execute custom-view checks, so storage kind no longer gates either.
+        // Both descriptor read paths and descriptor DELETE execute custom-view checks, so storage kind gates
+        // only the write verbs now.
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
             DescriptorResource(),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -383,8 +383,6 @@ public class Given_RelationalAuthorizationPlanner
 
     [TestCase(NamespaceAuthorizationOperation.Update, false)]
     [TestCase(NamespaceAuthorizationOperation.Update, true)]
-    [TestCase(NamespaceAuthorizationOperation.Delete, false)]
-    [TestCase(NamespaceAuthorizationOperation.Delete, true)]
     public void It_returns_still_unsupported_for_custom_views_on_operations_that_do_not_execute_them(
         NamespaceAuthorizationOperation operation,
         bool hasEducationOrganizationClaims
@@ -403,14 +401,19 @@ public class Given_RelationalAuthorizationPlanner
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
     }
 
-    [TestCase(false)]
-    [TestCase(true)]
-    public void It_plans_custom_views_for_a_regular_resource_read_single(bool hasEducationOrganizationClaims)
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle, false)]
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle, true)]
+    [TestCase(NamespaceAuthorizationOperation.Delete, false)]
+    [TestCase(NamespaceAuthorizationOperation.Delete, true)]
+    public void It_plans_custom_views_for_a_regular_resource_single_record_operation(
+        NamespaceAuthorizationOperation operation,
+        bool hasEducationOrganizationClaims
+    )
     {
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(2, "PlainResource"), ResourceKey(3, "Student")),
             ResourceWithoutSecurableElements(),
-            NamespaceAuthorizationOperation.ReadSingle,
+            operation,
             [Strategy("StudentWithCTECourseEnrollments", 0)],
             new RelationalAuthorizationContext(hasEducationOrganizationClaims ? [255901L] : [])
         );
@@ -425,15 +428,18 @@ public class Given_RelationalAuthorizationPlanner
         plan.NonNamespaceConfiguredStrategies.Should().BeEmpty();
     }
 
-    [Test]
-    public void It_returns_still_unsupported_for_custom_views_on_a_descriptor_read_single()
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    public void It_returns_still_unsupported_for_custom_views_on_a_descriptor_single_record_operation(
+        NamespaceAuthorizationOperation operation
+    )
     {
-        // The descriptor GET-by-id path does not execute custom-view checks yet, so it must keep failing
-        // closed even though the regular-resource path for the same operation now enforces them.
+        // The descriptor single-record paths do not execute custom-view checks yet, so they must keep failing
+        // closed even though the regular-resource paths for the same operations now enforce them.
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
             DescriptorResource(),
-            NamespaceAuthorizationOperation.ReadSingle,
+            operation,
             [Strategy("StudentWithCTECourseEnrollments", 0)],
             TwoPrefixContext()
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -401,6 +401,22 @@ public class Given_RelationalAuthorizationPlanner
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
     }
 
+    [Test]
+    public void It_does_not_yet_plan_custom_views_for_a_single_record_update()
+    {
+        // The proposed value source is wired but the repository does not plan it yet, so Update stays behind
+        // the enforcement gate: a configured custom view keeps its 501 rather than being silently dropped.
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(2, "PlainResource"), ResourceKey(3, "Student")),
+            ResourceWithoutSecurableElements(),
+            NamespaceAuthorizationOperation.Update,
+            [Strategy("StudentWithCTECourseEnrollments", 0)],
+            new RelationalAuthorizationContext([])
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
     [TestCase(NamespaceAuthorizationOperation.ReadSingle, false)]
     [TestCase(NamespaceAuthorizationOperation.ReadSingle, true)]
     [TestCase(NamespaceAuthorizationOperation.Delete, false)]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -410,29 +410,13 @@ public class Given_RelationalAuthorizationPlanner
         plan.NonNamespaceConfiguredStrategies.Should().BeEmpty();
     }
 
-    [Test]
-    public void It_returns_still_unsupported_for_custom_views_on_a_descriptor_update()
-    {
-        // The descriptor write path does not execute custom-view checks yet, so it must keep failing closed
-        // even though the regular-resource POST/PUT paths now enforce them.
-        var outcome = RelationalAuthorizationPlanner.Plan(
-            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
-            DescriptorResource(),
-            NamespaceAuthorizationOperation.Update,
-            [Strategy("StudentWithCTECourseEnrollments", 0)],
-            TwoPrefixContext()
-        );
-
-        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
-    }
-
     [TestCase(NamespaceAuthorizationOperation.ReadMany)]
     [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
     [TestCase(NamespaceAuthorizationOperation.Delete)]
-    public void It_plans_custom_views_for_a_descriptor_read(NamespaceAuthorizationOperation operation)
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    public void It_plans_custom_views_for_a_descriptor_operation(NamespaceAuthorizationOperation operation)
     {
-        // Both descriptor read paths and descriptor DELETE execute custom-view checks, so storage kind gates
-        // only the write verbs now.
+        // Every descriptor path executes custom-view checks now, so storage kind no longer gates any of them.
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
             DescriptorResource(),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SecurableElementBasisResourcePathMetadataTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SecurableElementBasisResourcePathMetadataTests.cs
@@ -1,0 +1,546 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+/// <summary>
+/// Covers the terminal-reference metadata the custom view-based basis path resolution carries alongside
+/// its column path steps. The metadata names the securable element a custom view decided on, which is what
+/// the ProblemDetails wording reports; the steps themselves must be identical to the step-only overloads.
+/// </summary>
+[TestFixture]
+public class Given_SecurableElementColumnPathResolver_BasisPathMetadata
+{
+    private static readonly DbSchemaName EdFiSchema = new("edfi");
+    private static readonly DbSchemaName DmsSchema = new("dms");
+
+    private static DbTableName Table(string name) => new(EdFiSchema, name);
+
+    private static DbTableName DescriptorTable => new(DmsSchema, "Descriptor");
+
+    private static DbColumnName Col(string name) => new(name);
+
+    private static JsonPathExpression Path(string canonical) => new(canonical, []);
+
+    private static ResourceKeyEntry ResourceKey(
+        short id,
+        string project,
+        string resource,
+        bool isAbstract = false
+    ) => new(id, new QualifiedResourceName(project, resource), "1.0", isAbstract);
+
+    private static DbTableModel CreateRootTable(
+        DbTableName table,
+        IReadOnlyList<DbColumnModel>? columns = null
+    ) =>
+        new(
+            table,
+            Path("$"),
+            new TableKey("PK_Test", [new DbKeyColumn(Col("DocumentId"), ColumnKind.Scalar)]),
+            columns ?? [],
+            []
+        );
+
+    private static DbColumnModel DocumentFkColumn(string name, string targetResource) =>
+        new(
+            Col(name),
+            ColumnKind.DocumentFk,
+            null,
+            false,
+            null,
+            new QualifiedResourceName("Ed-Fi", targetResource)
+        );
+
+    private static RelationalResourceModel CreateModel(
+        string project,
+        string resource,
+        DbTableModel root,
+        IReadOnlyList<DocumentReferenceBinding>? bindings = null,
+        IReadOnlyList<DescriptorEdgeSource>? descriptorEdges = null
+    ) =>
+        new(
+            new QualifiedResourceName(project, resource),
+            EdFiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root],
+            bindings ?? [],
+            descriptorEdges ?? []
+        );
+
+    private static ConcreteResourceModel CreateConcrete(
+        short keyId,
+        string project,
+        string resource,
+        RelationalResourceModel model
+    ) => new(ResourceKey(keyId, project, resource), ResourceStorageKind.RelationalTables, model);
+
+    private static IReadOnlyDictionary<QualifiedResourceName, ConcreteResourceModel> CreateLookup(
+        params ConcreteResourceModel[] resources
+    ) => resources.ToDictionary(resource => resource.ResourceKey.Resource);
+
+    private static DerivedRelationalModelSet CreateModelSet(
+        IReadOnlyList<ConcreteResourceModel> resources,
+        IReadOnlyList<AbstractUnionViewInfo>? abstractUnionViews = null
+    ) =>
+        new(
+            new EffectiveSchemaInfo("1.0", "1.0", "test", 0, [], [], []),
+            SqlDialect.Pgsql,
+            [],
+            resources,
+            [],
+            abstractUnionViews ?? [],
+            [],
+            []
+        );
+
+    private static ReferenceIdentityBinding IdentityBinding(
+        string identityJsonPath,
+        string referenceJsonPath,
+        string column
+    ) => new(Path(identityJsonPath), Path(referenceJsonPath), Col(column));
+
+    [Test]
+    public void It_should_report_no_terminal_reference_paths_when_the_basis_is_the_subject()
+    {
+        var subjectRoot = CreateRootTable(Table("Student"));
+        var subject = CreateConcrete(1, "Ed-Fi", "Student", CreateModel("Ed-Fi", "Student", subjectRoot));
+
+        var result = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            subject,
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            CreateLookup(subject),
+            []
+        );
+
+        result.Steps.Should().ContainSingle();
+        result.Steps[0].SourceColumnName.Should().Be(Col("DocumentId"));
+        result.TerminalReferenceJsonPaths.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_should_report_the_terminal_reference_identity_path_for_a_direct_basis_reference()
+    {
+        var studentRoot = CreateRootTable(Table("Student"));
+        var subjectRoot = CreateRootTable(
+            Table("CourseTranscript"),
+            [DocumentFkColumn("Student_DocumentId", "Student")]
+        );
+
+        var subjectBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.studentReference"),
+            subjectRoot.Table,
+            Col("Student_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            [
+                IdentityBinding(
+                    "$.studentUniqueId",
+                    "$.studentReference.studentUniqueId",
+                    "Student_StudentUniqueId"
+                ),
+            ],
+            IsRequired: true
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "Ed-Fi",
+            "CourseTranscript",
+            CreateModel("Ed-Fi", "CourseTranscript", subjectRoot, [subjectBinding])
+        );
+        var student = CreateConcrete(2, "Ed-Fi", "Student", CreateModel("Ed-Fi", "Student", studentRoot));
+
+        var result = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            subject,
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            CreateLookup(subject, student),
+            []
+        );
+
+        result.Steps.Should().ContainSingle();
+        result.Steps[0].SourceColumnName.Should().Be(Col("Student_DocumentId"));
+        result.TerminalReferenceJsonPaths.Should().Equal("$.studentReference.studentUniqueId");
+    }
+
+    [Test]
+    public void It_should_report_the_last_hops_reference_path_for_an_indirect_basis_reference()
+    {
+        // CourseTranscript -> StudentAcademicRecord -> Student. auth.md's POC reports 'StudentUniqueId'
+        // for this shape, which is the LAST hop's reference path, not the first hop's.
+        var studentRoot = CreateRootTable(Table("Student"));
+        var academicRecordRoot = CreateRootTable(
+            Table("StudentAcademicRecord"),
+            [DocumentFkColumn("Student_DocumentId", "Student")]
+        );
+        var subjectRoot = CreateRootTable(
+            Table("CourseTranscript"),
+            [DocumentFkColumn("StudentAcademicRecord_DocumentId", "StudentAcademicRecord")]
+        );
+
+        var subjectBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.studentAcademicRecordReference"),
+            subjectRoot.Table,
+            Col("StudentAcademicRecord_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "StudentAcademicRecord"),
+            [
+                IdentityBinding(
+                    "$.schoolYear",
+                    "$.studentAcademicRecordReference.schoolYear",
+                    "StudentAcademicRecord_SchoolYear"
+                ),
+            ],
+            IsRequired: true
+        );
+        var academicRecordBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.studentReference"),
+            academicRecordRoot.Table,
+            Col("Student_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            [
+                IdentityBinding(
+                    "$.studentUniqueId",
+                    "$.studentReference.studentUniqueId",
+                    "Student_StudentUniqueId"
+                ),
+            ],
+            IsRequired: true
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "Ed-Fi",
+            "CourseTranscript",
+            CreateModel("Ed-Fi", "CourseTranscript", subjectRoot, [subjectBinding])
+        );
+        var academicRecord = CreateConcrete(
+            2,
+            "Ed-Fi",
+            "StudentAcademicRecord",
+            CreateModel("Ed-Fi", "StudentAcademicRecord", academicRecordRoot, [academicRecordBinding])
+        );
+        var student = CreateConcrete(3, "Ed-Fi", "Student", CreateModel("Ed-Fi", "Student", studentRoot));
+
+        var result = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            subject,
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            CreateLookup(subject, academicRecord, student),
+            []
+        );
+
+        result.Steps.Should().HaveCount(2);
+        result.Steps[^1].SourceColumnName.Should().Be(Col("Student_DocumentId"));
+        result.TerminalReferenceJsonPaths.Should().Equal("$.studentReference.studentUniqueId");
+        result.TerminalReferenceJsonPaths.Should().NotContain("$.studentAcademicRecordReference.schoolYear");
+    }
+
+    [Test]
+    public void It_should_report_every_identity_path_of_a_composite_key_terminal_reference_in_binding_order()
+    {
+        var courseRoot = CreateRootTable(Table("Course"));
+        var subjectRoot = CreateRootTable(
+            Table("CourseTranscript"),
+            [DocumentFkColumn("Course_DocumentId", "Course")]
+        );
+
+        var subjectBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.courseReference"),
+            subjectRoot.Table,
+            Col("Course_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Course"),
+            [
+                IdentityBinding("$.courseCode", "$.courseReference.courseCode", "Course_CourseCode"),
+                IdentityBinding(
+                    "$.educationOrganizationId",
+                    "$.courseReference.educationOrganizationId",
+                    "Course_EducationOrganizationId"
+                ),
+            ],
+            IsRequired: true
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "Ed-Fi",
+            "CourseTranscript",
+            CreateModel("Ed-Fi", "CourseTranscript", subjectRoot, [subjectBinding])
+        );
+        var course = CreateConcrete(2, "Ed-Fi", "Course", CreateModel("Ed-Fi", "Course", courseRoot));
+
+        var result = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            subject,
+            new QualifiedResourceName("Ed-Fi", "Course"),
+            CreateLookup(subject, course),
+            []
+        );
+
+        result
+            .TerminalReferenceJsonPaths.Should()
+            .Equal("$.courseReference.courseCode", "$.courseReference.educationOrganizationId");
+    }
+
+    [Test]
+    public void It_should_report_the_descriptor_value_path_for_a_directly_referenced_descriptor_basis()
+    {
+        var subjectRoot = CreateRootTable(
+            Table("StudentTransportation"),
+            [
+                new DbColumnModel(
+                    Col("TransportationTypeDescriptor_DescriptorId"),
+                    ColumnKind.DescriptorFk,
+                    null,
+                    false,
+                    null,
+                    null
+                ),
+            ]
+        );
+
+        var descriptorEdge = new DescriptorEdgeSource(
+            true,
+            Path("$.transportationTypeDescriptor"),
+            subjectRoot.Table,
+            Col("TransportationTypeDescriptor_DescriptorId"),
+            new QualifiedResourceName("Ed-Fi", "TransportationTypeDescriptor")
+        );
+
+        var descriptorRoot = CreateRootTable(Table("TransportationTypeDescriptor"));
+        var subject = CreateConcrete(
+            1,
+            "Ed-Fi",
+            "StudentTransportation",
+            CreateModel("Ed-Fi", "StudentTransportation", subjectRoot, [], [descriptorEdge])
+        );
+        var descriptor = CreateConcrete(
+            2,
+            "Ed-Fi",
+            "TransportationTypeDescriptor",
+            CreateModel("Ed-Fi", "TransportationTypeDescriptor", descriptorRoot)
+        );
+
+        var result = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            subject,
+            new QualifiedResourceName("Ed-Fi", "TransportationTypeDescriptor"),
+            CreateLookup(subject, descriptor),
+            []
+        );
+
+        result.Steps.Should().ContainSingle();
+        result.Steps[0].TargetTable.Should().Be(DescriptorTable);
+        result.TerminalReferenceJsonPaths.Should().Equal("$.transportationTypeDescriptor");
+    }
+
+    [Test]
+    public void It_should_report_an_unresolved_path_when_the_subject_resource_is_not_in_the_model_set()
+    {
+        var student = CreateConcrete(
+            1,
+            "Ed-Fi",
+            "Student",
+            CreateModel("Ed-Fi", "Student", CreateRootTable(Table("Student")))
+        );
+
+        var result = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            new QualifiedResourceName("Ed-Fi", "CourseTranscript"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            CreateModelSet([student])
+        );
+
+        result.Steps.Should().BeEmpty();
+        result.TerminalReferenceJsonPaths.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_should_report_an_unresolved_path_when_no_join_path_reaches_the_basis()
+    {
+        var subject = CreateConcrete(
+            1,
+            "Ed-Fi",
+            "BellSchedule",
+            CreateModel("Ed-Fi", "BellSchedule", CreateRootTable(Table("BellSchedule")))
+        );
+        var student = CreateConcrete(
+            2,
+            "Ed-Fi",
+            "Student",
+            CreateModel("Ed-Fi", "Student", CreateRootTable(Table("Student")))
+        );
+
+        var result = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            new QualifiedResourceName("Ed-Fi", "BellSchedule"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            CreateModelSet([subject, student])
+        );
+
+        result.Steps.Should().BeEmpty();
+        result.TerminalReferenceJsonPaths.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_should_return_the_same_steps_as_the_step_only_overloads()
+    {
+        var studentRoot = CreateRootTable(Table("Student"));
+        var subjectRoot = CreateRootTable(
+            Table("CourseTranscript"),
+            [DocumentFkColumn("Student_DocumentId", "Student")]
+        );
+
+        var subjectBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.studentReference"),
+            subjectRoot.Table,
+            Col("Student_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            [
+                IdentityBinding(
+                    "$.studentUniqueId",
+                    "$.studentReference.studentUniqueId",
+                    "Student_StudentUniqueId"
+                ),
+            ],
+            IsRequired: true
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "Ed-Fi",
+            "CourseTranscript",
+            CreateModel("Ed-Fi", "CourseTranscript", subjectRoot, [subjectBinding])
+        );
+        var student = CreateConcrete(2, "Ed-Fi", "Student", CreateModel("Ed-Fi", "Student", studentRoot));
+        var lookup = CreateLookup(subject, student);
+        var modelSet = CreateModelSet([subject, student]);
+        var basis = new QualifiedResourceName("Ed-Fi", "Student");
+        var subjectName = new QualifiedResourceName("Ed-Fi", "CourseTranscript");
+
+        var metadata = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            subject,
+            basis,
+            lookup,
+            []
+        );
+
+        SecurableElementColumnPathResolver
+            .ResolveBasisResourcePath(subject, basis, lookup, [])
+            .Should()
+            .Equal(metadata.Steps);
+        SecurableElementColumnPathResolver
+            .ResolveBasisResourcePath(subjectName, basis, modelSet)
+            .Should()
+            .Equal(metadata.Steps);
+        SecurableElementColumnPathResolver
+            .ResolveSecurableElementColumnPath(subjectName, basis, modelSet)
+            .Should()
+            .Equal(metadata.Steps);
+    }
+
+    [Test]
+    public void It_should_keep_the_abstract_basis_ranking_and_report_the_winning_paths_reference()
+    {
+        // auth.md requires StudentSchoolAssociation -> GraduationPlan -> EducationOrganization to win
+        // over the direct School union-arm route. The metadata must describe that winner, proving the
+        // added metadata does not perturb candidate ranking.
+        var schoolRoot = CreateRootTable(Table("School"));
+        var graduationPlanRoot = CreateRootTable(
+            Table("GraduationPlan"),
+            [DocumentFkColumn("EducationOrganization_DocumentId", "EducationOrganization")]
+        );
+        var subjectRoot = CreateRootTable(
+            Table("StudentSchoolAssociation"),
+            [
+                DocumentFkColumn("School_DocumentId", "School"),
+                DocumentFkColumn("GraduationPlan_DocumentId", "GraduationPlan"),
+            ]
+        );
+
+        var schoolBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.schoolReference"),
+            subjectRoot.Table,
+            Col("School_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "School"),
+            [IdentityBinding("$.schoolId", "$.schoolReference.schoolId", "School_SchoolId")],
+            IsRequired: true
+        );
+        var graduationPlanBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.graduationPlanReference"),
+            subjectRoot.Table,
+            Col("GraduationPlan_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "GraduationPlan"),
+            [
+                IdentityBinding(
+                    "$.educationOrganizationId",
+                    "$.graduationPlanReference.educationOrganizationId",
+                    "GraduationPlan_EducationOrganizationId"
+                ),
+            ],
+            IsRequired: true
+        );
+        var edOrgBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.educationOrganizationReference"),
+            graduationPlanRoot.Table,
+            Col("EducationOrganization_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "EducationOrganization"),
+            [
+                IdentityBinding(
+                    "$.educationOrganizationId",
+                    "$.educationOrganizationReference.educationOrganizationId",
+                    "EducationOrganization_EducationOrganizationId"
+                ),
+            ],
+            IsRequired: true
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "Ed-Fi",
+            "StudentSchoolAssociation",
+            CreateModel(
+                "Ed-Fi",
+                "StudentSchoolAssociation",
+                subjectRoot,
+                [schoolBinding, graduationPlanBinding]
+            )
+        );
+        var graduationPlan = CreateConcrete(
+            2,
+            "Ed-Fi",
+            "GraduationPlan",
+            CreateModel("Ed-Fi", "GraduationPlan", graduationPlanRoot, [edOrgBinding])
+        );
+        var school = CreateConcrete(3, "Ed-Fi", "School", CreateModel("Ed-Fi", "School", schoolRoot));
+
+        var abstractView = new AbstractUnionViewInfo(
+            ResourceKey(100, "Ed-Fi", "EducationOrganization", true),
+            Table("EducationOrganization"),
+            [],
+            [new AbstractUnionViewArm(ResourceKey(3, "Ed-Fi", "School"), Table("School"), [])]
+        );
+
+        var result = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+            subject,
+            new QualifiedResourceName("Ed-Fi", "EducationOrganization"),
+            CreateLookup(subject, graduationPlan, school),
+            [abstractView]
+        );
+
+        result.Steps.Should().HaveCount(2);
+        result.Steps[0].SourceColumnName.Should().Be(Col("GraduationPlan_DocumentId"));
+        result.Steps[^1].SourceColumnName.Should().Be(Col("EducationOrganization_DocumentId"));
+        result
+            .TerminalReferenceJsonPaths.Should()
+            .Equal("$.educationOrganizationReference.educationOrganizationId");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationPlannerTests.cs
@@ -1,0 +1,778 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+public class Given_SingleRecordCustomViewAuthorizationPlanner
+{
+    private static readonly DbSchemaName EdFiSchema = new("edfi");
+    private static readonly DbSchemaName DmsSchema = new("dms");
+    private static readonly DbSchemaName AuthSchema = new("auth");
+
+    private static DbTableName Table(string name) => new(EdFiSchema, name);
+
+    private static DbColumnName Col(string name) => new(name);
+
+    private static JsonPathExpression Path(string canonical) => new(canonical, []);
+
+    private static ResourceKeyEntry ResourceKey(short id, string resource, bool isAbstract = false) =>
+        new(id, new QualifiedResourceName("Ed-Fi", resource), "1.0", isAbstract);
+
+    private static DbTableModel CreateRootTable(
+        DbTableName table,
+        IReadOnlyList<DbColumnModel>? columns = null
+    ) =>
+        new(
+            table,
+            Path("$"),
+            new TableKey("PK_Test", [new DbKeyColumn(Col("DocumentId"), ColumnKind.Scalar)]),
+            columns ?? [],
+            []
+        );
+
+    private static DbTableModel CreateChildTable(DbTableName table, IReadOnlyList<DbColumnModel> columns) =>
+        new(
+            table,
+            Path("$.items[*]"),
+            new TableKey("PK_Child", [new DbKeyColumn(Col("CollectionItemId"), ColumnKind.Scalar)]),
+            columns,
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Unspecified,
+                [Col("CollectionItemId")],
+                [Col("DocumentId")],
+                [],
+                []
+            ),
+        };
+
+    private static DbColumnModel DocumentFkColumn(string name, string targetResource) =>
+        new(
+            Col(name),
+            ColumnKind.DocumentFk,
+            null,
+            false,
+            null,
+            new QualifiedResourceName("Ed-Fi", targetResource)
+        );
+
+    private static RelationalResourceModel CreateModel(
+        string resource,
+        DbTableModel root,
+        IReadOnlyList<DocumentReferenceBinding>? bindings = null,
+        IReadOnlyList<DescriptorEdgeSource>? descriptorEdges = null,
+        IReadOnlyList<DbTableModel>? tables = null
+    ) =>
+        new(
+            new QualifiedResourceName("Ed-Fi", resource),
+            EdFiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            tables ?? [root],
+            bindings ?? [],
+            descriptorEdges ?? []
+        );
+
+    private static ConcreteResourceModel CreateConcrete(
+        short keyId,
+        string resource,
+        RelationalResourceModel model
+    ) => new(ResourceKey(keyId, resource), ResourceStorageKind.RelationalTables, model);
+
+    /// <summary>
+    /// A reference identity binding. <c>IdentityJsonPath</c> is the identity path on the <em>target</em>
+    /// resource, so by default it is the reference path's leaf rehung at the root — the shape MetaEd emits.
+    /// </summary>
+    private static ReferenceIdentityBinding IdentityBinding(
+        string referenceJsonPath,
+        string column,
+        string? identityJsonPath = null
+    ) =>
+        new(
+            Path(identityJsonPath ?? DeriveIdentityJsonPath(referenceJsonPath)),
+            Path(referenceJsonPath),
+            Col(column)
+        );
+
+    private static string DeriveIdentityJsonPath(string referenceJsonPath)
+    {
+        var segments = referenceJsonPath.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+        return $"$.{segments[^1]}";
+    }
+
+    private static MappingSet CreateMappingSet(params ConcreteResourceModel[] resources) =>
+        new(
+            new MappingSetKey("hash", SqlDialect.Pgsql, "v1"),
+            new DerivedRelationalModelSet(
+                new EffectiveSchemaInfo("1.0", "1.0", "test", 0, [], [], []),
+                SqlDialect.Pgsql,
+                [],
+                resources,
+                [],
+                [],
+                [],
+                []
+            ),
+            new Dictionary<QualifiedResourceName, ResourceWritePlan>(),
+            new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            new Dictionary<QualifiedResourceName, short>(),
+            new Dictionary<short, ResourceKeyEntry>(),
+            new Dictionary<QualifiedResourceName, IReadOnlyList<ResolvedSecurableElementPath>>()
+        );
+
+    private static SupportedCustomViewAuthorizationStrategy Strategy(
+        string strategyName,
+        string basisResource,
+        int rawConfiguredIndex = 0,
+        int authorizationLocalOrder = 0
+    ) =>
+        new(
+            new ConfiguredAuthorizationStrategy(strategyName, rawConfiguredIndex),
+            authorizationLocalOrder,
+            new QualifiedResourceName("Ed-Fi", basisResource)
+        );
+
+    /// <summary>CourseTranscript -> Student via a root-owned reference.</summary>
+    private static (MappingSet MappingSet, ConcreteResourceModel Subject) DirectStudentBasisFixture()
+    {
+        var studentRoot = CreateRootTable(Table("Student"));
+        var subjectRoot = CreateRootTable(
+            Table("CourseTranscript"),
+            [DocumentFkColumn("Student_DocumentId", "Student")]
+        );
+        var subjectBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.studentReference"),
+            subjectRoot.Table,
+            Col("Student_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            [IdentityBinding("$.studentReference.studentUniqueId", "Student_StudentUniqueId")],
+            IsRequired: true
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "CourseTranscript",
+            CreateModel("CourseTranscript", subjectRoot, [subjectBinding])
+        );
+        var student = CreateConcrete(2, "Student", CreateModel("Student", studentRoot));
+
+        return (CreateMappingSet(subject, student), subject);
+    }
+
+    [Test]
+    public void It_should_reject_ReadMany_because_GET_many_has_its_own_planner()
+    {
+        var (mappingSet, subject) = DirectStudentBasisFixture();
+
+        var act = () =>
+            SingleRecordCustomViewAuthorizationPlanner.Plan(
+                mappingSet,
+                subject,
+                [Strategy("StudentWithCTECourseEnrollments", "Student")],
+                NamespaceAuthorizationOperation.ReadMany
+            );
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("operation");
+    }
+
+    [Test]
+    public void It_should_plan_no_checks_when_no_custom_views_are_configured()
+    {
+        var (mappingSet, subject) = DirectStudentBasisFixture();
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            subject,
+            [],
+            NamespaceAuthorizationOperation.Update
+        );
+
+        outcome
+            .Should()
+            .BeOfType<SingleRecordCustomViewAuthorizationPlanOutcome.Plan>()
+            .Subject.Checks.Should()
+            .BeEmpty();
+    }
+
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    public void It_should_plan_only_a_stored_check_for_read_single_and_delete(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        var (mappingSet, subject) = DirectStudentBasisFixture();
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            operation
+        );
+
+        checks.Should().ContainSingle();
+        checks[0].Index.Should().Be(0);
+        checks[0].ValueSource.Should().Be(CustomViewAuthorizationCheckValueSource.Stored);
+        checks[0].AuthView.Should().Be(new DbTableName(AuthSchema, "StudentWithCTECourseEnrollments"));
+        checks[0].AuthViewDocumentIdColumn.Should().Be(Col("DocumentId"));
+        checks[0].BasisResource.Should().Be(new QualifiedResourceName("Ed-Fi", "Student"));
+        checks[0].ReadableSecurableElements.Should().Equal("StudentUniqueId");
+        checks[0].FailureHint.Should().Be("You may need a Student with CTE Course Enrollments.");
+        checks[0]
+            .CheckTarget.Should()
+            .BeOfType<CustomViewAuthorizationCheckTarget.Stored>()
+            .Which.RootTable.Should()
+            .Be(Table("CourseTranscript"));
+    }
+
+    [Test]
+    public void It_should_plan_a_stored_then_proposed_pair_for_update()
+    {
+        var (mappingSet, subject) = DirectStudentBasisFixture();
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            NamespaceAuthorizationOperation.Update
+        );
+
+        checks.Should().HaveCount(2);
+        checks[0].Index.Should().Be(0);
+        checks[0].ValueSource.Should().Be(CustomViewAuthorizationCheckValueSource.Stored);
+        checks[1].Index.Should().Be(1);
+        checks[1].ValueSource.Should().Be(CustomViewAuthorizationCheckValueSource.Proposed);
+        var binding = checks[1]
+            .CheckTarget.Should()
+            .BeOfType<CustomViewAuthorizationCheckTarget.Proposed>()
+            .Subject.Binding;
+        binding.Table.Should().Be(Table("CourseTranscript"));
+        binding.Column.Should().Be(Col("Student_DocumentId"));
+        binding.ParameterSeed.Should().Be("customViewAuthorization1");
+    }
+
+    [Test]
+    public void It_should_emit_every_stored_check_before_any_proposed_check()
+    {
+        // Stored values are authorized before proposed values, so with two strategies the indexes must read
+        // stored, stored, proposed, proposed rather than interleaving per strategy.
+        var (mappingSet, subject) = DirectStudentBasisFixture();
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [
+                Strategy("StudentWithCTECourseEnrollments", "Student", rawConfiguredIndex: 0),
+                Strategy("StudentWithAnIep", "Student", rawConfiguredIndex: 1, authorizationLocalOrder: 1),
+            ],
+            NamespaceAuthorizationOperation.Update
+        );
+
+        checks
+            .Select(check => check.ValueSource)
+            .Should()
+            .Equal(
+                CustomViewAuthorizationCheckValueSource.Stored,
+                CustomViewAuthorizationCheckValueSource.Stored,
+                CustomViewAuthorizationCheckValueSource.Proposed,
+                CustomViewAuthorizationCheckValueSource.Proposed
+            );
+        checks.Select(check => check.Index).Should().Equal(0, 1, 2, 3);
+        checks
+            .Select(check => check.ConfiguredStrategy.StrategyName)
+            .Should()
+            .Equal(
+                "StudentWithCTECourseEnrollments",
+                "StudentWithAnIep",
+                "StudentWithCTECourseEnrollments",
+                "StudentWithAnIep"
+            );
+    }
+
+    [Test]
+    public void It_should_preserve_the_configured_index_each_check_is_ordered_by()
+    {
+        // RawConfiguredIndex is the only input that orders custom-view checks against NamespaceBased, so it
+        // must survive planning unchanged on both the stored and proposed check of a strategy.
+        var (mappingSet, subject) = DirectStudentBasisFixture();
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student", rawConfiguredIndex: 7)],
+            NamespaceAuthorizationOperation.Update
+        );
+
+        checks.Select(check => check.ConfiguredStrategy.RawConfiguredIndex).Should().AllBeEquivalentTo(7);
+    }
+
+    [Test]
+    public void It_should_plan_a_self_basis_stored_check_against_the_root_document_id()
+    {
+        var (mappingSet, subject) = SelfBasisStudentFixture();
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        checks.Should().ContainSingle();
+        checks[0].PathToBasisResource.Should().ContainSingle();
+        checks[0].PathToBasisResource[0].SourceColumnName.Should().Be(Col("DocumentId"));
+        // A self-basis path terminates on the subject's own DocumentId, so no reference names the element.
+        // The basis resource's own authoritative identity is used instead; the cross-boundary failure carries
+        // only this list, so the planner is the last layer that can supply it.
+        checks[0].ReadableSecurableElements.Should().Equal("StudentUniqueId");
+    }
+
+    [Test]
+    public void It_should_prefer_a_non_role_named_reference_when_resolving_a_self_basis_identity()
+    {
+        // A role-named reference to the basis must not win the identity lookup, so the readable name does not
+        // depend on which resource happens to reference the basis first.
+        var studentRoot = CreateRootTable(Table("Student"));
+        var subject = CreateConcrete(1, "Student", CreateModel("Student", studentRoot));
+        var roleNamedReferrer = CreateConcrete(
+            2,
+            "AlphaAssociation",
+            CreateModel(
+                "AlphaAssociation",
+                CreateRootTable(
+                    Table("AlphaAssociation"),
+                    [DocumentFkColumn("ReferencedStudent_DocumentId", "Student")]
+                ),
+                [
+                    new DocumentReferenceBinding(
+                        true,
+                        Path("$.referencedStudentReference"),
+                        Table("AlphaAssociation"),
+                        Col("ReferencedStudent_DocumentId"),
+                        new QualifiedResourceName("Ed-Fi", "Student"),
+                        [
+                            IdentityBinding(
+                                "$.referencedStudentReference.roleNamedUniqueId",
+                                "ReferencedStudent_StudentUniqueId"
+                            ),
+                        ],
+                        IsRequired: true,
+                        IsRoleNamed: true
+                    ),
+                ]
+            )
+        );
+        var plainReferrer = CreateConcrete(
+            3,
+            "ZuluAssociation",
+            CreateModel(
+                "ZuluAssociation",
+                CreateRootTable(
+                    Table("ZuluAssociation"),
+                    [DocumentFkColumn("Student_DocumentId", "Student")]
+                ),
+                [
+                    new DocumentReferenceBinding(
+                        true,
+                        Path("$.studentReference"),
+                        Table("ZuluAssociation"),
+                        Col("Student_DocumentId"),
+                        new QualifiedResourceName("Ed-Fi", "Student"),
+                        [IdentityBinding("$.studentReference.studentUniqueId", "Student_StudentUniqueId")],
+                        IsRequired: true
+                    ),
+                ]
+            )
+        );
+        var mappingSet = CreateMappingSet(subject, roleNamedReferrer, plainReferrer);
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        checks[0].ReadableSecurableElements.Should().Equal("StudentUniqueId");
+    }
+
+    [Test]
+    public void It_should_preserve_every_part_of_a_composite_self_basis_identity()
+    {
+        var courseRoot = CreateRootTable(Table("Course"));
+        var subject = CreateConcrete(1, "Course", CreateModel("Course", courseRoot));
+        var referrer = CreateConcrete(
+            2,
+            "CourseOffering",
+            CreateModel(
+                "CourseOffering",
+                CreateRootTable(Table("CourseOffering"), [DocumentFkColumn("Course_DocumentId", "Course")]),
+                [
+                    new DocumentReferenceBinding(
+                        true,
+                        Path("$.courseReference"),
+                        Table("CourseOffering"),
+                        Col("Course_DocumentId"),
+                        new QualifiedResourceName("Ed-Fi", "Course"),
+                        [
+                            IdentityBinding("$.courseReference.courseCode", "Course_CourseCode"),
+                            IdentityBinding(
+                                "$.courseReference.educationOrganizationId",
+                                "Course_EducationOrganizationId"
+                            ),
+                        ],
+                        IsRequired: true
+                    ),
+                ]
+            )
+        );
+        var mappingSet = CreateMappingSet(subject, referrer);
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("CourseWithAnHonorsFlag", "Course")],
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        checks[0].ReadableSecurableElements.Should().Equal("CourseCode", "EducationOrganizationId");
+    }
+
+    [Test]
+    public void It_should_fall_back_to_the_basis_resource_name_when_nothing_references_it()
+    {
+        // A descriptor reached by its own view is the realistic case: descriptor edges carry only the
+        // referencing value path, so no authoritative identity path exists to name.
+        var descriptorRoot = CreateRootTable(Table("TransportationTypeDescriptor"));
+        var subject = CreateConcrete(
+            1,
+            "TransportationTypeDescriptor",
+            CreateModel("TransportationTypeDescriptor", descriptorRoot)
+        );
+        var mappingSet = CreateMappingSet(subject);
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("TransportationTypeDescriptorWithABus", "TransportationTypeDescriptor")],
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        checks[0].ReadableSecurableElements.Should().Equal("TransportationTypeDescriptor");
+    }
+
+    [Test]
+    public void It_should_plan_a_self_basis_proposed_check_as_unprovable_rather_than_binding_a_value()
+    {
+        var (mappingSet, subject) = SelfBasisStudentFixture();
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            NamespaceAuthorizationOperation.Update
+        );
+
+        checks.Should().HaveCount(2);
+        checks[1].ValueSource.Should().Be(CustomViewAuthorizationCheckValueSource.Proposed);
+        checks[1]
+            .CheckTarget.Should()
+            .BeOfType<CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable>()
+            .Which.RootTable.Should()
+            .Be(Table("Student"));
+    }
+
+    [Test]
+    public void It_should_plan_a_directly_referenced_descriptor_basis()
+    {
+        var subjectRoot = CreateRootTable(
+            Table("StudentTransportation"),
+            [
+                new DbColumnModel(
+                    Col("TransportationTypeDescriptor_DescriptorId"),
+                    ColumnKind.DescriptorFk,
+                    null,
+                    false,
+                    null,
+                    null
+                ),
+            ]
+        );
+        var descriptorEdge = new DescriptorEdgeSource(
+            true,
+            Path("$.transportationTypeDescriptor"),
+            subjectRoot.Table,
+            Col("TransportationTypeDescriptor_DescriptorId"),
+            new QualifiedResourceName("Ed-Fi", "TransportationTypeDescriptor")
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "StudentTransportation",
+            CreateModel("StudentTransportation", subjectRoot, [], [descriptorEdge])
+        );
+        var descriptor = CreateConcrete(
+            2,
+            "TransportationTypeDescriptor",
+            CreateModel(
+                "TransportationTypeDescriptor",
+                CreateRootTable(Table("TransportationTypeDescriptor"))
+            )
+        );
+        var mappingSet = CreateMappingSet(subject, descriptor);
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("TransportationTypeDescriptorWithABus", "TransportationTypeDescriptor")],
+            NamespaceAuthorizationOperation.Update
+        );
+
+        checks.Should().HaveCount(2);
+        checks[0].PathToBasisResource[^1].TargetTable.Should().Be(new DbTableName(DmsSchema, "Descriptor"));
+        checks[0].ReadableSecurableElements.Should().Equal("TransportationTypeDescriptor");
+        checks[0].FailureHint.Should().Be("You may need a Transportation Type Descriptor with A Bus.");
+        checks[1]
+            .CheckTarget.Should()
+            .BeOfType<CustomViewAuthorizationCheckTarget.Proposed>()
+            .Subject.Binding.Column.Should()
+            .Be(Col("TransportationTypeDescriptor_DescriptorId"));
+    }
+
+    [Test]
+    public void It_should_report_every_readable_element_of_a_composite_identity_basis()
+    {
+        var courseRoot = CreateRootTable(Table("Course"));
+        var subjectRoot = CreateRootTable(
+            Table("CourseTranscript"),
+            [DocumentFkColumn("Course_DocumentId", "Course")]
+        );
+        var subjectBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.courseReference"),
+            subjectRoot.Table,
+            Col("Course_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Course"),
+            [
+                IdentityBinding("$.courseReference.courseCode", "Course_CourseCode"),
+                IdentityBinding(
+                    "$.courseReference.educationOrganizationId",
+                    "Course_EducationOrganizationId"
+                ),
+            ],
+            IsRequired: true
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "CourseTranscript",
+            CreateModel("CourseTranscript", subjectRoot, [subjectBinding])
+        );
+        var course = CreateConcrete(2, "Course", CreateModel("Course", courseRoot));
+        var mappingSet = CreateMappingSet(subject, course);
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("CourseWithAnHonorsFlag", "Course")],
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        checks[0].ReadableSecurableElements.Should().Equal("CourseCode", "EducationOrganizationId");
+    }
+
+    [Test]
+    public void It_should_report_a_security_configuration_failure_when_no_join_path_reaches_the_basis()
+    {
+        var subject = CreateConcrete(
+            1,
+            "BellSchedule",
+            CreateModel("BellSchedule", CreateRootTable(Table("BellSchedule")))
+        );
+        var student = CreateConcrete(2, "Student", CreateModel("Student", CreateRootTable(Table("Student"))));
+        var mappingSet = CreateMappingSet(subject, student);
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        var securityConfiguration = outcome
+            .Should()
+            .BeOfType<SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration>()
+            .Subject;
+        securityConfiguration.PlannedChecks.Should().BeEmpty();
+        securityConfiguration.Failures.Should().ContainSingle();
+        securityConfiguration
+            .Failures[0]
+            .FailureKind.Should()
+            .Be(RelationshipAuthorizationFailureKind.NoCustomViewJoinPath);
+        securityConfiguration
+            .Failures[0]
+            .Location!.AuthorizationObjectName.Should()
+            .Be("auth.StudentWithCTECourseEnrollments");
+    }
+
+    [Test]
+    public void It_should_carry_checks_planned_ahead_of_a_failure_so_earlier_views_can_still_be_validated()
+    {
+        var (mappingSet, subject) = DirectStudentBasisFixture();
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            subject,
+            [
+                Strategy("StudentWithCTECourseEnrollments", "Student", rawConfiguredIndex: 0),
+                Strategy("BellScheduleWithAPeriod", "BellSchedule", rawConfiguredIndex: 1),
+            ],
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        var securityConfiguration = outcome
+            .Should()
+            .BeOfType<SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration>()
+            .Subject;
+        securityConfiguration.Failures.Should().ContainSingle();
+        securityConfiguration.PlannedChecks.Should().ContainSingle();
+        securityConfiguration
+            .PlannedChecks[0]
+            .ConfiguredStrategy.StrategyName.Should()
+            .Be("StudentWithCTECourseEnrollments");
+    }
+
+    [Test]
+    public void It_should_fail_closed_for_a_write_whose_basis_is_reached_only_through_a_child_collection()
+    {
+        var (mappingSet, subject) = ChildCollectionBasisFixture();
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            NamespaceAuthorizationOperation.Update
+        );
+
+        var securityConfiguration = outcome
+            .Should()
+            .BeOfType<SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration>()
+            .Subject;
+        securityConfiguration.PlannedChecks.Should().BeEmpty();
+        securityConfiguration
+            .Failures[0]
+            .FailureKind.Should()
+            .Be(RelationshipAuthorizationFailureKind.MissingProposedCustomViewRootBinding);
+    }
+
+    [Test]
+    public void It_should_still_plan_a_stored_only_check_for_a_child_collection_basis_path()
+    {
+        // A stored check can walk the child hop: the root DocumentId is known. Only a proposed check cannot,
+        // so GET-by-id and DELETE keep working where a write fails closed.
+        var (mappingSet, subject) = ChildCollectionBasisFixture();
+
+        var checks = PlannedChecks(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        checks.Should().ContainSingle();
+        checks[0].ValueSource.Should().Be(CustomViewAuthorizationCheckValueSource.Stored);
+        checks[0].PathToBasisResource.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// Student as its own basis, with another resource referencing Student so the basis's authoritative
+    /// identity path is discoverable — the shape every real Data Standard model has.
+    /// </summary>
+    private static (MappingSet MappingSet, ConcreteResourceModel Subject) SelfBasisStudentFixture()
+    {
+        var studentRoot = CreateRootTable(Table("Student"));
+        var subject = CreateConcrete(1, "Student", CreateModel("Student", studentRoot));
+        var referrer = CreateConcrete(
+            2,
+            "StudentSchoolAssociation",
+            CreateModel(
+                "StudentSchoolAssociation",
+                CreateRootTable(
+                    Table("StudentSchoolAssociation"),
+                    [DocumentFkColumn("Student_DocumentId", "Student")]
+                ),
+                [
+                    new DocumentReferenceBinding(
+                        true,
+                        Path("$.studentReference"),
+                        Table("StudentSchoolAssociation"),
+                        Col("Student_DocumentId"),
+                        new QualifiedResourceName("Ed-Fi", "Student"),
+                        [IdentityBinding("$.studentReference.studentUniqueId", "Student_StudentUniqueId")],
+                        IsRequired: true
+                    ),
+                ]
+            )
+        );
+
+        return (CreateMappingSet(subject, referrer), subject);
+    }
+
+    /// <summary>
+    /// A subject whose only route to Student is an identity reference living on a child collection table.
+    /// </summary>
+    private static (MappingSet MappingSet, ConcreteResourceModel Subject) ChildCollectionBasisFixture()
+    {
+        var studentRoot = CreateRootTable(Table("Student"));
+        var subjectRoot = CreateRootTable(Table("Section"));
+        var childTable = CreateChildTable(
+            Table("SectionStudent"),
+            [
+                new DbColumnModel(Col("DocumentId"), ColumnKind.Scalar, null, false, null, null),
+                DocumentFkColumn("Student_DocumentId", "Student"),
+            ]
+        );
+        var childBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.students[*].studentReference"),
+            childTable.Table,
+            Col("Student_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            [IdentityBinding("$.students[*].studentReference.studentUniqueId", "Student_StudentUniqueId")],
+            IsRequired: true
+        );
+
+        var subject = CreateConcrete(
+            1,
+            "Section",
+            CreateModel("Section", subjectRoot, [childBinding], tables: [subjectRoot, childTable])
+        );
+        var student = CreateConcrete(2, "Student", CreateModel("Student", studentRoot));
+
+        return (CreateMappingSet(subject, student), subject);
+    }
+
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks(
+        MappingSet mappingSet,
+        ConcreteResourceModel subject,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> strategies,
+        NamespaceAuthorizationOperation operation
+    ) =>
+        SingleRecordCustomViewAuthorizationPlanner
+            .Plan(mappingSet, subject, strategies, operation)
+            .Should()
+            .BeOfType<SingleRecordCustomViewAuthorizationPlanOutcome.Plan>()
+            .Subject.Checks;
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationPlannerTests.cs
@@ -678,6 +678,34 @@ public class Given_SingleRecordCustomViewAuthorizationPlanner
     }
 
     [Test]
+    public void It_should_locate_the_child_path_failure_on_the_terminal_steps_own_table()
+    {
+        // A 3-hop basis path: Section.DocumentId -> SectionStudent -> StudentSchoolAssociation -> Student.
+        // The reported location must be a table/column pair from the same step; pairing the first hop's
+        // table with the terminal hop's column would name a column that table does not have.
+        var (mappingSet, subject) = ChildCollectionIntermediateBasisFixture();
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            subject,
+            [Strategy("StudentWithCTECourseEnrollments", "Student")],
+            NamespaceAuthorizationOperation.Update
+        );
+
+        var securityConfiguration = outcome
+            .Should()
+            .BeOfType<SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration>()
+            .Subject;
+        securityConfiguration
+            .Failures[0]
+            .FailureKind.Should()
+            .Be(RelationshipAuthorizationFailureKind.MissingProposedCustomViewRootBinding);
+        var location = securityConfiguration.Failures[0].Location!;
+        location.Table.Should().Be(Table("StudentSchoolAssociation"));
+        location.Column.Should().Be(Col("Student_DocumentId"));
+    }
+
+    [Test]
     public void It_should_still_plan_a_stored_only_check_for_a_child_collection_basis_path()
     {
         // A stored check can walk the child hop: the root DocumentId is known. Only a proposed check cannot,
@@ -762,6 +790,67 @@ public class Given_SingleRecordCustomViewAuthorizationPlanner
         var student = CreateConcrete(2, "Student", CreateModel("Student", studentRoot));
 
         return (CreateMappingSet(subject, student), subject);
+    }
+
+    /// <summary>
+    /// A subject whose only route to Student crosses a child collection table and then an intermediate
+    /// resource: Section.DocumentId -> SectionStudent -> StudentSchoolAssociation -> Student.
+    /// </summary>
+    private static (
+        MappingSet MappingSet,
+        ConcreteResourceModel Subject
+    ) ChildCollectionIntermediateBasisFixture()
+    {
+        var studentRoot = CreateRootTable(Table("Student"));
+        var associationRoot = CreateRootTable(
+            Table("StudentSchoolAssociation"),
+            [DocumentFkColumn("Student_DocumentId", "Student")]
+        );
+        var associationBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.studentReference"),
+            associationRoot.Table,
+            Col("Student_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            [IdentityBinding("$.studentReference.studentUniqueId", "Student_StudentUniqueId")],
+            IsRequired: true
+        );
+        var association = CreateConcrete(
+            3,
+            "StudentSchoolAssociation",
+            CreateModel("StudentSchoolAssociation", associationRoot, [associationBinding])
+        );
+
+        var subjectRoot = CreateRootTable(Table("Section"));
+        var childTable = CreateChildTable(
+            Table("SectionStudent"),
+            [
+                new DbColumnModel(Col("DocumentId"), ColumnKind.Scalar, null, false, null, null),
+                DocumentFkColumn("StudentSchoolAssociation_DocumentId", "StudentSchoolAssociation"),
+            ]
+        );
+        var childBinding = new DocumentReferenceBinding(
+            true,
+            Path("$.students[*].studentSchoolAssociationReference"),
+            childTable.Table,
+            Col("StudentSchoolAssociation_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "StudentSchoolAssociation"),
+            [
+                IdentityBinding(
+                    "$.students[*].studentSchoolAssociationReference.studentUniqueId",
+                    "StudentSchoolAssociation_StudentUniqueId"
+                ),
+            ],
+            IsRequired: true
+        );
+        var subject = CreateConcrete(
+            1,
+            "Section",
+            CreateModel("Section", subjectRoot, [childBinding], tables: [subjectRoot, childTable])
+        );
+        var student = CreateConcrete(2, "Student", CreateModel("Student", studentRoot));
+
+        return (CreateMappingSet(subject, student, association), subject);
     }
 
     private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationSqlCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationSqlCompilerTests.cs
@@ -1,0 +1,724 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_SingleRecordCustomViewAuthorizationSqlCompiler
+{
+    private const string DocumentIdParameter = "documentId";
+
+    private static readonly DbSchemaName EdFiSchema = new("edfi");
+    private static readonly DbSchemaName AuthSchema = new("auth");
+    private static readonly DbSchemaName DmsSchema = new("dms");
+    private static readonly DbColumnName DocumentIdColumn = new("DocumentId");
+
+    private static DbTableName Table(string name) => new(EdFiSchema, name);
+
+    private static DbColumnName Col(string name) => new(name);
+
+    private static DbTableName AuthView(string strategyName) => new(AuthSchema, strategyName);
+
+    private static SingleRecordCustomViewAuthorizationCheckSpec Check(
+        int index,
+        CustomViewAuthorizationCheckValueSource valueSource,
+        IReadOnlyList<ColumnPathStep> path,
+        CustomViewAuthorizationCheckTarget checkTarget,
+        string strategyName = "StudentWithCTECourseEnrollments"
+    ) =>
+        new(
+            new ConfiguredAuthorizationStrategy(strategyName, 0),
+            index,
+            valueSource,
+            AuthView(strategyName),
+            DocumentIdColumn,
+            path,
+            checkTarget,
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            ["StudentUniqueId"],
+            "You may need a Student with CTE Course Enrollments."
+        );
+
+    /// <summary>CourseTranscript.Student_DocumentId -> Student. One root-owned hop.</summary>
+    private static IReadOnlyList<ColumnPathStep> DirectPath() =>
+        [new ColumnPathStep(Table("CourseTranscript"), Col("Student_DocumentId"), null, null)];
+
+    /// <summary>Student.DocumentId. The basis is the subject.</summary>
+    private static IReadOnlyList<ColumnPathStep> SelfBasisPath() =>
+        [new ColumnPathStep(Table("Student"), DocumentIdColumn, null, null)];
+
+    /// <summary>CourseTranscript -> StudentAcademicRecord -> Student.</summary>
+    private static IReadOnlyList<ColumnPathStep> TransitivePath() =>
+        [
+            new ColumnPathStep(
+                Table("CourseTranscript"),
+                Col("StudentAcademicRecord_DocumentId"),
+                Table("StudentAcademicRecord"),
+                DocumentIdColumn
+            ),
+            new ColumnPathStep(Table("StudentAcademicRecord"), Col("Student_DocumentId"), null, null),
+        ];
+
+    private static CustomViewAuthorizationCheckTarget.Stored StoredTarget(string rootTable) =>
+        new(Table(rootTable), DocumentIdColumn);
+
+    private static CustomViewAuthorizationCheckTarget.Proposed ProposedTarget(
+        string rootTable,
+        string column,
+        int index
+    ) =>
+        new(
+            Table(rootTable),
+            new CustomViewAuthorizationProposedValueBinding(
+                Table(rootTable),
+                Col(column),
+                $"logical:{column}",
+                $"customViewAuthorization{index}"
+            )
+        );
+
+    private static SingleRecordCustomViewAuthorizationSqlPlan Compile(
+        SqlDialect dialect,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        string? rowGuardPredicateSql = null
+    ) =>
+        new SingleRecordCustomViewAuthorizationSqlCompiler(dialect).Compile(
+            new SingleRecordCustomViewAuthorizationSqlSpec(checks, DocumentIdParameter, rowGuardPredicateSql)
+        );
+
+    /// <summary>
+    /// Splits the batch into statements. Trimming first is required: the compiler ends each statement with a
+    /// newline, so a trailing whitespace-only entry would otherwise survive RemoveEmptyEntries.
+    /// </summary>
+    private static string[] SplitStatements(string sql) =>
+        sql.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static string Normalize(string sql) =>
+        string.Join(' ', sql.Split((char[])['\r', '\n', ' ', '\t'], StringSplitOptions.RemoveEmptyEntries));
+
+    [Test]
+    public void It_should_compile_a_stored_direct_path_check_for_postgresql()
+    {
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+            ]
+        );
+
+        Normalize(plan.AuthorizationSql)
+            .Should()
+            .Be(
+                "SELECT CASE "
+                    + "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"CourseTranscript\" r "
+                    + "WHERE r.\"DocumentId\" = @documentId "
+                    + "AND r.\"Student_DocumentId\" IN (SELECT cv.\"DocumentId\" FROM \"auth\".\"StudentWithCTECourseEnrollments\" cv)) THEN 1 "
+                    + "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"CourseTranscript\" r "
+                    + "WHERE r.\"DocumentId\" = @documentId "
+                    + "AND (r.\"Student_DocumentId\" IS NULL)) THEN \"dms\".\"throw_error\"('AUTH1', 'cv1|0|u') "
+                    + "WHEN NOT EXISTS (SELECT 1 FROM \"edfi\".\"CourseTranscript\" r "
+                    + "WHERE r.\"DocumentId\" = @documentId) THEN \"dms\".\"throw_error\"('AUTH1', 'cv1|0|s') "
+                    + "ELSE \"dms\".\"throw_error\"('AUTH1', 'cv1|0|n') "
+                    + "END;"
+            );
+    }
+
+    [Test]
+    public void It_should_compile_a_stored_direct_path_check_for_sql_server()
+    {
+        var plan = Compile(
+            SqlDialect.Mssql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+            ]
+        );
+
+        Normalize(plan.AuthorizationSql)
+            .Should()
+            .Be(
+                "SELECT CASE "
+                    + "WHEN EXISTS (SELECT 1 FROM [edfi].[CourseTranscript] r "
+                    + "WHERE r.[DocumentId] = @documentId "
+                    + "AND r.[Student_DocumentId] IN (SELECT cv.[DocumentId] FROM [auth].[StudentWithCTECourseEnrollments] cv)) THEN 1 "
+                    + "WHEN EXISTS (SELECT 1 FROM [edfi].[CourseTranscript] r "
+                    + "WHERE r.[DocumentId] = @documentId "
+                    + "AND (r.[Student_DocumentId] IS NULL)) THEN CAST('AUTH1 - cv1|0|u' AS INT) "
+                    + "WHEN NOT EXISTS (SELECT 1 FROM [edfi].[CourseTranscript] r "
+                    + "WHERE r.[DocumentId] = @documentId) THEN CAST('AUTH1 - cv1|0|s' AS INT) "
+                    + "ELSE CAST('AUTH1 - cv1|0|n' AS INT) "
+                    + "END;"
+            );
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_should_quote_the_custom_view_identifier_for_the_dialect(SqlDialect dialect)
+    {
+        // auth.md requires case-sensitive matching through quoted identifiers on both engines, which is what
+        // makes quoted PascalCase DDL mandatory on PostgreSQL.
+        var plan = Compile(
+            dialect,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+            ]
+        );
+
+        var expectedAuthView =
+            dialect is SqlDialect.Pgsql
+                ? "\"auth\".\"StudentWithCTECourseEnrollments\""
+                : "[auth].[StudentWithCTECourseEnrollments]";
+
+        plan.AuthorizationSql.Should().Contain(expectedAuthView);
+        plan.AuthorizationSql.Should().NotContain("auth.StudentWithCTECourseEnrollments");
+    }
+
+    [Test]
+    public void It_should_omit_the_uninitialized_branch_for_a_self_basis_stored_check()
+    {
+        // The path terminates on the root's own DocumentId, which is NOT NULL, so an uninitialized branch
+        // would be dead SQL.
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    SelfBasisPath(),
+                    StoredTarget("Student")
+                ),
+            ]
+        );
+
+        Normalize(plan.AuthorizationSql)
+            .Should()
+            .Be(
+                "SELECT CASE "
+                    + "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"Student\" r "
+                    + "WHERE r.\"DocumentId\" = @documentId "
+                    + "AND r.\"DocumentId\" IN (SELECT cv.\"DocumentId\" FROM \"auth\".\"StudentWithCTECourseEnrollments\" cv)) THEN 1 "
+                    + "WHEN NOT EXISTS (SELECT 1 FROM \"edfi\".\"Student\" r "
+                    + "WHERE r.\"DocumentId\" = @documentId) THEN \"dms\".\"throw_error\"('AUTH1', 'cv1|0|s') "
+                    + "ELSE \"dms\".\"throw_error\"('AUTH1', 'cv1|0|n') "
+                    + "END;"
+            );
+        plan.AuthorizationSql.Should().NotContain("cv1|0|u");
+    }
+
+    [Test]
+    public void It_should_correlate_a_stored_transitive_path_to_the_addressed_row()
+    {
+        // No uncorrelated root re-scan: the target is already bound, unlike the GET-many page shape.
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    TransitivePath(),
+                    StoredTarget("CourseTranscript")
+                ),
+            ]
+        );
+
+        Normalize(plan.AuthorizationSql)
+            .Should()
+            .Be(
+                "SELECT CASE "
+                    + "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"CourseTranscript\" r "
+                    + "JOIN \"edfi\".\"StudentAcademicRecord\" t1 ON t1.\"DocumentId\" = r.\"StudentAcademicRecord_DocumentId\" "
+                    + "WHERE r.\"DocumentId\" = @documentId "
+                    + "AND t1.\"Student_DocumentId\" IN (SELECT cv.\"DocumentId\" FROM \"auth\".\"StudentWithCTECourseEnrollments\" cv)) THEN 1 "
+                    + "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"CourseTranscript\" r "
+                    + "LEFT JOIN \"edfi\".\"StudentAcademicRecord\" t1 ON t1.\"DocumentId\" = r.\"StudentAcademicRecord_DocumentId\" "
+                    + "WHERE r.\"DocumentId\" = @documentId "
+                    + "AND (r.\"StudentAcademicRecord_DocumentId\" IS NULL OR t1.\"Student_DocumentId\" IS NULL)) "
+                    + "THEN \"dms\".\"throw_error\"('AUTH1', 'cv1|0|u') "
+                    + "WHEN NOT EXISTS (SELECT 1 FROM \"edfi\".\"CourseTranscript\" r "
+                    + "WHERE r.\"DocumentId\" = @documentId) THEN \"dms\".\"throw_error\"('AUTH1', 'cv1|0|s') "
+                    + "ELSE \"dms\".\"throw_error\"('AUTH1', 'cv1|0|n') "
+                    + "END;"
+            );
+    }
+
+    [Test]
+    public void It_should_compile_a_proposed_direct_path_check_for_postgresql()
+    {
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    DirectPath(),
+                    ProposedTarget("CourseTranscript", "Student_DocumentId", 0)
+                ),
+            ]
+        );
+
+        Normalize(plan.AuthorizationSql)
+            .Should()
+            .Be(
+                "SELECT CASE "
+                    + "WHEN @customViewAuthorization0 IS NULL THEN \"dms\".\"throw_error\"('AUTH1', 'cv1|0|r') "
+                    + "WHEN @customViewAuthorization0 IN (SELECT cv.\"DocumentId\" FROM \"auth\".\"StudentWithCTECourseEnrollments\" cv) THEN 1 "
+                    + "ELSE \"dms\".\"throw_error\"('AUTH1', 'cv1|0|n') "
+                    + "END;"
+            );
+    }
+
+    [Test]
+    public void It_should_compile_a_proposed_direct_path_check_for_sql_server()
+    {
+        var plan = Compile(
+            SqlDialect.Mssql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    DirectPath(),
+                    ProposedTarget("CourseTranscript", "Student_DocumentId", 0)
+                ),
+            ]
+        );
+
+        Normalize(plan.AuthorizationSql)
+            .Should()
+            .Be(
+                "SELECT CASE "
+                    + "WHEN @customViewAuthorization0 IS NULL THEN CAST('AUTH1 - cv1|0|r' AS INT) "
+                    + "WHEN @customViewAuthorization0 IN (SELECT cv.[DocumentId] FROM [auth].[StudentWithCTECourseEnrollments] cv) THEN 1 "
+                    + "ELSE CAST('AUTH1 - cv1|0|n' AS INT) "
+                    + "END;"
+            );
+    }
+
+    [Test]
+    public void It_should_start_a_proposed_transitive_path_at_the_row_the_bound_value_addresses()
+    {
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    TransitivePath(),
+                    ProposedTarget("CourseTranscript", "StudentAcademicRecord_DocumentId", 0)
+                ),
+            ]
+        );
+
+        Normalize(plan.AuthorizationSql)
+            .Should()
+            .Be(
+                "SELECT CASE "
+                    + "WHEN @customViewAuthorization0 IS NULL THEN \"dms\".\"throw_error\"('AUTH1', 'cv1|0|r') "
+                    + "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"StudentAcademicRecord\" t1 "
+                    + "WHERE t1.\"DocumentId\" = @customViewAuthorization0 "
+                    + "AND t1.\"Student_DocumentId\" IN (SELECT cv.\"DocumentId\" FROM \"auth\".\"StudentWithCTECourseEnrollments\" cv)) THEN 1 "
+                    + "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"StudentAcademicRecord\" t1 "
+                    + "WHERE t1.\"DocumentId\" = @customViewAuthorization0 "
+                    + "AND (t1.\"Student_DocumentId\" IS NULL)) THEN \"dms\".\"throw_error\"('AUTH1', 'cv1|0|r') "
+                    + "ELSE \"dms\".\"throw_error\"('AUTH1', 'cv1|0|n') "
+                    + "END;"
+            );
+    }
+
+    [Test]
+    public void It_should_emit_a_descriptor_basis_check_against_the_shared_descriptor_document_id()
+    {
+        var descriptorPath = new[]
+        {
+            new ColumnPathStep(
+                Table("StudentTransportation"),
+                Col("TransportationTypeDescriptor_DescriptorId"),
+                new DbTableName(DmsSchema, "Descriptor"),
+                DocumentIdColumn
+            ),
+        };
+
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    descriptorPath,
+                    StoredTarget("StudentTransportation"),
+                    "TransportationTypeDescriptorWithABus"
+                ),
+            ]
+        );
+
+        // The descriptor FK already holds the descriptor's DocumentId, so the terminal step's dms.Descriptor
+        // target drives no extra join.
+        Normalize(plan.AuthorizationSql)
+            .Should()
+            .Contain(
+                "AND r.\"TransportationTypeDescriptor_DescriptorId\" IN "
+                    + "(SELECT cv.\"DocumentId\" FROM \"auth\".\"TransportationTypeDescriptorWithABus\" cv)"
+            );
+        plan.AuthorizationSql.Should().NotContain("Descriptor\" t1");
+    }
+
+    [Test]
+    public void It_should_emit_stored_checks_before_proposed_checks_with_matching_payload_indexes()
+    {
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+                Check(
+                    1,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    DirectPath(),
+                    ProposedTarget("CourseTranscript", "Student_DocumentId", 1)
+                ),
+            ]
+        );
+
+        plan.EmittedCheckIndexesInOrder.Should().Equal(0, 1);
+        var statements = SplitStatements(plan.AuthorizationSql);
+        statements.Should().HaveCount(2);
+        statements[0].Should().Contain("cv1|0|s").And.NotContain("cv1|1");
+        statements[1].Should().Contain("cv1|1|r").And.NotContain("cv1|0");
+    }
+
+    [Test]
+    public void It_should_emit_no_statement_for_a_self_basis_proposed_check()
+    {
+        // Its answer depends on whether a target was captured and on the paired stored check's outcome, so
+        // it is decided in C#. The emitted-index list is what keeps result sets aligned to checks.
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    SelfBasisPath(),
+                    StoredTarget("Student")
+                ),
+                Check(
+                    1,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    SelfBasisPath(),
+                    new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(Table("Student"))
+                ),
+            ]
+        );
+
+        plan.EmittedCheckIndexesInOrder.Should().Equal(0);
+        plan.ProposedValueParametersInOrder.Should().BeEmpty();
+        SplitStatements(plan.AuthorizationSql).Should().HaveCount(1);
+        plan.AuthorizationSql.Should().NotContain("cv1|1");
+    }
+
+    [Test]
+    public void It_should_compile_to_empty_sql_when_every_check_is_decided_outside_sql()
+    {
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    SelfBasisPath(),
+                    new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(Table("Student"))
+                ),
+            ]
+        );
+
+        plan.AuthorizationSql.Should().BeEmpty();
+        plan.EmittedCheckIndexesInOrder.Should().BeEmpty();
+        plan.ParametersInOrder.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_should_append_the_row_guard_to_every_emitted_statement()
+    {
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+                Check(
+                    1,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    DirectPath(),
+                    ProposedTarget("CourseTranscript", "Student_DocumentId", 1)
+                ),
+            ],
+            rowGuardPredicateSql: "target.DocumentId IS NOT NULL"
+        );
+
+        var statements = SplitStatements(plan.AuthorizationSql);
+        statements.Should().HaveCount(2);
+        statements
+            .Should()
+            .AllSatisfy(statement =>
+                Normalize(statement).Should().EndWith("END WHERE target.DocumentId IS NOT NULL")
+            );
+    }
+
+    [Test]
+    public void It_should_bind_the_document_id_parameter_only_when_a_stored_check_is_present()
+    {
+        var storedOnly = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+            ]
+        );
+        var proposedOnly = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    DirectPath(),
+                    ProposedTarget("CourseTranscript", "Student_DocumentId", 0)
+                ),
+            ]
+        );
+
+        storedOnly
+            .ParametersInOrder.Select(parameter => parameter.ParameterName)
+            .Should()
+            .Equal("documentId");
+        proposedOnly
+            .ParametersInOrder.Select(parameter => parameter.ParameterName)
+            .Should()
+            .Equal("customViewAuthorization0");
+    }
+
+    [Test]
+    public void It_should_order_parameters_document_id_first_then_each_proposed_value()
+    {
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+                Check(
+                    1,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    TransitivePath(),
+                    StoredTarget("CourseTranscript"),
+                    "StudentWithAnIep"
+                ),
+                Check(
+                    2,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    DirectPath(),
+                    ProposedTarget("CourseTranscript", "Student_DocumentId", 2)
+                ),
+                Check(
+                    3,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    TransitivePath(),
+                    ProposedTarget("CourseTranscript", "StudentAcademicRecord_DocumentId", 3),
+                    "StudentWithAnIep"
+                ),
+            ]
+        );
+
+        plan.ParametersInOrder.Select(parameter => parameter.ParameterName)
+            .Should()
+            .Equal("documentId", "customViewAuthorization2", "customViewAuthorization3");
+        plan.ProposedValueParametersInOrder.Select(parameter => parameter.CheckIndex).Should().Equal(2, 3);
+        plan.EmittedCheckIndexesInOrder.Should().Equal(0, 1, 2, 3);
+    }
+
+    [Test]
+    public void It_should_reject_an_empty_check_list()
+    {
+        var act = () => Compile(SqlDialect.Pgsql, []);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*at least one check spec*");
+    }
+
+    [Test]
+    public void It_should_reject_a_check_whose_index_does_not_match_its_emission_position()
+    {
+        // The cv1 payload reports only an index and the failure mapper resolves it positionally, so a
+        // mismatch would report a denial as some other check's category.
+        var act = () =>
+            Compile(
+                SqlDialect.Pgsql,
+                [
+                    Check(
+                        3,
+                        CustomViewAuthorizationCheckValueSource.Stored,
+                        DirectPath(),
+                        StoredTarget("CourseTranscript")
+                    ),
+                ]
+            );
+
+        act.Should().Throw<ArgumentException>().WithMessage("*indexes must match emission position*");
+    }
+
+    [Test]
+    public void It_should_reject_a_check_with_no_resolved_path()
+    {
+        var act = () =>
+            Compile(
+                SqlDialect.Pgsql,
+                [
+                    Check(
+                        0,
+                        CustomViewAuthorizationCheckValueSource.Stored,
+                        [],
+                        StoredTarget("CourseTranscript")
+                    ),
+                ]
+            );
+
+        act.Should().Throw<ArgumentException>().WithMessage("*no path to its basis resource*");
+    }
+
+    [Test]
+    public void It_should_reject_checks_that_do_not_share_one_root_table()
+    {
+        var act = () =>
+            Compile(
+                SqlDialect.Pgsql,
+                [
+                    Check(
+                        0,
+                        CustomViewAuthorizationCheckValueSource.Stored,
+                        DirectPath(),
+                        StoredTarget("CourseTranscript")
+                    ),
+                    Check(
+                        1,
+                        CustomViewAuthorizationCheckValueSource.Stored,
+                        SelfBasisPath(),
+                        StoredTarget("Student")
+                    ),
+                ]
+            );
+
+        act.Should().Throw<ArgumentException>().WithMessage("*must share one root table*");
+    }
+
+    [Test]
+    public void It_should_reject_an_unusable_proposed_parameter_seed()
+    {
+        var act = () =>
+            Compile(
+                SqlDialect.Pgsql,
+                [
+                    Check(
+                        0,
+                        CustomViewAuthorizationCheckValueSource.Proposed,
+                        DirectPath(),
+                        new CustomViewAuthorizationCheckTarget.Proposed(
+                            Table("CourseTranscript"),
+                            new CustomViewAuthorizationProposedValueBinding(
+                                Table("CourseTranscript"),
+                                Col("Student_DocumentId"),
+                                "logical",
+                                "not a valid parameter"
+                            )
+                        )
+                    ),
+                ]
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_should_keep_the_branch_order_that_selects_the_problem_details_category(SqlDialect dialect)
+    {
+        var plan = Compile(
+            dialect,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+            ]
+        );
+
+        var uninitializedPosition = plan.AuthorizationSql.IndexOf("cv1|0|u", StringComparison.Ordinal);
+        var stalePosition = plan.AuthorizationSql.IndexOf("cv1|0|s", StringComparison.Ordinal);
+        var mismatchPosition = plan.AuthorizationSql.IndexOf("cv1|0|n", StringComparison.Ordinal);
+        var authorizedPosition = plan.AuthorizationSql.IndexOf("THEN 1", StringComparison.Ordinal);
+
+        authorizedPosition.Should().BeLessThan(uninitializedPosition);
+        uninitializedPosition.Should().BeLessThan(stalePosition);
+        stalePosition.Should().BeLessThan(mismatchPosition);
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_should_bind_no_list_valued_parameters(SqlDialect dialect)
+    {
+        // Custom-view checks bind at most the target DocumentId plus one value per proposed check, so they
+        // never consume the table-valued-parameter budget that forces ordered segments elsewhere.
+        var plan = Compile(
+            dialect,
+            [
+                Check(
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    TransitivePath(),
+                    StoredTarget("CourseTranscript")
+                ),
+                Check(
+                    1,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    TransitivePath(),
+                    ProposedTarget("CourseTranscript", "StudentAcademicRecord_DocumentId", 1)
+                ),
+            ]
+        );
+
+        plan.ParametersInOrder.Should().HaveCount(2);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationSqlCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationSqlCompilerTests.cs
@@ -578,16 +578,22 @@ public class Given_SingleRecordCustomViewAuthorizationSqlCompiler
     }
 
     [Test]
-    public void It_should_reject_a_check_whose_index_does_not_match_its_emission_position()
+    public void It_should_reject_a_gap_in_the_check_indexes()
     {
-        // The cv1 payload reports only an index and the failure mapper resolves it positionally, so a
-        // mismatch would report a denial as some other check's category.
+        // The cv1 payload reports only an index and the failure mapper resolves it positionally against the
+        // request's planned list, so a gap would report a denial as some other check's category.
         var act = () =>
             Compile(
                 SqlDialect.Pgsql,
                 [
                     Check(
-                        3,
+                        0,
+                        CustomViewAuthorizationCheckValueSource.Stored,
+                        DirectPath(),
+                        StoredTarget("CourseTranscript")
+                    ),
+                    Check(
+                        2,
                         CustomViewAuthorizationCheckValueSource.Stored,
                         DirectPath(),
                         StoredTarget("CourseTranscript")
@@ -595,7 +601,56 @@ public class Given_SingleRecordCustomViewAuthorizationSqlCompiler
                 ]
             );
 
-        act.Should().Throw<ArgumentException>().WithMessage("*indexes must match emission position*");
+        act.Should().Throw<ArgumentException>().WithMessage("*must run contiguously from 0*");
+    }
+
+    [Test]
+    public void It_should_accept_a_batch_whose_indexes_start_above_zero()
+    {
+        // One request can emit several batches — views configured before and after a namespace check, or a
+        // stored batch and a proposed one. Batches sharing a command share one provider exception, so their
+        // indexes stay unique across the request instead of restarting at zero per batch.
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    2,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    DirectPath(),
+                    StoredTarget("CourseTranscript")
+                ),
+                Check(
+                    3,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    TransitivePath(),
+                    StoredTarget("CourseTranscript"),
+                    "StudentWithAnIep"
+                ),
+            ]
+        );
+
+        plan.EmittedCheckIndexesInOrder.Should().Equal(2, 3);
+        plan.AuthorizationSql.Should().Contain("cv1|2|n").And.Contain("cv1|3|n");
+        plan.AuthorizationSql.Should().NotContain("cv1|0").And.NotContain("cv1|1");
+    }
+
+    [Test]
+    public void It_should_reject_a_negative_first_check_index()
+    {
+        var act = () =>
+            Compile(
+                SqlDialect.Pgsql,
+                [
+                    Check(
+                        -1,
+                        CustomViewAuthorizationCheckValueSource.Stored,
+                        DirectPath(),
+                        StoredTarget("CourseTranscript")
+                    ),
+                ]
+            );
+
+        act.Should().Throw<ArgumentException>().WithMessage("*cannot be negative*");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationSqlCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SingleRecordCustomViewAuthorizationSqlCompilerTests.cs
@@ -578,22 +578,52 @@ public class Given_SingleRecordCustomViewAuthorizationSqlCompiler
     }
 
     [Test]
-    public void It_should_reject_a_gap_in_the_check_indexes()
+    public void It_should_accept_a_gap_left_by_a_check_settled_outside_sql()
     {
-        // The cv1 payload reports only an index and the failure mapper resolves it positionally against the
-        // request's planned list, so a gap would report a denial as some other check's category.
+        // A request-wide index the caller settles in C# — a self-basis proposed check emits no statement — is
+        // simply absent from the run. The cv1 payload resolves against the request's full planned list, so the
+        // gap addresses nothing and both emitted checks keep the index the planner assigned them.
+        var plan = Compile(
+            SqlDialect.Pgsql,
+            [
+                Check(
+                    3,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    DirectPath(),
+                    ProposedTarget("CourseTranscript", "Student_DocumentId", 3)
+                ),
+                Check(
+                    5,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    DirectPath(),
+                    ProposedTarget("CourseTranscript", "Student_DocumentId", 5)
+                ),
+            ]
+        );
+
+        plan.EmittedCheckIndexesInOrder.Should().Equal(3, 5);
+        plan.AuthorizationSql.Should().Contain("cv1|3|").And.Contain("cv1|5|");
+        plan.AuthorizationSql.Should().NotContain("cv1|4|");
+    }
+
+    [TestCase(3, 3, TestName = "It_should_reject_a_duplicate_check_index")]
+    [TestCase(5, 3, TestName = "It_should_reject_a_decreasing_check_index")]
+    public void It_should_reject_check_indexes_that_do_not_increase(int firstIndex, int secondIndex)
+    {
+        // Unlike a gap, these are ambiguous: one payload index would address two emitted statements, or would
+        // report a check the run had already passed.
         var act = () =>
             Compile(
                 SqlDialect.Pgsql,
                 [
                     Check(
-                        0,
+                        firstIndex,
                         CustomViewAuthorizationCheckValueSource.Stored,
                         DirectPath(),
                         StoredTarget("CourseTranscript")
                     ),
                     Check(
-                        2,
+                        secondIndex,
                         CustomViewAuthorizationCheckValueSource.Stored,
                         DirectPath(),
                         StoredTarget("CourseTranscript")
@@ -601,7 +631,7 @@ public class Given_SingleRecordCustomViewAuthorizationSqlCompiler
                 ]
             );
 
-        act.Should().Throw<ArgumentException>().WithMessage("*must run contiguously from 0*");
+        act.Should().Throw<ArgumentException>().WithMessage("*indexes must increase*");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationAuth1FailurePayload.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationAuth1FailurePayload.cs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Runtime failure kinds encoded in the compact AUTH1 custom view-based authorization payload.
+/// </summary>
+/// <remarks>
+/// Stored-value checks emit <see cref="NoMatchingCustomViewRow"/>, <see cref="StoredBasisValueNull"/>, and
+/// <see cref="StoredTargetMissing"/>; proposed-value checks emit <see cref="NoMatchingCustomViewRow"/> and
+/// <see cref="ProposedBasisValueMissing"/>. Neither value source emits the other's uninitialized kind, which
+/// mirrors how the namespace codec splits its stored and proposed kinds.
+/// <para>
+/// A missing or non-conforming <c>auth.{StrategyName}</c> view is not encoded here: it is not an
+/// authorization decision but a security-configuration problem, and it surfaces as the
+/// <c>urn:ed-fi:api:system</c> 500 rather than through this channel.
+/// </para>
+/// </remarks>
+public enum CustomViewAuthorizationAuth1FailureKind
+{
+    /// <summary>
+    /// The basis resource's DocumentId resolved, but it is not present in the custom authorization view.
+    /// Maps to the auth.md §2.4 403 (authorization denied without EdOrg-claims wording).
+    /// </summary>
+    NoMatchingCustomViewRow,
+
+    /// <summary>
+    /// The stored basis value is null somewhere along the resolved path, so no basis DocumentId exists to
+    /// authorize. Only reachable when the basis maps to a nullable/non-PK column. Maps to auth.md §2.7.
+    /// </summary>
+    StoredBasisValueNull,
+
+    /// <summary>
+    /// The proposed basis value is absent, so the request body supplies no basis DocumentId to authorize.
+    /// Maps to auth.md §2.8.
+    /// </summary>
+    ProposedBasisValueMissing,
+
+    /// <summary>
+    /// The stored target row no longer exists. The row was deleted between the unlocked target lookup and
+    /// the stored check, so the check has nothing to authorize. Read paths re-resolve the target and
+    /// surface the resulting 404; locked write and delete paths row-lock the target before the check runs,
+    /// so they never reach this branch.
+    /// </summary>
+    StoredTargetMissing,
+}
+
+/// <summary>
+/// Provider-independent AUTH1 failure payload for one failed custom view-based authorization check.
+/// </summary>
+public sealed record CustomViewAuthorizationAuth1FailurePayload
+{
+    public CustomViewAuthorizationAuth1FailurePayload(
+        int emittedAuth1Index,
+        CustomViewAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        if (emittedAuth1Index < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(emittedAuth1Index),
+                emittedAuth1Index,
+                "Emitted AUTH1 index cannot be negative."
+            );
+        }
+
+        EmittedAuth1Index = emittedAuth1Index;
+        FailureKind = failureKind;
+    }
+
+    public int EmittedAuth1Index { get; init; }
+
+    public CustomViewAuthorizationAuth1FailureKind FailureKind { get; init; }
+}
+
+/// <summary>
+/// Encodes, extracts, and parses the compact AUTH1 custom view-based authorization payload
+/// (<c>cv1|index|kind</c>).
+/// </summary>
+/// <remarks>
+/// The payload shares the AUTH1 SqlState / message-prefix transport with the relationship and namespace
+/// codecs, but carries a distinct <c>cv1</c> discriminator. Because each codec owns its own discriminator,
+/// each also owns an independent index space: a custom-view index can never be mistaken for a namespace or
+/// relationship index, so the three families need no shared counter.
+/// </remarks>
+public static class CustomViewAuthorizationAuth1FailurePayloadCodec
+{
+    public const string ProviderFailureCode = "AUTH1";
+    public const string PayloadDiscriminator = "cv1";
+
+    public static string Encode(CustomViewAuthorizationAuth1FailurePayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{PayloadDiscriminator}|{payload.EmittedAuth1Index}|{EncodeFailureKind(payload.FailureKind)}"
+        );
+    }
+
+    public static bool TryParsePayload(
+        string payloadText,
+        out CustomViewAuthorizationAuth1FailurePayload? payload
+    )
+    {
+        payload = null;
+
+        if (string.IsNullOrWhiteSpace(payloadText))
+        {
+            return false;
+        }
+
+        var payloadSections = payloadText.Split('|');
+
+        if (
+            payloadSections.Length is not 3
+            || !string.Equals(payloadSections[0], PayloadDiscriminator, StringComparison.Ordinal)
+            || !TryParseNonNegativeInt(payloadSections[1], out var emittedAuth1Index)
+            || !TryDecodeFailureKind(payloadSections[2], out var failureKind)
+        )
+        {
+            return false;
+        }
+
+        payload = new CustomViewAuthorizationAuth1FailurePayload(emittedAuth1Index, failureKind);
+        return true;
+    }
+
+    private static bool TryParseNonNegativeInt(string text, out int value)
+    {
+        if (int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value) && value >= 0)
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static string EncodeFailureKind(CustomViewAuthorizationAuth1FailureKind failureKind) =>
+        failureKind switch
+        {
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow => "n",
+            CustomViewAuthorizationAuth1FailureKind.StoredBasisValueNull => "u",
+            CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing => "r",
+            CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing => "s",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failureKind),
+                failureKind,
+                "Unsupported AUTH1 custom view failure kind."
+            ),
+        };
+
+    private static bool TryDecodeFailureKind(
+        string failureKindCode,
+        out CustomViewAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        switch (failureKindCode)
+        {
+            case "n":
+                failureKind = CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow;
+                return true;
+            case "u":
+                failureKind = CustomViewAuthorizationAuth1FailureKind.StoredBasisValueNull;
+                return true;
+            case "r":
+                failureKind = CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing;
+                return true;
+            case "s":
+                failureKind = CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing;
+                return true;
+            default:
+                failureKind = CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow;
+                return false;
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationCheckValueSource.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationCheckValueSource.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Whether a planned custom view-based authorization check evaluates the stored row or the proposed request
+/// body.
+/// </summary>
+/// <remarks>
+/// Used by the AUTH1 failure mapper to interpret a failed check ordinal as stored- or proposed-valued, which
+/// is what selects between the auth.md §2.7 (existing data) and §2.8 (proposed data) ProblemDetails.
+/// </remarks>
+public enum CustomViewAuthorizationCheckValueSource
+{
+    Stored,
+    Proposed,
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationContracts.cs
@@ -68,10 +68,24 @@ public abstract record CustomViewAuthorizationCheckTarget
     /// subject resource and the operation is a POST that resolves to a create.
     /// </summary>
     /// <remarks>
-    /// ODS reaches the same dead end — the basis row does not exist yet, so no view row can reference it —
-    /// and denies. DMS denies too, and does so without issuing the membership SQL. The custom view is still
-    /// validated for existence and contract, so a misconfigured view keeps its 500 instead of being
+    /// <para>
+    /// The planner cannot tell a create from an update: a POST resolves to one or the other only when the
+    /// target capture runs. So this target is planned for every proposed check on a self-basis strategy, and
+    /// carries both execution branches:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b>No captured target (create).</b> Deny with §2.4. ODS reaches the same dead end — the basis row does
+    /// not exist yet, so no view row can reference it. The membership SQL is not issued; the custom view is
+    /// still validated for existence and contract, so a misconfigured view keeps its 500 rather than being
     /// reported as this 403.
+    /// </description></item>
+    /// <item><description>
+    /// <b>Captured target (update).</b> Satisfied. A document's own <c>DocumentId</c> is immutable, so the
+    /// proposed basis value is the very value the paired stored check already authorized against this view;
+    /// re-checking it could only produce the same answer.
+    /// </description></item>
+    /// </list>
     /// </remarks>
     public sealed record ProposedSelfBasisUnavailable(DbTableName RootTable)
         : CustomViewAuthorizationCheckTarget;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationContracts.cs
@@ -36,6 +36,102 @@ public abstract record CustomViewAuthorizationPlanOutcome
     ) : CustomViewAuthorizationPlanOutcome;
 }
 
+/// <summary>
+/// What a single-record custom view-based check evaluates the basis <c>DocumentId</c> against.
+/// </summary>
+/// <remarks>
+/// GET-many needs no equivalent: it filters a page rather than deciding one record, so it has neither a
+/// stored target to address nor a proposed value to bind.
+/// </remarks>
+public abstract record CustomViewAuthorizationCheckTarget
+{
+    private CustomViewAuthorizationCheckTarget() { }
+
+    /// <summary>
+    /// The stored row identified by the target <c>DocumentId</c> parameter. The resolved path is walked
+    /// forward from that row to reach the basis resource's <c>DocumentId</c>.
+    /// </summary>
+    public sealed record Stored(DbTableName RootTable, DbColumnName RootDocumentIdColumn)
+        : CustomViewAuthorizationCheckTarget;
+
+    /// <summary>
+    /// The proposed request body. The resolved path's first hop is bound as a parameter taken from the
+    /// finalized root row — reference resolution has already turned the submitted reference into a
+    /// <c>..._DocumentId</c> value by then — and any remaining hops are joined in SQL.
+    /// </summary>
+    public sealed record Proposed(DbTableName RootTable, CustomViewAuthorizationProposedValueBinding Binding)
+        : CustomViewAuthorizationCheckTarget;
+
+    /// <summary>
+    /// The proposed basis <c>DocumentId</c> is the not-yet-assigned <c>DocumentId</c> of the row being
+    /// created, so view membership cannot be proven. Only reachable when the basis resource <em>is</em> the
+    /// subject resource and the operation is a POST that resolves to a create.
+    /// </summary>
+    /// <remarks>
+    /// ODS reaches the same dead end — the basis row does not exist yet, so no view row can reference it —
+    /// and denies. DMS denies too, and does so without issuing the membership SQL. The custom view is still
+    /// validated for existence and contract, so a misconfigured view keeps its 500 instead of being
+    /// reported as this 403.
+    /// </remarks>
+    public sealed record ProposedSelfBasisUnavailable(DbTableName RootTable)
+        : CustomViewAuthorizationCheckTarget;
+}
+
+/// <summary>
+/// The root-row column a proposed custom-view check reads its basis value from.
+/// </summary>
+/// <param name="Table">The concrete root table the value is bound from.</param>
+/// <param name="Column">The root-table column holding the first hop of the resolved basis path.</param>
+/// <param name="LogicalKey">Stable identity for the binding, used in diagnostics.</param>
+/// <param name="ParameterSeed">Seed the SQL compiler derives a collision-free parameter name from.</param>
+public sealed record CustomViewAuthorizationProposedValueBinding(
+    DbTableName Table,
+    DbColumnName Column,
+    string LogicalKey,
+    string ParameterSeed
+);
+
+/// <summary>
+/// One planned single-record custom view-based authorization check, in emission order.
+/// </summary>
+/// <param name="ConfiguredStrategy">
+/// The CMS-configured strategy. Its <c>RawConfiguredIndex</c> is what orders this check against
+/// <c>NamespaceBased</c>, since both are AND filters executing in configured order.
+/// </param>
+/// <param name="Index">
+/// Zero-based position in the custom-view check list this request emits. Matches the index carried by the
+/// <c>cv1</c> AUTH1 payload on failure. Independent of the namespace and relationship index spaces, because
+/// each payload family owns its own discriminator.
+/// </param>
+/// <param name="ValueSource">Whether this check evaluates the stored row or the proposed request body.</param>
+/// <param name="AuthView">The <c>auth.{StrategyName}</c> view.</param>
+/// <param name="AuthViewDocumentIdColumn">The view's <c>DocumentId</c> output column.</param>
+/// <param name="PathToBasisResource">
+/// The resolved column path from the subject to the basis resource's <c>DocumentId</c>.
+/// </param>
+/// <param name="CheckTarget">What the basis <c>DocumentId</c> is evaluated against.</param>
+/// <param name="BasisResource">The basis resource extracted from the strategy name.</param>
+/// <param name="ReadableSecurableElements">
+/// User-facing names of the securable element this check decides on, in path order, for the §2.4/2.7/2.8
+/// wording. A composite-identity basis contributes more than one, which is what the multiple-element
+/// phrasing in §2.4 exists for.
+/// </param>
+/// <param name="FailureHint">
+/// The §"Authorization Failure Hints" sentence for this strategy, without a <c>Hint:</c> prefix.
+/// </param>
+public sealed record SingleRecordCustomViewAuthorizationCheckSpec(
+    ConfiguredAuthorizationStrategy ConfiguredStrategy,
+    int Index,
+    CustomViewAuthorizationCheckValueSource ValueSource,
+    DbTableName AuthView,
+    DbColumnName AuthViewDocumentIdColumn,
+    IReadOnlyList<ColumnPathStep> PathToBasisResource,
+    CustomViewAuthorizationCheckTarget CheckTarget,
+    QualifiedResourceName BasisResource,
+    IReadOnlyList<string> ReadableSecurableElements,
+    string FailureHint
+);
+
 internal static class PageDocumentIdCustomViewAdapter
 {
     public static IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> AdaptFromChecks(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationFailureMapper.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Maps a decoded custom view-based AUTH1 payload back to a cross-boundary
+/// <see cref="CustomViewAuthorizationFailure"/>.
+/// </summary>
+/// <remarks>
+/// The payload carries only an index and a failure kind, so the planned check list is what supplies the
+/// strategy name, readable securable elements, and hint. The index is therefore validated against that list
+/// and the kind against the indexed check's value source: a payload the planner could not have produced maps
+/// to nothing and falls through to the invalid-payload security-configuration path rather than becoming a
+/// misleading 403.
+/// </remarks>
+public static class CustomViewAuthorizationFailureMapper
+{
+    public static bool TryMapAuth1Failure(
+        CustomViewAuthorizationAuth1FailurePayload payload,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
+        out CustomViewAuthorizationFailure? failure
+    )
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ArgumentNullException.ThrowIfNull(plannedChecks);
+
+        failure = null;
+
+        if (payload.EmittedAuth1Index >= plannedChecks.Count)
+        {
+            return false;
+        }
+
+        var check = plannedChecks[payload.EmittedAuth1Index];
+
+        if (!IsFailureKindCompatibleWithValueSource(payload.FailureKind, check.ValueSource))
+        {
+            return false;
+        }
+
+        if (!TryMapFailureKind(payload.FailureKind, out var failureKind))
+        {
+            return false;
+        }
+
+        failure = new CustomViewAuthorizationFailure(
+            failureKind,
+            MapValueSource(check.ValueSource),
+            payload.EmittedAuth1Index,
+            check.ConfiguredStrategy.StrategyName,
+            [.. check.ReadableSecurableElements],
+            check.FailureHint
+        );
+        return true;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="payload"/> reports that the stored target row no longer exists. Read paths
+    /// map this to a retry so the target is re-resolved and a still-missing row surfaces as a 404 rather
+    /// than an authorization denial; locked write and delete paths never observe it.
+    /// </summary>
+    /// <remarks>
+    /// Only honored when the indexed planned check is a stored-value check, which is the only shape the SQL
+    /// compiler emits the stale kind from. A payload pairing the stale kind with a proposed check, or with an
+    /// out-of-range index, is malformed and returns <see langword="false"/> so it reaches the
+    /// invalid-payload security-configuration path instead of silently becoming a retry.
+    /// </remarks>
+    public static bool IsStaleStoredTargetFailure(
+        CustomViewAuthorizationAuth1FailurePayload payload,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks
+    )
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ArgumentNullException.ThrowIfNull(plannedChecks);
+
+        return payload.FailureKind is CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing
+            && payload.EmittedAuth1Index < plannedChecks.Count
+            && plannedChecks[payload.EmittedAuth1Index].ValueSource
+                is CustomViewAuthorizationCheckValueSource.Stored;
+    }
+
+    private static bool IsFailureKindCompatibleWithValueSource(
+        CustomViewAuthorizationAuth1FailureKind failureKind,
+        CustomViewAuthorizationCheckValueSource valueSource
+    ) =>
+        (failureKind, valueSource) switch
+        {
+            (CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow, _) => true,
+            (
+                CustomViewAuthorizationAuth1FailureKind.StoredBasisValueNull,
+                CustomViewAuthorizationCheckValueSource.Stored
+            ) => true,
+            (
+                CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing,
+                CustomViewAuthorizationCheckValueSource.Proposed
+            ) => true,
+            _ => false,
+        };
+
+    /// <summary>
+    /// Maps the payload kind to its cross-boundary counterpart. The stale-target kind has none — it is a
+    /// retry signal, not a response — so it maps to nothing rather than throwing, and
+    /// <see cref="IsStaleStoredTargetFailure"/> is the seam that recognizes it.
+    /// </summary>
+    private static bool TryMapFailureKind(
+        CustomViewAuthorizationAuth1FailureKind failureKind,
+        out CustomViewAuthorizationFailureKind mappedFailureKind
+    )
+    {
+        switch (failureKind)
+        {
+            case CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow:
+                mappedFailureKind = CustomViewAuthorizationFailureKind.NoMatchingRow;
+                return true;
+            case CustomViewAuthorizationAuth1FailureKind.StoredBasisValueNull:
+                mappedFailureKind = CustomViewAuthorizationFailureKind.StoredValueUninitialized;
+                return true;
+            case CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing:
+                mappedFailureKind = CustomViewAuthorizationFailureKind.ProposedValueMissing;
+                return true;
+            default:
+                mappedFailureKind = CustomViewAuthorizationFailureKind.NoMatchingRow;
+                return false;
+        }
+    }
+
+    private static CustomViewAuthorizationFailureValueSource MapValueSource(
+        CustomViewAuthorizationCheckValueSource valueSource
+    ) =>
+        valueSource switch
+        {
+            CustomViewAuthorizationCheckValueSource.Stored =>
+                CustomViewAuthorizationFailureValueSource.Stored,
+            CustomViewAuthorizationCheckValueSource.Proposed =>
+                CustomViewAuthorizationFailureValueSource.Proposed,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(valueSource),
+                valueSource,
+                "Unsupported custom view authorization value source."
+            ),
+        };
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationHintFormatter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CustomViewAuthorizationHintFormatter.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Builds the authorization failure hint auth.md §"Authorization Failure Hints" specifies for a custom
+/// view-based strategy: <c>You may need {a/an} {Display Text}.</c>, for example
+/// <c>You may need a Student with CTE Course Enrollments.</c> for
+/// <c>StudentWithCTECourseEnrollments</c>.
+/// </summary>
+/// <remarks>
+/// The built-in relationship auth views carry fixed hint strings on their auth-object definitions. A custom
+/// view has no such definition — it is configured in CMS after the schema was generated — so its hint has to
+/// be derived from the strategy name itself.
+/// <para>
+/// The returned text carries no <c>Hint:</c> prefix. Callers compose it into the ProblemDetails
+/// <c>detail</c>, which supplies that prefix, exactly as the relationship auth-object hints do.
+/// </para>
+/// </remarks>
+public static class CustomViewAuthorizationHintFormatter
+{
+    private const string WithToken = "With";
+
+    /// <summary>
+    /// Formats the hint sentence for <paramref name="strategyName"/>.
+    /// </summary>
+    public static string Format(string strategyName)
+    {
+        var displayText = FormatDisplayText(strategyName);
+
+        return $"You may need {SelectArticle(displayText)} {displayText}.";
+    }
+
+    /// <summary>
+    /// Converts a <c>{BasisResource}With{SomeDescription}</c> strategy name into its display text by
+    /// splitting on camel-case boundaries and lowercasing the <c>With</c> separator:
+    /// <c>StudentWithCTECourseEnrollments</c> becomes <c>Student with CTE Course Enrollments</c>.
+    /// </summary>
+    /// <remarks>
+    /// Acronym runs survive as single words (<c>CTE</c>, not <c>C T E</c>). Every token that is exactly
+    /// <c>With</c> is lowercased, not only the convention's separator, so a description that itself contains
+    /// <c>With</c> still reads as prose.
+    /// </remarks>
+    public static string FormatDisplayText(string strategyName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(strategyName);
+
+        var tokens = SplitCamelCaseTokens(strategyName);
+
+        return string.Join(
+            ' ',
+            tokens.Select(static token =>
+                string.Equals(token, WithToken, StringComparison.Ordinal)
+                    ? token.ToLower(CultureInfo.InvariantCulture)
+                    : token
+            )
+        );
+    }
+
+    /// <summary>
+    /// Splits on camel-case boundaries while keeping acronym runs intact. A boundary opens before an
+    /// uppercase letter that follows a lowercase letter or a digit, and before the last uppercase letter of
+    /// a run that is followed by a lowercase letter — which is what keeps <c>CTECourse</c> as
+    /// <c>CTE</c> + <c>Course</c> rather than <c>CTEC</c> + <c>ourse</c>.
+    /// </summary>
+    private static List<string> SplitCamelCaseTokens(string value)
+    {
+        List<string> tokens = [];
+        var currentToken = new StringBuilder();
+
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+
+            if (currentToken.Length > 0 && IsTokenBoundary(value, index))
+            {
+                tokens.Add(currentToken.ToString());
+                currentToken.Clear();
+            }
+
+            currentToken.Append(character);
+        }
+
+        if (currentToken.Length > 0)
+        {
+            tokens.Add(currentToken.ToString());
+        }
+
+        return tokens;
+    }
+
+    private static bool IsTokenBoundary(string value, int index)
+    {
+        if (!char.IsUpper(value[index]))
+        {
+            return false;
+        }
+
+        var previousCharacter = value[index - 1];
+
+        if (char.IsLower(previousCharacter) || char.IsDigit(previousCharacter))
+        {
+            return true;
+        }
+
+        // Closing an acronym run: the current uppercase letter starts the next word when a lowercase
+        // letter follows it.
+        return char.IsUpper(previousCharacter) && index + 1 < value.Length && char.IsLower(value[index + 1]);
+    }
+
+    private static string SelectArticle(string displayText) =>
+        displayText.Length > 0 && "AEIOU".Contains(char.ToUpperInvariant(displayText[0])) ? "an" : "a";
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationAuth1Dispatcher.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationAuth1Dispatcher.cs
@@ -20,14 +20,18 @@ public abstract record RelationalAuthorizationAuth1DispatchResult
     public sealed record Namespace(NamespaceAuthorizationAuth1FailurePayload Payload)
         : RelationalAuthorizationAuth1DispatchResult;
 
+    public sealed record CustomView(CustomViewAuthorizationAuth1FailurePayload Payload)
+        : RelationalAuthorizationAuth1DispatchResult;
+
     public sealed record InvalidPayload(string RawPayload) : RelationalAuthorizationAuth1DispatchResult;
 }
 
 /// <summary>
-/// Routes an AUTH1 provider failure to either the relationship or namespace payload codec based on the
-/// payload's leading discriminator. Relationship payloads start with <c>1|</c>; namespace payloads start
-/// with <c>ns1|</c>. Any other payload returns <see cref="RelationalAuthorizationAuth1DispatchResult.InvalidPayload"/>
-/// so the caller can log and fall through to a generic security failure.
+/// Routes an AUTH1 provider failure to the relationship, namespace, or custom-view payload codec based on
+/// the payload's leading discriminator. Relationship payloads start with <c>1|</c>; namespace payloads start
+/// with <c>ns1|</c>; custom view-based payloads start with <c>cv1|</c>. Any other payload returns
+/// <see cref="RelationalAuthorizationAuth1DispatchResult.InvalidPayload"/> so the caller can log and fall
+/// through to a generic security failure.
 /// </summary>
 public static class RelationalAuthorizationAuth1Dispatcher
 {
@@ -35,6 +39,8 @@ public static class RelationalAuthorizationAuth1Dispatcher
         RelationshipAuthorizationAuth1FailurePayloadCodec.PayloadVersion + "|";
     private const string NamespaceDiscriminatorPrefix =
         NamespaceAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|";
+    private const string CustomViewDiscriminatorPrefix =
+        CustomViewAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|";
 
     /// <summary>
     /// Attempts to extract and dispatch an AUTH1 payload from a provider exception.
@@ -83,6 +89,19 @@ public static class RelationalAuthorizationAuth1Dispatcher
         )
         {
             result = new RelationalAuthorizationAuth1DispatchResult.Namespace(namespacePayload);
+            return true;
+        }
+
+        if (
+            payloadText.StartsWith(CustomViewDiscriminatorPrefix, StringComparison.Ordinal)
+            && CustomViewAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+                payloadText,
+                out var customViewPayload
+            )
+            && customViewPayload is not null
+        )
+        {
+            result = new RelationalAuthorizationAuth1DispatchResult.CustomView(customViewPayload);
             return true;
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -297,9 +297,9 @@ public static class RelationalAuthorizationPlanner
     /// </para>
     /// <list type="bullet">
     /// <item><description><c>ReadMany</c> — both storage kinds execute page filters (DMS-1062).</description></item>
-    /// <item><description><c>ReadSingle</c> — the regular-resource GET-by-id path executes stored checks;
-    /// the descriptor GET-by-id path does not yet.</description></item>
-    /// <item><description><c>Delete</c> and <c>Update</c> — no caller executes them yet.</description></item>
+    /// <item><description><c>ReadSingle</c> and <c>Delete</c> — the regular-resource GET-by-id and DELETE
+    /// paths execute stored checks; their descriptor counterparts do not yet.</description></item>
+    /// <item><description><c>Update</c> — no caller executes them yet.</description></item>
     /// </list>
     /// <para>
     /// Each entry flips in the phase that wires that caller, and the corresponding
@@ -316,7 +316,8 @@ public static class RelationalAuthorizationPlanner
         return operation switch
         {
             NamespaceAuthorizationOperation.ReadMany => true,
-            NamespaceAuthorizationOperation.ReadSingle => !isDescriptor,
+            NamespaceAuthorizationOperation.ReadSingle or NamespaceAuthorizationOperation.Delete =>
+                !isDescriptor,
             _ => false,
         };
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -145,7 +145,7 @@ public static class RelationalAuthorizationPlanner
             relationshipClassification is
             { Outcome: RelationshipAuthorizationClassificationOutcome.SecurityConfigurationError };
 
-        var enforcesCustomViewChecks = EnforcesCustomViewChecks(operation, resource);
+        var enforcesCustomViewChecks = EnforcesCustomViewChecks(operation);
 
         if (hasSecurityConfigurationError && !enforcesCustomViewChecks)
         {
@@ -284,50 +284,34 @@ public static class RelationalAuthorizationPlanner
     }
 
     /// <summary>
-    /// Whether the caller for this operation and storage kind executes the custom-view checks this planner
-    /// hands back. When it does not, a configured custom view fails the request closed with 501 instead of
-    /// being silently dropped — dropping it would serve data the strategy was configured to restrict.
+    /// Whether the caller for this operation executes the custom-view checks this planner hands back. When it
+    /// does not, a configured custom view fails the request closed with 501 instead of being silently dropped —
+    /// dropping it would serve data the strategy was configured to restrict.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This is a property of the call site, not of the strategy: the same operation reaches the planner from
-    /// both the regular-resource and descriptor paths, which are wired independently. Descriptors are
-    /// therefore split out by <see cref="ResourceStorageKind.SharedDescriptorTable"/> rather than assumed to
-    /// follow the resource path.
+    /// Every operation's callers now execute them, for both storage kinds: the regular-resource paths carry the
+    /// checks in their <c>AUTH1</c> statements, and the descriptor paths — which have no <c>AUTH1</c> statement
+    /// to carry them — run them as their own membership query ordered against that path's namespace check.
+    /// <c>Update</c> covers both write verbs, because a POST resolves to a create or an upsert-as-update only
+    /// in-session, so both value sources are planned the same way.
     /// </para>
-    /// <list type="bullet">
-    /// <item><description><c>ReadMany</c> — both storage kinds execute page filters (DMS-1062).</description></item>
-    /// <item><description><c>ReadSingle</c> — both storage kinds execute stored checks. The descriptor
-    /// GET-by-id path has no <c>AUTH1</c> statement to carry them, so it runs them as their own membership
-    /// query ordered against its in-memory namespace check.</description></item>
-    /// <item><description><c>Delete</c> — both storage kinds execute stored checks. The descriptor DELETE
-    /// path runs them inside its locked-target boundary as their own membership query, ordered against its
-    /// namespace check.</description></item>
-    /// <item><description><c>Update</c> — the regular-resource POST/PUT paths execute them; their descriptor
-    /// counterpart does not yet. It covers both write verbs because a POST resolves to a create or an
-    /// upsert-as-update only in-session, so both value sources are planned the same way.</description></item>
-    /// </list>
     /// <para>
-    /// Each entry flips in the phase that wires that caller, and the corresponding
-    /// still-fails-closed test flips with it.
+    /// The predicate is kept rather than inlined so an operation added without such a caller defaults to
+    /// failing closed instead of inheriting enforcement it does not implement.
     /// </para>
     /// </remarks>
-    private static bool EnforcesCustomViewChecks(
-        NamespaceAuthorizationOperation operation,
-        ConcreteResourceModel resource
-    )
-    {
-        var isDescriptor = resource.StorageKind is ResourceStorageKind.SharedDescriptorTable;
-
-        return operation switch
+    private static bool EnforcesCustomViewChecks(NamespaceAuthorizationOperation operation) =>
+        operation switch
         {
             NamespaceAuthorizationOperation.ReadMany
             or NamespaceAuthorizationOperation.ReadSingle
-            or NamespaceAuthorizationOperation.Delete => true,
-            NamespaceAuthorizationOperation.Update => !isDescriptor,
+            or NamespaceAuthorizationOperation.Delete
+            or NamespaceAuthorizationOperation.Update => true,
+            // Unreachable for today's operations, and deliberately fail-closed: an operation added without a
+            // caller that executes the checks must keep its 501 rather than silently dropping them.
             _ => false,
         };
-    }
 
     /// <summary>
     /// Lowest <c>RawConfiguredIndex</c> among <paramref name="failures"/>. A failure without a configured

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -145,7 +145,9 @@ public static class RelationalAuthorizationPlanner
             relationshipClassification is
             { Outcome: RelationshipAuthorizationClassificationOutcome.SecurityConfigurationError };
 
-        if (hasSecurityConfigurationError && operation is not NamespaceAuthorizationOperation.ReadMany)
+        var enforcesCustomViewChecks = EnforcesCustomViewChecks(operation, resource);
+
+        if (hasSecurityConfigurationError && !enforcesCustomViewChecks)
         {
             return new RelationalAuthorizationPlanOutcome.SecurityConfigurationError(
                 nonNamespaceStrategies,
@@ -160,9 +162,9 @@ public static class RelationalAuthorizationPlanner
 
         if (hasSecurityConfigurationError)
         {
-            // ReadMany: Namespace-based and custom view-based are AND strategies that execute in
-            // CMS-configured order, so a classifier failure must not leap ahead of a Namespace
-            // terminal configured before it. Both namespace terminals participate — no configured
+            // Namespace-based and custom view-based are AND strategies that execute in CMS-configured
+            // order, so a classifier failure must not leap ahead of a Namespace terminal configured
+            // before it. Only reached by callers that enforce custom views; the rest returned above. Both namespace terminals participate — no configured
             // prefixes and no usable root column. Every other combination — no Namespace terminal,
             // or a Namespace terminal configured after the failing strategy — keeps the classifier's
             // security-configuration error.
@@ -186,7 +188,7 @@ public static class RelationalAuthorizationPlanner
 
         var classifiedCustomViewStrategies = relationshipClassification?.SupportedCustomViewStrategies ?? [];
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> supportedCustomViewStrategies =
-            operation is NamespaceAuthorizationOperation.ReadMany ? classifiedCustomViewStrategies : [];
+            enforcesCustomViewChecks ? classifiedCustomViewStrategies : [];
 
         if (namespaceOutcome is NamespaceAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot)
         {
@@ -211,14 +213,11 @@ public static class RelationalAuthorizationPlanner
             };
         }
 
-        // Custom-view strategies are only implemented for ReadMany. For every other operation their
-        // presence fails the request closed with 501, ranked after both namespace terminals above:
-        // like OwnershipBased — the other unimplemented AND strategy — an unimplemented custom view
-        // does not displace an earlier Namespace terminal.
-        if (
-            classifiedCustomViewStrategies.Count > 0
-            && operation is not NamespaceAuthorizationOperation.ReadMany
-        )
+        // A caller that does not yet execute custom-view checks fails the request closed with 501 rather
+        // than dropping the checks and serving unauthorized data. Ranked after both namespace terminals
+        // above: like OwnershipBased — the other unimplemented AND strategy — an unimplemented custom
+        // view does not displace an earlier Namespace terminal.
+        if (classifiedCustomViewStrategies.Count > 0 && !enforcesCustomViewChecks)
         {
             return new RelationalAuthorizationPlanOutcome.StillUnsupported(
                 nonNamespaceStrategies,
@@ -282,6 +281,44 @@ public static class RelationalAuthorizationPlanner
             relationshipConfiguredStrategies,
             supportedCustomViewStrategies
         );
+    }
+
+    /// <summary>
+    /// Whether the caller for this operation and storage kind executes the custom-view checks this planner
+    /// hands back. When it does not, a configured custom view fails the request closed with 501 instead of
+    /// being silently dropped — dropping it would serve data the strategy was configured to restrict.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is a property of the call site, not of the strategy: the same operation reaches the planner from
+    /// both the regular-resource and descriptor paths, which are wired independently. Descriptors are
+    /// therefore split out by <see cref="ResourceStorageKind.SharedDescriptorTable"/> rather than assumed to
+    /// follow the resource path.
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><c>ReadMany</c> — both storage kinds execute page filters (DMS-1062).</description></item>
+    /// <item><description><c>ReadSingle</c> — the regular-resource GET-by-id path executes stored checks;
+    /// the descriptor GET-by-id path does not yet.</description></item>
+    /// <item><description><c>Delete</c> and <c>Update</c> — no caller executes them yet.</description></item>
+    /// </list>
+    /// <para>
+    /// Each entry flips in the phase that wires that caller, and the corresponding
+    /// still-fails-closed test flips with it.
+    /// </para>
+    /// </remarks>
+    private static bool EnforcesCustomViewChecks(
+        NamespaceAuthorizationOperation operation,
+        ConcreteResourceModel resource
+    )
+    {
+        var isDescriptor = resource.StorageKind is ResourceStorageKind.SharedDescriptorTable;
+
+        return operation switch
+        {
+            NamespaceAuthorizationOperation.ReadMany => true,
+            NamespaceAuthorizationOperation.ReadSingle => !isDescriptor,
+            _ => false,
+        };
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -297,9 +297,10 @@ public static class RelationalAuthorizationPlanner
     /// </para>
     /// <list type="bullet">
     /// <item><description><c>ReadMany</c> — both storage kinds execute page filters (DMS-1062).</description></item>
-    /// <item><description><c>ReadSingle</c> and <c>Delete</c> — the regular-resource GET-by-id and DELETE
-    /// paths execute stored checks; their descriptor counterparts do not yet.</description></item>
-    /// <item><description><c>Update</c> — no caller executes them yet.</description></item>
+    /// <item><description><c>ReadSingle</c>, <c>Delete</c>, and <c>Update</c> — the regular-resource
+    /// GET-by-id, DELETE, and POST/PUT paths execute them; their descriptor counterparts do not yet.
+    /// <c>Update</c> covers both write verbs because a POST resolves to a create or an upsert-as-update only
+    /// in-session, so both value sources are planned the same way.</description></item>
     /// </list>
     /// <para>
     /// Each entry flips in the phase that wires that caller, and the corresponding
@@ -316,8 +317,9 @@ public static class RelationalAuthorizationPlanner
         return operation switch
         {
             NamespaceAuthorizationOperation.ReadMany => true,
-            NamespaceAuthorizationOperation.ReadSingle or NamespaceAuthorizationOperation.Delete =>
-                !isDescriptor,
+            NamespaceAuthorizationOperation.ReadSingle
+            or NamespaceAuthorizationOperation.Delete
+            or NamespaceAuthorizationOperation.Update => !isDescriptor,
             _ => false,
         };
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -300,10 +300,12 @@ public static class RelationalAuthorizationPlanner
     /// <item><description><c>ReadSingle</c> — both storage kinds execute stored checks. The descriptor
     /// GET-by-id path has no <c>AUTH1</c> statement to carry them, so it runs them as their own membership
     /// query ordered against its in-memory namespace check.</description></item>
-    /// <item><description><c>Delete</c> and <c>Update</c> — the regular-resource DELETE and POST/PUT paths
-    /// execute them; their descriptor counterparts do not yet. <c>Update</c> covers both write verbs because
-    /// a POST resolves to a create or an upsert-as-update only in-session, so both value sources are planned
-    /// the same way.</description></item>
+    /// <item><description><c>Delete</c> — both storage kinds execute stored checks. The descriptor DELETE
+    /// path runs them inside its locked-target boundary as their own membership query, ordered against its
+    /// namespace check.</description></item>
+    /// <item><description><c>Update</c> — the regular-resource POST/PUT paths execute them; their descriptor
+    /// counterpart does not yet. It covers both write verbs because a POST resolves to a create or an
+    /// upsert-as-update only in-session, so both value sources are planned the same way.</description></item>
     /// </list>
     /// <para>
     /// Each entry flips in the phase that wires that caller, and the corresponding
@@ -319,8 +321,10 @@ public static class RelationalAuthorizationPlanner
 
         return operation switch
         {
-            NamespaceAuthorizationOperation.ReadMany or NamespaceAuthorizationOperation.ReadSingle => true,
-            NamespaceAuthorizationOperation.Delete or NamespaceAuthorizationOperation.Update => !isDescriptor,
+            NamespaceAuthorizationOperation.ReadMany
+            or NamespaceAuthorizationOperation.ReadSingle
+            or NamespaceAuthorizationOperation.Delete => true,
+            NamespaceAuthorizationOperation.Update => !isDescriptor,
             _ => false,
         };
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -297,10 +297,13 @@ public static class RelationalAuthorizationPlanner
     /// </para>
     /// <list type="bullet">
     /// <item><description><c>ReadMany</c> — both storage kinds execute page filters (DMS-1062).</description></item>
-    /// <item><description><c>ReadSingle</c>, <c>Delete</c>, and <c>Update</c> — the regular-resource
-    /// GET-by-id, DELETE, and POST/PUT paths execute them; their descriptor counterparts do not yet.
-    /// <c>Update</c> covers both write verbs because a POST resolves to a create or an upsert-as-update only
-    /// in-session, so both value sources are planned the same way.</description></item>
+    /// <item><description><c>ReadSingle</c> — both storage kinds execute stored checks. The descriptor
+    /// GET-by-id path has no <c>AUTH1</c> statement to carry them, so it runs them as their own membership
+    /// query ordered against its in-memory namespace check.</description></item>
+    /// <item><description><c>Delete</c> and <c>Update</c> — the regular-resource DELETE and POST/PUT paths
+    /// execute them; their descriptor counterparts do not yet. <c>Update</c> covers both write verbs because
+    /// a POST resolves to a create or an upsert-as-update only in-session, so both value sources are planned
+    /// the same way.</description></item>
     /// </list>
     /// <para>
     /// Each entry flips in the phase that wires that caller, and the corresponding
@@ -316,10 +319,8 @@ public static class RelationalAuthorizationPlanner
 
         return operation switch
         {
-            NamespaceAuthorizationOperation.ReadMany => true,
-            NamespaceAuthorizationOperation.ReadSingle
-            or NamespaceAuthorizationOperation.Delete
-            or NamespaceAuthorizationOperation.Update => !isDescriptor,
+            NamespaceAuthorizationOperation.ReadMany or NamespaceAuthorizationOperation.ReadSingle => true,
+            NamespaceAuthorizationOperation.Delete or NamespaceAuthorizationOperation.Update => !isDescriptor,
             _ => false,
         };
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationshipAuthorizationContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationshipAuthorizationContracts.cs
@@ -365,6 +365,14 @@ public enum RelationshipAuthorizationFailureKind
     ProposedValueMissing,
     MissingPeopleAuthViewAssociations,
     NoCustomViewJoinPath,
+
+    /// <summary>
+    /// A custom view's basis resource is reachable only through a child collection table, so a write's
+    /// proposed-value check has no root-table value to bind. Stored-value-only operations can still walk
+    /// such a path; an operation that must authorize proposed data fails closed instead of skipping the
+    /// strategy, because auth.md restricts authorization checks to the resource or descriptor root table.
+    /// </summary>
+    MissingProposedCustomViewRootBinding,
 }
 
 public sealed record RelationshipAuthorizationFailureLocation(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SecurableElementColumnPathResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SecurableElementColumnPathResolver.cs
@@ -30,6 +30,17 @@ internal static class SecurableElementColumnPathResolver
     private static readonly DbTableName DescriptorTable = new(new DbSchemaName("dms"), "Descriptor");
 
     /// <summary>
+    /// One explored subject-to-basis path, with the ranking inputs the winner is chosen by plus the
+    /// terminal reference metadata carried alongside them.
+    /// </summary>
+    private sealed record BasisPathCandidate(
+        IReadOnlyList<(bool IsIdentity, bool IsRequired, bool IsRoleNamed)> Hops,
+        bool PreferExactAbstractBasis,
+        IReadOnlyList<ColumnPathStep> Steps,
+        IReadOnlyList<string> TerminalReferenceJsonPaths
+    );
+
+    /// <summary>
     /// Resolves all securable element column paths for a single concrete resource.
     /// Returns a list of resolved paths, each carrying the element kind and the column path chain.
     /// </summary>
@@ -161,6 +172,17 @@ internal static class SecurableElementColumnPathResolver
         QualifiedResourceName subjectResource,
         QualifiedResourceName basisResource,
         DerivedRelationalModelSet modelSet
+    ) => ResolveBasisResourcePathWithMetadata(subjectResource, basisResource, modelSet).Steps;
+
+    /// <summary>
+    /// Resolves the preferred join path from a subject resource name to a basis resource name, together
+    /// with the JSON paths of the reference that terminates the winning path. The steps are identical to
+    /// those returned by the step-only overload; only the reference metadata is additional.
+    /// </summary>
+    public static ResolvedBasisResourcePath ResolveBasisResourcePathWithMetadata(
+        QualifiedResourceName subjectResource,
+        QualifiedResourceName basisResource,
+        DerivedRelationalModelSet modelSet
     )
     {
         ArgumentNullException.ThrowIfNull(modelSet);
@@ -169,8 +191,8 @@ internal static class SecurableElementColumnPathResolver
         return
             !resourceLookup.TryGetValue(subjectResource, out var subjectConcreteResource)
             || !IsKnownBasisResource(basisResource, resourceLookup, modelSet.AbstractUnionViewsInNameOrder)
-            ? []
-            : ResolveBasisResourcePath(
+            ? ResolvedBasisResourcePath.Unresolved
+            : ResolveBasisResourcePathWithMetadata(
                 subjectConcreteResource,
                 basisResource,
                 resourceLookup,
@@ -198,6 +220,23 @@ internal static class SecurableElementColumnPathResolver
         QualifiedResourceName basisResource,
         IReadOnlyDictionary<QualifiedResourceName, ConcreteResourceModel> resourceLookup,
         IReadOnlyList<AbstractUnionViewInfo> abstractUnionViews
+    ) =>
+        ResolveBasisResourcePathWithMetadata(
+            subjectResource,
+            basisResource,
+            resourceLookup,
+            abstractUnionViews
+        ).Steps;
+
+    /// <summary>
+    /// Resolves the preferred join path from a subject resource model to a basis resource, together with
+    /// the JSON paths of the reference that terminates the winning path.
+    /// </summary>
+    public static ResolvedBasisResourcePath ResolveBasisResourcePathWithMetadata(
+        ConcreteResourceModel subjectResource,
+        QualifiedResourceName basisResource,
+        IReadOnlyDictionary<QualifiedResourceName, ConcreteResourceModel> resourceLookup,
+        IReadOnlyList<AbstractUnionViewInfo> abstractUnionViews
     )
     {
         ArgumentNullException.ThrowIfNull(subjectResource);
@@ -220,25 +259,29 @@ internal static class SecurableElementColumnPathResolver
 
         if (IsBasisMatch(subjectModel.Resource, basisResource, abstractBasisMembersByResource))
         {
-            return
-            [
-                new ColumnPathStep(
-                    subjectRoot.Table,
-                    PersonJoinPathResolver.ResolveToCanonicalColumn(
-                        subjectRoot,
-                        RelationalNameConventions.DocumentIdColumnName
+            // The basis is the subject itself, so the path terminates on the subject's own DocumentId
+            // rather than on a reference. There is no terminal reference JSON path to report.
+            return new ResolvedBasisResourcePath(
+                [
+                    new ColumnPathStep(
+                        subjectRoot.Table,
+                        PersonJoinPathResolver.ResolveToCanonicalColumn(
+                            subjectRoot,
+                            RelationalNameConventions.DocumentIdColumnName
+                        ),
+                        null,
+                        null
                     ),
-                    null,
-                    null
-                ),
-            ];
+                ],
+                []
+            );
         }
 
         var candidates = Explore(subjectModel, [subjectModel.Resource], [], []);
 
         if (candidates.Count == 0)
         {
-            return [];
+            return ResolvedBasisResourcePath.Unresolved;
         }
 
         var bestCandidate = candidates[0];
@@ -250,25 +293,16 @@ internal static class SecurableElementColumnPathResolver
             }
         }
 
-        return bestCandidate.Steps;
+        return new ResolvedBasisResourcePath(bestCandidate.Steps, bestCandidate.TerminalReferenceJsonPaths);
 
-        List<(
-            IReadOnlyList<(bool IsIdentity, bool IsRequired, bool IsRoleNamed)> Hops,
-            bool PreferExactAbstractBasis,
-            IReadOnlyList<ColumnPathStep> Steps
-        )> Explore(
+        List<BasisPathCandidate> Explore(
             RelationalResourceModel currentModel,
             HashSet<QualifiedResourceName> visitedResources,
             List<(bool IsIdentity, bool IsRequired, bool IsRoleNamed)> hopsSoFar,
             List<ColumnPathStep> stepsSoFar
         )
         {
-            var foundCandidates =
-                new List<(
-                    IReadOnlyList<(bool IsIdentity, bool IsRequired, bool IsRoleNamed)> Hops,
-                    bool PreferExactAbstractBasis,
-                    IReadOnlyList<ColumnPathStep> Steps
-                )>();
+            var foundCandidates = new List<BasisPathCandidate>();
 
             foreach (var binding in currentModel.DocumentReferenceBindings)
             {
@@ -354,7 +388,16 @@ internal static class SecurableElementColumnPathResolver
                 };
 
                 foundCandidates.Add(
-                    (terminalHops, basisIsAbstract && binding.TargetResource == basisResource, terminalSteps)
+                    new BasisPathCandidate(
+                        terminalHops,
+                        basisIsAbstract && binding.TargetResource == basisResource,
+                        terminalSteps,
+                        [
+                            .. binding.IdentityBindings.Select(static identityBinding =>
+                                identityBinding.ReferenceJsonPath.Canonical
+                            ),
+                        ]
+                    )
                 );
             }
 
@@ -390,7 +433,14 @@ internal static class SecurableElementColumnPathResolver
                     GetDescriptorEdgePriority(descriptorEdge, owningTable),
                 };
 
-                foundCandidates.Add((descriptorHops, false, descriptorSteps));
+                foundCandidates.Add(
+                    new BasisPathCandidate(
+                        descriptorHops,
+                        false,
+                        descriptorSteps,
+                        [descriptorEdge.DescriptorValuePath.Canonical]
+                    )
+                );
             }
 
             return foundCandidates;
@@ -449,18 +499,10 @@ internal static class SecurableElementColumnPathResolver
                 && reachedAbstractMembers.Contains(basis)
             );
 
-        static int CompareCandidates(
-            (
-                IReadOnlyList<(bool IsIdentity, bool IsRequired, bool IsRoleNamed)> Hops,
-                bool PreferExactAbstractBasis,
-                IReadOnlyList<ColumnPathStep> Steps
-            ) left,
-            (
-                IReadOnlyList<(bool IsIdentity, bool IsRequired, bool IsRoleNamed)> Hops,
-                bool PreferExactAbstractBasis,
-                IReadOnlyList<ColumnPathStep> Steps
-            ) right
-        )
+        // Ranking reads only Hops, PreferExactAbstractBasis, and Steps. TerminalReferenceJsonPaths is
+        // carried metadata and deliberately takes no part in candidate selection, so adding it cannot
+        // change which path wins.
+        static int CompareCandidates(BasisPathCandidate left, BasisPathCandidate right)
         {
             // auth.md requires StudentSchoolAssociation -> GraduationPlan -> EducationOrganization
             // to win over the direct School union-arm route for an EducationOrganization basis.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationPlanner.cs
@@ -355,8 +355,10 @@ public static class SingleRecordCustomViewAuthorizationPlanner
             subjectResource,
             strategy.ConfiguredStrategy,
             strategy.AuthorizationLocalOrder,
+            // Both taken from the terminal step so the pair names a column on the table it lives on; mixing
+            // steps would point diagnostics at a table.column combination that does not exist for 3+ hop paths.
             Location: new RelationshipAuthorizationFailureLocation(
-                Table: resolvedPath.Steps[0].TargetTable,
+                Table: resolvedPath.Steps[^1].SourceTable,
                 Column: resolvedPath.Steps[^1].SourceColumnName,
                 AuthorizationObjectName: $"auth.{strategy.ConfiguredStrategy.StrategyName}"
             ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationPlanner.cs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.RelationalModel;
+using EdFi.DataManagementService.Backend.RelationalModel.Naming;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Outcome of planning the single-record custom view-based checks for one operation.
+/// </summary>
+public abstract record SingleRecordCustomViewAuthorizationPlanOutcome
+{
+    private SingleRecordCustomViewAuthorizationPlanOutcome() { }
+
+    /// <summary>The checks the SQL layer must execute, in emission order.</summary>
+    public sealed record Plan(IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks)
+        : SingleRecordCustomViewAuthorizationPlanOutcome;
+
+    /// <summary>
+    /// At least one configured custom view could not be planned for this operation. <paramref name="PlannedChecks"/>
+    /// carries the checks that <em>did</em> plan, so a caller can still validate the custom views configured
+    /// ahead of the earliest failure before reporting it — custom views are AND filters executing in
+    /// CMS-configured order, so an earlier missing or non-conforming <c>auth.{StrategyName}</c> must surface
+    /// its own error rather than being hidden by a later strategy's planning failure. Mirrors the shape
+    /// <see cref="CustomViewAuthorizationPlanOutcome.SecurityConfiguration"/> uses for GET-many.
+    /// </summary>
+    public sealed record SecurityConfiguration(
+        IReadOnlyList<RelationshipAuthorizationFailureMetadata> Failures,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks
+    ) : SingleRecordCustomViewAuthorizationPlanOutcome;
+}
+
+/// <summary>
+/// Plans the custom view-based authorization checks for a single-record operation: resolves each configured
+/// strategy's basis path, derives the wording metadata a denial reports, and expands the strategy into the
+/// stored and proposed checks the operation requires.
+/// </summary>
+/// <remarks>
+/// GET-many is planned by <see cref="CustomViewAuthorizationPlanner"/> instead. It filters a page rather than
+/// deciding one record, so it needs neither a value source nor a check target, and passing
+/// <see cref="NamespaceAuthorizationOperation.ReadMany"/> here is rejected rather than silently planned.
+/// </remarks>
+public static class SingleRecordCustomViewAuthorizationPlanner
+{
+    private static readonly DbSchemaName AuthSchema = new("auth");
+    private static readonly DbColumnName DocumentIdColumn = new("DocumentId");
+    private const string ProposedValueParameterSeedPrefix = "customViewAuthorization";
+
+    public static SingleRecordCustomViewAuthorizationPlanOutcome Plan(
+        MappingSet mappingSet,
+        ConcreteResourceModel resource,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        ArgumentNullException.ThrowIfNull(mappingSet);
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(customViewStrategies);
+
+        if (operation is NamespaceAuthorizationOperation.ReadMany)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(operation),
+                operation,
+                "GET-many custom view authorization is planned by CustomViewAuthorizationPlanner, not the single-record planner."
+            );
+        }
+
+        var subjectResource = resource.RelationalModel.Resource;
+        var rootTable = resource.RelationalModel.Root.Table;
+        var rootDocumentIdColumn = PersonJoinPathResolver.ResolveToCanonicalColumn(
+            resource.RelationalModel.Root,
+            RelationalNameConventions.DocumentIdColumnName
+        );
+        var plansProposedChecks = operation is NamespaceAuthorizationOperation.Update;
+
+        List<PlannedStrategy> plannedStrategies = [];
+        List<RelationshipAuthorizationFailureMetadata> failures = [];
+
+        foreach (var strategy in customViewStrategies)
+        {
+            var resolvedPath = SecurableElementColumnPathResolver.ResolveBasisResourcePathWithMetadata(
+                subjectResource,
+                strategy.BasisResource,
+                mappingSet.Model
+            );
+
+            if (resolvedPath.Steps.Count == 0)
+            {
+                failures.Add(BuildNoJoinPathFailure(subjectResource, strategy));
+                continue;
+            }
+
+            // A path whose first hop leaves the root through the root's own DocumentId reaches the basis
+            // through a child collection table. Stored checks can still walk it — the root DocumentId is
+            // known — but a proposed check cannot: it would have to bind a value from child rows that the
+            // request has not written yet. auth.md is explicit that authorization checks apply to the
+            // resource or descriptor root table and not to collection items, so an operation that needs a
+            // proposed check fails closed rather than silently skipping this strategy.
+            var startsFromRootDocumentId = IsRootDocumentIdSourced(
+                resolvedPath.Steps[0],
+                rootTable,
+                rootDocumentIdColumn
+            );
+            var isSelfBasis = resolvedPath.Steps.Count == 1 && startsFromRootDocumentId;
+            var reachesBasisThroughChildTable = resolvedPath.Steps.Count > 1 && startsFromRootDocumentId;
+
+            if (plansProposedChecks && reachesBasisThroughChildTable)
+            {
+                failures.Add(BuildChildTablePathFailure(subjectResource, strategy, resolvedPath));
+                continue;
+            }
+
+            plannedStrategies.Add(
+                new PlannedStrategy(
+                    strategy,
+                    resolvedPath,
+                    isSelfBasis,
+                    BuildReadableSecurableElements(resolvedPath, strategy.BasisResource, mappingSet.Model),
+                    CustomViewAuthorizationHintFormatter.Format(strategy.ConfiguredStrategy.StrategyName)
+                )
+            );
+        }
+
+        var checks = BuildChecks(plannedStrategies, rootTable, rootDocumentIdColumn, plansProposedChecks);
+
+        return failures.Count > 0
+            ? new SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration(failures, checks)
+            : new SingleRecordCustomViewAuthorizationPlanOutcome.Plan(checks);
+    }
+
+    /// <summary>
+    /// Expands the planned strategies into checks. All stored checks are emitted before any proposed check,
+    /// so the indexes read <c>0..n-1</c> stored then <c>n..2n-1</c> proposed. That ordering is the design's
+    /// requirement that stored values are authorized before proposed values, and it matches how
+    /// <see cref="NamespaceAuthorizationPlanner"/> numbers its own stored/proposed pair.
+    /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> BuildChecks(
+        IReadOnlyList<PlannedStrategy> plannedStrategies,
+        DbTableName rootTable,
+        DbColumnName rootDocumentIdColumn,
+        bool plansProposedChecks
+    )
+    {
+        List<SingleRecordCustomViewAuthorizationCheckSpec> checks = [];
+
+        foreach (var planned in plannedStrategies)
+        {
+            checks.Add(
+                CreateCheck(
+                    planned,
+                    checks.Count,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    new CustomViewAuthorizationCheckTarget.Stored(rootTable, rootDocumentIdColumn)
+                )
+            );
+        }
+
+        if (!plansProposedChecks)
+        {
+            return checks;
+        }
+
+        foreach (var planned in plannedStrategies)
+        {
+            checks.Add(
+                CreateCheck(
+                    planned,
+                    checks.Count,
+                    CustomViewAuthorizationCheckValueSource.Proposed,
+                    CreateProposedTarget(planned, rootTable, checks.Count)
+                )
+            );
+        }
+
+        return checks;
+    }
+
+    private static SingleRecordCustomViewAuthorizationCheckSpec CreateCheck(
+        PlannedStrategy planned,
+        int index,
+        CustomViewAuthorizationCheckValueSource valueSource,
+        CustomViewAuthorizationCheckTarget checkTarget
+    ) =>
+        new(
+            planned.Strategy.ConfiguredStrategy,
+            index,
+            valueSource,
+            new DbTableName(AuthSchema, planned.Strategy.ConfiguredStrategy.StrategyName),
+            DocumentIdColumn,
+            planned.ResolvedPath.Steps,
+            checkTarget,
+            planned.Strategy.BasisResource,
+            planned.ReadableSecurableElements,
+            planned.FailureHint
+        );
+
+    private static CustomViewAuthorizationCheckTarget CreateProposedTarget(
+        PlannedStrategy planned,
+        DbTableName rootTable,
+        int index
+    )
+    {
+        if (planned.IsSelfBasis)
+        {
+            return new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(rootTable);
+        }
+
+        var firstStep = planned.ResolvedPath.Steps[0];
+
+        return new CustomViewAuthorizationCheckTarget.Proposed(
+            rootTable,
+            new CustomViewAuthorizationProposedValueBinding(
+                firstStep.SourceTable,
+                firstStep.SourceColumnName,
+                $"{planned.Strategy.ConfiguredStrategy.StrategyName}:{firstStep.SourceColumnName.Value}",
+                $"{ProposedValueParameterSeedPrefix}{index}"
+            )
+        );
+    }
+
+    /// <summary>
+    /// Whether <paramref name="step"/> leaves the subject root through the root's own <c>DocumentId</c>
+    /// rather than through a basis-bearing foreign key. The resolver builds exactly that step both for a
+    /// self-basis path (as the only step) and as the prefix hop of a path that reaches the basis through a
+    /// child collection table.
+    /// </summary>
+    private static bool IsRootDocumentIdSourced(
+        ColumnPathStep step,
+        DbTableName rootTable,
+        DbColumnName rootDocumentIdColumn
+    ) => step.SourceTable.Equals(rootTable) && step.SourceColumnName.Equals(rootDocumentIdColumn);
+
+    /// <summary>
+    /// Readable names for the securable element the check decides on.
+    /// </summary>
+    /// <remarks>
+    /// Normally these come from the terminal reference's identity JSON paths. A self-basis path has none — it
+    /// terminates on the subject's own <c>DocumentId</c> rather than on a reference — so the basis resource's
+    /// own authoritative identity is resolved instead. The names must be produced here: the cross-boundary
+    /// failure carries only this list, so a later layer has nothing left to reconstruct them from.
+    /// </remarks>
+    private static IReadOnlyList<string> BuildReadableSecurableElements(
+        ResolvedBasisResourcePath resolvedPath,
+        QualifiedResourceName basisResource,
+        DerivedRelationalModelSet modelSet
+    )
+    {
+        var readableNames = ToReadableNames(resolvedPath.TerminalReferenceJsonPaths);
+
+        if (readableNames.Count > 0)
+        {
+            return readableNames;
+        }
+
+        var basisIdentityNames = ToReadableNames(ResolveBasisIdentityJsonPaths(basisResource, modelSet));
+
+        // Nothing in the model references the basis, so no authoritative identity path exists to name — a
+        // descriptor basis reached by its own view is the realistic case, since descriptor edges carry only
+        // the referencing value path. The resource name is the closest truthful label left.
+        return basisIdentityNames.Count > 0 ? basisIdentityNames : [basisResource.ResourceName];
+    }
+
+    /// <summary>
+    /// The basis resource's authoritative identity JSON paths, read from any document reference that targets
+    /// it. <see cref="ReferenceIdentityBinding.IdentityJsonPath"/> is defined as the identity path <em>on the
+    /// target resource</em>, so a reference to the basis names the basis's own identity — which is what a
+    /// self-basis check decides on. All parts of a composite identity are kept, in binding order.
+    /// </summary>
+    /// <remarks>
+    /// Resources are scanned in name order and a non-role-named reference wins, so the result does not depend
+    /// on which resource happens to reference the basis first. An abstract basis resolves through references
+    /// to the abstract resource itself, giving <c>EducationOrganizationId</c> rather than a concrete arm's
+    /// own key.
+    /// </remarks>
+    private static IReadOnlyList<string> ResolveBasisIdentityJsonPaths(
+        QualifiedResourceName basisResource,
+        DerivedRelationalModelSet modelSet
+    )
+    {
+        IReadOnlyList<string>? roleNamedFallback = null;
+
+        foreach (var resource in modelSet.ConcreteResourcesInNameOrder)
+        {
+            foreach (var binding in resource.RelationalModel.DocumentReferenceBindings)
+            {
+                if (binding.TargetResource != basisResource || binding.IdentityBindings.Count == 0)
+                {
+                    continue;
+                }
+
+                IReadOnlyList<string> identityJsonPaths =
+                [
+                    .. binding.IdentityBindings.Select(static identityBinding =>
+                        identityBinding.IdentityJsonPath.Canonical
+                    ),
+                ];
+
+                if (!binding.IsRoleNamed)
+                {
+                    return identityJsonPaths;
+                }
+
+                roleNamedFallback ??= identityJsonPaths;
+            }
+        }
+
+        return roleNamedFallback ?? [];
+    }
+
+    private static IReadOnlyList<string> ToReadableNames(IReadOnlyList<string> jsonPaths) =>
+        [
+            .. jsonPaths
+                .Select(ToReadableName)
+                .Where(static readableName => !string.IsNullOrWhiteSpace(readableName))
+                .Distinct(StringComparer.Ordinal),
+        ];
+
+    // Matches RelationalPeopleAuthorizationSubjectSelector.ToReadableName. Both feed the same
+    // ProblemDetails vocabulary, so the two must agree on how a JSON path becomes a user-facing name.
+    private static string ToReadableName(string jsonPath)
+    {
+        var leaf = jsonPath.Split('.', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? jsonPath;
+        leaf = leaf.Replace("[*]", string.Empty, StringComparison.Ordinal);
+
+        return string.IsNullOrEmpty(leaf) ? jsonPath : leaf[..1].ToUpperInvariant() + leaf[1..];
+    }
+
+    private static RelationshipAuthorizationFailureMetadata BuildNoJoinPathFailure(
+        QualifiedResourceName subjectResource,
+        SupportedCustomViewAuthorizationStrategy strategy
+    ) =>
+        new(
+            RelationshipAuthorizationFailureKind.NoCustomViewJoinPath,
+            subjectResource,
+            strategy.ConfiguredStrategy,
+            strategy.AuthorizationLocalOrder,
+            Location: new RelationshipAuthorizationFailureLocation(
+                AuthorizationObjectName: $"auth.{strategy.ConfiguredStrategy.StrategyName}"
+            ),
+            Hint: $"No DocumentId join path could be resolved from subject resource '{subjectResource.ProjectName}.{subjectResource.ResourceName}' to custom view basis resource '{strategy.BasisResource.ProjectName}.{strategy.BasisResource.ResourceName}'."
+        );
+
+    private static RelationshipAuthorizationFailureMetadata BuildChildTablePathFailure(
+        QualifiedResourceName subjectResource,
+        SupportedCustomViewAuthorizationStrategy strategy,
+        ResolvedBasisResourcePath resolvedPath
+    ) =>
+        new(
+            RelationshipAuthorizationFailureKind.MissingProposedCustomViewRootBinding,
+            subjectResource,
+            strategy.ConfiguredStrategy,
+            strategy.AuthorizationLocalOrder,
+            Location: new RelationshipAuthorizationFailureLocation(
+                Table: resolvedPath.Steps[0].TargetTable,
+                Column: resolvedPath.Steps[^1].SourceColumnName,
+                AuthorizationObjectName: $"auth.{strategy.ConfiguredStrategy.StrategyName}"
+            ),
+            Hint: $"Custom view basis resource '{strategy.BasisResource.ProjectName}.{strategy.BasisResource.ResourceName}' is reached from subject resource '{subjectResource.ProjectName}.{subjectResource.ResourceName}' through a child collection table, so no root-table value can authorize proposed data for a write."
+        );
+
+    private sealed record PlannedStrategy(
+        SupportedCustomViewAuthorizationStrategy Strategy,
+        ResolvedBasisResourcePath ResolvedPath,
+        bool IsSelfBasis,
+        IReadOnlyList<string> ReadableSecurableElements,
+        string FailureHint
+    );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlCompiler.cs
@@ -115,14 +115,14 @@ public sealed class SingleRecordCustomViewAuthorizationSqlCompiler(SqlDialect di
     }
 
     /// <summary>
-    /// Enforces the invariants the payload contract and the emitted SQL depend on: indexes run contiguously
-    /// from the first check's index, a resolved path exists, every check addresses the same root table, and
-    /// every proposed binding names a usable parameter.
+    /// Enforces the invariants the payload contract and the emitted SQL depend on: indexes are nonnegative and
+    /// strictly increasing, a resolved path exists, every check addresses the same root table, and every
+    /// proposed binding names a usable parameter.
     /// </summary>
     /// <remarks>
-    /// Indexes are contiguous rather than zero-based because one request can emit several batches — custom
-    /// views configured before and after a <c>NamespaceBased</c> check, or a stored batch and a proposed one.
-    /// When those batches share a command they also share one provider exception, so a zero-based index in
+    /// Indexes are request-wide rather than zero-based per batch because one request can emit several batches —
+    /// custom views configured before and after a <c>NamespaceBased</c> check, or a stored batch and a proposed
+    /// one. When those batches share a command they also share one provider exception, so a zero-based index in
     /// each would name two different checks. Keeping the index unique across the request lets the failure
     /// mapper resolve it against the request's whole planned list.
     /// </remarks>
@@ -139,20 +139,26 @@ public sealed class SingleRecordCustomViewAuthorizationSqlCompiler(SqlDialect di
             );
         }
 
+        var previousIndex = firstCheckIndex - 1;
+
         for (var position = 0; position < spec.Checks.Count; position++)
         {
             var check = spec.Checks[position];
 
-            // The cv1 payload reports only an index, and the failure mapper resolves it positionally against
-            // the request's planned list. A gap or reorder here would report a denial as some other check's
-            // category.
-            if (check.Index != firstCheckIndex + position)
+            // The cv1 payload reports only an index, and the failure mapper resolves it against the request's
+            // full planned list rather than against this emitted slice. A gap is therefore not ambiguous: it is
+            // what a check the caller settled in C# — a self-basis proposed check, which emits no statement —
+            // leaves behind, and it addresses nothing. A duplicate or a decrease is the real hazard: two
+            // statements would answer for one planned check, or a payload would report an earlier one.
+            if (check.Index <= previousIndex)
             {
                 throw new ArgumentException(
-                    $"Custom view authorization check at position {position} carries index {check.Index}; indexes must run contiguously from {firstCheckIndex}.",
+                    $"Custom view authorization check at position {position} carries index {check.Index}; indexes must increase across the emitted checks, but the preceding check carries index {previousIndex}.",
                     nameof(spec)
                 );
             }
+
+            previousIndex = check.Index;
 
             if (check.PathToBasisResource.Count == 0)
             {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlCompiler.cs
@@ -115,24 +115,41 @@ public sealed class SingleRecordCustomViewAuthorizationSqlCompiler(SqlDialect di
     }
 
     /// <summary>
-    /// Enforces the invariants the payload contract and the emitted SQL depend on: index equals position, a
-    /// resolved path exists, every check addresses the same root table, and every proposed binding names a
-    /// usable parameter.
+    /// Enforces the invariants the payload contract and the emitted SQL depend on: indexes run contiguously
+    /// from the first check's index, a resolved path exists, every check addresses the same root table, and
+    /// every proposed binding names a usable parameter.
     /// </summary>
+    /// <remarks>
+    /// Indexes are contiguous rather than zero-based because one request can emit several batches — custom
+    /// views configured before and after a <c>NamespaceBased</c> check, or a stored batch and a proposed one.
+    /// When those batches share a command they also share one provider exception, so a zero-based index in
+    /// each would name two different checks. Keeping the index unique across the request lets the failure
+    /// mapper resolve it against the request's whole planned list.
+    /// </remarks>
     private static void ValidateChecks(SingleRecordCustomViewAuthorizationSqlSpec spec)
     {
         DbTableName? rootTable = null;
+        var firstCheckIndex = spec.Checks[0].Index;
+
+        if (firstCheckIndex < 0)
+        {
+            throw new ArgumentException(
+                $"Custom view authorization check indexes cannot be negative; the first check carries index {firstCheckIndex}.",
+                nameof(spec)
+            );
+        }
 
         for (var position = 0; position < spec.Checks.Count; position++)
         {
             var check = spec.Checks[position];
 
             // The cv1 payload reports only an index, and the failure mapper resolves it positionally against
-            // this same list. A gap or reorder here would report a denial as some other check's category.
-            if (check.Index != position)
+            // the request's planned list. A gap or reorder here would report a denial as some other check's
+            // category.
+            if (check.Index != firstCheckIndex + position)
             {
                 throw new ArgumentException(
-                    $"Custom view authorization check at position {position} carries index {check.Index}; indexes must match emission position.",
+                    $"Custom view authorization check at position {position} carries index {check.Index}; indexes must run contiguously from {firstCheckIndex}.",
                     nameof(spec)
                 );
             }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlCompiler.cs
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Ddl;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Compiles co-batched single-record custom view-based authorization SQL. Each check that can be decided in
+/// SQL becomes one <c>SELECT CASE</c> statement; the first failure raises AUTH1 with payload
+/// <c>cv1|&lt;index&gt;|&lt;kind&gt;</c> and aborts the batch.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Membership is always tested as <c>&lt;value&gt; IN (SELECT cv.DocumentId FROM auth.{StrategyName} cv)</c>
+/// rather than a join, per auth.md §"Sub-queries instead of joins": with no <c>DISTINCT</c> the plans stay
+/// simpler, and a single-record check cannot produce duplicate rows anyway.
+/// </para>
+/// <para>
+/// Branch order is the contract. A stored check answers authorized, then uninitialized, then stale target,
+/// then mismatch; a proposed check answers missing, then authorized, then mismatch. Each branch maps to one
+/// ProblemDetails category, so reordering them would silently change which error a caller sees.
+/// </para>
+/// <para>
+/// Unlike the GET-many compiler, a transitive path is walked by correlating joins to the addressed row rather
+/// than by an uncorrelated subquery that re-scans the root table. A single-record check already binds its
+/// target, so there is nothing to re-scan.
+/// </para>
+/// </remarks>
+public sealed class SingleRecordCustomViewAuthorizationSqlCompiler(SqlDialect dialect)
+{
+    private const string RootAlias = "r";
+    private const string AuthViewAlias = "cv";
+    private const string JoinAliasPrefix = "t";
+
+    private readonly SqlDialect _dialect = dialect;
+    private readonly ISqlDialect _sqlDialect = SqlDialectFactory.Create(dialect);
+
+    public SingleRecordCustomViewAuthorizationSqlPlan Compile(SingleRecordCustomViewAuthorizationSqlSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        ArgumentNullException.ThrowIfNull(spec.Checks);
+        PlanSqlWriterExtensions.ValidateBareParameterName(
+            spec.DocumentIdParameterName,
+            nameof(spec.DocumentIdParameterName)
+        );
+
+        if (spec.Checks.Count == 0)
+        {
+            throw new ArgumentException(
+                "Single-record custom view authorization requires at least one check spec.",
+                nameof(spec)
+            );
+        }
+
+        ValidateChecks(spec);
+        var writer = new SqlWriter(_sqlDialect);
+        List<int> emittedCheckIndexes = [];
+        List<CustomViewAuthorizationProposedValueSqlParameter> proposedValueParameters = [];
+        var hasStoredCheck = false;
+
+        foreach (var check in spec.Checks)
+        {
+            switch (check.CheckTarget)
+            {
+                case CustomViewAuthorizationCheckTarget.Stored stored:
+                    AppendStoredCheckSql(writer, check, stored, spec.DocumentIdParameterName);
+                    hasStoredCheck = true;
+                    break;
+
+                case CustomViewAuthorizationCheckTarget.Proposed proposed:
+                    AppendProposedCheckSql(writer, check, proposed);
+                    proposedValueParameters.Add(
+                        new CustomViewAuthorizationProposedValueSqlParameter(
+                            check.Index,
+                            proposed.Binding.ParameterSeed
+                        )
+                    );
+                    break;
+
+                // Decided in C#, not SQL: the answer depends on whether a target was captured and on the
+                // paired stored check's outcome. Emitting nothing keeps the batch honest — a statement here
+                // could only guess.
+                case CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable:
+                    continue;
+
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(spec),
+                        check.CheckTarget.GetType().Name,
+                        "Unsupported custom view authorization check target."
+                    );
+            }
+
+            if (spec.RowGuardPredicateSql is { } rowGuardPredicateSql)
+            {
+                writer.Append(" WHERE ");
+                writer.Append(rowGuardPredicateSql);
+            }
+
+            writer.AppendLine(";");
+            emittedCheckIndexes.Add(check.Index);
+        }
+
+        return new SingleRecordCustomViewAuthorizationSqlPlan(
+            emittedCheckIndexes.Count == 0 ? string.Empty : writer.ToString(),
+            BuildParametersInOrder(spec, hasStoredCheck, proposedValueParameters),
+            proposedValueParameters,
+            emittedCheckIndexes
+        );
+    }
+
+    /// <summary>
+    /// Enforces the invariants the payload contract and the emitted SQL depend on: index equals position, a
+    /// resolved path exists, every check addresses the same root table, and every proposed binding names a
+    /// usable parameter.
+    /// </summary>
+    private static void ValidateChecks(SingleRecordCustomViewAuthorizationSqlSpec spec)
+    {
+        DbTableName? rootTable = null;
+
+        for (var position = 0; position < spec.Checks.Count; position++)
+        {
+            var check = spec.Checks[position];
+
+            // The cv1 payload reports only an index, and the failure mapper resolves it positionally against
+            // this same list. A gap or reorder here would report a denial as some other check's category.
+            if (check.Index != position)
+            {
+                throw new ArgumentException(
+                    $"Custom view authorization check at position {position} carries index {check.Index}; indexes must match emission position.",
+                    nameof(spec)
+                );
+            }
+
+            if (check.PathToBasisResource.Count == 0)
+            {
+                throw new ArgumentException(
+                    $"Custom view authorization check '{check.Index}' has no path to its basis resource.",
+                    nameof(spec)
+                );
+            }
+
+            var checkRootTable = ResolveCheckRootTable(check);
+
+            if (rootTable is null)
+            {
+                rootTable = checkRootTable;
+            }
+            else if (!rootTable.Equals(checkRootTable))
+            {
+                throw new ArgumentException(
+                    $"Custom view authorization check specs must share one root table. Found '{checkRootTable}' and '{rootTable}'.",
+                    nameof(spec)
+                );
+            }
+
+            if (check.CheckTarget is CustomViewAuthorizationCheckTarget.Proposed proposed)
+            {
+                PlanSqlWriterExtensions.ValidateBareParameterName(
+                    proposed.Binding.ParameterSeed,
+                    $"{nameof(spec)}.{nameof(spec.Checks)}[{position}].Binding.ParameterSeed"
+                );
+            }
+        }
+    }
+
+    private static DbTableName ResolveCheckRootTable(SingleRecordCustomViewAuthorizationCheckSpec check) =>
+        check.CheckTarget switch
+        {
+            CustomViewAuthorizationCheckTarget.Stored stored => stored.RootTable,
+            CustomViewAuthorizationCheckTarget.Proposed proposed => proposed.RootTable,
+            CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable selfBasis => selfBasis.RootTable,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(check),
+                check.CheckTarget.GetType().Name,
+                "Unsupported custom view authorization check target."
+            ),
+        };
+
+    private void AppendStoredCheckSql(
+        SqlWriter writer,
+        SingleRecordCustomViewAuthorizationCheckSpec check,
+        CustomViewAuthorizationCheckTarget.Stored stored,
+        string documentIdParameterName
+    )
+    {
+        var steps = check.PathToBasisResource;
+        var isSelfBasis = steps.Count == 1 && steps[0].SourceColumnName.Equals(stored.RootDocumentIdColumn);
+
+        writer.AppendLine("SELECT CASE");
+
+        using (writer.Indent())
+        {
+            // Authorized: the addressed row's basis DocumentId is in the view.
+            writer.Append("WHEN EXISTS (");
+            AppendStoredPathSelect(writer, check, stored, documentIdParameterName, useLeftJoins: false);
+            writer.Append(" AND ");
+            AppendTerminalValueInAuthView(writer, check, ResolveTerminalAlias(steps));
+            writer.AppendLine(") THEN 1");
+
+            // A self-basis path terminates on the root's own DocumentId, which is never null, so the
+            // uninitialized branch is unreachable and is not emitted for it.
+            if (!isSelfBasis)
+            {
+                writer.Append("WHEN EXISTS (");
+                AppendStoredPathSelect(writer, check, stored, documentIdParameterName, useLeftJoins: true);
+                writer.Append(" AND ");
+                AppendAnyPathValueIsNull(writer, steps);
+                writer.Append(") THEN ");
+                AppendAuth1Throw(
+                    writer,
+                    check.Index,
+                    CustomViewAuthorizationAuth1FailureKind.StoredBasisValueNull
+                );
+                writer.AppendLine();
+            }
+
+            // No row for the target DocumentId at all. The target was deleted between the unlocked target
+            // lookup and this check; read paths re-resolve and surface a 404, and locked write and delete
+            // paths row-lock the target first so they never reach this branch.
+            writer.Append("WHEN NOT EXISTS (");
+            AppendRootRowByDocumentId(writer, stored, documentIdParameterName);
+            writer.Append(") THEN ");
+            AppendAuth1Throw(
+                writer,
+                check.Index,
+                CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing
+            );
+            writer.AppendLine();
+
+            writer.Append("ELSE ");
+            AppendAuth1Throw(
+                writer,
+                check.Index,
+                CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+            );
+            writer.AppendLine();
+        }
+
+        writer.Append("END");
+    }
+
+    private void AppendProposedCheckSql(
+        SqlWriter writer,
+        SingleRecordCustomViewAuthorizationCheckSpec check,
+        CustomViewAuthorizationCheckTarget.Proposed proposed
+    )
+    {
+        var steps = check.PathToBasisResource;
+
+        writer.AppendLine("SELECT CASE");
+
+        using (writer.Indent())
+        {
+            // The request body supplies no basis value at all.
+            writer.Append("WHEN ");
+            writer.AppendParameter(proposed.Binding.ParameterSeed);
+            writer.Append(" IS NULL THEN ");
+            AppendAuth1Throw(
+                writer,
+                check.Index,
+                CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing
+            );
+            writer.AppendLine();
+
+            if (steps.Count == 1)
+            {
+                // The bound value is already the basis DocumentId, so no traversal is needed.
+                writer.Append("WHEN ");
+                writer.AppendParameter(proposed.Binding.ParameterSeed);
+                AppendInAuthView(writer, check);
+                writer.AppendLine(" THEN 1");
+            }
+            else
+            {
+                writer.Append("WHEN EXISTS (");
+                AppendProposedPathSelect(writer, check, proposed, useLeftJoins: false);
+                writer.Append(" AND ");
+                AppendTerminalValueInAuthView(writer, check, ResolveTerminalAlias(steps));
+                writer.AppendLine(") THEN 1");
+
+                // The referenced row resolves but carries no onward basis value. From the caller's side the
+                // submitted data still supplies nothing authorizable, so this reports the same
+                // proposed-value-missing category rather than the stored-data one.
+                writer.Append("WHEN EXISTS (");
+                AppendProposedPathSelect(writer, check, proposed, useLeftJoins: true);
+                writer.Append(" AND ");
+                AppendAnyPathValueIsNull(writer, steps, skipFirstStep: true);
+                writer.Append(") THEN ");
+                AppendAuth1Throw(
+                    writer,
+                    check.Index,
+                    CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing
+                );
+                writer.AppendLine();
+            }
+
+            writer.Append("ELSE ");
+            AppendAuth1Throw(
+                writer,
+                check.Index,
+                CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+            );
+            writer.AppendLine();
+        }
+
+        writer.Append("END");
+    }
+
+    /// <summary>
+    /// <c>SELECT 1 FROM &lt;root&gt; r [JOIN each hop] WHERE r.DocumentId = @documentId</c>. Joins are
+    /// <c>LEFT</c> when the caller is probing for a null anywhere along the path, so a missing hop row reads
+    /// as a null rather than eliminating the row.
+    /// </summary>
+    private static void AppendStoredPathSelect(
+        SqlWriter writer,
+        SingleRecordCustomViewAuthorizationCheckSpec check,
+        CustomViewAuthorizationCheckTarget.Stored stored,
+        string documentIdParameterName,
+        bool useLeftJoins
+    )
+    {
+        writer.Append("SELECT 1 FROM ");
+        writer.AppendRelation(new SqlRelationRef.PhysicalTable(stored.RootTable));
+        writer.Append($" {RootAlias}");
+        AppendPathJoins(writer, check.PathToBasisResource, RootAlias, firstStepIndex: 0, useLeftJoins);
+        writer.Append($" WHERE {RootAlias}.");
+        writer.AppendQuoted(stored.RootDocumentIdColumn.Value);
+        writer.Append(" = ");
+        writer.AppendParameter(documentIdParameterName);
+    }
+
+    /// <summary>
+    /// <c>SELECT 1 FROM &lt;firstHopTarget&gt; t1 [JOIN remaining hops] WHERE t1.&lt;key&gt; = @proposed</c>.
+    /// The first hop is not joined: its value arrives as the bound parameter, so traversal starts at the row
+    /// that value addresses.
+    /// </summary>
+    private static void AppendProposedPathSelect(
+        SqlWriter writer,
+        SingleRecordCustomViewAuthorizationCheckSpec check,
+        CustomViewAuthorizationCheckTarget.Proposed proposed,
+        bool useLeftJoins
+    )
+    {
+        var steps = check.PathToBasisResource;
+        var firstStep = steps[0];
+        var firstHopTable =
+            firstStep.TargetTable
+            ?? throw new InvalidOperationException(
+                "Transitive custom view authorization path steps must carry a target table."
+            );
+        var firstHopColumn =
+            firstStep.TargetColumnName
+            ?? throw new InvalidOperationException(
+                "Transitive custom view authorization path steps must carry a target column."
+            );
+        var firstHopAlias = BuildJoinAlias(0);
+
+        writer.Append("SELECT 1 FROM ");
+        writer.AppendRelation(new SqlRelationRef.PhysicalTable(firstHopTable));
+        writer.Append($" {firstHopAlias}");
+        AppendPathJoins(writer, steps, firstHopAlias, firstStepIndex: 1, useLeftJoins);
+        writer.Append($" WHERE {firstHopAlias}.");
+        writer.AppendQuoted(firstHopColumn.Value);
+        writer.Append(" = ");
+        writer.AppendParameter(proposed.Binding.ParameterSeed);
+    }
+
+    /// <summary>
+    /// Emits one join per non-terminal hop from <paramref name="firstStepIndex"/> onward, chaining each hop's
+    /// target table to the previous alias's foreign key.
+    /// </summary>
+    private static void AppendPathJoins(
+        SqlWriter writer,
+        IReadOnlyList<ColumnPathStep> steps,
+        string sourceAlias,
+        int firstStepIndex,
+        bool useLeftJoins
+    )
+    {
+        var currentSourceAlias = sourceAlias;
+
+        for (var stepIndex = firstStepIndex; stepIndex < steps.Count - 1; stepIndex++)
+        {
+            var step = steps[stepIndex];
+            var targetTable =
+                step.TargetTable
+                ?? throw new InvalidOperationException(
+                    "Transitive custom view authorization path steps must carry a target table."
+                );
+            var targetColumn =
+                step.TargetColumnName
+                ?? throw new InvalidOperationException(
+                    "Transitive custom view authorization path steps must carry a target column."
+                );
+            var joinAlias = BuildJoinAlias(stepIndex);
+
+            writer.Append(useLeftJoins ? " LEFT JOIN " : " JOIN ");
+            writer.AppendRelation(new SqlRelationRef.PhysicalTable(targetTable));
+            writer.Append($" {joinAlias} ON {joinAlias}.");
+            writer.AppendQuoted(targetColumn.Value);
+            writer.Append($" = {currentSourceAlias}.");
+            writer.AppendQuoted(step.SourceColumnName.Value);
+
+            currentSourceAlias = joinAlias;
+        }
+    }
+
+    private static void AppendRootRowByDocumentId(
+        SqlWriter writer,
+        CustomViewAuthorizationCheckTarget.Stored stored,
+        string documentIdParameterName
+    )
+    {
+        writer.Append("SELECT 1 FROM ");
+        writer.AppendRelation(new SqlRelationRef.PhysicalTable(stored.RootTable));
+        writer.Append($" {RootAlias} WHERE {RootAlias}.");
+        writer.AppendQuoted(stored.RootDocumentIdColumn.Value);
+        writer.Append(" = ");
+        writer.AppendParameter(documentIdParameterName);
+    }
+
+    private static void AppendTerminalValueInAuthView(
+        SqlWriter writer,
+        SingleRecordCustomViewAuthorizationCheckSpec check,
+        string terminalAlias
+    )
+    {
+        writer.Append($"{terminalAlias}.");
+        writer.AppendQuoted(check.PathToBasisResource[^1].SourceColumnName.Value);
+        AppendInAuthView(writer, check);
+    }
+
+    private static void AppendInAuthView(SqlWriter writer, SingleRecordCustomViewAuthorizationCheckSpec check)
+    {
+        writer.Append($" IN (SELECT {AuthViewAlias}.");
+        writer.AppendQuoted(check.AuthViewDocumentIdColumn.Value);
+        writer.Append(" FROM ");
+        writer.AppendRelation(new SqlRelationRef.PhysicalTable(check.AuthView));
+        writer.Append($" {AuthViewAlias})");
+    }
+
+    /// <summary>
+    /// A disjunction over every followed value on the path. Covers a null foreign key at any hop and, because
+    /// the probe uses left joins, a hop row that does not exist.
+    /// </summary>
+    private static void AppendAnyPathValueIsNull(
+        SqlWriter writer,
+        IReadOnlyList<ColumnPathStep> steps,
+        bool skipFirstStep = false
+    )
+    {
+        writer.Append("(");
+
+        var appendedAny = false;
+
+        for (var stepIndex = skipFirstStep ? 1 : 0; stepIndex < steps.Count; stepIndex++)
+        {
+            if (appendedAny)
+            {
+                writer.Append(" OR ");
+            }
+
+            writer.Append($"{ResolveAliasForStep(stepIndex)}.");
+            writer.AppendQuoted(steps[stepIndex].SourceColumnName.Value);
+            writer.Append(" IS NULL");
+            appendedAny = true;
+        }
+
+        writer.Append(")");
+    }
+
+    /// <summary>
+    /// The alias owning the terminal step's source column: the root when the path is a single hop, otherwise
+    /// the join alias introduced by the preceding hop.
+    /// </summary>
+    private static string ResolveTerminalAlias(IReadOnlyList<ColumnPathStep> steps) =>
+        ResolveAliasForStep(steps.Count - 1);
+
+    private static string ResolveAliasForStep(int stepIndex) =>
+        stepIndex == 0 ? RootAlias : BuildJoinAlias(stepIndex - 1);
+
+    private static string BuildJoinAlias(int stepIndex) => $"{JoinAliasPrefix}{stepIndex + 1}";
+
+    private void AppendAuth1Throw(
+        SqlWriter writer,
+        int emittedIndex,
+        CustomViewAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        var payload = CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(
+            new CustomViewAuthorizationAuth1FailurePayload(emittedIndex, failureKind)
+        );
+
+        switch (_dialect)
+        {
+            case SqlDialect.Pgsql:
+                writer.AppendQuoted("dms");
+                writer.Append(".");
+                writer.AppendQuoted("throw_error");
+                writer.Append("('");
+                writer.Append(CustomViewAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode);
+                writer.Append("', '");
+                writer.Append(payload);
+                writer.Append("')");
+                return;
+
+            case SqlDialect.Mssql:
+                writer.Append("CAST('");
+                writer.Append(CustomViewAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode);
+                writer.Append(" - ");
+                writer.Append(payload);
+                writer.Append("' AS INT)");
+                return;
+
+            default:
+                throw new NotSupportedException(
+                    $"Single-record custom view authorization SQL does not support SQL dialect '{_dialect}'."
+                );
+        }
+    }
+
+    private static IReadOnlyList<QuerySqlParameter> BuildParametersInOrder(
+        SingleRecordCustomViewAuthorizationSqlSpec spec,
+        bool hasStoredCheck,
+        IReadOnlyList<CustomViewAuthorizationProposedValueSqlParameter> proposedValueParameters
+    )
+    {
+        List<QuerySqlParameter> parameters = [];
+
+        if (hasStoredCheck)
+        {
+            parameters.Add(new QuerySqlParameter(QuerySqlParameterRole.Filter, spec.DocumentIdParameterName));
+        }
+
+        parameters.AddRange(
+            proposedValueParameters.Select(static proposedValueParameter => new QuerySqlParameter(
+                QuerySqlParameterRole.Filter,
+                proposedValueParameter.ParameterName
+            ))
+        );
+
+        return parameters;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlModels.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlModels.cs
@@ -11,8 +11,9 @@ namespace EdFi.DataManagementService.Backend.Plans;
 /// Input for compiling the co-batched single-record custom view-based authorization SQL.
 /// </summary>
 /// <param name="Checks">
-/// The planned checks in emission order. Each check's <c>Index</c> must equal its position, because the
-/// <c>cv1</c> AUTH1 payload reports that index and the failure mapper resolves it positionally.
+/// The checks this batch emits, in emission order. Their <c>Index</c> values must run contiguously, but need
+/// not start at zero: one request can emit several batches, and an index has to identify a check uniquely
+/// across all of them because batches sharing a command also share one provider exception.
 /// </param>
 /// <param name="DocumentIdParameterName">
 /// Bare parameter name carrying the stored row's <c>DocumentId</c>. Bound only when a stored check is present.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlModels.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlModels.cs
@@ -11,9 +11,10 @@ namespace EdFi.DataManagementService.Backend.Plans;
 /// Input for compiling the co-batched single-record custom view-based authorization SQL.
 /// </summary>
 /// <param name="Checks">
-/// The checks this batch emits, in emission order. Their <c>Index</c> values must run contiguously, but need
-/// not start at zero: one request can emit several batches, and an index has to identify a check uniquely
-/// across all of them because batches sharing a command also share one provider exception.
+/// The checks this batch emits, in emission order. Their <c>Index</c> values must be nonnegative and strictly
+/// increasing, but need not start at zero or be consecutive: one request can emit several batches, and an index
+/// has to identify a check uniquely across all of them because batches sharing a command also share one
+/// provider exception. A gap is what a check the caller settles in C# leaves behind.
 /// </param>
 /// <param name="DocumentIdParameterName">
 /// Bare parameter name carrying the stored row's <c>DocumentId</c>. Bound only when a stored check is present.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlModels.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SingleRecordCustomViewAuthorizationSqlModels.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Input for compiling the co-batched single-record custom view-based authorization SQL.
+/// </summary>
+/// <param name="Checks">
+/// The planned checks in emission order. Each check's <c>Index</c> must equal its position, because the
+/// <c>cv1</c> AUTH1 payload reports that index and the failure mapper resolves it positionally.
+/// </param>
+/// <param name="DocumentIdParameterName">
+/// Bare parameter name carrying the stored row's <c>DocumentId</c>. Bound only when a stored check is present.
+/// </param>
+/// <param name="RowGuardPredicateSql">
+/// Optional raw predicate appended as a <c>WHERE</c> clause to every emitted check select. When it is false
+/// the check's result set is empty and none of its branches — including the abort device — evaluates, which
+/// is how checks co-batched behind a captured target stay vacuous for a write that resolved to no existing
+/// document.
+/// </param>
+public sealed record SingleRecordCustomViewAuthorizationSqlSpec(
+    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks,
+    string DocumentIdParameterName,
+    string? RowGuardPredicateSql = null
+);
+
+/// <summary>
+/// Generated SQL parameter carrying one proposed custom-view basis value.
+/// </summary>
+public sealed record CustomViewAuthorizationProposedValueSqlParameter(int CheckIndex, string ParameterName);
+
+/// <summary>
+/// Compiled single-record custom view-based authorization SQL plan.
+/// </summary>
+/// <param name="AuthorizationSql">The compiled SQL command body. Empty when no check emits SQL.</param>
+/// <param name="ParametersInOrder">Deterministic parameter metadata in plan order.</param>
+/// <param name="ProposedValueParametersInOrder">
+/// The proposed-value parameters the caller must bind, each tagged with the check it belongs to.
+/// </param>
+/// <param name="EmittedCheckIndexesInOrder">
+/// The checks that produced a statement, in statement order. A self-basis proposed check produces none — its
+/// answer depends on whether a target was captured and on the paired stored check's outcome, neither of which
+/// SQL can see — so callers use this to map result sets back to checks rather than assuming one statement per
+/// check.
+/// </param>
+public sealed record SingleRecordCustomViewAuthorizationSqlPlan(
+    string AuthorizationSql,
+    IReadOnlyList<QuerySqlParameter> ParametersInOrder,
+    IReadOnlyList<CustomViewAuthorizationProposedValueSqlParameter> ProposedValueParametersInOrder,
+    IReadOnlyList<int> EmittedCheckIndexesInOrder
+);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCustomViewAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCustomViewAuthorizationTests.cs
@@ -61,6 +61,21 @@ public class Given_A_Postgresql_Relational_Query_Authorization_With_A_Custom_Vie
     /// </summary>
     private const string DollarQuotedCustomViewStrategyName = "SchoolWithDollar$$QuoteCustomViewProviderTest";
 
+    /// <summary>
+    /// Descriptor DELETE authorizes inside the locked-target boundary rather than through an AUTH1
+    /// statement, so it needs its own descriptor-basis views: one excluding the delete target and one
+    /// including it.
+    /// </summary>
+    private const string DescriptorDeleteCustomViewStrategyName =
+        "GradeLevelDescriptorWithLockedDeleteCustomViewProviderTest";
+    private const string DescriptorDeleteAuthorizingCustomViewStrategyName =
+        "GradeLevelDescriptorWithLockedDeleteAuthorizingCustomViewProviderTest";
+    private static readonly DocumentUuid _gradeLevelDescriptorDocumentUuid = new(
+        Guid.Parse("60666666-6666-6666-6666-666666666666")
+    );
+    private const string GradeLevelDescriptorCodeValue = "Tenth grade";
+    private const string StaleETag = "\"stale-etag\"";
+
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
         new(new DocumentUuid(Guid.Parse("77777777-0000-0000-0000-000000000001")), 100, "Authorized School"),
@@ -145,6 +160,16 @@ public class Given_A_Postgresql_Relational_Query_Authorization_With_A_Custom_Vie
             NamespaceIntersectionCustomViewStrategyName,
             [1, 3]
         );
+        // The excluding view authorizes a different descriptor's code value, so the GradeLevelDescriptor
+        // delete target is genuinely absent from it rather than the view being empty.
+        await _context.CreateDescriptorCustomAuthViewAsync(
+            DescriptorDeleteCustomViewStrategyName,
+            ["School"]
+        );
+        await _context.CreateDescriptorCustomAuthViewAsync(
+            DescriptorDeleteAuthorizingCustomViewStrategyName,
+            [GradeLevelDescriptorCodeValue]
+        );
         await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, 100);
         await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, 200);
     }
@@ -155,6 +180,8 @@ public class Given_A_Postgresql_Relational_Query_Authorization_With_A_Custom_Vie
         if (_context is not null)
         {
             await _context.DropCustomAuthViewAsync(CustomViewStrategyName);
+            await _context.DropCustomAuthViewAsync(DescriptorDeleteCustomViewStrategyName);
+            await _context.DropCustomAuthViewAsync(DescriptorDeleteAuthorizingCustomViewStrategyName);
             await _context.DropCustomAuthViewAsync(DollarQuotedCustomViewStrategyName);
             await _context.DropCustomAuthViewAsync(InvalidCustomViewStrategyName);
             await _context.DropCustomAuthViewAsync(IncompatibleDocumentIdCustomViewStrategyName);
@@ -473,6 +500,142 @@ public class Given_A_Postgresql_Relational_Query_Authorization_With_A_Custom_Vie
 
         var exception = await AssertCustomViewValidationFailure(act);
         exception.Message.Should().Contain("Invalid custom authorization view DocumentId contract.");
+    }
+
+    [Test]
+    public async Task It_denies_delete_for_a_school_the_custom_view_excludes_and_leaves_the_row()
+    {
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[1].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            [CustomViewStrategyName]
+        );
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(CustomViewStrategyName);
+        // The check runs inside the locked-target boundary before the delete, so a denial must leave the row.
+        (await _context.CountDocumentRowsAsync(_schoolSeeds[1].DocumentUuid))
+            .Should()
+            .Be(1);
+    }
+
+    [Test]
+    public async Task It_denies_delete_with_if_match_for_a_school_the_custom_view_excludes()
+    {
+        // The If-Match delete authorizes through a different seam than the plain delete — the locked
+        // precondition path — so the denial has to hold there too, and ahead of the precondition outcome.
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[1].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            [CustomViewStrategyName],
+            ifMatch: "*"
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>();
+        (await _context.CountDocumentRowsAsync(_schoolSeeds[1].DocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_wraps_a_provider_error_when_the_configured_custom_view_does_not_exist_on_delete()
+    {
+        // GET-many already proves the view contract at the provider level; this proves the single-record
+        // DELETE path reaches it rather than reporting a generic delete failure.
+        await AssertCustomViewValidationFailure(async () =>
+            await _context.DeleteByIdAsync(
+                "ed-fi",
+                "School",
+                _schoolSeeds[0].DocumentUuid,
+                [ClaimEducationOrganizationId],
+                [MissingCustomViewStrategyName]
+            )
+        );
+
+        (await _context.CountDocumentRowsAsync(_schoolSeeds[0].DocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_reports_a_referencing_document_failure_after_the_custom_view_authorizes_the_delete()
+    {
+        // School 100 IS in the view, so authorization passes and the delete proceeds — and then fails because
+        // a ClassPeriod references it. A denial would stop before the delete and prove nothing, so this is the
+        // case that shows custom-view validation and error attribution do not swallow an ordinary failure.
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[0].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            [CustomViewStrategyName]
+        );
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureReference>()
+            .Which.ReferencingDocumentResourceNames.Should()
+            .NotBeEmpty();
+        (await _context.CountDocumentRowsAsync(_schoolSeeds[0].DocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_denies_a_descriptor_delete_when_the_custom_view_excludes_the_target()
+    {
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "GradeLevelDescriptor",
+            _gradeLevelDescriptorDocumentUuid,
+            [ClaimEducationOrganizationId],
+            [DescriptorDeleteCustomViewStrategyName]
+        );
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(DescriptorDeleteCustomViewStrategyName);
+        (await _context.CountDocumentRowsAsync(_gradeLevelDescriptorDocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_denies_a_descriptor_delete_with_a_stale_if_match_when_the_custom_view_excludes_the_target()
+    {
+        // A stale If-Match would also fail the delete, so reporting the custom-view denial proves the check
+        // runs inside the locked-target boundary ahead of the precondition outcome rather than after it.
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "GradeLevelDescriptor",
+            _gradeLevelDescriptorDocumentUuid,
+            [ClaimEducationOrganizationId],
+            [DescriptorDeleteCustomViewStrategyName],
+            ifMatch: StaleETag
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>();
+        (await _context.CountDocumentRowsAsync(_gradeLevelDescriptorDocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_reports_the_stale_if_match_when_the_custom_view_authorizes_the_descriptor_delete()
+    {
+        // Same request as above against a view that includes the target: the precondition failure surfaces,
+        // which is what makes the denial above attributable to the view rather than to descriptor deletes
+        // being refused outright. Deleting nothing also keeps the seeded descriptor available to other tests.
+        var result = await _context.DeleteByIdAsync(
+            "ed-fi",
+            "GradeLevelDescriptor",
+            _gradeLevelDescriptorDocumentUuid,
+            [ClaimEducationOrganizationId],
+            [DescriptorDeleteAuthorizingCustomViewStrategyName],
+            ifMatch: StaleETag
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        (await _context.CountDocumentRowsAsync(_gradeLevelDescriptorDocumentUuid)).Should().Be(1);
     }
 
     private static async Task<PostgresException> AssertCustomViewValidationFailure(Func<Task> action)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCustomViewAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCustomViewAuthorizationTests.cs
@@ -561,6 +561,44 @@ public class Given_A_Postgresql_Relational_Query_Authorization_With_A_Custom_Vie
     }
 
     [Test]
+    public async Task It_throws_on_delete_when_the_custom_authorization_object_is_a_table_with_a_bigint_document_id()
+    {
+        // DELETE reaches the view through the co-batched stored run rather than a standalone query, and a table
+        // whose DocumentId is type-compatible answers that run's membership SQL without raising anything. Without
+        // validating the object the row would be deleted, or the caller denied, against something auth.md does
+        // not accept.
+        await _context.Database.ExecuteNonQueryAsync(
+            $"""
+            CREATE TABLE "auth"."{TableInsteadOfCustomViewStrategyName}" (
+                "DocumentId" bigint NOT NULL
+            );
+            """
+        );
+
+        try
+        {
+            var exception = await AssertCustomViewValidationFailure(async () =>
+                await _context.DeleteByIdAsync(
+                    "ed-fi",
+                    "School",
+                    _schoolSeeds[0].DocumentUuid,
+                    [ClaimEducationOrganizationId],
+                    [TableInsteadOfCustomViewStrategyName]
+                )
+            );
+
+            exception.Message.Should().Contain("Invalid custom authorization view DocumentId contract.");
+            (await _context.CountDocumentRowsAsync(_schoolSeeds[0].DocumentUuid)).Should().Be(1);
+        }
+        finally
+        {
+            await _context.Database.ExecuteNonQueryAsync(
+                $"""DROP TABLE IF EXISTS "auth"."{TableInsteadOfCustomViewStrategyName}";"""
+            );
+        }
+    }
+
+    [Test]
     public async Task It_reports_a_referencing_document_failure_after_the_custom_view_authorizes_the_delete()
     {
         // School 100 IS in the view, so authorization passes and the delete proceeds — and then fails because

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalGetByIdAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalGetByIdAuthorizationTests.cs
@@ -10,6 +10,7 @@ using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.External.Security;
 using FluentAssertions;
+using Npgsql;
 using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
@@ -58,6 +59,11 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
     /// </summary>
     private const string CustomViewStrategyName = "SchoolWithGetByIdProviderTest";
     private static readonly IReadOnlyList<string> _customViewStrategy = [CustomViewStrategyName];
+
+    /// <summary>
+    /// A configured strategy whose <c>auth</c> object the masquerade test creates as a table rather than a view.
+    /// </summary>
+    private const string TableInsteadOfCustomViewStrategyName = "SchoolWithGetByIdTableProviderTest";
 
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
@@ -338,6 +344,46 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
             .BeOfType<GetResult.GetFailureCustomViewNotAuthorized>()
             .Subject.CustomViewFailure;
         failure.StrategyName.Should().Be(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task Given_A_Custom_Authorization_Object_That_Is_A_Table_It_Throws_On_Get_By_Id()
+    {
+        // A table whose DocumentId is type-compatible answers the membership query without raising anything, so
+        // the request would authorize or deny against an object auth.md does not accept. The run has to prove the
+        // object is a view first, and surface the documented urn:ed-fi:api:system 500 instead.
+        await _context.Database.ExecuteNonQueryAsync(
+            $"""
+            CREATE TABLE "auth"."{TableInsteadOfCustomViewStrategyName}" (
+                "DocumentId" bigint NOT NULL
+            );
+            """
+        );
+
+        try
+        {
+            Func<Task> act = () =>
+                _context.GetByIdAsync(
+                    "ed-fi",
+                    "School",
+                    _schoolSeeds[0].DocumentUuid,
+                    [ClaimEducationOrganizationId],
+                    [TableInsteadOfCustomViewStrategyName]
+                );
+
+            var assertion = await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+            assertion
+                .Which.InnerException.Should()
+                .BeOfType<PostgresException>()
+                .Subject.Message.Should()
+                .Contain("Invalid custom authorization view DocumentId contract.");
+        }
+        finally
+        {
+            await _context.Database.ExecuteNonQueryAsync(
+                $"""DROP TABLE IF EXISTS "auth"."{TableInsteadOfCustomViewStrategyName}";"""
+            );
+        }
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalGetByIdAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalGetByIdAuthorizationTests.cs
@@ -52,6 +52,13 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
         AuthorizationStrategyNameConstants.OwnershipBased,
     ];
 
+    /// <summary>
+    /// A custom view over School authorizing School 100 only. School 200 is reachable through the claim's
+    /// edorg edges, so a denial on 200 can only come from the view's membership query.
+    /// </summary>
+    private const string CustomViewStrategyName = "SchoolWithGetByIdProviderTest";
+    private static readonly IReadOnlyList<string> _customViewStrategy = [CustomViewStrategyName];
+
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
         new(new DocumentUuid(Guid.Parse("22222222-0000-0000-0000-000000000001")), 100, "North School"),
@@ -280,6 +287,7 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
 
         await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, 100);
         await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, 200);
+        await _context.CreateSchoolCustomAuthViewAsync(CustomViewStrategyName, [100]);
         await _context.InsertAuthEdgeAsync(300, ClaimEducationOrganizationId);
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, ClaimEducationOrganizationId);
     }
@@ -289,6 +297,7 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
     {
         if (_context is not null)
         {
+            await _context.DropCustomAuthViewAsync(CustomViewStrategyName);
             await _context.DisposeAsync();
         }
     }
@@ -297,6 +306,38 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
     public void SetUp()
     {
         _context.ResetRecorder();
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Authorizes_A_School_The_View_Includes()
+    {
+        var result = await _context.GetByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[0].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Denies_A_School_The_View_Excludes()
+    {
+        var result = await _context.GetByIdAsync(
+            "ed-fi",
+            "School",
+            _schoolSeeds[1].DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        var failure = result
+            .Should()
+            .BeOfType<GetResult.GetFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure;
+        failure.StrategyName.Should().Be(CustomViewStrategyName);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalPostAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalPostAuthorizationTests.cs
@@ -31,6 +31,13 @@ public class Given_A_Postgresql_RelationalPost_Create_Authorization_With_A_Synth
     private const string TermDescriptor = "uri://ed-fi.org/TermDescriptor#Fall Semester";
     private const string EntryGradeLevelDescriptor = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade";
 
+    /// <summary>
+    /// A custom view over School authorizing School 100 only. A create carries its School as a proposed
+    /// reference value and has no stored value at all, so the view alone decides the write.
+    /// </summary>
+    private const string CustomViewStrategyName = "SchoolWithPostProviderTest";
+    private static readonly IReadOnlyList<string> _customViewStrategy = [CustomViewStrategyName];
+
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
         new(new DocumentUuid(Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001")), 100, "North School"),
@@ -155,6 +162,8 @@ public class Given_A_Postgresql_RelationalPost_Create_Authorization_With_A_Synth
         await _context.InsertAuthEdgeAsync(300, ClaimEducationOrganizationId);
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, ClaimEducationOrganizationId);
         _context.ResetRecorder();
+
+        await _context.CreateSchoolCustomAuthViewAsync(CustomViewStrategyName, [100]);
     }
 
     [OneTimeTearDown]
@@ -162,8 +171,47 @@ public class Given_A_Postgresql_RelationalPost_Create_Authorization_With_A_Synth
     {
         if (_context is not null)
         {
+            await _context.DropCustomAuthViewAsync(CustomViewStrategyName);
             await _context.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Authorizes_A_Create_Whose_Proposed_School_The_View_Includes()
+    {
+        var seed = CreateRootChildSeed(
+            "cccccccc-0000-0000-0000-000000000601",
+            601,
+            "custom-view-authorized-create",
+            100,
+            []
+        );
+
+        var result = await PostRootChildAsync(seed, _customViewStrategy);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        await AssertPersistedRowsAsync(seed);
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Denies_A_Create_Whose_Proposed_School_The_View_Excludes()
+    {
+        var seed = CreateRootChildSeed(
+            "cccccccc-0000-0000-0000-000000000602",
+            602,
+            "custom-view-denied-create",
+            200,
+            []
+        );
+
+        var result = await PostRootChildAsync(seed, _customViewStrategy);
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(CustomViewStrategyName);
+        await AssertNoCreateSideEffectsAsync(seed);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalPutAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalPutAuthorizationTests.cs
@@ -105,6 +105,13 @@ public class Given_A_PostgresqlRelationalPutAuthorizationTests_With_A_Synthetic_
     private const long ClaimEducationOrganizationId =
         RelationshipAuthorizationCrudTestSupport.ClaimEducationOrganizationId;
 
+    /// <summary>
+    /// A custom view over School authorizing School 100 only. An update is checked twice against it, once
+    /// for the stored School and once for the proposed School, so the two are covered separately below.
+    /// </summary>
+    private const string CustomViewStrategyName = "SchoolWithPutProviderTest";
+    private static readonly IReadOnlyList<string> _customViewStrategy = [CustomViewStrategyName];
+
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
         new(new DocumentUuid(Guid.Parse("aaaaaaaa-1111-0000-0000-000000000001")), 100, "North School"),
@@ -156,6 +163,8 @@ public class Given_A_PostgresqlRelationalPutAuthorizationTests_With_A_Synthetic_
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, 300);
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, ClaimEducationOrganizationId);
         _context.ResetRecorder();
+
+        await _context.CreateSchoolCustomAuthViewAsync(CustomViewStrategyName, [100]);
     }
 
     [OneTimeTearDown]
@@ -163,8 +172,99 @@ public class Given_A_PostgresqlRelationalPutAuthorizationTests_With_A_Synthetic_
     {
         if (_context is not null)
         {
+            await _context.DropCustomAuthViewAsync(CustomViewStrategyName);
             await _context.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Authorizes_An_Update_Whose_Stored_And_Proposed_Schools_The_View_Includes()
+    {
+        var existingSeed = CreateRootChildSeed(
+            "cccccccc-1111-0000-0000-000000000601",
+            601,
+            "custom-view-authorized-existing",
+            100,
+            []
+        );
+        var proposedSeed = existingSeed with { Name = "custom-view-authorized-change" };
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationRootChildAsync(existingSeed)
+        );
+
+        var result = await _context.UpdateAuthorizationRootChildByIdAsync(
+            proposedSeed,
+            existingSeed.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        result.Should().BeOfType<UpdateResult.UpdateSuccess>();
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Denies_An_Update_Whose_Proposed_School_The_View_Excludes()
+    {
+        // The stored School is inside the view, so only the proposed School can produce this denial. Seeding
+        // the target row with an authorized School is what keeps the stored check from masking it.
+        var existingSeed = CreateRootChildSeed(
+            "cccccccc-1111-0000-0000-000000000602",
+            602,
+            "custom-view-proposed-denied-existing",
+            100,
+            []
+        );
+        var proposedSeed = existingSeed with { Name = "custom-view-proposed-denied-change", SchoolId = 200 };
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationRootChildAsync(existingSeed)
+        );
+
+        var result = await _context.UpdateAuthorizationRootChildByIdAsync(
+            proposedSeed,
+            existingSeed.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task Given_A_Custom_View_Strategy_It_Denies_An_Update_Whose_Stored_School_The_View_Excludes()
+    {
+        // The mirror image: the proposed School is inside the view and the stored School is not, so this
+        // denial can only come from the stored check.
+        var existingSeed = CreateRootChildSeed(
+            "cccccccc-1111-0000-0000-000000000603",
+            603,
+            "custom-view-stored-denied-existing",
+            200,
+            []
+        );
+        var proposedSeed = existingSeed with { Name = "custom-view-stored-denied-change", SchoolId = 100 };
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationRootChildAsync(existingSeed)
+        );
+
+        var result = await _context.UpdateAuthorizationRootChildByIdAsync(
+            proposedSeed,
+            existingSeed.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _customViewStrategy
+        );
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(CustomViewStrategyName);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryAuthorizationTests.cs
@@ -1097,6 +1097,32 @@ internal sealed class PostgresqlRelationalQueryAuthorizationTestContext : IAsync
     }
 
     /// <summary>
+    /// Creates a custom authorization view over descriptor storage, authorizing the supplied code values.
+    /// Every descriptor resource shares one root table, so a descriptor basis filters that table rather than
+    /// a per-resource one.
+    /// </summary>
+    public async Task CreateDescriptorCustomAuthViewAsync(
+        string strategyName,
+        IReadOnlyList<string> authorizedCodeValues
+    )
+    {
+        var codeValueList = string.Join(
+            ", ",
+            authorizedCodeValues.Select(codeValue => $"'{codeValue.Replace("'", "''")}'")
+        );
+
+        await DropCustomAuthViewAsync(strategyName);
+        await Database.ExecuteNonQueryAsync(
+            $"""
+            CREATE VIEW "auth"."{strategyName}" AS
+            SELECT "DocumentId"
+            FROM "dms"."Descriptor"
+            WHERE "CodeValue" IN ({codeValueList});
+            """
+        );
+    }
+
+    /// <summary>
     /// Creates the custom authorization view with an <em>unquoted</em> name, which PostgreSQL folds to
     /// lower case: the object lands as <c>auth.{lowercased}</c> while the configured strategy name stays
     /// PascalCase. This is the mistake hand-written DDL actually makes, as opposed to simulating the

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
@@ -315,12 +315,16 @@ public class Given_The_Composite_Relational_Delete_Command
     }
 
     [Test]
-    public async Task It_emits_a_custom_view_configured_after_NamespaceBased_behind_it()
+    public async Task It_runs_a_custom_view_configured_after_NamespaceBased_as_its_own_ordered_segment()
     {
         // The namespace planner stamps its check with configured index 0, so a view at index 1 runs after it.
+        // It takes a segment of its own rather than riding the opening command behind the namespace statement:
+        // its view may be validated only once that check has passed, and the deletes wait for both.
         var session = CreateSession(
             SqlDialect.Pgsql,
-            DeleteReader(rootDeleteOrdinal: 3, deleted: true, namespaceCheckCount: 2)
+            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            NamespaceCheckReader(checkCount: 1),
+            SegmentDeleteReader(deleted: true)
         );
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
@@ -328,14 +332,18 @@ public class Given_The_Composite_Relational_Delete_Command
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
         };
 
-        await CreateSut().ExecuteAsync(request, session);
+        var result = await CreateSut().ExecuteAsync(request, session);
 
-        var commandText = session.Commands[0].CommandText;
-        commandText
-            .IndexOf("namespacePrefixes", StringComparison.Ordinal)
-            .Should()
-            .BeLessThan(commandText.IndexOf("SchoolWithATag", StringComparison.Ordinal))
-            .And.BePositive();
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        session.Commands.Should().HaveCount(3);
+        session
+            .Commands[0]
+            .CommandText.Should()
+            .Contain("namespacePrefixes")
+            .And.NotContain("SchoolWithATag")
+            .And.NotContain("DELETE FROM");
+        session.Commands[1].CommandText.Should().Contain("SchoolWithATag");
+        session.Commands[2].CommandText.Should().Contain("DELETE FROM");
     }
 
     [Test]
@@ -367,9 +375,13 @@ public class Given_The_Composite_Relational_Delete_Command
     [Test]
     public async Task It_straddles_the_namespace_check_with_both_custom_view_runs_in_configured_order()
     {
+        // The view configured before NamespaceBased rides the opening command ahead of it; the one configured
+        // after follows as a segment, and the deletes wait for that segment.
         var session = CreateSession(
             SqlDialect.Pgsql,
-            DeleteReader(rootDeleteOrdinal: 4, deleted: true, namespaceCheckCount: 3)
+            CaptureOnlyReader(captured: true, namespaceCheckCount: 2),
+            NamespaceCheckReader(checkCount: 1),
+            SegmentDeleteReader(deleted: true)
         );
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
@@ -382,16 +394,18 @@ public class Given_The_Composite_Relational_Delete_Command
 
         await CreateSut().ExecuteAsync(request, session);
 
-        var commandText = session.Commands[0].CommandText;
-        var earlyPosition = commandText.IndexOf("SchoolWithAnEarlyTag", StringComparison.Ordinal);
-        var namespacePosition = commandText.IndexOf("namespacePrefixes", StringComparison.Ordinal);
-        var latePosition = commandText.IndexOf("SchoolWithALateTag", StringComparison.Ordinal);
+        var openingCommandText = session.Commands[0].CommandText;
+        var earlyPosition = openingCommandText.IndexOf("SchoolWithAnEarlyTag", StringComparison.Ordinal);
+        var namespacePosition = openingCommandText.IndexOf("namespacePrefixes", StringComparison.Ordinal);
 
         earlyPosition.Should().BePositive();
         earlyPosition.Should().BeLessThan(namespacePosition);
-        namespacePosition.Should().BeLessThan(latePosition);
+        openingCommandText.Should().NotContain("SchoolWithALateTag").And.NotContain("DELETE FROM");
+        session.Commands[1].CommandText.Should().Contain("SchoolWithALateTag");
+        session.Commands[2].CommandText.Should().Contain("DELETE FROM");
         // Each run keeps its request-wide indexes, so the two runs' payloads stay distinguishable.
-        commandText.Should().Contain("cv1|0|n").And.Contain("cv1|1|n");
+        openingCommandText.Should().Contain("cv1|0|n");
+        session.Commands[1].CommandText.Should().Contain("cv1|1|n");
     }
 
     [Test]
@@ -460,6 +474,159 @@ public class Given_The_Composite_Relational_Delete_Command
             .Commands.Should()
             .AllSatisfy(command => command.CommandText.Should().NotContain("DELETE FROM"));
     }
+
+    [Test]
+    public async Task It_authorizes_the_relationship_after_an_owed_custom_view_segment_rather_than_in_the_opening_command()
+    {
+        // The regression this pins: relationship authorization runs after every configured AND filter, so
+        // while a custom-view segment is owed the relationship check cannot ride the opening command. Emitted
+        // there, its denial would answer before the segment ever ran, and a view the CMS configured would
+        // never be enforced on this delete.
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            NamespaceCheckReader(checkCount: 1),
+            new FakeDbException("AUTH1", "AUTH1")
+        );
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
+            StoredRelationshipAuthorization = CreateStoredRelationshipAuthorization(SqlDialect.Pgsql),
+        };
+        var payload = RelationshipAuthorizationAuth1FailurePayloadCodec.Encode(
+            new RelationshipAuthorizationAuth1FailurePayload(
+                CompositeRelationalDeleteCommand.RelationshipAuthorizationAuth1Index,
+                [
+                    new RelationshipAuthorizationAuth1SubjectFailure(
+                        0,
+                        0,
+                        RelationshipAuthorizationAuth1SubjectFailureKind.NoRelationship
+                    ),
+                ]
+            )
+        );
+
+        var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", payload))
+            .ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureRelationshipNotAuthorized>();
+        session.Commands.Should().HaveCount(3);
+        session
+            .Commands[0]
+            .CommandText.Should()
+            .Contain("namespacePrefixes")
+            .And.NotContain("SchoolWithALateTag")
+            .And.NotContain("AuthorizationResult");
+        session.Commands[1].CommandText.Should().Contain("SchoolWithALateTag");
+        session.Commands[2].CommandText.Should().Contain("AuthorizationResult");
+        session
+            .Commands.Should()
+            .AllSatisfy(command => command.CommandText.Should().NotContain("DELETE FROM"));
+    }
+
+    [Test]
+    public async Task It_reports_an_owed_custom_view_segment_denial_over_a_relationship_that_would_also_deny()
+    {
+        // Configured order decides: the view precedes the relationship group, so its denial is the answer and
+        // the relationship check is never issued at all.
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            new FakeDbException("AUTH1", "AUTH1")
+        );
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
+            StoredRelationshipAuthorization = CreateStoredRelationshipAuthorization(SqlDialect.Pgsql),
+        };
+
+        var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", EncodeCustomViewPayload(0)))
+            .ExecuteAsync(request, session);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.StrategyName.Should()
+            .Be("SchoolWithALateTag");
+        session.Commands.Should().HaveCount(2);
+        // The relationship statement never joined the opening command, so nothing carried it ahead of the
+        // segment, and the segment's denial ended the request before it could be issued on its own.
+        session
+            .Commands.Should()
+            .AllSatisfy(command =>
+                command.CommandText.Should().NotContain("AuthorizationResult").And.NotContain("DELETE FROM")
+            );
+        session.Commands[1].CommandText.Should().Contain("SchoolWithALateTag");
+    }
+
+    [Test]
+    public async Task It_reports_an_invalid_view_configured_before_NamespaceBased_over_the_namespace_denial()
+    {
+        // The view rides the opening command ahead of the namespace statement, so its contract is settled
+        // before that command runs at all: a table masquerading as auth.{StrategyName} answers the membership
+        // SQL without raising anything, and the configured order puts its 500 ahead of the namespace denial.
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithAnEarlyTag", 0)),
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+        };
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("invalid custom authorization view DocumentId contract", "P0001")
+        );
+
+        var act = async () =>
+            await CreateSut(
+                    new StubProviderFailureExtractor("AUTH1", NamespaceDenialPayload()),
+                    customViewValidationCommandExecutor: validationExecutor
+                )
+                .ExecuteAsync(request, session);
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithAnEarlyTag");
+        // The opening command never ran, so nothing was deleted and the namespace denial was never reached.
+        session.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_reports_the_namespace_denial_over_an_invalid_view_configured_after_NamespaceBased()
+    {
+        // The mirror case: the view is configured after NamespaceBased, so it runs as a later segment and the
+        // namespace denial the opening command raises is the one the caller sees. Validating every planned view
+        // up front, or validating the segment's view before the namespace check, would report a 500 instead.
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+        };
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("invalid custom authorization view DocumentId contract", "P0001")
+        );
+
+        var result = await CreateSut(
+                new StubProviderFailureExtractor("AUTH1", NamespaceDenialPayload()),
+                customViewValidationCommandExecutor: validationExecutor
+            )
+            .ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>();
+        validationExecutor.ExecutedCommands.Should().BeEmpty();
+    }
+
+    private static string NamespaceDenialPayload() =>
+        NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
 
     [Test]
     public async Task It_attributes_a_non_auth1_failure_in_a_custom_view_statement_to_the_configured_view()
@@ -888,7 +1055,8 @@ public class Given_The_Composite_Relational_Delete_Command
         IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null,
         IRelationalWriteExceptionClassifier? classifier = null,
         IRelationalDeleteConstraintResolver? constraintResolver = null,
-        RelationalCommandBudget? commandBudget = null
+        RelationalCommandBudget? commandBudget = null,
+        IRelationalCommandExecutor? customViewValidationCommandExecutor = null
     ) =>
         new(
             new RelationalCurrentEtagPreconditionChecker(
@@ -898,7 +1066,8 @@ public class Given_The_Composite_Relational_Delete_Command
             classifier ?? new ConfigurableRelationalWriteExceptionClassifier(),
             constraintResolver ?? A.Fake<IRelationalDeleteConstraintResolver>(),
             relationshipAuthorizationProviderFailureExtractor: providerFailureExtractor,
-            commandBudget: commandBudget
+            commandBudget: commandBudget,
+            customViewValidationCommandExecutor: customViewValidationCommandExecutor
         );
 
     /// <summary>The served etag a client would hold for a document at <paramref name="contentVersion"/>.</summary>
@@ -1234,6 +1403,31 @@ public class Given_The_Composite_Relational_Delete_Command
     {
         public RelationshipAuthorizationProviderFailure Extract(DbException exception) =>
             new(providerErrorCode, providerMessage);
+    }
+
+    /// <summary>
+    /// Stands in for the fresh-connection executor the custom-view validation probe uses, recording what it was
+    /// asked to run and optionally failing the way an object that is not a conforming view would.
+    /// </summary>
+    private sealed class StubValidationCommandExecutor(DbException? failure = null)
+        : IRelationalCommandExecutor
+    {
+        public SqlDialect Dialect => SqlDialect.Pgsql;
+
+        public List<RelationalCommand> ExecutedCommands { get; } = [];
+
+        public Task<TResult> ExecuteReaderAsync<TResult>(
+            RelationalCommand command,
+            Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ExecutedCommands.Add(command);
+
+            return failure is null
+                ? Task.FromResult(default(TResult)!)
+                : Task.FromException<TResult>(failure);
+        }
     }
 
     private sealed class FakeDbException(string message, string sqlState) : DbException(message)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
@@ -651,6 +651,31 @@ public class Given_The_Composite_Relational_Delete_Command
     }
 
     [Test]
+    public async Task It_maps_a_transient_failure_in_a_custom_view_command_to_a_write_conflict()
+    {
+        // A deadlock on the opening command carries no AUTH1 payload either, but it proves nothing about
+        // the configured view: it must keep the retryable 409 write-conflict classification instead of
+        // being relabelled as a custom-view validation 500.
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("deadlock detected", "40P01"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        var classifier = new ConfigurableRelationalWriteExceptionClassifier
+        {
+            IsTransientFailureToReturn = true,
+        };
+
+        var result = await CreateSut(
+                new StubProviderFailureExtractor("40P01", "deadlock detected"),
+                classifier: classifier
+            )
+            .ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureWriteConflict>();
+    }
+
+    [Test]
     public async Task It_maps_a_namespace_auth1_failure_to_the_namespace_denial()
     {
         var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
@@ -166,6 +166,314 @@ public class Given_The_Composite_Relational_Delete_Command
             .And.BePositive();
     }
 
+    /// <summary>
+    /// One stored custom-view check per configured strategy, indexed across the request the way the planner
+    /// assigns them. A self-basis path keeps the fixture independent of any reference model.
+    /// </summary>
+    private static RelationalCustomViewAuthorization CreateStoredCustomViewAuthorization(
+        params (string StrategyName, int RawConfiguredIndex)[] strategies
+    ) =>
+        new([
+            .. strategies.Select(
+                (strategy, index) =>
+                    new SingleRecordCustomViewAuthorizationCheckSpec(
+                        new ConfiguredAuthorizationStrategy(
+                            strategy.StrategyName,
+                            strategy.RawConfiguredIndex
+                        ),
+                        index,
+                        CustomViewAuthorizationCheckValueSource.Stored,
+                        new DbTableName(new DbSchemaName("auth"), strategy.StrategyName),
+                        new DbColumnName("DocumentId"),
+                        [
+                            new ColumnPathStep(
+                                new DbTableName(new DbSchemaName("edfi"), "School"),
+                                new DbColumnName("DocumentId"),
+                                null,
+                                null
+                            ),
+                        ],
+                        new CustomViewAuthorizationCheckTarget.Stored(
+                            new DbTableName(new DbSchemaName("edfi"), "School"),
+                            new DbColumnName("DocumentId")
+                        ),
+                        new QualifiedResourceName("Ed-Fi", "School"),
+                        [$"{strategy.StrategyName}Element"],
+                        $"You may need a {strategy.StrategyName} hint."
+                    )
+            ),
+        ]);
+
+    private static string EncodeCustomViewPayload(
+        int index,
+        CustomViewAuthorizationAuth1FailureKind failureKind =
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+    ) =>
+        CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(
+            new CustomViewAuthorizationAuth1FailurePayload(index, failureKind)
+        );
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public async Task It_emits_the_custom_view_checks_before_the_deletes(SqlDialect dialect)
+    {
+        var session = CreateSession(
+            dialect,
+            DeleteReader(rootDeleteOrdinal: 2, deleted: true, namespaceCheckCount: 1)
+        );
+        var request = CreateRequest(dialect) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+
+        var result = await CreateSut().ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        session.Commands.Should().ContainSingle();
+        // "the delete does not happen" when unauthorized only holds if the check precedes the deletes in the
+        // same command, where the AUTH1 abort stops the batch.
+        session
+            .Commands[0]
+            .CommandText.IndexOf("SchoolWithATag", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(IndexOfRootDelete(session, dialect))
+            .And.BePositive();
+    }
+
+    [Test]
+    public async Task It_maps_a_custom_view_auth1_failure_to_the_custom_view_denial()
+    {
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+
+        var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", EncodeCustomViewPayload(0)))
+            .ExecuteAsync(request, session);
+
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>().Subject;
+        failure.CustomViewFailure.StrategyName.Should().Be("SchoolWithATag");
+        failure.CustomViewFailure.ReadableSecurableElements.Should().Equal("SchoolWithATagElement");
+        failure.CustomViewFailure.Hint.Should().Be("You may need a SchoolWithATag hint.");
+    }
+
+    [Test]
+    public async Task It_maps_a_stale_custom_view_target_to_not_exists()
+    {
+        // Unreachable while the capture lock holds; the same defensive mapping the namespace path uses.
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        var payload = EncodeCustomViewPayload(0, CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing);
+
+        var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", payload))
+            .ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNotExists>();
+    }
+
+    [Test]
+    public async Task It_maps_an_unmappable_custom_view_payload_to_a_security_configuration_failure()
+    {
+        // Index 4 addresses no planned check, so the payload is a configuration defect rather than a denial.
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+
+        var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", EncodeCustomViewPayload(4)))
+            .ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>();
+    }
+
+    [Test]
+    public async Task It_emits_a_custom_view_configured_before_NamespaceBased_ahead_of_it()
+    {
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            DeleteReader(rootDeleteOrdinal: 3, deleted: true, namespaceCheckCount: 2)
+        );
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+        };
+
+        await CreateSut().ExecuteAsync(request, session);
+
+        var commandText = session.Commands[0].CommandText;
+        commandText
+            .IndexOf("SchoolWithATag", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(commandText.IndexOf("namespacePrefixes", StringComparison.Ordinal))
+            .And.BePositive();
+    }
+
+    [Test]
+    public async Task It_emits_a_custom_view_configured_after_NamespaceBased_behind_it()
+    {
+        // The namespace planner stamps its check with configured index 0, so a view at index 1 runs after it.
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            DeleteReader(rootDeleteOrdinal: 3, deleted: true, namespaceCheckCount: 2)
+        );
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 1)),
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+        };
+
+        await CreateSut().ExecuteAsync(request, session);
+
+        var commandText = session.Commands[0].CommandText;
+        commandText
+            .IndexOf("namespacePrefixes", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(commandText.IndexOf("SchoolWithATag", StringComparison.Ordinal))
+            .And.BePositive();
+    }
+
+    [Test]
+    public async Task It_resolves_a_straddling_split_payload_against_the_full_planned_check_list()
+    {
+        // Two views surround the namespace check, so the later view lands in the second run. Its payload
+        // index is non-zero, and the mapper must resolve it against the request's whole planned list rather
+        // than against the run that raised it — otherwise the denial would report the earlier view.
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+                ("SchoolWithAnEarlyTag", 0),
+                ("SchoolWithALateTag", 2)
+            ),
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+        };
+
+        var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", EncodeCustomViewPayload(1)))
+            .ExecuteAsync(request, session);
+
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>().Subject;
+        failure.CustomViewFailure.StrategyName.Should().Be("SchoolWithALateTag");
+        failure.CustomViewFailure.ReadableSecurableElements.Should().Equal("SchoolWithALateTagElement");
+        failure.CustomViewFailure.Hint.Should().Be("You may need a SchoolWithALateTag hint.");
+        failure.CustomViewFailure.EmittedAuth1Index.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_straddles_the_namespace_check_with_both_custom_view_runs_in_configured_order()
+    {
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            DeleteReader(rootDeleteOrdinal: 4, deleted: true, namespaceCheckCount: 3)
+        );
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+                ("SchoolWithAnEarlyTag", 0),
+                ("SchoolWithALateTag", 2)
+            ),
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+        };
+
+        await CreateSut().ExecuteAsync(request, session);
+
+        var commandText = session.Commands[0].CommandText;
+        var earlyPosition = commandText.IndexOf("SchoolWithAnEarlyTag", StringComparison.Ordinal);
+        var namespacePosition = commandText.IndexOf("namespacePrefixes", StringComparison.Ordinal);
+        var latePosition = commandText.IndexOf("SchoolWithALateTag", StringComparison.Ordinal);
+
+        earlyPosition.Should().BePositive();
+        earlyPosition.Should().BeLessThan(namespacePosition);
+        namespacePosition.Should().BeLessThan(latePosition);
+        // Each run keeps its request-wide indexes, so the two runs' payloads stay distinguishable.
+        commandText.Should().Contain("cv1|0|n").And.Contain("cv1|1|n");
+    }
+
+    [Test]
+    public async Task It_runs_a_custom_view_configured_after_a_segmented_namespace_check_as_its_own_segment()
+    {
+        // The regression this pins: when the namespace check cannot fit the opening command it runs as a
+        // later segment, so the custom views configured after it cannot ride the opening command either. If
+        // they were simply dropped, the row would be deleted without a configured view ever being enforced.
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            CaptureOnlyReader(captured: true),
+            NamespaceCheckReader(checkCount: 1),
+            NamespaceCheckReader(checkCount: 1),
+            SegmentDeleteReader(deleted: true)
+        );
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
+        };
+
+        // A budget the capture's own two parameters consume, so the namespace statement cannot join it.
+        var result = await CreateSut(commandBudget: new RelationalCommandBudget(2, 1000))
+            .ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        session.Commands.Should().HaveCount(4);
+        session.Commands[0].CommandText.Should().NotContain("SchoolWithALateTag").And.NotContain("DELETE FROM");
+        session.Commands[1].CommandText.Should().Contain("namespacePrefixes");
+        session.Commands[2].CommandText.Should().Contain("SchoolWithALateTag");
+        session.Commands[3].CommandText.Should().Contain("DELETE FROM");
+    }
+
+    [Test]
+    public async Task It_denies_from_a_segmented_custom_view_run_before_deleting()
+    {
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            CaptureOnlyReader(captured: true),
+            NamespaceCheckReader(checkCount: 1),
+            new FakeDbException("AUTH1", "AUTH1")
+        );
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
+        };
+
+        var result = await CreateSut(
+                new StubProviderFailureExtractor("AUTH1", EncodeCustomViewPayload(0)),
+                commandBudget: new RelationalCommandBudget(2, 1000)
+            )
+            .ExecuteAsync(request, session);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.StrategyName.Should()
+            .Be("SchoolWithALateTag");
+        session.Commands.Should().HaveCount(3);
+        session.Commands.Should().AllSatisfy(command => command.CommandText.Should().NotContain("DELETE FROM"));
+    }
+
+    [Test]
+    public async Task It_attributes_a_non_auth1_failure_in_a_custom_view_statement_to_the_configured_view()
+    {
+        // A dropped or revoked auth.{StrategyName} raises no AUTH1 payload. auth.md requires that to surface
+        // as the urn:ed-fi:api:system 500, which the middleware derives from this exception, rather than as a
+        // generic delete failure.
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("relation does not exist", "42P01"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+
+        var act = async () =>
+            await CreateSut(new StubProviderFailureExtractor("42P01", "relation does not exist"))
+                .ExecuteAsync(request, session);
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+    }
+
     [Test]
     public async Task It_maps_a_namespace_auth1_failure_to_the_namespace_denial()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
@@ -223,7 +223,7 @@ public class Given_The_Composite_Relational_Delete_Command
         );
         var request = CreateRequest(dialect) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
 
         var result = await CreateSut().ExecuteAsync(request, session);
@@ -246,7 +246,7 @@ public class Given_The_Composite_Relational_Delete_Command
         var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
 
         var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", EncodeCustomViewPayload(0)))
@@ -265,7 +265,7 @@ public class Given_The_Composite_Relational_Delete_Command
         var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
         var payload = EncodeCustomViewPayload(0, CustomViewAuthorizationAuth1FailureKind.StoredTargetMissing);
 
@@ -282,7 +282,7 @@ public class Given_The_Composite_Relational_Delete_Command
         var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
 
         var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", EncodeCustomViewPayload(4)))
@@ -300,7 +300,7 @@ public class Given_The_Composite_Relational_Delete_Command
         );
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
         };
 
@@ -324,7 +324,7 @@ public class Given_The_Composite_Relational_Delete_Command
         );
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 1)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 1)),
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
         };
 
@@ -347,7 +347,7 @@ public class Given_The_Composite_Relational_Delete_Command
         var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(
                 ("SchoolWithAnEarlyTag", 0),
                 ("SchoolWithALateTag", 2)
             ),
@@ -373,7 +373,7 @@ public class Given_The_Composite_Relational_Delete_Command
         );
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(
                 ("SchoolWithAnEarlyTag", 0),
                 ("SchoolWithALateTag", 2)
             ),
@@ -410,7 +410,7 @@ public class Given_The_Composite_Relational_Delete_Command
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
         };
 
         // A budget the capture's own two parameters consume, so the namespace statement cannot join it.
@@ -419,7 +419,11 @@ public class Given_The_Composite_Relational_Delete_Command
 
         result.Should().BeOfType<DeleteResult.DeleteSuccess>();
         session.Commands.Should().HaveCount(4);
-        session.Commands[0].CommandText.Should().NotContain("SchoolWithALateTag").And.NotContain("DELETE FROM");
+        session
+            .Commands[0]
+            .CommandText.Should()
+            .NotContain("SchoolWithALateTag")
+            .And.NotContain("DELETE FROM");
         session.Commands[1].CommandText.Should().Contain("namespacePrefixes");
         session.Commands[2].CommandText.Should().Contain("SchoolWithALateTag");
         session.Commands[3].CommandText.Should().Contain("DELETE FROM");
@@ -437,7 +441,7 @@ public class Given_The_Composite_Relational_Delete_Command
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
         };
 
         var result = await CreateSut(
@@ -452,7 +456,9 @@ public class Given_The_Composite_Relational_Delete_Command
             .Subject.CustomViewFailure.StrategyName.Should()
             .Be("SchoolWithALateTag");
         session.Commands.Should().HaveCount(3);
-        session.Commands.Should().AllSatisfy(command => command.CommandText.Should().NotContain("DELETE FROM"));
+        session
+            .Commands.Should()
+            .AllSatisfy(command => command.CommandText.Should().NotContain("DELETE FROM"));
     }
 
     [Test]
@@ -461,10 +467,13 @@ public class Given_The_Composite_Relational_Delete_Command
         // A dropped or revoked auth.{StrategyName} raises no AUTH1 payload. auth.md requires that to surface
         // as the urn:ed-fi:api:system 500, which the middleware derives from this exception, rather than as a
         // generic delete failure.
-        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("relation does not exist", "42P01"));
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            new FakeDbException("relation does not exist", "42P01")
+        );
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
 
         var act = async () =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
@@ -763,6 +763,44 @@ public class Given_The_Composite_Relational_Write_First_Phase
     }
 
     [Test]
+    public async Task It_denies_from_a_segmented_after_namespace_custom_view_run_with_a_request_wide_index()
+    {
+        // The after-namespace run is its own segment carrying a non-zero request-wide index. The namespace
+        // segment has already passed, so the reported denial must be the later view's, resolved against the
+        // full planned list, and nothing downstream may run.
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+                ("SchoolWithAnEarlyTag", 0),
+                ("SchoolWithALateTag", 2)
+            ),
+            StoredRelationshipAuthorization = new RelationshipAuthorizationResult.NoClaims([], []),
+        };
+        var session = new ScriptedWriteSession(
+            CreateCaptureReader(new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value)),
+            CreateReader(CreateAuthorizationTable()),
+            CreateReader(CreateAuthorizationTable()),
+            new FakeDbException("late custom view denial")
+        );
+
+        var resolution = await CreateSut(providerFailureExtractor: CustomViewFailureExtractor(1))
+            .ResolveAsync(input, session);
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.StrategyName.Should()
+            .Be("SchoolWithALateTag");
+        // Capture, the early view, the namespace segment, then the denying late view — and nothing after it,
+        // so the deferred relationship denial, reference lookup, and hydration never ran.
+        session.Commands.Should().HaveCount(4);
+        session.Commands[3].CommandText.Should().Contain("SchoolWithALateTag");
+    }
+
+    [Test]
     public async Task It_denies_from_a_segmented_custom_view_run_before_the_namespace_segment_runs()
     {
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
@@ -569,6 +569,280 @@ public class Given_The_Composite_Relational_Write_First_Phase
         );
     }
 
+    [Test]
+    public async Task It_emits_the_stored_custom_view_checks_in_the_opening_command()
+    {
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        var session = new ScriptedWriteSession(
+            CreateReader(
+                CreateCaptureTable(new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value)),
+                CreateAuthorizationTable()
+            )
+        );
+
+        await CreateSut().ResolveAsync(input, session);
+
+        session.Commands.Should().ContainSingle();
+        session.Commands[0].CommandText.Should().Contain("SchoolWithATag");
+    }
+
+    [Test]
+    public async Task It_maps_a_stored_custom_view_auth1_denial_to_the_custom_view_failure()
+    {
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        // One composite command carries capture and checks, so the abort is that command's failure.
+        var session = new ScriptedWriteSession(new FakeDbException("custom view denial"));
+
+        var resolution = await CreateSut(providerFailureExtractor: CustomViewFailureExtractor(0))
+            .ResolveAsync(input, session);
+
+        var failure = resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Subject;
+        failure.CustomViewFailure.StrategyName.Should().Be("SchoolWithATag");
+        failure.CustomViewFailure.Hint.Should().Be("You may need a SchoolWithATag hint.");
+    }
+
+    [Test]
+    public async Task It_maps_a_stored_custom_view_denial_on_a_post_to_the_upsert_failure()
+    {
+        var input = CreateInput(RelationalWriteOperationKind.Post, includeReadPlan: false) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        // One composite command carries capture and checks, so the abort is that command's failure.
+        var session = new ScriptedWriteSession(new FakeDbException("custom view denial"));
+
+        var resolution = await CreateSut(providerFailureExtractor: CustomViewFailureExtractor(0))
+            .ResolveAsync(input, session);
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>();
+    }
+
+    [Test]
+    public async Task It_maps_an_unmappable_custom_view_payload_to_security_configuration_failure()
+    {
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        // One composite command carries capture and checks, so the abort is that command's failure.
+        var session = new ScriptedWriteSession(new FakeDbException("custom view denial"));
+
+        // Index 4 addresses no planned check, so the payload is a configuration defect, not a denial.
+        var resolution = await CreateSut(providerFailureExtractor: CustomViewFailureExtractor(4))
+            .ResolveAsync(input, session);
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>();
+    }
+
+    [Test]
+    public async Task It_attributes_a_non_auth1_failure_in_a_custom_view_command_to_the_configured_view()
+    {
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        var session = new ScriptedWriteSession(new FakeDbException("relation does not exist"));
+
+        var act = async () =>
+            await CreateSut(providerFailureExtractor: new TestProviderFailureExtractor("42P01", "missing"))
+                .ResolveAsync(input, session);
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+    }
+
+    [Test]
+    public async Task It_emits_the_custom_view_runs_around_the_namespace_check_in_configured_order()
+    {
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+                ("SchoolWithAnEarlyTag", 0),
+                ("SchoolWithALateTag", 2)
+            ),
+        };
+        var session = new ScriptedWriteSession(
+            CreateReader(
+                CreateCaptureTable(new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value)),
+                CreateAuthorizationTable(),
+                CreateAuthorizationTable(),
+                CreateAuthorizationTable()
+            )
+        );
+
+        await CreateSut().ResolveAsync(input, session);
+
+        var commandText = session.Commands[0].CommandText;
+        var earlyPosition = commandText.IndexOf("SchoolWithAnEarlyTag", StringComparison.Ordinal);
+        var namespacePosition = commandText.IndexOf("namespacePrefixes", StringComparison.Ordinal);
+        var latePosition = commandText.IndexOf("SchoolWithALateTag", StringComparison.Ordinal);
+
+        earlyPosition.Should().BePositive();
+        earlyPosition.Should().BeLessThan(namespacePosition);
+        namespacePosition.Should().BeLessThan(latePosition);
+        // Each run keeps its request-wide indexes, so the two runs' payloads stay distinguishable.
+        commandText.Should().Contain("cv1|0|n").And.Contain("cv1|1|n");
+    }
+
+    [Test]
+    public async Task It_resolves_a_straddling_split_payload_against_the_full_planned_check_list()
+    {
+        // The later view lands in the second run and carries a non-zero index. Mapping must use the request's
+        // whole planned list, or the denial would name the earlier view.
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+                ("SchoolWithAnEarlyTag", 0),
+                ("SchoolWithALateTag", 2)
+            ),
+        };
+        // One composite command carries capture and checks, so the abort is that command's failure.
+        var session = new ScriptedWriteSession(new FakeDbException("custom view denial"));
+
+        var resolution = await CreateSut(providerFailureExtractor: CustomViewFailureExtractor(1))
+            .ResolveAsync(input, session);
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.StrategyName.Should()
+            .Be("SchoolWithALateTag");
+    }
+
+    [Test]
+    public async Task It_runs_the_custom_view_runs_around_the_namespace_segment_in_the_ordered_path()
+    {
+        // A deferred no-claims relationship denial sends the request to ordered segments, so every stored
+        // check runs as its own command. Configured order still has to hold: the view configured before
+        // NamespaceBased, then the namespace check, then the view configured after it.
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+                ("SchoolWithAnEarlyTag", 0),
+                ("SchoolWithALateTag", 2)
+            ),
+            StoredRelationshipAuthorization = new RelationshipAuthorizationResult.NoClaims([], []),
+        };
+        var session = new ScriptedWriteSession(
+            CreateCaptureReader(new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value)),
+            CreateReader(CreateAuthorizationTable()),
+            CreateReader(CreateAuthorizationTable()),
+            CreateReader(CreateAuthorizationTable())
+        );
+
+        await CreateSut().ResolveAsync(input, session);
+
+        session.Commands.Should().HaveCount(4);
+        session.Commands[0].CommandText.Should().NotContain("SchoolWith");
+        session.Commands[1].CommandText.Should().Contain("SchoolWithAnEarlyTag");
+        session.Commands[2].CommandText.Should().Contain("namespacePrefixes");
+        session.Commands[3].CommandText.Should().Contain("SchoolWithALateTag");
+    }
+
+    [Test]
+    public async Task It_denies_from_a_segmented_custom_view_run_before_the_namespace_segment_runs()
+    {
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithAnEarlyTag", 0)),
+            StoredRelationshipAuthorization = new RelationshipAuthorizationResult.NoClaims([], []),
+        };
+        var session = new ScriptedWriteSession(
+            CreateCaptureReader(new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value)),
+            new FakeDbException("custom view denial")
+        );
+
+        var resolution = await CreateSut(providerFailureExtractor: CustomViewFailureExtractor(0))
+            .ResolveAsync(input, session);
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.StrategyName.Should()
+            .Be("SchoolWithAnEarlyTag");
+        // The namespace segment never ran: the earlier view's denial is the one reported.
+        session.Commands.Should().HaveCount(2);
+        session
+            .Commands.Should()
+            .AllSatisfy(command => command.CommandText.Should().NotContain("namespacePrefixes"));
+    }
+
+    /// <summary>
+    /// One stored custom-view check per configured strategy, indexed across the request the way the planner
+    /// assigns them. A self-basis path keeps the fixture independent of any reference model.
+    /// </summary>
+    private static RelationalCustomViewAuthorization CreateStoredCustomViewAuthorization(
+        params (string StrategyName, int RawConfiguredIndex)[] strategies
+    ) =>
+        new([
+            .. strategies.Select(
+                (strategy, index) =>
+                    new SingleRecordCustomViewAuthorizationCheckSpec(
+                        new ConfiguredAuthorizationStrategy(
+                            strategy.StrategyName,
+                            strategy.RawConfiguredIndex
+                        ),
+                        index,
+                        CustomViewAuthorizationCheckValueSource.Stored,
+                        new DbTableName(new DbSchemaName("auth"), strategy.StrategyName),
+                        new DbColumnName("DocumentId"),
+                        [
+                            new ColumnPathStep(
+                                new DbTableName(new DbSchemaName("edfi"), "School"),
+                                new DbColumnName("DocumentId"),
+                                null,
+                                null
+                            ),
+                        ],
+                        new CustomViewAuthorizationCheckTarget.Stored(
+                            new DbTableName(new DbSchemaName("edfi"), "School"),
+                            new DbColumnName("DocumentId")
+                        ),
+                        new QualifiedResourceName("Ed-Fi", "School"),
+                        [$"{strategy.StrategyName}Element"],
+                        $"You may need a {strategy.StrategyName} hint."
+                    )
+            ),
+        ]);
+
+    private static TestProviderFailureExtractor CustomViewFailureExtractor(
+        int index,
+        CustomViewAuthorizationAuth1FailureKind failureKind =
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+    ) =>
+        new(
+            CustomViewAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+            CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(
+                new CustomViewAuthorizationAuth1FailurePayload(index, failureKind)
+            )
+        );
+
     private static RelationalWriteNamespaceAuthorization CreateStoredNamespaceAuthorization() =>
         new(
             [

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
@@ -496,12 +496,14 @@ public class Given_The_Composite_Relational_Write_First_Phase
     private static CompositeRelationalWriteFirstPhase CreateSut(
         TestReferenceResolverAdapterFactory? adapterFactory = null,
         IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null,
-        RelationalCommandBudget? commandBudget = null
+        RelationalCommandBudget? commandBudget = null,
+        IRelationalCommandExecutor? customViewValidationCommandExecutor = null
     ) =>
         new(
             adapterFactory ?? new TestReferenceResolverAdapterFactory(),
             relationshipAuthorizationProviderFailureExtractor: providerFailureExtractor,
-            commandBudget: commandBudget
+            commandBudget: commandBudget,
+            customViewValidationCommandExecutor: customViewValidationCommandExecutor
         );
 
     private static RelationalWriteLockedTarget CreateLockProof(
@@ -670,8 +672,45 @@ public class Given_The_Composite_Relational_Write_First_Phase
     }
 
     [Test]
-    public async Task It_emits_the_custom_view_runs_around_the_namespace_check_in_configured_order()
+    public async Task It_validates_a_co_batched_custom_view_before_running_the_opening_command()
     {
+        // The view's statement rides the opening command, so a table masquerading as auth.{StrategyName} would
+        // answer it silently. Its contract is settled before that command is sent, which is also what keeps the
+        // 500 ahead of anything the command decides.
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        var session = new ScriptedWriteSession(
+            CreateReader(
+                CreateCaptureTable(new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value)),
+                CreateAuthorizationTable()
+            )
+        );
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("invalid custom authorization view DocumentId contract")
+        );
+
+        var act = async () =>
+            await CreateSut(customViewValidationCommandExecutor: validationExecutor)
+                .ResolveAsync(input, session);
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithATag");
+        session.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_declines_the_single_composite_plan_for_a_custom_view_run_after_the_namespace_check()
+    {
+        // Nothing else here forces ordered segments: the run configured after NamespaceBased does, because its
+        // view may be validated only once that check has passed, which one command cannot express. Co-batched
+        // behind the namespace statement, a table masquerading as the view would answer the membership SQL and
+        // the request would proceed on it.
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
@@ -681,54 +720,19 @@ public class Given_The_Composite_Relational_Write_First_Phase
             ),
         };
         var session = new ScriptedWriteSession(
-            CreateReader(
-                CreateCaptureTable(new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value)),
-                CreateAuthorizationTable(),
-                CreateAuthorizationTable(),
-                CreateAuthorizationTable()
-            )
+            CreateCaptureReader(new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value)),
+            CreateReader(CreateAuthorizationTable()),
+            CreateReader(CreateAuthorizationTable()),
+            CreateReader(CreateAuthorizationTable())
         );
 
         await CreateSut().ResolveAsync(input, session);
 
-        var commandText = session.Commands[0].CommandText;
-        var earlyPosition = commandText.IndexOf("SchoolWithAnEarlyTag", StringComparison.Ordinal);
-        var namespacePosition = commandText.IndexOf("namespacePrefixes", StringComparison.Ordinal);
-        var latePosition = commandText.IndexOf("SchoolWithALateTag", StringComparison.Ordinal);
-
-        earlyPosition.Should().BePositive();
-        earlyPosition.Should().BeLessThan(namespacePosition);
-        namespacePosition.Should().BeLessThan(latePosition);
-        // Each run keeps its request-wide indexes, so the two runs' payloads stay distinguishable.
-        commandText.Should().Contain("cv1|0|n").And.Contain("cv1|1|n");
-    }
-
-    [Test]
-    public async Task It_resolves_a_straddling_split_payload_against_the_full_planned_check_list()
-    {
-        // The later view lands in the second run and carries a non-zero index. Mapping must use the request's
-        // whole planned list, or the denial would name the earlier view.
-        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
-        {
-            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
-            CustomViewAuthorization = CreateStoredCustomViewAuthorization(
-                ("SchoolWithAnEarlyTag", 0),
-                ("SchoolWithALateTag", 2)
-            ),
-        };
-        // One composite command carries capture and checks, so the abort is that command's failure.
-        var session = new ScriptedWriteSession(new FakeDbException("custom view denial"));
-
-        var resolution = await CreateSut(providerFailureExtractor: CustomViewFailureExtractor(1))
-            .ResolveAsync(input, session);
-
-        resolution
-            .ImmediateResult.Should()
-            .BeOfType<RelationalWriteExecutorResult.Update>()
-            .Which.Result.Should()
-            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
-            .Subject.CustomViewFailure.StrategyName.Should()
-            .Be("SchoolWithALateTag");
+        session.Commands.Should().HaveCount(4);
+        session.Commands[0].CommandText.Should().NotContain("SchoolWith");
+        session.Commands[1].CommandText.Should().Contain("SchoolWithAnEarlyTag");
+        session.Commands[2].CommandText.Should().Contain("namespacePrefixes");
+        session.Commands[3].CommandText.Should().Contain("SchoolWithALateTag");
     }
 
     [Test]
@@ -1047,6 +1051,31 @@ public class Given_The_Composite_Relational_Write_First_Phase
 
                 return Task.FromResult<IReadOnlyList<ReferenceLookupResult>>([]);
             }
+        }
+    }
+
+    /// <summary>
+    /// Stands in for the fresh-connection executor the custom-view validation probe uses, recording what it was
+    /// asked to run and optionally failing the way an object that is not a conforming view would.
+    /// </summary>
+    private sealed class StubValidationCommandExecutor(DbException? failure = null)
+        : IRelationalCommandExecutor
+    {
+        public SqlDialect Dialect => SqlDialect.Pgsql;
+
+        public List<RelationalCommand> ExecutedCommands { get; } = [];
+
+        public Task<TResult> ExecuteReaderAsync<TResult>(
+            RelationalCommand command,
+            Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ExecutedCommands.Add(command);
+
+            return failure is null
+                ? Task.FromResult(default(TResult)!)
+                : Task.FromException<TResult>(failure);
         }
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
@@ -574,7 +574,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
     {
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
         var session = new ScriptedWriteSession(
             CreateReader(
@@ -594,7 +594,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
     {
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
         // One composite command carries capture and checks, so the abort is that command's failure.
         var session = new ScriptedWriteSession(new FakeDbException("custom view denial"));
@@ -617,7 +617,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
     {
         var input = CreateInput(RelationalWriteOperationKind.Post, includeReadPlan: false) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
         // One composite command carries capture and checks, so the abort is that command's failure.
         var session = new ScriptedWriteSession(new FakeDbException("custom view denial"));
@@ -637,7 +637,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
     {
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
         // One composite command carries capture and checks, so the abort is that command's failure.
         var session = new ScriptedWriteSession(new FakeDbException("custom view denial"));
@@ -658,7 +658,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
     {
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
         };
         var session = new ScriptedWriteSession(new FakeDbException("relation does not exist"));
 
@@ -675,7 +675,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(
                 ("SchoolWithAnEarlyTag", 0),
                 ("SchoolWithALateTag", 2)
             ),
@@ -711,7 +711,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(
                 ("SchoolWithAnEarlyTag", 0),
                 ("SchoolWithALateTag", 2)
             ),
@@ -740,7 +740,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(
                 ("SchoolWithAnEarlyTag", 0),
                 ("SchoolWithALateTag", 2)
             ),
@@ -771,7 +771,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(
                 ("SchoolWithAnEarlyTag", 0),
                 ("SchoolWithALateTag", 2)
             ),
@@ -806,7 +806,7 @@ public class Given_The_Composite_Relational_Write_First_Phase
         var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
         {
             StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
-            StoredCustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithAnEarlyTag", 0)),
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithAnEarlyTag", 0)),
             StoredRelationshipAuthorization = new RelationshipAuthorizationResult.NoClaims([], []),
         };
         var session = new ScriptedWriteSession(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Unit.Composite;
+using EdFi.DataManagementService.Backend.Tests.Unit.TestSupport;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using FluentAssertions;
@@ -497,13 +498,15 @@ public class Given_The_Composite_Relational_Write_First_Phase
         TestReferenceResolverAdapterFactory? adapterFactory = null,
         IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null,
         RelationalCommandBudget? commandBudget = null,
-        IRelationalCommandExecutor? customViewValidationCommandExecutor = null
+        IRelationalCommandExecutor? customViewValidationCommandExecutor = null,
+        IRelationalWriteExceptionClassifier? writeExceptionClassifier = null
     ) =>
         new(
             adapterFactory ?? new TestReferenceResolverAdapterFactory(),
             relationshipAuthorizationProviderFailureExtractor: providerFailureExtractor,
             commandBudget: commandBudget,
-            customViewValidationCommandExecutor: customViewValidationCommandExecutor
+            customViewValidationCommandExecutor: customViewValidationCommandExecutor,
+            writeExceptionClassifier: writeExceptionClassifier
         );
 
     private static RelationalWriteLockedTarget CreateLockProof(
@@ -669,6 +672,35 @@ public class Given_The_Composite_Relational_Write_First_Phase
                 .ResolveAsync(input, session);
 
         await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+    }
+
+    [Test]
+    public async Task It_maps_a_transient_failure_in_a_custom_view_command_to_a_write_conflict()
+    {
+        // A deadlock at reader-open carries no AUTH1 payload either, but it proves nothing about the
+        // configured view: it must keep the retryable 409 write-conflict classification instead of being
+        // relabelled as a custom-view validation 500.
+        var input = CreateInput(RelationalWriteOperationKind.Put, includeReadPlan: false) with
+        {
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithATag", 0)),
+        };
+        var session = new ScriptedWriteSession(new FakeDbException("deadlock detected"));
+        var classifier = new ConfigurableRelationalWriteExceptionClassifier
+        {
+            IsTransientFailureToReturn = true,
+        };
+
+        var resolution = await CreateSut(
+                providerFailureExtractor: new TestProviderFailureExtractor("40P01", "deadlock detected"),
+                writeExceptionClassifier: classifier
+            )
+            .ResolveAsync(input, session);
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureWriteConflict>();
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Data.Common;
 using System.Linq;
 using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.Composite;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
@@ -415,6 +416,193 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
         session.Commands.Should().BeEmpty();
     }
 
+    [Test]
+    public async Task It_reports_an_invalid_view_behind_a_failure_that_carries_no_authorization_payload()
+    {
+        // The command aborted with something that is not an AUTH1 payload. Position cannot say whether the
+        // custom-view statement caused it, so the emitted views are probed instead; this one is broken, so the
+        // documented configuration 500 is what the caller must see.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(new FakeDbException("relation does not exist", "42P01"));
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("missing authorization view", "42P01")
+        );
+
+        var act = async () =>
+            await CreateSut(
+                    new StubProviderFailureExtractor("42P01", "relation does not exist"),
+                    validationExecutor
+                )
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        validationExecutor.ExecutedCommands.Should().ContainSingle();
+        validationExecutor.ExecutedCommands[0].CommandText.Should().Contain("SchoolWithATag");
+    }
+
+    [Test]
+    public async Task It_probes_only_the_views_the_failing_command_actually_emitted()
+    {
+        // The self-basis view is configured after the early one and carries no statement, so this command
+        // never touched it. Probing it anyway could blame an unrelated view for the failure.
+        var request = CreateRequest(
+            CreateSelfBasisPlan(("SchoolWithASelfTag", 2), ("SchoolWithAnEarlyTag", 0)),
+            resolveToCreate: true
+        );
+        var session = new ScriptedWriteSession(new FakeDbException("relation does not exist", "42P01"));
+        var validationExecutor = new StubValidationCommandExecutor();
+
+        var act = async () =>
+            await CreateSut(
+                    new StubProviderFailureExtractor("42P01", "relation does not exist"),
+                    validationExecutor
+                )
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        await act.Should().ThrowAsync<DbException>();
+        var probed = validationExecutor.ExecutedCommands.Should().ContainSingle().Subject.CommandText;
+        probed.Should().Contain("SchoolWithAnEarlyTag").And.NotContain("SchoolWithASelfTag");
+    }
+
+    [Test]
+    public async Task It_leaves_a_non_authorization_failure_alone_when_the_emitted_views_are_valid()
+    {
+        // A constraint violation must not be relabelled as a security configuration error just because a
+        // custom-view statement shared the command.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var originalFailure = new FakeDbException("duplicate key value", "23505");
+        var session = new ScriptedWriteSession(originalFailure);
+        var validationExecutor = new StubValidationCommandExecutor();
+
+        var act = async () =>
+            await CreateSut(
+                    new StubProviderFailureExtractor("23505", "duplicate key value"),
+                    validationExecutor
+                )
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        (await act.Should().ThrowAsync<DbException>()).Which.Should().BeSameAs(originalFailure);
+        validationExecutor.ExecutedCommands.Should().ContainSingle();
+    }
+
+    [Test]
+    public async Task It_does_not_probe_the_views_for_a_recognized_custom_view_denial()
+    {
+        // A cv1 payload already names the failing check, so probing would be a wasted round trip.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+        var validationExecutor = new StubValidationCommandExecutor();
+
+        await CreateSut(CustomViewFailureExtractor(0), validationExecutor)
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        validationExecutor.ExecutedCommands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_does_not_probe_the_views_for_another_families_authorization_payload()
+    {
+        // A namespace denial shares the command with a custom-view statement. It is a recognized authorization
+        // answer, so it belongs to the namespace mapper: probing the views here would be a wasted round trip,
+        // and a view that happened to be broken would replace the denial the caller must see with a 500.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)), withNamespace: true);
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("missing authorization view", "42P01")
+        );
+
+        var resolution = await CreateSut(NamespaceFailureExtractor(), validationExecutor)
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>();
+        validationExecutor.ExecutedCommands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_emits_the_proposed_custom_view_check_before_the_document_and_resource_dml()
+    {
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(CreateDmlReader(Authorized(), Sentinel(1), Scalar(77L)));
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateChangedMergeResult(request),
+                RelationalWriteSecondCommandMode.Dml,
+                session
+            );
+
+        resolution.ImmediateResult.Should().BeNull();
+        var commandText = session.Commands.Should().ContainSingle().Subject.CommandText;
+        var checkPosition = commandText.IndexOf("SchoolWithATag", StringComparison.Ordinal);
+        var updatePosition = commandText.IndexOf(
+            "update edfi.\"School\"",
+            StringComparison.OrdinalIgnoreCase
+        );
+
+        checkPosition.Should().BePositive();
+        updatePosition.Should().BePositive();
+        checkPosition.Should().BeLessThan(updatePosition);
+    }
+
+    [Test]
+    public async Task It_issues_no_dml_when_a_custom_view_run_placed_in_an_earlier_command_denies()
+    {
+        // A budget of three fits the root row's own parameters but not the check alongside them, so the check
+        // becomes its own earlier command. Its denial has to stop the write before any row is touched.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+
+        var resolution = await CreateSut(
+                CustomViewFailureExtractor(0),
+                commandBudget: new RelationalCommandBudget(3, 1000)
+            )
+            .ResolveAsync(
+                request,
+                CreateChangedMergeResult(request),
+                RelationalWriteSecondCommandMode.Dml,
+                session
+            );
+
+        FailureOf(resolution).StrategyName.Should().Be("SchoolWithATag");
+        resolution.PersistResult.Should().BeNull();
+        session.Commands.Should().ContainSingle();
+        session
+            .Commands[0]
+            .CommandText.Should()
+            .NotContainEquivalentOf("update edfi.\"School\"")
+            .And.NotContainEquivalentOf("insert into edfi.\"School\"");
+    }
+
     private static CustomViewAuthorizationFailure FailureOf(
         RelationalWriteSecondCommandResolution resolution
     ) =>
@@ -540,8 +728,16 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
         ]);
 
     private static CompositeRelationalWriteSecondCommand CreateSut(
-        IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
-    ) => new(relationalParameterConfigurator: null, providerFailureExtractor);
+        IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null,
+        IRelationalCommandExecutor? customViewValidationCommandExecutor = null,
+        RelationalCommandBudget? commandBudget = null
+    ) =>
+        new(
+            relationalParameterConfigurator: null,
+            providerFailureExtractor,
+            commandBudget: commandBudget,
+            customViewValidationCommandExecutor: customViewValidationCommandExecutor
+        );
 
     private static StubProviderFailureExtractor CustomViewFailureExtractor(
         int index,
@@ -552,6 +748,17 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
             CustomViewAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
             CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(
                 new CustomViewAuthorizationAuth1FailurePayload(index, failureKind)
+            )
+        );
+
+    private static StubProviderFailureExtractor NamespaceFailureExtractor() =>
+        new(
+            NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+            NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+                new NamespaceAuthorizationAuth1FailurePayload(
+                    0,
+                    NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing
+                )
             )
         );
 
@@ -633,6 +840,64 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
         );
 
     private static FakeDbException CreateAuth1Failure() => new("custom view denial", "P0001");
+
+    /// <summary>A root row whose merged Name differs from the stored one, so DML mode has a row to write.</summary>
+    private static RelationalWriteMergeResult CreateChangedMergeResult(
+        RelationalWriteExecutorRequest request
+    ) =>
+        Given_Default_Relational_Write_Executor.CreateMergeResult(
+            request.WritePlan.TablePlansInDependencyOrder[0],
+            currentSchoolId: 255901,
+            mergedSchoolId: 255901,
+            currentName: "uri://ed-fi.org/Survey",
+            mergedName: "uri://ed-fi.org/Renamed"
+        );
+
+    private static DbDataReader CreateDmlReader(params IReadOnlyList<object?[]>[] resultSets) =>
+        new ScriptedDbDataReader(
+            resultSets,
+            [.. resultSets.Select(static _ => new[] { "AuthorizationResult" })]
+        );
+
+    private static IReadOnlyList<object?[]> Authorized() =>
+        [
+            [1],
+        ];
+
+    private static IReadOnlyList<object?[]> Sentinel(int ordinal) =>
+        [
+            [ordinal],
+        ];
+
+    private static IReadOnlyList<object?[]> Scalar(object? value) =>
+        [
+            [value],
+        ];
+
+    /// <summary>
+    /// Stands in for the fresh-connection executor the validation probe uses, recording what it was asked to
+    /// run and optionally failing the way a missing view would.
+    /// </summary>
+    private sealed class StubValidationCommandExecutor(DbException? failure = null)
+        : IRelationalCommandExecutor
+    {
+        public SqlDialect Dialect => SqlDialect.Pgsql;
+
+        public List<RelationalCommand> ExecutedCommands { get; } = [];
+
+        public Task<TResult> ExecuteReaderAsync<TResult>(
+            RelationalCommand command,
+            Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ExecutedCommands.Add(command);
+
+            return failure is null
+                ? Task.FromResult(default(TResult)!)
+                : Task.FromException<TResult>(failure);
+        }
+    }
 
     private static DbDataReader CreateReader(params DataTable[] tables) => new DataTableReader(tables);
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
@@ -648,12 +648,71 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
     }
 
     [Test]
-    public async Task It_does_not_probe_the_views_for_another_families_authorization_payload()
+    public async Task It_reports_an_invalid_view_configured_before_the_namespace_check_that_denied()
     {
-        // A namespace denial shares the command with a custom-view statement. It is a recognized authorization
-        // answer, so it belongs to the namespace mapper: probing the views here would be a wasted round trip,
-        // and a view that happened to be broken would replace the denial the caller must see with a 500.
-        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)), withNamespace: true);
+        // The namespace denial is a recognized answer from another family, but the view configured before it
+        // already ran: a table masquerading as auth.{StrategyName} satisfies the membership SQL and lets the
+        // batch reach the namespace statement. Its urn:ed-fi:api:system 500 is owed from the earlier
+        // configured position, so the namespace 403 cannot be the caller's answer.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithAnEarlyTag", 0)), withNamespace: true);
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("missing authorization view", "42P01")
+        );
+
+        var act = async () =>
+            await CreateSut(NamespaceFailureExtractor(), validationExecutor)
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithAnEarlyTag");
+    }
+
+    [Test]
+    public async Task It_still_reports_the_namespace_denial_when_the_view_configured_before_it_conforms()
+    {
+        // The probe that precedes the namespace answer only reclassifies a broken object. A conforming view
+        // leaves the namespace payload's own denial intact.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithAnEarlyTag", 0)), withNamespace: true);
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+        var validationExecutor = new StubValidationCommandExecutor();
+
+        var resolution = await CreateSut(NamespaceFailureExtractor(), validationExecutor)
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>();
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithAnEarlyTag");
+    }
+
+    [Test]
+    public async Task It_does_not_probe_a_view_configured_after_the_namespace_check_that_denied()
+    {
+        // The command aborts at its first AUTH1, so a run emitted behind the namespace statement never
+        // executed. Probing that view would report its contract failure ahead of the namespace answer
+        // configured before it.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithALateTag", 2)), withNamespace: true);
         var session = new ScriptedWriteSession(CreateAuth1Failure());
         var validationExecutor = new StubValidationCommandExecutor(
             new FakeDbException("missing authorization view", "42P01")
@@ -673,6 +732,59 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
             .Which.Result.Should()
             .BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>();
         validationExecutor.ExecutedCommands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_reports_an_invalid_emitted_view_before_the_relationship_check_that_denied()
+    {
+        // The relationship statement is emitted last, so every view the command carried ran ahead of it. A
+        // broken object among them owes its 500 before this denial, exactly as it does before a namespace one.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)), withRelationship: true);
+        var session = new ScriptedWriteSession(new FakeDbException("AUTH1", "AUTH1"));
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("missing authorization view", "42P01")
+        );
+
+        var act = async () =>
+            await CreateSut(RelationshipFailureExtractor(), validationExecutor)
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithATag");
+    }
+
+    [Test]
+    public async Task It_still_reports_the_relationship_denial_when_the_emitted_view_conforms()
+    {
+        // The mirror: a conforming view leaves the relationship payload's own denial intact.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)), withRelationship: true);
+        var session = new ScriptedWriteSession(new FakeDbException("AUTH1", "AUTH1"));
+        var validationExecutor = new StubValidationCommandExecutor();
+
+        var act = async () =>
+            await CreateSut(RelationshipFailureExtractor(), validationExecutor)
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        await act.Should().ThrowAsync<RelationalWriteRelationshipAuthorizationNotAuthorizedException>();
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithATag");
     }
 
     [Test]
@@ -993,12 +1105,32 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
             )
         );
 
+    private static StubProviderFailureExtractor RelationshipFailureExtractor() =>
+        new(
+            "AUTH1",
+            RelationshipAuthorizationAuth1FailurePayloadCodec.Encode(
+                new RelationshipAuthorizationAuth1FailurePayload(
+                    RelationalWriteExecutorResults.GetRelationshipAuthorizationAuth1Index(
+                        RelationalWriteOperationKind.Put
+                    ),
+                    [
+                        new RelationshipAuthorizationAuth1SubjectFailure(
+                            0,
+                            0,
+                            RelationshipAuthorizationAuth1SubjectFailureKind.NoRelationship
+                        ),
+                    ]
+                )
+            )
+        );
+
     private static RelationalWriteExecutorRequest CreateRequest(
         RelationalCustomViewAuthorization customViewAuthorization,
         bool withNamespace = false,
         bool resolveToCreate = false,
         DbColumnName? basisColumn = null,
-        DbColumnName? namespaceColumn = null
+        DbColumnName? namespaceColumn = null,
+        bool withRelationship = false
     )
     {
         var rootPlan = Given_Default_Relational_Write_Executor.CreateRootPlan();
@@ -1052,6 +1184,18 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
                         "namespacePrefixes"
                     )
                 ),
+            };
+        }
+
+        if (withRelationship)
+        {
+            input = input with
+            {
+                ProposedRelationshipAuthorization =
+                    Given_Default_Relational_Write_Executor.CreateProposedSchoolIdRelationshipAuthorization(
+                        input,
+                        null
+                    ),
             };
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
@@ -1,0 +1,663 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Unit.Composite;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// Owns the proposed custom view-based checks the second command issues: which runs it emits, the order it
+/// emits them in relative to <c>NamespaceBased</c>, how a <c>cv1</c> payload maps back to a caller-visible
+/// denial, and how a self-basis check is settled without SQL.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authorization
+{
+    private static readonly DocumentUuid ExistingDocumentUuid = new(
+        Guid.Parse("cccccccc-1111-2222-3333-dddddddddddd")
+    );
+    private static readonly DbTableName RootTable = new(new DbSchemaName("edfi"), "School");
+    private static readonly DbColumnName BasisColumn = new("SchoolId");
+    private static readonly DocumentUuid CreatedDocumentUuid = new(
+        Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb")
+    );
+
+    [Test]
+    public async Task It_emits_one_run_carrying_the_planner_assigned_index()
+    {
+        // The proposed slice follows the stored one, so its first index is 1 rather than 0. That index is what
+        // the payload carries, so it has to survive into the emitted SQL.
+        var request = CreateRequest(CreateStoredAndProposedPlan("SchoolWithATag", storedIndex: 0));
+        var session = new ScriptedWriteSession(CreateReader(CreateAuthorizedTable()));
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution.ImmediateResult.Should().BeNull();
+        session.Commands.Should().ContainSingle();
+        session.Commands[0].CommandText.Should().Contain("cv1|1|").And.Contain("SchoolWithATag");
+    }
+
+    [Test]
+    public async Task It_binds_the_proposed_basis_value_from_the_finalized_root_row()
+    {
+        var request = CreateRequest(CreateStoredAndProposedPlan("SchoolWithATag", storedIndex: 0));
+        var session = new ScriptedWriteSession(CreateReader(CreateAuthorizedTable()));
+
+        await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        // 255901 is the merged SchoolId, not the stored target's DocumentId: a proposed check authorizes the
+        // value that will be persisted.
+        session.Commands[0].Parameters.Should().Contain(parameter => Equals(parameter.Value, 255901));
+    }
+
+    [Test]
+    public async Task It_emits_no_stored_document_id_parameter_for_a_proposed_only_run()
+    {
+        var request = CreateRequest(CreateStoredAndProposedPlan("SchoolWithATag", storedIndex: 0));
+        var session = new ScriptedWriteSession(CreateReader(CreateAuthorizedTable()));
+
+        await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        session
+            .Commands[0]
+            .Parameters.Should()
+            .NotContain(parameter =>
+                parameter.Name.Contains("documentId", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    [Test]
+    public async Task It_emits_the_custom_view_runs_around_the_namespace_check_in_configured_order()
+    {
+        var request = CreateRequest(
+            CreateProposedOnlyPlan(("SchoolWithAnEarlyTag", 0), ("SchoolWithALateTag", 2)),
+            withNamespace: true
+        );
+        var session = new ScriptedWriteSession(
+            CreateReader(CreateAuthorizedTable(), CreateAuthorizedTable(), CreateAuthorizedTable())
+        );
+
+        await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        var commandText = session.Commands.Should().ContainSingle().Subject.CommandText;
+        var earlyPosition = commandText.IndexOf("SchoolWithAnEarlyTag", StringComparison.Ordinal);
+        var namespacePosition = commandText.IndexOf("namespacePrefixes", StringComparison.Ordinal);
+        var latePosition = commandText.IndexOf("SchoolWithALateTag", StringComparison.Ordinal);
+
+        earlyPosition.Should().BePositive();
+        earlyPosition.Should().BeLessThan(namespacePosition);
+        namespacePosition.Should().BeLessThan(latePosition);
+    }
+
+    [Test]
+    public async Task It_resolves_a_straddling_run_payload_against_the_full_planned_check_list()
+    {
+        // The later view lands in the second run and carries index 1. Mapping has to use the request's whole
+        // planned list, or the denial would name the earlier view.
+        var request = CreateRequest(
+            CreateProposedOnlyPlan(("SchoolWithAnEarlyTag", 0), ("SchoolWithALateTag", 2)),
+            withNamespace: true
+        );
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+
+        var resolution = await CreateSut(CustomViewFailureExtractor(1))
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        FailureOf(resolution).StrategyName.Should().Be("SchoolWithALateTag");
+    }
+
+    [Test]
+    public async Task It_maps_a_no_matching_row_payload_to_the_access_denied_failure()
+    {
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+
+        var resolution = await CreateSut(CustomViewFailureExtractor(0))
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        var failure = FailureOf(resolution);
+        failure.FailureKind.Should().Be(CustomViewAuthorizationFailureKind.NoMatchingRow);
+        failure.ValueSource.Should().Be(CustomViewAuthorizationFailureValueSource.Proposed);
+        failure.ReadableSecurableElements.Should().Equal("SchoolWithATagElement");
+        failure.Hint.Should().Be("You may need a SchoolWithATag hint.");
+    }
+
+    [Test]
+    public async Task It_maps_a_missing_proposed_value_payload_to_the_element_required_failure()
+    {
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+
+        var resolution = await CreateSut(
+                CustomViewFailureExtractor(
+                    0,
+                    CustomViewAuthorizationAuth1FailureKind.ProposedBasisValueMissing
+                )
+            )
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        FailureOf(resolution)
+            .FailureKind.Should()
+            .Be(CustomViewAuthorizationFailureKind.ProposedValueMissing);
+    }
+
+    [Test]
+    public async Task It_maps_a_payload_addressing_no_planned_check_to_a_security_configuration_failure()
+    {
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+
+        var resolution = await CreateSut(CustomViewFailureExtractor(7))
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>();
+    }
+
+    [Test]
+    public async Task It_denies_a_self_basis_check_on_a_create_without_issuing_a_membership_statement()
+    {
+        var request = CreateRequest(CreateSelfBasisPlan(("SchoolWithATag", 0)), resolveToCreate: true);
+        // The only command the session may see is the view validation; a membership statement would need a
+        // result set this script does not offer.
+        var session = new ScriptedWriteSession(CreateReader(CreateAuthorizedTable()));
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        var failure = resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure;
+        failure.StrategyName.Should().Be("SchoolWithATag");
+        failure.FailureKind.Should().Be(CustomViewAuthorizationFailureKind.NoMatchingRow);
+        failure.ReadableSecurableElements.Should().Equal("SchoolWithATagElement");
+        session.Commands.Should().ContainSingle();
+        session.Commands[0].CommandText.Should().Contain("pg_catalog");
+    }
+
+    [Test]
+    public async Task It_reports_a_missing_view_rather_than_the_self_basis_denial()
+    {
+        // Eager validation runs before the 403 precisely so this stays a 500: a view that is absent or does
+        // not meet the DocumentId contract is a configuration defect, not an authorization answer.
+        var request = CreateRequest(CreateSelfBasisPlan(("SchoolWithATag", 0)), resolveToCreate: true);
+        var session = new ScriptedWriteSession(new FakeDbException("relation does not exist", "42P01"));
+
+        var act = async () =>
+            await CreateSut()
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+    }
+
+    [Test]
+    public async Task It_runs_an_earlier_custom_view_before_settling_a_later_self_basis_denial()
+    {
+        var request = CreateRequest(
+            CreateSelfBasisPlan(("SchoolWithASelfTag", 2), ("SchoolWithAnEarlyTag", 0)),
+            resolveToCreate: true
+        );
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+
+        // The earlier view denies, so its denial is the one reported and the self-basis check never settles.
+        var resolution = await CreateSut(CustomViewFailureExtractor(1))
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.StrategyName.Should()
+            .Be("SchoolWithAnEarlyTag");
+    }
+
+    [Test]
+    public async Task It_does_not_issue_a_custom_view_configured_after_a_self_basis_denial()
+    {
+        // The denial is deterministic at its configured position, so the run would have aborted before the
+        // later view. Issuing it anyway could report that view's denial as the first failure instead.
+        var request = CreateRequest(
+            CreateSelfBasisPlan(("SchoolWithASelfTag", 0), ("SchoolWithALaterTag", 2)),
+            resolveToCreate: true
+        );
+        var session = new ScriptedWriteSession(CreateReader(CreateAuthorizedTable()));
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.StrategyName.Should()
+            .Be("SchoolWithASelfTag");
+        // The one command is the view validation probe, not a membership statement.
+        session.Commands.Should().ContainSingle();
+        session.Commands[0].CommandText.Should().NotContain("SchoolWithALaterTag");
+    }
+
+    [Test]
+    public async Task It_does_not_issue_the_namespace_check_a_self_basis_denial_preempts()
+    {
+        // NamespaceBased is configured after the self-basis view, so the run would have aborted before
+        // reaching it. Issuing it anyway could report the wrong first failure.
+        var request = CreateRequest(
+            CreateSelfBasisPlan(("SchoolWithATag", 0)),
+            withNamespace: true,
+            resolveToCreate: true
+        );
+        var session = new ScriptedWriteSession(CreateReader(CreateAuthorizedTable()));
+
+        await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        session.Commands.Should().ContainSingle();
+        session.Commands[0].CommandText.Should().NotContain("namespacePrefixes");
+    }
+
+    [Test]
+    public async Task It_treats_a_self_basis_check_as_satisfied_when_a_paired_stored_check_was_planned()
+    {
+        // An existing target's DocumentId is immutable, so the stored check already authorized the very value
+        // the proposed check would bind.
+        var request = CreateRequest(CreateSelfBasisPlanWithStoredPair("SchoolWithATag"));
+        var session = new ScriptedWriteSession();
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution.ImmediateResult.Should().BeNull();
+        session.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_fails_closed_when_a_self_basis_check_has_no_paired_stored_check()
+    {
+        // Nothing authorized the existing row against this view, so treating the check as satisfied would
+        // serve a write the strategy restricts.
+        var request = CreateRequest(CreateSelfBasisPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession();
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>();
+        session.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_fails_closed_when_the_proposed_basis_column_is_not_bound_by_the_write_plan()
+    {
+        var request = CreateRequest(
+            CreateProposedOnlyPlan(("SchoolWithATag", 0)),
+            basisColumn: new DbColumnName("NotAColumn")
+        );
+        var session = new ScriptedWriteSession();
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>();
+        session.Commands.Should().BeEmpty();
+    }
+
+    private static CustomViewAuthorizationFailure FailureOf(
+        RelationalWriteSecondCommandResolution resolution
+    ) =>
+        resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure;
+
+    private static SingleRecordCustomViewAuthorizationCheckSpec Check(
+        int index,
+        CustomViewAuthorizationCheckValueSource valueSource,
+        string strategyName,
+        int rawConfiguredIndex,
+        CustomViewAuthorizationCheckTarget target
+    ) =>
+        new(
+            new ConfiguredAuthorizationStrategy(strategyName, rawConfiguredIndex),
+            index,
+            valueSource,
+            new DbTableName(new DbSchemaName("auth"), strategyName),
+            new DbColumnName("DocumentId"),
+            [new ColumnPathStep(RootTable, new DbColumnName("DocumentId"), null, null)],
+            target,
+            new QualifiedResourceName("Ed-Fi", "School"),
+            [$"{strategyName}Element"],
+            $"You may need a {strategyName} hint."
+        );
+
+    private static CustomViewAuthorizationCheckTarget ProposedTarget(DbColumnName basisColumn) =>
+        new CustomViewAuthorizationCheckTarget.Proposed(
+            RootTable,
+            new CustomViewAuthorizationProposedValueBinding(
+                RootTable,
+                basisColumn,
+                basisColumn.Value,
+                "cvBasis"
+            )
+        );
+
+    /// <summary>A PUT plan: the stored check first, then its proposed pair, indexed request-wide.</summary>
+    private static RelationalCustomViewAuthorization CreateStoredAndProposedPlan(
+        string strategyName,
+        int storedIndex
+    ) =>
+        new([
+            Check(
+                storedIndex,
+                CustomViewAuthorizationCheckValueSource.Stored,
+                strategyName,
+                0,
+                new CustomViewAuthorizationCheckTarget.Stored(RootTable, new DbColumnName("DocumentId"))
+            ),
+            Check(
+                storedIndex + 1,
+                CustomViewAuthorizationCheckValueSource.Proposed,
+                strategyName,
+                0,
+                ProposedTarget(BasisColumn)
+            ),
+        ]);
+
+    private static RelationalCustomViewAuthorization CreateProposedOnlyPlan(
+        params (string StrategyName, int RawConfiguredIndex)[] strategies
+    ) => CreateProposedOnlyPlanOn(BasisColumn, strategies);
+
+    private static RelationalCustomViewAuthorization CreateProposedOnlyPlanOn(
+        DbColumnName basisColumn,
+        params (string StrategyName, int RawConfiguredIndex)[] strategies
+    ) =>
+        new([
+            .. strategies.Select(
+                (strategy, index) =>
+                    Check(
+                        index,
+                        CustomViewAuthorizationCheckValueSource.Proposed,
+                        strategy.StrategyName,
+                        strategy.RawConfiguredIndex,
+                        ProposedTarget(basisColumn)
+                    )
+            ),
+        ]);
+
+    /// <summary>
+    /// The first strategy is the self-basis one; any others are ordinary proposed checks, so the fixture can
+    /// place a decidable view before or after the self-basis position.
+    /// </summary>
+    private static RelationalCustomViewAuthorization CreateSelfBasisPlan(
+        params (string StrategyName, int RawConfiguredIndex)[] strategies
+    ) =>
+        new([
+            .. strategies.Select(
+                (strategy, index) =>
+                    Check(
+                        index,
+                        CustomViewAuthorizationCheckValueSource.Proposed,
+                        strategy.StrategyName,
+                        strategy.RawConfiguredIndex,
+                        index == 0
+                            ? new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(RootTable)
+                            : ProposedTarget(BasisColumn)
+                    )
+            ),
+        ]);
+
+    private static RelationalCustomViewAuthorization CreateSelfBasisPlanWithStoredPair(string strategyName) =>
+        new([
+            Check(
+                0,
+                CustomViewAuthorizationCheckValueSource.Stored,
+                strategyName,
+                0,
+                new CustomViewAuthorizationCheckTarget.Stored(RootTable, new DbColumnName("DocumentId"))
+            ),
+            Check(
+                1,
+                CustomViewAuthorizationCheckValueSource.Proposed,
+                strategyName,
+                0,
+                new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(RootTable)
+            ),
+        ]);
+
+    private static CompositeRelationalWriteSecondCommand CreateSut(
+        IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
+    ) => new(relationalParameterConfigurator: null, providerFailureExtractor);
+
+    private static StubProviderFailureExtractor CustomViewFailureExtractor(
+        int index,
+        CustomViewAuthorizationAuth1FailureKind failureKind =
+            CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+    ) =>
+        new(
+            CustomViewAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+            CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(
+                new CustomViewAuthorizationAuth1FailurePayload(index, failureKind)
+            )
+        );
+
+    private static RelationalWriteExecutorRequest CreateRequest(
+        RelationalCustomViewAuthorization customViewAuthorization,
+        bool withNamespace = false,
+        bool resolveToCreate = false,
+        DbColumnName? basisColumn = null
+    )
+    {
+        var rootPlan = Given_Default_Relational_Write_Executor.CreateRootPlan();
+        var resourceModel = Given_Default_Relational_Write_Executor.CreateRelationalResourceModel(
+            rootPlan.TableModel
+        );
+        var writePlan = new ResourceWritePlan(resourceModel, [rootPlan]);
+        var mappingSet = Given_Default_Relational_Write_Executor.CreateMappingSet(
+            resourceModel,
+            [rootPlan],
+            SqlDialect.Pgsql
+        );
+        var input = new RelationalWriteExecutorInput(
+            mappingSet,
+            resolveToCreate ? RelationalWriteOperationKind.Post : RelationalWriteOperationKind.Put,
+            resolveToCreate
+                ? new RelationalWriteTargetRequest.Post(
+                    new ReferentialId(Guid.Parse("11111111-2222-3333-4444-555555555555")),
+                    CreatedDocumentUuid
+                )
+                : new RelationalWriteTargetRequest.Put(ExistingDocumentUuid),
+            writePlan,
+            Given_Default_Relational_Write_Executor.CreateReadPlan(resourceModel, SqlDialect.Pgsql),
+            JsonNode.Parse("""{"schoolId":255901,"name":"uri://ed-fi.org/Survey"}""")!,
+            allowIdentityUpdates: false,
+            new TraceId("composite-proposed-custom-view-test"),
+            new ReferenceResolverRequest(mappingSet, resourceModel.Resource, [], [])
+        )
+        {
+            CustomViewAuthorization = basisColumn is { } unboundBasisColumn
+                ? CreateProposedOnlyPlanOn(unboundBasisColumn, ("SchoolWithATag", 0))
+                : customViewAuthorization,
+        };
+
+        if (withNamespace)
+        {
+            input = input with
+            {
+                ProposedNamespaceAuthorization = new RelationalWriteNamespaceAuthorization(
+                    [
+                        new NamespaceAuthorizationCheckSpec(
+                            1,
+                            NamespaceAuthorizationCheckValueSource.Proposed,
+                            rootPlan.TableModel.Table,
+                            new DbColumnName("Name")
+                        ),
+                    ],
+                    NamespacePrefixParameterizationFactory.Create(
+                        SqlDialect.Pgsql,
+                        ["uri://ed-fi.org/"],
+                        "namespacePrefixes"
+                    )
+                ),
+            };
+        }
+
+        return input.Resolve(
+            resolveToCreate
+                ? new RelationalWriteTargetContext.CreateNew(CreatedDocumentUuid)
+                : new RelationalWriteTargetContext.ExistingDocument(345L, ExistingDocumentUuid, 44L)
+        );
+    }
+
+    private static RelationalWriteMergeResult CreateMergeResult(RelationalWriteExecutorRequest request) =>
+        Given_Default_Relational_Write_Executor.CreateMergeResult(
+            request.WritePlan.TablePlansInDependencyOrder[0],
+            currentSchoolId: 255901,
+            mergedSchoolId: 255901,
+            currentName: "uri://ed-fi.org/Survey",
+            mergedName: "uri://ed-fi.org/Survey"
+        );
+
+    private static FakeDbException CreateAuth1Failure() => new("custom view denial", "P0001");
+
+    private static DbDataReader CreateReader(params DataTable[] tables) => new DataTableReader(tables);
+
+    private static DataTable CreateAuthorizedTable()
+    {
+        var table = new DataTable();
+        table.Columns.Add("AuthorizationResult", typeof(int));
+        table.Rows.Add(1);
+
+        return table;
+    }
+
+    private sealed class StubProviderFailureExtractor(string? providerErrorCode, string providerMessage)
+        : IRelationshipAuthorizationProviderFailureExtractor
+    {
+        public RelationshipAuthorizationProviderFailure Extract(DbException exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            return new RelationshipAuthorizationProviderFailure(providerErrorCode, providerMessage);
+        }
+    }
+
+    private sealed class FakeDbException(string message, string sqlState) : DbException(message)
+    {
+        public override string SqlState => sqlState;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
@@ -129,6 +129,73 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
     }
 
     [Test]
+    public async Task It_runs_a_custom_view_configured_before_namespace_before_reporting_a_namespace_planning_failure()
+    {
+        // The namespace check names a column the write plan does not bind, so its plan cannot be reconciled
+        // with the finalized root row. The view configured before NamespaceBased still executes first, so its
+        // denial is the answer rather than the later namespace security-configuration failure, and the
+        // namespace check itself is never emitted.
+        var request = CreateRequest(
+            CreateProposedOnlyPlan(("SchoolWithAnEarlyTag", 0)),
+            withNamespace: true,
+            namespaceColumn: new DbColumnName("NotANamespaceColumn")
+        );
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+
+        var resolution = await CreateSut(CustomViewFailureExtractor(0))
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        FailureOf(resolution).StrategyName.Should().Be("SchoolWithAnEarlyTag");
+        var commandText = session.Commands.Should().ContainSingle().Subject.CommandText;
+        commandText.Should().Contain("SchoolWithAnEarlyTag");
+        commandText.Should().NotContain("namespacePrefixes");
+    }
+
+    [Test]
+    public async Task It_does_not_plan_a_custom_view_configured_after_namespace_when_namespace_planning_failed()
+    {
+        // The mirror of the case above. The only custom view is configured after NamespaceBased, and its
+        // proposed basis column is unbound, so extracting it would report an invalid plan ahead of the
+        // namespace failure that precedes it. It must not be planned at all: the namespace failure stands and
+        // no custom-view statement is built.
+        var request = CreateRequest(
+            CreateProposedOnlyPlanOn(new DbColumnName("NotAColumn"), ("SchoolWithALateTag", 2)),
+            withNamespace: true,
+            namespaceColumn: new DbColumnName("NotANamespaceColumn")
+        );
+        var session = new ScriptedWriteSession();
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        var errors = resolution
+            .ImmediateResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>()
+            .Subject.Errors;
+        // The two families word their failures distinctly, which is what tells the namespace failure apart
+        // from the custom-view invalid-plan failure that must not preempt it.
+        errors.Should().ContainSingle().Which.Should().StartWith("Proposed namespace authorization");
+        errors
+            .Should()
+            .NotContain(error =>
+                error.Contains("Proposed custom view authorization", StringComparison.Ordinal)
+            );
+        session.Commands.Should().BeEmpty();
+    }
+
+    [Test]
     public async Task It_resolves_a_straddling_run_payload_against_the_full_planned_check_list()
     {
         // The later view lands in the second run and carries index 1. Mapping has to use the request's whole
@@ -766,7 +833,8 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
         RelationalCustomViewAuthorization customViewAuthorization,
         bool withNamespace = false,
         bool resolveToCreate = false,
-        DbColumnName? basisColumn = null
+        DbColumnName? basisColumn = null,
+        DbColumnName? namespaceColumn = null
     )
     {
         var rootPlan = Given_Default_Relational_Write_Executor.CreateRootPlan();
@@ -811,7 +879,7 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
                             1,
                             NamespaceAuthorizationCheckValueSource.Proposed,
                             rootPlan.TableModel.Table,
-                            new DbColumnName("Name")
+                            namespaceColumn ?? new DbColumnName("Name")
                         ),
                     ],
                     NamespacePrefixParameterizationFactory.Create(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteProposedCustomViewTests.cs
@@ -568,14 +568,15 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
     }
 
     [Test]
-    public async Task It_does_not_probe_the_views_for_a_recognized_custom_view_denial()
+    public async Task It_still_reports_a_recognized_custom_view_denial_when_the_emitted_view_conforms()
     {
-        // A cv1 payload already names the failing check, so probing would be a wasted round trip.
+        // The probe that precedes the denial only reclassifies a broken object. A conforming view leaves the
+        // cv1 payload's own answer intact.
         var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
         var session = new ScriptedWriteSession(CreateAuth1Failure());
         var validationExecutor = new StubValidationCommandExecutor();
 
-        await CreateSut(CustomViewFailureExtractor(0), validationExecutor)
+        var resolution = await CreateSut(CustomViewFailureExtractor(0), validationExecutor)
             .ResolveAsync(
                 request,
                 CreateMergeResult(request),
@@ -583,7 +584,67 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
                 session
             );
 
-        validationExecutor.ExecutedCommands.Should().BeEmpty();
+        FailureOf(resolution).StrategyName.Should().Be("SchoolWithATag");
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithATag");
+    }
+
+    [Test]
+    public async Task It_reports_an_invalid_view_rather_than_the_denial_its_own_no_match_payload_carries()
+    {
+        // A non-view table at auth.{StrategyName} with a compatible DocumentId answers the membership SQL, so
+        // a row it does not contain raises the ordinary cv1 no-match — the same payload a conforming view
+        // raises. Without probing before the mapping, that object's misconfiguration is served as a 403
+        // instead of the documented urn:ed-fi:api:system 500.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("invalid custom authorization view DocumentId contract", "P0001")
+        );
+
+        var act = async () =>
+            await CreateSut(CustomViewFailureExtractor(0), validationExecutor)
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+    }
+
+    [Test]
+    public async Task It_probes_no_view_the_denying_check_preempted()
+    {
+        // The early view denies, so the command aborted before the namespace check and before the view
+        // configured after it. Probing that later view would report its contract failure ahead of a namespace
+        // answer that precedes it — the ordering the two separate runs exist to preserve.
+        var request = CreateRequest(
+            CreateProposedOnlyPlan(("SchoolWithAnEarlyTag", 0), ("SchoolWithALateTag", 2)),
+            withNamespace: true
+        );
+        var session = new ScriptedWriteSession(CreateAuth1Failure());
+        var validationExecutor = new StubValidationCommandExecutor();
+
+        var resolution = await CreateSut(CustomViewFailureExtractor(0), validationExecutor)
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        FailureOf(resolution).StrategyName.Should().Be("SchoolWithAnEarlyTag");
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithAnEarlyTag")
+            .And.NotContain("SchoolWithALateTag");
     }
 
     [Test]
@@ -670,6 +731,66 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
             .And.NotContainEquivalentOf("insert into edfi.\"School\"");
     }
 
+    [Test]
+    public async Task It_reports_an_invalid_view_behind_a_run_that_answered_without_failing()
+    {
+        // The run authorized, which is exactly what a table masquerading as auth.{StrategyName} does: it satisfies
+        // the membership SQL and raises nothing, so no failure path ever probes it. Validating the emitted run
+        // once the command has answered is what turns that into the documented 500 — and the write it shared the
+        // transaction with is not committed.
+        var request = CreateRequest(CreateProposedOnlyPlan(("SchoolWithATag", 0)));
+        var session = new ScriptedWriteSession(CreateReader(CreateAuthorizedTable()));
+        var validationExecutor = new StubValidationCommandExecutor(
+            new FakeDbException("invalid custom authorization view DocumentId contract", "P0001")
+        );
+
+        var act = async () =>
+            await CreateSut(customViewValidationCommandExecutor: validationExecutor)
+                .ResolveAsync(
+                    request,
+                    CreateMergeResult(request),
+                    RelationalWriteSecondCommandMode.AuthorizationOnly,
+                    session
+                );
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        validationExecutor
+            .ExecutedCommands.Should()
+            .ContainSingle()
+            .Subject.CommandText.Should()
+            .Contain("SchoolWithATag");
+    }
+
+    [Test]
+    public async Task It_runs_both_sql_backed_checks_around_a_self_basis_check_configured_between_them()
+    {
+        // The self-basis check is settled in C# against its stored pair, so it emits no statement and the run
+        // carries request-wide indexes 1 and 3. Both SQL-backed checks still have to run, in configured order:
+        // requiring the run's indexes to be consecutive failed a valid configuration before authorization.
+        var request = CreateRequest(CreateSelfBasisBetweenProposedPlan());
+        var session = new ScriptedWriteSession(
+            CreateReader(CreateAuthorizedTable(), CreateAuthorizedTable())
+        );
+
+        var resolution = await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateMergeResult(request),
+                RelationalWriteSecondCommandMode.AuthorizationOnly,
+                session
+            );
+
+        resolution.ImmediateResult.Should().BeNull();
+        var commandText = session.Commands.Should().ContainSingle().Subject.CommandText;
+        commandText
+            .IndexOf("cv1|1|", StringComparison.Ordinal)
+            .Should()
+            .BePositive()
+            .And.BeLessThan(commandText.IndexOf("cv1|3|", StringComparison.Ordinal));
+        // The self-basis check owns index 2 and answers outside SQL, so no statement reports it.
+        commandText.Should().NotContain("cv1|2|").And.NotContain("SchoolWithASelfTag");
+    }
+
     private static CustomViewAuthorizationFailure FailureOf(
         RelationalWriteSecondCommandResolution resolution
     ) =>
@@ -700,14 +821,21 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
             $"You may need a {strategyName} hint."
         );
 
-    private static CustomViewAuthorizationCheckTarget ProposedTarget(DbColumnName basisColumn) =>
+    /// <summary>
+    /// The planner seeds one parameter name per check index, so a run carrying two proposed checks needs two
+    /// distinct seeds — a single command cannot bind one name to two values.
+    /// </summary>
+    private static CustomViewAuthorizationCheckTarget ProposedTarget(
+        DbColumnName basisColumn,
+        string parameterSeed = "cvBasis"
+    ) =>
         new CustomViewAuthorizationCheckTarget.Proposed(
             RootTable,
             new CustomViewAuthorizationProposedValueBinding(
                 RootTable,
                 basisColumn,
                 basisColumn.Value,
-                "cvBasis"
+                parameterSeed
             )
         );
 
@@ -773,6 +901,42 @@ public class Given_The_Composite_Relational_Write_Proposed_Custom_View_Authoriza
                             ? new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(RootTable)
                             : ProposedTarget(BasisColumn)
                     )
+            ),
+        ]);
+
+    /// <summary>
+    /// A PUT plan whose self-basis proposed check is configured between two SQL-backed ones, with the stored
+    /// pair that settles it. The emitted run therefore skips the index the self-basis check holds.
+    /// </summary>
+    private static RelationalCustomViewAuthorization CreateSelfBasisBetweenProposedPlan() =>
+        new([
+            Check(
+                0,
+                CustomViewAuthorizationCheckValueSource.Stored,
+                "SchoolWithASelfTag",
+                1,
+                new CustomViewAuthorizationCheckTarget.Stored(RootTable, new DbColumnName("DocumentId"))
+            ),
+            Check(
+                1,
+                CustomViewAuthorizationCheckValueSource.Proposed,
+                "SchoolWithAnEarlyTag",
+                0,
+                ProposedTarget(BasisColumn, "cvBasisEarly")
+            ),
+            Check(
+                2,
+                CustomViewAuthorizationCheckValueSource.Proposed,
+                "SchoolWithASelfTag",
+                1,
+                new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(RootTable)
+            ),
+            Check(
+                3,
+                CustomViewAuthorizationCheckValueSource.Proposed,
+                "SchoolWithALateTag",
+                2,
+                ProposedTarget(BasisColumn, "cvBasisLate")
             ),
         ]);
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationExecutorTests.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Unit.TestSupport;
+using EdFi.DataManagementService.Core.External.Backend;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// Owns how the standalone custom-view membership run attributes a provider failure that carries no AUTH1
+/// payload: a broken <c>auth.{StrategyName}</c> contract is the documented validation 500, while a transient
+/// provider failure is never evidence about the view and must reach the caller's retryable handling.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_The_Custom_View_Authorization_Executor
+{
+    [Test]
+    public async Task It_does_not_wrap_a_transient_non_auth1_failure_as_a_custom_view_validation_failure()
+    {
+        var transientFailure = new FakeDbException("deadlock detected", "40P01");
+        var classifier = new ConfigurableRelationalWriteExceptionClassifier
+        {
+            IsTransientFailureToReturn = true,
+        };
+        var sut = new CustomViewAuthorizationExecutor(
+            new ThrowingCommandExecutor(transientFailure),
+            new StubProviderFailureExtractor("40P01", "deadlock detected"),
+            writeExceptionClassifier: classifier
+        );
+
+        var act = async () => await sut.ExecuteAsync(CreateRequest());
+
+        var assertion = await act.Should().ThrowAsync<DbException>();
+        assertion.Which.Should().BeSameAs(transientFailure);
+    }
+
+    [Test]
+    public async Task It_still_wraps_a_missing_view_failure_as_a_custom_view_validation_failure()
+    {
+        var missingViewFailure = new FakeDbException("relation does not exist", "42P01");
+        var sut = new CustomViewAuthorizationExecutor(
+            new ThrowingCommandExecutor(missingViewFailure),
+            new StubProviderFailureExtractor("42P01", "relation does not exist"),
+            writeExceptionClassifier: new ConfigurableRelationalWriteExceptionClassifier()
+        );
+
+        var act = async () => await sut.ExecuteAsync(CreateRequest());
+
+        var assertion = await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        assertion.Which.InnerException.Should().BeSameAs(missingViewFailure);
+    }
+
+    /// <summary>One self-basis stored check, so the run emits membership SQL without a reference model.</summary>
+    private static CustomViewAuthorizationExecutionRequest CreateRequest()
+    {
+        var rootPlan = Given_Default_Relational_Write_Executor.CreateRootPlan();
+        var mappingSet = Given_Default_Relational_Write_Executor.CreateMappingSet(
+            Given_Default_Relational_Write_Executor.CreateRelationalResourceModel(rootPlan.TableModel),
+            [rootPlan],
+            SqlDialect.Pgsql
+        );
+        var rootTable = new DbTableName(new DbSchemaName("edfi"), "School");
+
+        return new CustomViewAuthorizationExecutionRequest(
+            mappingSet,
+            DocumentId: 345L,
+            Checks:
+            [
+                new SingleRecordCustomViewAuthorizationCheckSpec(
+                    new ConfiguredAuthorizationStrategy("SchoolWithATag", 0),
+                    0,
+                    CustomViewAuthorizationCheckValueSource.Stored,
+                    new DbTableName(new DbSchemaName("auth"), "SchoolWithATag"),
+                    new DbColumnName("DocumentId"),
+                    [new ColumnPathStep(rootTable, new DbColumnName("DocumentId"), null, null)],
+                    new CustomViewAuthorizationCheckTarget.Stored(rootTable, new DbColumnName("DocumentId")),
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    ["SchoolWithATagElement"],
+                    "You may need a SchoolWithATag hint."
+                ),
+            ]
+        );
+    }
+
+    private sealed class ThrowingCommandExecutor(DbException failure) : IRelationalCommandExecutor
+    {
+        public SqlDialect Dialect => SqlDialect.Pgsql;
+
+        public Task<TResult> ExecuteReaderAsync<TResult>(
+            RelationalCommand command,
+            Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+            CancellationToken cancellationToken = default
+        ) => Task.FromException<TResult>(failure);
+    }
+
+    private sealed class StubProviderFailureExtractor(string? providerErrorCode, string providerMessage)
+        : IRelationshipAuthorizationProviderFailureExtractor
+    {
+        public RelationshipAuthorizationProviderFailure Extract(DbException exception) =>
+            new(providerErrorCode, providerMessage);
+    }
+
+    private sealed class FakeDbException(string message, string sqlState) : DbException(message)
+    {
+        public override string SqlState => sqlState;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// A single command can carry namespace, custom-view, and relationship AUTH1 statements at once. Each
+/// family's provider-failure mapper must therefore yield on a payload it does not own, so the mapper that
+/// owns the discriminator produces the response. Without that, whichever mapper is consulted first would
+/// convert another family's 403 into its own security-configuration 500.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_AnAuth1PayloadFromAnotherFamily
+{
+    private static readonly DbTableName RootTable = new(new DbSchemaName("edfi"), "GradebookEntry");
+    private static readonly DbColumnName NamespaceColumn = new("Namespace");
+
+    private static readonly IReadOnlyList<NamespaceAuthorizationCheckSpec> NamespaceChecks =
+    [
+        new(0, NamespaceAuthorizationCheckValueSource.Stored, RootTable, NamespaceColumn),
+    ];
+
+    private static readonly IReadOnlyList<NamespaceAuthorizationCheckValueSource> NamespaceValueSources =
+    [
+        NamespaceAuthorizationCheckValueSource.Stored,
+    ];
+
+    [TestCase("cv1|0|n")]
+    [TestCase("cv1|0|u")]
+    [TestCase("cv1|1|r")]
+    [TestCase("cv1|0|s")]
+    public void It_should_not_be_claimed_as_a_namespace_authorization_failure(string payloadText)
+    {
+        var mapped = NamespaceAuthorizationProviderFailureMapper.TryMapNamespaceAuthorizationFailure(
+            SqlDialect.Pgsql,
+            new FakeDbException(payloadText, "AUTH1"),
+            new StubProviderFailureExtractor("AUTH1", payloadText),
+            NamespaceValueSources,
+            ["uri://ed-fi.org"],
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_not_be_claimed_as_a_namespace_stale_stored_target()
+    {
+        // The custom-view stale code is also 's'. Reading it as a namespace stale target would turn a
+        // custom-view retry signal into a namespace one, silently retrying against the wrong plan.
+        NamespaceAuthorizationProviderFailureMapper
+            .IsStaleStoredTargetFailure(
+                SqlDialect.Pgsql,
+                new FakeDbException("cv1|0|s", "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", "cv1|0|s"),
+                NamespaceValueSources
+            )
+            .Should()
+            .BeFalse();
+    }
+
+    [TestCase("cv1|0|n")]
+    [TestCase("cv1|0|u")]
+    [TestCase("cv1|0|s")]
+    public void It_should_not_be_reported_as_namespace_invalid_authorization_metadata(string payloadText)
+    {
+        // The regression this pins: the diagnostics switch used to route every unrecognized dispatch result
+        // through a catch-all that claimed it as namespace invalid-authorization metadata, which would have
+        // turned a custom-view 403 into a namespace 500 as soon as one command carried both.
+        var built =
+            NamespaceAuthorizationProviderFailureMapper.TryBuildInvalidAuthorizationFailureDiagnostics(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                NamespaceValueSources,
+                NamespaceChecks,
+                out var diagnostics
+            );
+
+        built.Should().BeFalse();
+        diagnostics.Should().BeNull();
+    }
+
+    [TestCase("cv1|0|n")]
+    [TestCase("cv1|0|u")]
+    [TestCase("ns1|0|m")]
+    public void It_should_not_be_claimed_as_a_relationship_authorization_failure_or_diagnostic(
+        string payloadText
+    )
+    {
+        var mapped = RelationshipAuthorizationProviderFailureMapper.TryMapRelationshipAuthorizationFailure(
+            SqlDialect.Pgsql,
+            new FakeDbException(payloadText, "AUTH1"),
+            new StubProviderFailureExtractor("AUTH1", payloadText),
+            expectedEmittedAuth1Index: 0,
+            [],
+            [],
+            out var relationshipFailure,
+            out var invalidFailureDiagnostic
+        );
+
+        mapped.Should().BeFalse();
+        relationshipFailure.Should().BeNull();
+        // No diagnostic either: a diagnostic makes callers report their own invalid-payload 500, which is
+        // exactly the misclassification being prevented.
+        invalidFailureDiagnostic.Should().BeNull();
+    }
+
+    [TestCase("garbage-with-no-discriminator")]
+    [TestCase("1|0|1|not-a-subject-failure")]
+    public void It_should_still_report_a_relationship_diagnostic_for_its_own_undecodable_payload(
+        string payloadText
+    )
+    {
+        // Only *known* foreign discriminators yield. A corrupt payload that is not attributable to another
+        // family must stay a loud relationship security-configuration error rather than falling through to
+        // generic database-failure handling.
+        var mapped = RelationshipAuthorizationProviderFailureMapper.TryMapRelationshipAuthorizationFailure(
+            SqlDialect.Pgsql,
+            new FakeDbException(payloadText, "AUTH1"),
+            new StubProviderFailureExtractor("AUTH1", payloadText),
+            expectedEmittedAuth1Index: 0,
+            [],
+            [],
+            out var relationshipFailure,
+            out var invalidFailureDiagnostic
+        );
+
+        mapped.Should().BeFalse();
+        relationshipFailure.Should().BeNull();
+        invalidFailureDiagnostic.Should().NotBeNull();
+    }
+
+    [Test]
+    public void It_should_still_let_the_namespace_mapper_claim_its_own_payload()
+    {
+        // The yield must be narrow: namespace mapping of ns1 payloads is unchanged.
+        var mapped = NamespaceAuthorizationProviderFailureMapper.TryMapNamespaceAuthorizationFailure(
+            SqlDialect.Pgsql,
+            new FakeDbException("ns1|0|m", "AUTH1"),
+            new StubProviderFailureExtractor("AUTH1", "ns1|0|m"),
+            NamespaceValueSources,
+            ["uri://ed-fi.org"],
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure.Should().NotBeNull();
+    }
+
+    private sealed class StubProviderFailureExtractor(string? providerErrorCode, string providerMessage)
+        : IRelationshipAuthorizationProviderFailureExtractor
+    {
+        public RelationshipAuthorizationProviderFailure Extract(DbException exception) =>
+            new(providerErrorCode, providerMessage);
+    }
+
+    private sealed class FakeDbException(string message, string sqlState) : DbException(message)
+    {
+        public override string SqlState => sqlState;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
@@ -107,6 +107,285 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
         request.RelationalAuthorizationContext.NamespacePrefixes.Should().BeEmpty();
     }
 
+    [Test]
+    public async Task It_authorizes_a_descriptor_get_by_id_custom_view_against_the_fetched_document_id()
+    {
+        // The descriptor read has already materialized the row by the time the check runs, so the membership
+        // query is bound to that row's DocumentId rather than to a re-resolved target.
+        List<CustomViewAuthorizationExecutionRequest> capturedRequests = [];
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(CreateDescriptorRow(documentId: 101L)),
+            ]),
+        ]);
+        var sut = CreateSut(
+            commandExecutor,
+            CustomViewExecutorReturning(
+                new CustomViewAuthorizationExecutionResult.Authorized(),
+                capturedRequests
+            )
+        );
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(namespacePrefixes: [], authorizationStrategies: [CustomViewStrategy()])
+        );
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+        capturedRequests.Should().ContainSingle().Which.DocumentId.Should().Be(101L);
+        capturedRequests[0]
+            .Checks.Should()
+            .ContainSingle()
+            .Which.ConfiguredStrategy.StrategyName.Should()
+            .Be(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_returns_a_custom_view_403_for_a_descriptor_get_by_id_the_view_excludes()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(CreateDescriptorRow()),
+            ]),
+        ]);
+        var denial = CustomViewDenial();
+        var sut = CreateSut(
+            commandExecutor,
+            CustomViewExecutorReturning(new CustomViewAuthorizationExecutionResult.NotAuthorized(denial))
+        );
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(namespacePrefixes: [], authorizationStrategies: [CustomViewStrategy()])
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.Should()
+            .BeSameAs(denial);
+    }
+
+    [Test]
+    public async Task It_reports_a_custom_view_configured_before_NamespaceBased_ahead_of_a_namespace_denial()
+    {
+        // Both are AND filters executing in CMS-configured order and the first failure is reported. The
+        // namespace value here would also fail, so only ordering can produce the custom-view answer.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://other.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var denial = CustomViewDenial();
+        var sut = CreateSut(
+            commandExecutor,
+            CustomViewExecutorReturning(new CustomViewAuthorizationExecutionResult.NotAuthorized(denial))
+        );
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies: [CustomViewStrategy(), NamespaceStrategy()]
+            )
+        );
+
+        result.Should().BeOfType<GetResult.GetFailureCustomViewNotAuthorized>();
+    }
+
+    [Test]
+    public async Task It_reports_a_namespace_denial_ahead_of_a_custom_view_configured_after_it()
+    {
+        // The mirror of the previous case: the custom view would also deny, so a namespace answer proves the
+        // later-configured view did not run first.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://other.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(
+            commandExecutor,
+            CustomViewExecutorReturning(
+                new CustomViewAuthorizationExecutionResult.NotAuthorized(CustomViewDenial())
+            )
+        );
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies: [NamespaceStrategy(), CustomViewStrategy()]
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
+    }
+
+    [Test]
+    public async Task It_returns_not_exists_for_a_descriptor_get_by_id_whose_row_was_deleted_before_the_check()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(CreateDescriptorRow()),
+            ]),
+        ]);
+        var sut = CreateSut(
+            commandExecutor,
+            CustomViewExecutorReturning(new CustomViewAuthorizationExecutionResult.StaleTarget())
+        );
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(namespacePrefixes: [], authorizationStrategies: [CustomViewStrategy()])
+        );
+
+        result.Should().BeOfType<GetResult.GetFailureNotExists>();
+    }
+
+    [Test]
+    public async Task It_returns_security_configuration_500_when_a_descriptor_get_by_id_custom_view_reports_an_unmappable_payload()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(CreateDescriptorRow()),
+            ]),
+        ]);
+        var sut = CreateSut(
+            commandExecutor,
+            CustomViewExecutorReturning(
+                new CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure("bad payload", null)
+            )
+        );
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(namespacePrefixes: [], authorizationStrategies: [CustomViewStrategy()])
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .Equal("bad payload");
+    }
+
+    [Test]
+    public async Task It_validates_a_descriptor_get_by_id_custom_view_configured_before_a_namespace_no_prefixes_terminal()
+    {
+        // The namespace 403 resolves before any row is fetched, but a custom view configured ahead of it still
+        // executes first, so a missing or non-conforming view has to keep its own 500.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: [],
+                authorizationStrategies: [CustomViewStrategy(), NamespaceStrategy()]
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        commandExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.CommandText.Should()
+            .Contain(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_does_not_validate_a_descriptor_get_by_id_custom_view_configured_after_a_namespace_no_prefixes_terminal()
+    {
+        // The run would have aborted at the namespace position, so a view configured after it never executes
+        // and must not be probed either.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: [],
+                authorizationStrategies: [NamespaceStrategy(), CustomViewStrategy()]
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        commandExecutor.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_validates_a_descriptor_get_by_id_custom_view_configured_before_a_classifier_security_configuration_terminal()
+    {
+        // An unrecognized strategy is a 500 from the relationship classifier. A custom view configured ahead of
+        // it executes first, so its own configuration failure must not be masked.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies:
+                [
+                    CustomViewStrategy(),
+                    new AuthorizationStrategyEvaluator("UnknownDescriptorStrategy", [], FilterOperator.And),
+                ]
+            )
+        );
+
+        result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>();
+        commandExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.CommandText.Should()
+            .Contain(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_validates_a_descriptor_get_by_id_custom_view_configured_before_an_unsupported_strategy()
+    {
+        // OwnershipBased fails closed with a 501, but a custom view configured ahead of it executes first, so
+        // a missing or non-conforming view has to keep its own 500 rather than being hidden by the 501. The one
+        // scripted execution is the validation probe; a row fetch never happens on this path.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies:
+                [
+                    CustomViewStrategy(),
+                    new AuthorizationStrategyEvaluator(
+                        AuthorizationStrategyNameConstants.OwnershipBased,
+                        [],
+                        FilterOperator.And
+                    ),
+                ]
+            )
+        );
+
+        result.Should().BeOfType<GetResult.GetFailureNotImplemented>();
+        commandExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.CommandText.Should()
+            .Contain(CustomViewStrategyName);
+    }
+
     [TestCase(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly)]
     [TestCase(AuthorizationStrategyNameConstants.OwnershipBased)]
     public async Task It_fails_closed_for_descriptor_get_by_id_with_an_unsupported_strategy_without_executing_sql(
@@ -734,16 +1013,55 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
         AuthorizationStrategyEvaluator authorizationStrategy,
         SqlDialect dialect = SqlDialect.Pgsql,
         RelationalGetRequestReadMode readMode = RelationalGetRequestReadMode.ExternalResponse
+    ) => CreateGetByIdRequest(namespacePrefixes, [authorizationStrategy], dialect, readMode);
+
+    private static DescriptorGetByIdRequest CreateGetByIdRequest(
+        IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator[] authorizationStrategies,
+        SqlDialect dialect = SqlDialect.Pgsql,
+        RelationalGetRequestReadMode readMode = RelationalGetRequestReadMode.ExternalResponse
     ) =>
         new(
             CreateMappingSet(dialect),
             _descriptorResource,
             _documentUuid,
             readMode,
-            [authorizationStrategy],
+            authorizationStrategies,
             readableProfileProjectionContext: null,
             new TraceId("descriptor-get-namespace"),
             new RelationalAuthorizationContext([], namespacePrefixes)
+        );
+
+    private const string CustomViewStrategyName = "SchoolTypeDescriptorWithATag";
+
+    private static AuthorizationStrategyEvaluator CustomViewStrategy(string? strategyName = null) =>
+        new(strategyName ?? CustomViewStrategyName, [], FilterOperator.And);
+
+    private static ICustomViewAuthorizationExecutor CustomViewExecutorReturning(
+        CustomViewAuthorizationExecutionResult result,
+        List<CustomViewAuthorizationExecutionRequest>? capturedRequests = null
+    )
+    {
+        var executor = A.Fake<ICustomViewAuthorizationExecutor>();
+        A.CallTo(() =>
+                executor.ExecuteAsync(A<CustomViewAuthorizationExecutionRequest>._, A<CancellationToken>._)
+            )
+            .Invokes(call =>
+                capturedRequests?.Add(call.GetArgument<CustomViewAuthorizationExecutionRequest>(0)!)
+            )
+            .Returns(Task.FromResult(result));
+
+        return executor;
+    }
+
+    private static CustomViewAuthorizationFailure CustomViewDenial() =>
+        new(
+            CustomViewAuthorizationFailureKind.NoMatchingRow,
+            CustomViewAuthorizationFailureValueSource.Stored,
+            0,
+            CustomViewStrategyName,
+            ["SchoolTypeDescriptorId"],
+            "You may need a School Type Descriptor with a Tag."
         );
 
     private static DescriptorQueryRequest CreateQueryRequest(
@@ -766,13 +1084,17 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
             new RelationalAuthorizationContext([], namespacePrefixes)
         );
 
-    private static DescriptorReadHandler CreateSut(InMemoryRelationalCommandExecutor commandExecutor) =>
+    private static DescriptorReadHandler CreateSut(
+        InMemoryRelationalCommandExecutor commandExecutor,
+        ICustomViewAuthorizationExecutor? customViewAuthorizationExecutor = null
+    ) =>
         new(
             commandExecutor,
             A.Fake<Core.Profile.IReadableProfileProjector>(),
             new EdFi.DataManagementService.Backend.Etag.ServedEtagComposer(),
             NullLogger<DescriptorReadHandler>.Instance,
-            PassthroughDocumentCacheReadAccelerationCoordinator.Instance
+            PassthroughDocumentCacheReadAccelerationCoordinator.Instance,
+            customViewAuthorizationExecutor ?? A.Fake<ICustomViewAuthorizationExecutor>()
         );
 
     private static IReadOnlyDictionary<string, object?> CreateDescriptorRow(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -1130,7 +1130,8 @@ public class Given_DescriptorReadHandler
 
         var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
         failure.Errors.Should().ContainSingle();
-        failure.Errors[0].Should().Contain("no DocumentId join path could be resolved");
+        failure.Errors[0].Should().Contain("No DocumentId join path could be resolved");
+        failure.Errors[0].Should().EndWith("Should a different authorization strategy be used?");
         failure.Errors[0].Should().Contain("auth.MeetingWithCustomViewProviderTest");
         failure.Errors[0].Should().Contain("MeetingWithCustomViewProviderTest");
         failure.Errors[0].Should().NotContain("is not a recognized built-in strategy");

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -851,6 +851,100 @@ public class Given_DescriptorReadHandler
     }
 
     [Test]
+    public async Task It_validates_a_descriptor_get_by_id_custom_view_configured_before_an_unsupported_relationship_terminal()
+    {
+        // The GET-many sibling of this case validates the view ahead of its 501. GET-by-id owes the same:
+        // the unsupported relationship strategy is what makes the request not implemented, but a view
+        // configured ahead of that terminal still executes, so a missing one keeps its own 500.
+        var commandExecutor = A.Fake<IRelationalCommandExecutor>();
+        var databaseException = new StubDbException("custom view does not exist");
+        A.CallTo(() =>
+                commandExecutor.ExecuteReaderAsync(
+                    A<RelationalCommand>._,
+                    A<Func<IRelationalCommandReader, CancellationToken, Task<bool>>>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Throws(databaseException);
+        var sut = CreateHandler(commandExecutor);
+
+        var action = () =>
+            sut.HandleGetByIdAsync(
+                new DescriptorGetByIdRequest(
+                    CreateQueryMappingSet(SqlDialect.Pgsql, CreateSupportedDescriptorQueryCapability()),
+                    _descriptorResource,
+                    new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-141414141414")),
+                    RelationalGetRequestReadMode.ExternalResponse,
+                    [
+                        CreateAuthorizationStrategyEvaluator(
+                            AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                        ),
+                        CreateAuthorizationStrategyEvaluator("StudentWithCustomViewProviderTest"),
+                    ],
+                    readableProfileProjectionContext: null,
+                    new TraceId("descriptor-get-custom-view-unsupported-relationship"),
+                    new RelationalAuthorizationContext([], ["uri://ed-fi.org/"])
+                )
+            );
+
+        var assertion = await action.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+
+        assertion.Which.InnerException.Should().BeSameAs(databaseException);
+    }
+
+    [Test]
+    public async Task It_excludes_the_resolved_custom_view_from_the_descriptor_get_by_id_not_implemented_message()
+    {
+        // Same shape with a view that validates cleanly, so the 501 is returned. A resolved custom view is
+        // supported on GET-by-id too, so it must not appear among the unsupported effective strategies and
+        // the message must not claim only NamespaceBased/NoFurtherAuthorizationRequired are supported.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        var sut = CreateHandler(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            new DescriptorGetByIdRequest(
+                CreateQueryMappingSet(SqlDialect.Pgsql, CreateSupportedDescriptorQueryCapability()),
+                _descriptorResource,
+                new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-151515151515")),
+                RelationalGetRequestReadMode.ExternalResponse,
+                [
+                    CreateAuthorizationStrategyEvaluator(
+                        AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                    ),
+                    CreateAuthorizationStrategyEvaluator("StudentWithCustomViewProviderTest"),
+                ],
+                readableProfileProjectionContext: null,
+                new TraceId("descriptor-get-custom-view-excluded-from-message"),
+                new RelationalAuthorizationContext([], ["uri://ed-fi.org/"])
+            )
+        );
+
+        var failureMessage = result
+            .Should()
+            .BeOfType<GetResult.GetFailureNotImplemented>()
+            .Subject.FailureMessage;
+        failureMessage.Should().NotContain("StudentWithCustomViewProviderTest");
+        failureMessage
+            .Should()
+            .Contain(
+                $"Effective strategies: ['{AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly}']."
+            );
+        failureMessage
+            .Should()
+            .Contain("and/or a resolved custom view-based strategy are currently supported.");
+        // The view was resolved and validated, which is what makes excluding it correct.
+        commandExecutor
+            .Commands.Select(command => command.CommandText)
+            .Should()
+            .ContainSingle(sql =>
+                sql.Contains("StudentWithCustomViewProviderTest", StringComparison.Ordinal)
+                && sql.Contains("LIMIT 0", StringComparison.Ordinal)
+            );
+    }
+
+    [Test]
     public async Task It_validates_a_descriptor_get_by_id_custom_view_configured_before_a_no_usable_root_column_terminal()
     {
         // The no-usable-root-column 500 resolves before any row is fetched, but a custom view configured ahead
@@ -1032,6 +1126,48 @@ public class Given_DescriptorReadHandler
         result
             .Should()
             .BeOfType<QueryResult.QueryFailureNotImplemented>()
+            .Which.FailureMessage.Should()
+            .Contain(AuthorizationStrategyNameConstants.OwnershipBased)
+            .And.NotContain("StudentWithCustomViewProviderTest");
+        commandExecutor
+            .Commands.Select(command => command.CommandText)
+            .Should()
+            .ContainSingle(sql =>
+                sql.Contains("StudentWithCustomViewProviderTest", StringComparison.Ordinal)
+                && sql.Contains("LIMIT 0", StringComparison.Ordinal)
+            );
+    }
+
+    [Test]
+    public async Task It_excludes_the_resolved_custom_view_from_the_descriptor_get_by_id_OwnershipBased_message()
+    {
+        // The GET-by-id mirror of the sibling above. OwnershipBased is what fails the request closed, so it
+        // belongs in the message; the resolved custom view is supported on this path too and must not be
+        // named alongside it.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        var sut = CreateHandler(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            new DescriptorGetByIdRequest(
+                CreateQueryMappingSet(SqlDialect.Pgsql, CreateSupportedDescriptorQueryCapability()),
+                _descriptorResource,
+                new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-161616161616")),
+                RelationalGetRequestReadMode.ExternalResponse,
+                [
+                    CreateAuthorizationStrategyEvaluator("StudentWithCustomViewProviderTest"),
+                    CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+                ],
+                readableProfileProjectionContext: null,
+                new TraceId("descriptor-get-custom-view-ownership"),
+                new RelationalAuthorizationContext([], ["uri://ed-fi.org/"])
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNotImplemented>()
             .Which.FailureMessage.Should()
             .Contain(AuthorizationStrategyNameConstants.OwnershipBased)
             .And.NotContain("StudentWithCustomViewProviderTest");

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -247,10 +247,11 @@ public class Given_DescriptorReadHandler
     [Test]
     public async Task It_returns_namespace_403_for_descriptor_get_by_id_when_no_prefixes_precede_an_unsupported_custom_view()
     {
-        // Custom views are implemented for ReadMany only, so on GET-by-id they fail closed with 501 —
-        // but ranked after the namespace terminals, exactly as OwnershipBased is. Custom-view-only
-        // GET-by-id remains 501; that ordering is pinned in Given_RelationalAuthorizationPlanner.
-        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        // The namespace 403 still outranks the custom view's own outcome, but the view is configured ahead of
+        // that terminal, so it executes first and its auth view is validated before the 403 is reported.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
         var sut = CreateHandler(commandExecutor);
 
         var result = await sut.HandleGetByIdAsync(
@@ -274,7 +275,11 @@ public class Given_DescriptorReadHandler
             .BeOfType<GetResult.GetFailureNamespaceNotAuthorized>()
             .Which.NamespaceFailure.FailureKind.Should()
             .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
-        commandExecutor.Commands.Should().BeEmpty();
+        commandExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.CommandText.Should()
+            .Contain("StudentWithCustomViewProviderTest");
     }
 
     [Test]
@@ -843,6 +848,51 @@ public class Given_DescriptorReadHandler
                 sql.Contains("StudentWithCustomViewProviderTest", StringComparison.Ordinal)
                 && sql.Contains("LIMIT 0", StringComparison.Ordinal)
             );
+    }
+
+    [Test]
+    public async Task It_validates_a_descriptor_get_by_id_custom_view_configured_before_a_no_usable_root_column_terminal()
+    {
+        // The no-usable-root-column 500 resolves before any row is fetched, but a custom view configured ahead
+        // of it executes first, so a missing or non-conforming view keeps its own configuration failure rather
+        // than being hidden by this terminal.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        var sut = CreateHandler(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            new DescriptorGetByIdRequest(
+                CreateQueryMappingSet(
+                    SqlDialect.Pgsql,
+                    CreateSupportedDescriptorQueryCapability(),
+                    includeDescriptorMetadata: false
+                ),
+                _descriptorResource,
+                new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-131313131313")),
+                RelationalGetRequestReadMode.ExternalResponse,
+                [
+                    CreateAuthorizationStrategyEvaluator("StudentWithCustomViewProviderTest"),
+                    CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                ],
+                readableProfileProjectionContext: null,
+                new TraceId("descriptor-get-custom-view-no-usable-root"),
+                new RelationalAuthorizationContext([], ["uri://ed-fi.org/"])
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("no Namespace securable element resolves to a root table column");
+        commandExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.CommandText.Should()
+            .Contain("StudentWithCustomViewProviderTest");
     }
 
     [Test]
@@ -2261,18 +2311,21 @@ public class Given_DescriptorReadHandler
 
     private static DescriptorReadHandler CreateHandler(
         IRelationalCommandExecutor commandExecutor,
-        IReadableProfileProjector? readableProfileProjector = null
+        IReadableProfileProjector? readableProfileProjector = null,
+        ICustomViewAuthorizationExecutor? customViewAuthorizationExecutor = null
     ) =>
         CreateHandler(
             commandExecutor,
             PassthroughDocumentCacheReadAccelerationCoordinator.Instance,
-            readableProfileProjector
+            readableProfileProjector,
+            customViewAuthorizationExecutor
         );
 
     private static DescriptorReadHandler CreateHandler(
         IRelationalCommandExecutor commandExecutor,
         IDocumentCacheReadAccelerationCoordinator readAccelerationCoordinator,
-        IReadableProfileProjector? readableProfileProjector = null
+        IReadableProfileProjector? readableProfileProjector = null,
+        ICustomViewAuthorizationExecutor? customViewAuthorizationExecutor = null
     )
     {
         return new DescriptorReadHandler(
@@ -2280,7 +2333,8 @@ public class Given_DescriptorReadHandler
             readableProfileProjector ?? A.Fake<IReadableProfileProjector>(),
             _servedEtagComposer,
             NullLogger<DescriptorReadHandler>.Instance,
-            readAccelerationCoordinator
+            readAccelerationCoordinator,
+            customViewAuthorizationExecutor ?? A.Fake<ICustomViewAuthorizationExecutor>()
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -917,6 +917,100 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
     }
 
     [Test]
+    public async Task It_fails_closed_for_a_descriptor_write_custom_view_needing_a_proposed_reference_value_before_a_namespace_terminal()
+    {
+        // The view is configured before the namespace terminal, so it executes first. Planning it through the
+        // page planner accepted a basis this path cannot execute and reported the namespace 403 instead; the
+        // terminal has to plan with the same descriptor-write rules the Plan outcome uses.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: [],
+                authorizationStrategies: [CustomViewStrategy("StudentWithATag"), NamespaceStrategy()],
+                mappingSet: CreateMappingSetWithStudentReference(SqlDialect.Pgsql)
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(
+                CustomViewAuthorizationSecurityConfigurationMessages.UnsupportedProposedBasisForDescriptorWrite(
+                    "StudentWithATag"
+                )
+            );
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_validates_an_earlier_descriptor_write_custom_view_before_an_unknown_strategy_terminal()
+    {
+        // The later basis does not resolve, so the strategy-level planner reports it and the write stops at
+        // that terminal. The earlier self-basis view is configured before it and executes first, so the
+        // terminal has to carry and validate it. Reached through WriteTerminal, which is why this fails if
+        // that terminal plans with the page planner instead of the descriptor-write single-record path.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies: [DeleteCustomViewStrategy(), CustomViewStrategy("MeetingWithATag")]
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>();
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_validates_an_earlier_descriptor_write_custom_view_before_an_unsupported_proposed_basis()
+    {
+        // Same ordering rule for the fail-closed proposed-basis rejection: the view configured before it
+        // planned successfully and executes first, so it is validated before that failure is reported.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies: [DeleteCustomViewStrategy(), CustomViewStrategy("StudentWithATag")],
+                mappingSet: CreateMappingSetWithStudentReference(SqlDialect.Pgsql)
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(
+                CustomViewAuthorizationSecurityConfigurationMessages.UnsupportedProposedBasisForDescriptorWrite(
+                    "StudentWithATag"
+                )
+            );
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
     public async Task It_fails_closed_for_a_descriptor_write_custom_view_needing_a_proposed_reference_value()
     {
         // A basis reached through a document reference needs a proposed basis value bound from the finalized

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -844,6 +844,294 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
     }
 
     [Test]
+    public async Task It_validates_a_descriptor_post_custom_view_configured_before_a_namespace_no_prefixes_terminal()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: [],
+                authorizationStrategies: [DeleteCustomViewStrategy(), NamespaceStrategy()]
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_does_not_validate_a_descriptor_post_custom_view_configured_after_a_namespace_no_prefixes_terminal()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: [],
+                authorizationStrategies: [NamespaceStrategy(), DeleteCustomViewStrategy()]
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>();
+        validationExecutor.Commands.Should().BeEmpty();
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_validates_a_descriptor_put_custom_view_configured_before_an_unsupported_strategy()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+
+        var result = await sut.HandlePutAsync(
+            CreatePutRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies:
+                [
+                    DeleteCustomViewStrategy(),
+                    UnsupportedStrategy(AuthorizationStrategyNameConstants.OwnershipBased),
+                ]
+            )
+        );
+
+        result.Should().BeOfType<UpdateResult.UpdateFailureNotImplemented>();
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_fails_closed_for_a_descriptor_write_custom_view_needing_a_proposed_reference_value()
+    {
+        // A basis reached through a document reference needs a proposed basis value bound from the finalized
+        // root row, which descriptor writes have no equivalent of. Skipping the check would serve a write the
+        // strategy restricts, so the plan is rejected before the write session opens.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: [],
+                authorizationStrategies: [CustomViewStrategy("StudentWithATag")],
+                mappingSet: CreateMappingSetWithStudentReference(SqlDialect.Pgsql)
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(
+                CustomViewAuthorizationSecurityConfigurationMessages.UnsupportedProposedBasisForDescriptorWrite(
+                    "StudentWithATag"
+                )
+            );
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_reports_a_self_basis_denial_through_the_precondition_helper_without_a_later_namespace_check()
+    {
+        // Seam E: the If-None-Match create resolves through the shared locked-precondition helper rather than
+        // the plain create path. The exact defect this guards was the two paths disagreeing, so the same
+        // configured-order rule has to hold here — the denial preempts both the namespace check and the
+        // precondition outcome.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sut = CreateSut(
+            sessionFactory,
+            targetLookupService,
+            customViewValidationCommandExecutor: validationExecutor
+        );
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies: [DeleteCustomViewStrategy(), NamespaceStrategy()],
+                writePrecondition: new WritePrecondition.IfNoneMatch(["\"some-etag\""])
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(DeleteCustomViewStrategyName);
+        validationExecutor.Commands.Should().ContainSingle();
+        // The outcome is the same in either ordering once namespace authorizes, so the ordering is only
+        // observable in whether the namespace statement was issued at all.
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("namespacePrefixes", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    [Test]
+    public async Task It_runs_a_namespace_check_configured_first_before_a_precondition_helper_self_basis_denial()
+    {
+        // The mirror of the previous case through the same helper: NamespaceBased is configured first, so it
+        // runs, and the denial is reported only once it authorizes.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sut = CreateSut(
+            sessionFactory,
+            targetLookupService,
+            customViewValidationCommandExecutor: validationExecutor
+        );
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies: [NamespaceStrategy(), DeleteCustomViewStrategy()],
+                writePrecondition: new WritePrecondition.IfNoneMatch(["\"some-etag\""])
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(DeleteCustomViewStrategyName);
+        validationExecutor.Commands.Should().ContainSingle();
+        // The mirror assertion: configured first, the namespace statement is issued before the denial.
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .Contain(command =>
+                command.CommandText.Contains("namespacePrefixes", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    [Test]
+    public async Task It_reports_a_self_basis_denial_without_running_a_namespace_check_configured_after_it()
+    {
+        // Configured order decides the first failure. The denial is deterministic and configured first, so the
+        // namespace check never runs — no session is opened at all.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sut = CreateSut(
+            sessionFactory,
+            targetLookupService,
+            customViewValidationCommandExecutor: validationExecutor
+        );
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies: [DeleteCustomViewStrategy(), NamespaceStrategy()]
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(DeleteCustomViewStrategyName);
+        validationExecutor.Commands.Should().ContainSingle();
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_runs_a_namespace_check_configured_before_a_self_basis_denial_first()
+    {
+        // The mirror case: NamespaceBased is configured first, so it runs — which requires a session — and the
+        // denial is only reported once that check has authorized.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sut = CreateSut(
+            sessionFactory,
+            targetLookupService,
+            customViewValidationCommandExecutor: validationExecutor
+        );
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies: [NamespaceStrategy(), DeleteCustomViewStrategy()]
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Which.CustomViewFailure.StrategyName.Should()
+            .Be(DeleteCustomViewStrategyName);
+        // The session proves the earlier namespace check actually ran before the denial was reported.
+        sessionFactory.CreateAsyncCallCount.Should().Be(1);
+        validationExecutor.Commands.Should().ContainSingle();
+    }
+
+    [Test]
+    public async Task It_denies_a_descriptor_post_create_with_a_self_basis_custom_view_after_validating_the_view()
+    {
+        // The row does not exist yet, so no view row can reference it — a deterministic auth.md 2.4 denial. The
+        // view is still probed first so a misconfigured view keeps its own 500, and no session is opened.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sut = CreateSut(
+            sessionFactory,
+            targetLookupService,
+            customViewValidationCommandExecutor: validationExecutor
+        );
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(namespacePrefixes: [], authorizationStrategies: [DeleteCustomViewStrategy()])
+        );
+
+        var failure = result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure;
+        failure.StrategyName.Should().Be(DeleteCustomViewStrategyName);
+        failure.FailureKind.Should().Be(CustomViewAuthorizationFailureKind.NoMatchingRow);
+        failure.ValueSource.Should().Be(CustomViewAuthorizationFailureValueSource.Proposed);
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
     public async Task It_validates_a_descriptor_delete_custom_view_configured_before_a_namespace_no_prefixes_terminal()
     {
         // The namespace 403 resolves before the write session opens, but a custom view configured ahead of it
@@ -1270,6 +1558,29 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
 
     private static DescriptorWriteRequest CreatePostRequest(
         IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator[] authorizationStrategies,
+        string @namespace = "uri://ed-fi.org/SchoolTypeDescriptor",
+        string codeValue = "Charter",
+        SqlDialect dialect = SqlDialect.Pgsql,
+        WritePrecondition? writePrecondition = null,
+        MappingSet? mappingSet = null
+    ) =>
+        new(
+            mappingSet ?? CreateMappingSet(dialect),
+            _descriptorResource,
+            CreateDescriptorRequestBody(@namespace, codeValue),
+            _documentUuid,
+            new ReferentialId(Guid.Parse("11111111-2222-3333-4444-555555555555")),
+            new TraceId("descriptor-post-namespace"),
+            authorizationStrategies,
+            new RelationalAuthorizationContext([], namespacePrefixes)
+        )
+        {
+            WritePrecondition = writePrecondition ?? new WritePrecondition.None(),
+        };
+
+    private static DescriptorWriteRequest CreatePostRequest(
+        IReadOnlyList<string> namespacePrefixes,
         AuthorizationStrategyEvaluator authorizationStrategy,
         string @namespace = "uri://ed-fi.org/SchoolTypeDescriptor",
         string codeValue = "Charter",
@@ -1283,6 +1594,24 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             new ReferentialId(Guid.Parse("11111111-2222-3333-4444-555555555555")),
             new TraceId("descriptor-post-namespace"),
             [authorizationStrategy],
+            new RelationalAuthorizationContext([], namespacePrefixes)
+        );
+
+    private static DescriptorWriteRequest CreatePutRequest(
+        IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator[] authorizationStrategies,
+        string @namespace = "uri://ed-fi.org/SchoolTypeDescriptor",
+        string codeValue = "Charter",
+        SqlDialect dialect = SqlDialect.Pgsql
+    ) =>
+        new(
+            CreateMappingSet(dialect),
+            _descriptorResource,
+            CreateDescriptorRequestBody(@namespace, codeValue),
+            _documentUuid,
+            referentialId: null,
+            new TraceId("descriptor-put-namespace"),
+            authorizationStrategies,
             new RelationalAuthorizationContext([], namespacePrefixes)
         );
 
@@ -1325,6 +1654,9 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
 
     private static AuthorizationStrategyEvaluator DeleteCustomViewStrategy() =>
         new(DeleteCustomViewStrategyName, [], FilterOperator.And);
+
+    private static AuthorizationStrategyEvaluator CustomViewStrategy(string strategyName) =>
+        new(strategyName, [], FilterOperator.And);
 
     private static DescriptorDeleteRequest CreateDeleteRequest(
         IReadOnlyList<string> namespacePrefixes,
@@ -1419,9 +1751,19 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             }
         );
 
-    private static MappingSet CreateMappingSet(SqlDialect dialect)
+    /// <summary>
+    /// A descriptor mapping set whose root carries a document reference to <c>Ed-Fi.Student</c>. No shipped
+    /// ApiSchema produces this shape — see the ApiSchema pinning test — but nothing in the model builder
+    /// prevents it, so the descriptor write path's fail-closed branch needs a way to be reached.
+    /// </summary>
+    private static MappingSet CreateMappingSetWithStudentReference(SqlDialect dialect) =>
+        CreateMappingSet(dialect, withStudentReference: true);
+
+    private static MappingSet CreateMappingSet(SqlDialect dialect, bool withStudentReference = false)
     {
         var resourceKey = new ResourceKeyEntry(1, _descriptorResource, "1.0.0", true);
+        var studentResource = new QualifiedResourceName("Ed-Fi", "Student");
+        var studentResourceKey = new ResourceKeyEntry(2, studentResource, "1.0.0", true);
         var descriptorSchema = new DbSchemaName("dms");
         var rootTable = new DbTableModel(
             new DbTableName(descriptorSchema, "Descriptor"),
@@ -1449,6 +1791,20 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
                     null,
                     new ColumnStorage.Stored()
                 ),
+                .. withStudentReference
+                    ?
+                    [
+                        new DbColumnModel(
+                            new DbColumnName("StudentDocumentId"),
+                            ColumnKind.Scalar,
+                            new RelationalScalarType(ScalarKind.Int64),
+                            true,
+                            null,
+                            null,
+                            new ColumnStorage.Stored()
+                        ),
+                    ]
+                    : (DbColumnModel[])[],
             ],
             []
         );
@@ -1458,6 +1814,57 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             StorageKind: ResourceStorageKind.SharedDescriptorTable,
             Root: rootTable,
             TablesInDependencyOrder: [rootTable],
+            DocumentReferenceBindings: withStudentReference
+                ?
+                [
+                    new DocumentReferenceBinding(
+                        IsIdentityComponent: false,
+                        ReferenceObjectPath: new JsonPathExpression("$.studentReference", []),
+                        Table: rootTable.Table,
+                        FkColumn: new DbColumnName("StudentDocumentId"),
+                        TargetResource: studentResource,
+                        IdentityBindings:
+                        [
+                            new ReferenceIdentityBinding(
+                                IdentityJsonPath: new JsonPathExpression("$.studentUniqueId", []),
+                                ReferenceJsonPath: new JsonPathExpression(
+                                    "$.studentReference.studentUniqueId",
+                                    []
+                                ),
+                                Column: new DbColumnName("StudentDocumentId")
+                            ),
+                        ]
+                    ),
+                ]
+                : [],
+            DescriptorEdgeSources: []
+        );
+        var studentRootTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "Student"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_Student",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        );
+        var studentResourceModel = new RelationalResourceModel(
+            Resource: studentResource,
+            PhysicalSchema: new DbSchemaName("edfi"),
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: studentRootTable,
+            TablesInDependencyOrder: [studentRootTable],
             DocumentReferenceBindings: [],
             DescriptorEdgeSources: []
         );
@@ -1481,13 +1888,15 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
                     ApiSchemaFormatVersion: "1.0",
                     RelationalMappingVersion: "v1",
                     EffectiveSchemaHash: "schema-hash",
-                    ResourceKeyCount: 1,
+                    ResourceKeyCount: (short)(withStudentReference ? 2 : 1),
                     ResourceKeySeedHash: [1, 2, 3],
                     SchemaComponentsInEndpointOrder:
                     [
                         new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash"),
                     ],
-                    ResourceKeysInIdOrder: [resourceKey]
+                    ResourceKeysInIdOrder: withStudentReference
+                        ? [resourceKey, studentResourceKey]
+                        : [resourceKey]
                 ),
                 Dialect: dialect,
                 ProjectSchemasInEndpointOrder:
@@ -1502,6 +1911,16 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
                         resourceModel,
                         descriptorMetadata
                     ),
+                    .. withStudentReference
+                        ?
+                        [
+                            new ConcreteResourceModel(
+                                studentResourceKey,
+                                ResourceStorageKind.RelationalTables,
+                                studentResourceModel
+                            ),
+                        ]
+                        : (ConcreteResourceModel[])[],
                 ],
                 AbstractIdentityTablesInNameOrder: [],
                 AbstractUnionViewsInNameOrder: [],
@@ -1510,14 +1929,23 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             ),
             WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>(),
             ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
-            ResourceKeyIdByResource: new Dictionary<QualifiedResourceName, short>
-            {
-                [resourceKey.Resource] = resourceKey.ResourceKeyId,
-            },
-            ResourceKeyById: new Dictionary<short, ResourceKeyEntry>
-            {
-                [resourceKey.ResourceKeyId] = resourceKey,
-            },
+            ResourceKeyIdByResource: withStudentReference
+                ? new Dictionary<QualifiedResourceName, short>
+                {
+                    [resourceKey.Resource] = resourceKey.ResourceKeyId,
+                    [studentResource] = studentResourceKey.ResourceKeyId,
+                }
+                : new Dictionary<QualifiedResourceName, short>
+                {
+                    [resourceKey.Resource] = resourceKey.ResourceKeyId,
+                },
+            ResourceKeyById: withStudentReference
+                ? new Dictionary<short, ResourceKeyEntry>
+                {
+                    [resourceKey.ResourceKeyId] = resourceKey,
+                    [studentResourceKey.ResourceKeyId] = studentResourceKey,
+                }
+                : new Dictionary<short, ResourceKeyEntry> { [resourceKey.ResourceKeyId] = resourceKey },
             SecurableElementColumnPathsByResource: new Dictionary<
                 QualifiedResourceName,
                 IReadOnlyList<ResolvedSecurableElementPath>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -1226,6 +1226,103 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
     }
 
     [Test]
+    public async Task It_runs_a_descriptor_update_custom_view_configured_after_namespace_before_the_proposed_namespace_check()
+    {
+        // Every stored check AND-composes against the locked row, in configured order, before the proposed
+        // value's own check reads the request body. Running the proposed namespace check first would let its
+        // 403 mask the stored custom-view answer configured after NamespaceBased — here, the
+        // urn:ed-fi:api:system 500 its nonconforming view owes.
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PutResult = new RelationalWriteTargetLookupResult.ExistingDocument(
+                documentId,
+                _documentUuid,
+                44L
+            ),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        // The stored namespace check authorizes; the proposed one would deny, and must not get to answer
+        // while a stored check configured after it is still owed.
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(ProposedMismatchFailure())
+        );
+        var validationExecutor = new RecordingCustomViewValidationExecutor(
+            new StubDbException("missing authorization view")
+        );
+        var sut = CreateSut(
+            sessionFactory,
+            targetLookupService,
+            customViewValidationCommandExecutor: validationExecutor
+        );
+
+        var act = async () =>
+            await sut.HandlePutAsync(
+                CreatePutRequest(
+                    namespacePrefixes: ["uri://ed-fi.org/"],
+                    authorizationStrategies: [NamespaceStrategy(), DeleteCustomViewStrategy()],
+                    @namespace: "uri://other.org/SchoolTypeDescriptor"
+                )
+            );
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_runs_a_precondition_path_custom_view_configured_after_namespace_before_the_proposed_namespace_check()
+    {
+        // The same ordering through the shared locked-precondition helper. The exact defect this guards is the
+        // two paths disagreeing, so the stored sequence has to complete before the proposed check here too.
+        var documentId = 345L;
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        // IfMatch PUT path: resolve target via session executor -> lock scalar -> load persisted -> checks.
+        sessionFactory.Session.Executor.ResultSets.Enqueue([
+            CreateResolvedExistingDocumentRowWithId(documentId),
+        ]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(ProposedMismatchFailure())
+        );
+        var validationExecutor = new RecordingCustomViewValidationExecutor(
+            new StubDbException("missing authorization view")
+        );
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+        var request = CreatePutRequest(
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            authorizationStrategies: [NamespaceStrategy(), DeleteCustomViewStrategy()],
+            @namespace: "uri://other.org/SchoolTypeDescriptor"
+        ) with
+        {
+            WritePrecondition = new WritePrecondition.IfMatch("\"stale-etag\""),
+        };
+
+        var act = async () => await sut.HandlePutAsync(request);
+
+        await act.Should().ThrowAsync<CustomViewAuthorizationValidationException>();
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
     public async Task It_validates_a_descriptor_delete_custom_view_configured_before_a_namespace_no_prefixes_terminal()
     {
         // The namespace 403 resolves before the write session opens, but a custom view configured ahead of it
@@ -2192,9 +2289,11 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
 
 /// <summary>
 /// Records the custom-view validation probes a descriptor write terminal issues. The probe is parameterless
-/// catalog SQL, so the recorded command text is the whole observable effect.
+/// catalog SQL, so the recorded command text is the whole observable effect. Supplying
+/// <paramref name="failure"/> makes every probe fail the way a missing or nonconforming view does.
 /// </summary>
-internal sealed class RecordingCustomViewValidationExecutor : IRelationalCommandExecutor
+internal sealed class RecordingCustomViewValidationExecutor(DbException? failure = null)
+    : IRelationalCommandExecutor
 {
     public SqlDialect Dialect => SqlDialect.Pgsql;
 
@@ -2209,6 +2308,6 @@ internal sealed class RecordingCustomViewValidationExecutor : IRelationalCommand
         ArgumentNullException.ThrowIfNull(command);
         Commands.Add(command.CommandText);
 
-        return Task.FromResult(default(TResult)!);
+        return failure is null ? Task.FromResult(default(TResult)!) : Task.FromException<TResult>(failure);
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -844,6 +844,85 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
     }
 
     [Test]
+    public async Task It_validates_a_descriptor_delete_custom_view_configured_before_a_namespace_no_prefixes_terminal()
+    {
+        // The namespace 403 resolves before the write session opens, but a custom view configured ahead of it
+        // executes first, so a missing or non-conforming view keeps its own 500.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: [],
+                authorizationStrategies: [DeleteCustomViewStrategy(), NamespaceStrategy()]
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_does_not_validate_a_descriptor_delete_custom_view_configured_after_a_namespace_no_prefixes_terminal()
+    {
+        // The run would have aborted at the namespace position, so a view configured after it never executes
+        // and must not be probed either.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: [],
+                authorizationStrategies: [NamespaceStrategy(), DeleteCustomViewStrategy()]
+            )
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>();
+        validationExecutor.Commands.Should().BeEmpty();
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_validates_a_descriptor_delete_custom_view_configured_before_an_unsupported_strategy()
+    {
+        // OwnershipBased executes last regardless of configured position, so every resolved view is validated
+        // before its 501.
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var validationExecutor = new RecordingCustomViewValidationExecutor();
+        var sut = CreateSut(sessionFactory, customViewValidationCommandExecutor: validationExecutor);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategies:
+                [
+                    DeleteCustomViewStrategy(),
+                    UnsupportedStrategy(AuthorizationStrategyNameConstants.OwnershipBased),
+                ]
+            )
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNotImplemented>();
+        validationExecutor
+            .Commands.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(DeleteCustomViewStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
     public async Task It_returns_namespace_403_without_opening_a_session_when_the_client_has_no_prefixes()
     {
         var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
@@ -1228,7 +1307,8 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
     private static DescriptorWriteHandler CreateSut(
         RecordingNamespaceWriteSessionFactory sessionFactory,
         IRelationalWriteTargetLookupService? targetLookupService = null,
-        IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
+        IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null,
+        IRelationalCommandExecutor? customViewValidationCommandExecutor = null
     ) =>
         new(
             targetLookupService ?? A.Fake<IRelationalWriteTargetLookupService>(),
@@ -1237,7 +1317,26 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             sessionFactory,
             NullLogger<DescriptorWriteHandler>.Instance,
             new ServedEtagComposer(),
-            providerFailureExtractor
+            providerFailureExtractor,
+            customViewValidationCommandExecutor: customViewValidationCommandExecutor
+        );
+
+    private const string DeleteCustomViewStrategyName = "SchoolTypeDescriptorWithATag";
+
+    private static AuthorizationStrategyEvaluator DeleteCustomViewStrategy() =>
+        new(DeleteCustomViewStrategyName, [], FilterOperator.And);
+
+    private static DescriptorDeleteRequest CreateDeleteRequest(
+        IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator[] authorizationStrategies
+    ) =>
+        new(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            _documentUuid,
+            new TraceId("descriptor-delete-namespace"),
+            authorizationStrategies,
+            new RelationalAuthorizationContext([], namespacePrefixes)
         );
 
     private sealed class StubRelationalWriteTargetLookupService : IRelationalWriteTargetLookupService
@@ -1566,5 +1665,28 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             await using var reader = new InMemoryRelationalCommandReader(resultSets);
             return await readAsync(reader, cancellationToken);
         }
+    }
+}
+
+/// <summary>
+/// Records the custom-view validation probes a descriptor write terminal issues. The probe is parameterless
+/// catalog SQL, so the recorded command text is the whole observable effect.
+/// </summary>
+internal sealed class RecordingCustomViewValidationExecutor : IRelationalCommandExecutor
+{
+    public SqlDialect Dialect => SqlDialect.Pgsql;
+
+    public List<string> Commands { get; } = [];
+
+    public Task<TResult> ExecuteReaderAsync<TResult>(
+        RelationalCommand command,
+        Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        Commands.Add(command.CommandText);
+
+        return Task.FromResult(default(TResult)!);
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteOrchestrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteOrchestrationTests.cs
@@ -70,6 +70,7 @@ public class Given_No_Profile_Relational_Post
             AuthorizationSubjectSelectorTestSupport.Create(),
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
             A.Fake<INamespaceAuthorizationExecutor>(),
+            A.Fake<ICustomViewAuthorizationExecutor>(),
             A.Fake<IRelationalCommandExecutor>(),
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -161,6 +162,7 @@ public class Given_No_Profile_Relational_Put
             AuthorizationSubjectSelectorTestSupport.Create(),
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
             A.Fake<INamespaceAuthorizationExecutor>(),
+            A.Fake<ICustomViewAuthorizationExecutor>(),
             A.Fake<IRelationalCommandExecutor>(),
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -252,6 +254,7 @@ public class Given_A_Profiled_Relational_Post
             AuthorizationSubjectSelectorTestSupport.Create(),
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
             A.Fake<INamespaceAuthorizationExecutor>(),
+            A.Fake<ICustomViewAuthorizationExecutor>(),
             A.Fake<IRelationalCommandExecutor>(),
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -352,6 +355,7 @@ public class Given_A_Profiled_Relational_Put
             AuthorizationSubjectSelectorTestSupport.Create(),
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
             A.Fake<INamespaceAuthorizationExecutor>(),
+            A.Fake<ICustomViewAuthorizationExecutor>(),
             A.Fake<IRelationalCommandExecutor>(),
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ProposedCustomViewValueExtractorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ProposedCustomViewValueExtractorTests.cs
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_a_proposed_custom_view_value_extractor
+{
+    private static readonly DbTableName _rootTable = new(new DbSchemaName("edfi"), "CourseTranscript");
+    private static readonly DbTableName _otherTable = new(
+        new DbSchemaName("edfi"),
+        "StudentSchoolAssociation"
+    );
+    private static readonly DbColumnName _basisColumn = new("StudentDocumentId");
+
+    private static SingleRecordCustomViewAuthorizationCheckSpec ProposedCheck(
+        int index = 3,
+        DbColumnName? column = null,
+        DbTableName? rootTable = null,
+        DbTableName? bindingTable = null
+    ) =>
+        CheckWithTarget(
+            index,
+            CustomViewAuthorizationCheckValueSource.Proposed,
+            new CustomViewAuthorizationCheckTarget.Proposed(
+                rootTable ?? _rootTable,
+                new CustomViewAuthorizationProposedValueBinding(
+                    bindingTable ?? rootTable ?? _rootTable,
+                    column ?? _basisColumn,
+                    "StudentDocumentId",
+                    "cvBasis"
+                )
+            )
+        );
+
+    private static SingleRecordCustomViewAuthorizationCheckSpec SelfBasisCheck(
+        int index = 4,
+        DbTableName? rootTable = null
+    ) =>
+        CheckWithTarget(
+            index,
+            CustomViewAuthorizationCheckValueSource.Proposed,
+            new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(rootTable ?? _rootTable)
+        );
+
+    private static SingleRecordCustomViewAuthorizationCheckSpec CheckWithTarget(
+        int index,
+        CustomViewAuthorizationCheckValueSource valueSource,
+        CustomViewAuthorizationCheckTarget target
+    ) =>
+        new(
+            new ConfiguredAuthorizationStrategy("StudentWithCTECourseEnrollments", 0),
+            index,
+            valueSource,
+            new DbTableName(new DbSchemaName("auth"), "StudentWithCTECourseEnrollments"),
+            new DbColumnName("DocumentId"),
+            [new ColumnPathStep(_rootTable, _basisColumn, null, null)],
+            target,
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            ["StudentUniqueId"],
+            "You may need a Student with CTE Course Enrollments."
+        );
+
+    [Test]
+    public void It_extracts_the_basis_document_id_from_the_finalized_root_row_binding()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+
+        var result = ProposedCustomViewValueExtractor.Extract([ProposedCheck()], rootRow);
+
+        var work = result.Should().BeOfType<ProposedCustomViewExtractionResult.Ready>().Which.Work;
+        work.SelfBasisChecks.Should().BeEmpty();
+        work.SqlValues.Should().ContainSingle();
+        work.SqlValues[0].Check.Index.Should().Be(3);
+        work.SqlValues[0].BasisValue.Should().Be(9182L);
+    }
+
+    [Test]
+    public void It_extracts_a_null_basis_value_when_the_finalized_reference_is_null()
+    {
+        // A nullable reference the client omitted. The §2.8 proposed-value-missing decision belongs to the
+        // SQL, so extraction reports the null rather than treating it as a planning defect.
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(null));
+
+        var result = ProposedCustomViewValueExtractor.Extract([ProposedCheck()], rootRow);
+
+        result
+            .Should()
+            .BeOfType<ProposedCustomViewExtractionResult.Ready>()
+            .Which.Work.SqlValues[0]
+            .BasisValue.Should()
+            .BeNull();
+    }
+
+    [Test]
+    public void It_extracts_a_null_basis_value_when_the_finalized_reference_is_db_null()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(DBNull.Value));
+
+        var result = ProposedCustomViewValueExtractor.Extract([ProposedCheck()], rootRow);
+
+        result
+            .Should()
+            .BeOfType<ProposedCustomViewExtractionResult.Ready>()
+            .Which.Work.SqlValues[0]
+            .BasisValue.Should()
+            .BeNull();
+    }
+
+    [Test]
+    public void It_preserves_request_wide_indexes_across_a_slice_that_starts_above_zero()
+    {
+        // The proposed slice follows the stored one, so its first index is not zero. Execution maps cv1
+        // payloads against the full planned list, which only works if these indexes survive extraction.
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+
+        var result = ProposedCustomViewValueExtractor.Extract(
+            [ProposedCheck(index: 2), ProposedCheck(index: 3)],
+            rootRow
+        );
+
+        result
+            .Should()
+            .BeOfType<ProposedCustomViewExtractionResult.Ready>()
+            .Which.Work.SqlValues.Select(value => value.Check.Index)
+            .Should()
+            .Equal(2, 3);
+    }
+
+    [Test]
+    public void It_separates_self_basis_checks_from_the_checks_sql_decides()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+
+        var result = ProposedCustomViewValueExtractor.Extract(
+            [ProposedCheck(index: 2), SelfBasisCheck(index: 3)],
+            rootRow
+        );
+
+        var work = result.Should().BeOfType<ProposedCustomViewExtractionResult.Ready>().Which.Work;
+        work.SqlValues.Select(value => value.Check.Index).Should().Equal(2);
+        work.SelfBasisChecks.Select(check => check.Index).Should().Equal(3);
+    }
+
+    [Test]
+    public void It_returns_invalid_when_no_root_binding_matches_the_basis_column()
+    {
+        // Failing closed is required: skipping the check would serve a write the strategy restricts.
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+
+        var result = ProposedCustomViewValueExtractor.Extract(
+            [ProposedCheck(column: new DbColumnName("NotAColumn"))],
+            rootRow
+        );
+
+        result
+            .Should()
+            .BeOfType<ProposedCustomViewExtractionResult.InvalidAuthorizationPlan>()
+            .Which.FailureMessage.Should()
+            .Contain("NotAColumn");
+    }
+
+    [Test]
+    public void It_returns_invalid_when_a_check_targets_a_different_root_table()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+
+        var result = ProposedCustomViewValueExtractor.Extract(
+            [ProposedCheck(rootTable: _otherTable)],
+            rootRow
+        );
+
+        result.Should().BeOfType<ProposedCustomViewExtractionResult.InvalidAuthorizationPlan>();
+    }
+
+    [Test]
+    public void It_returns_invalid_when_the_binding_names_a_foreign_table_holding_a_root_column_name()
+    {
+        // The target root table is correct but the binding's table is not, and the bound column name does
+        // exist on the root. Matching on the column alone would read the root's value as though it were the
+        // foreign table's, so the mismatch has to fail closed on its own.
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+
+        var result = ProposedCustomViewValueExtractor.Extract(
+            [ProposedCheck(bindingTable: _otherTable)],
+            rootRow
+        );
+
+        result
+            .Should()
+            .BeOfType<ProposedCustomViewExtractionResult.InvalidAuthorizationPlan>()
+            .Which.FailureMessage.Should()
+            .Contain("StudentSchoolAssociation");
+    }
+
+    [Test]
+    public void It_returns_invalid_when_a_self_basis_check_targets_a_different_root_table()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+
+        var result = ProposedCustomViewValueExtractor.Extract(
+            [SelfBasisCheck(rootTable: _otherTable)],
+            rootRow
+        );
+
+        result.Should().BeOfType<ProposedCustomViewExtractionResult.InvalidAuthorizationPlan>();
+    }
+
+    [Test]
+    public void It_returns_invalid_when_a_check_is_not_a_proposed_value_source()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+        var storedCheck = CheckWithTarget(
+            0,
+            CustomViewAuthorizationCheckValueSource.Stored,
+            new CustomViewAuthorizationCheckTarget.Stored(_rootTable, new DbColumnName("DocumentId"))
+        );
+
+        var result = ProposedCustomViewValueExtractor.Extract([storedCheck], rootRow);
+
+        result.Should().BeOfType<ProposedCustomViewExtractionResult.InvalidAuthorizationPlan>();
+    }
+
+    [Test]
+    public void It_returns_invalid_when_a_proposed_check_carries_a_stored_target()
+    {
+        // Value source and target are separate fields, so a plan can disagree with itself. That disagreement
+        // is a configuration defect, not a denial.
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+        var mismatched = CheckWithTarget(
+            3,
+            CustomViewAuthorizationCheckValueSource.Proposed,
+            new CustomViewAuthorizationCheckTarget.Stored(_rootTable, new DbColumnName("DocumentId"))
+        );
+
+        var result = ProposedCustomViewValueExtractor.Extract([mismatched], rootRow);
+
+        result.Should().BeOfType<ProposedCustomViewExtractionResult.InvalidAuthorizationPlan>();
+    }
+
+    [Test]
+    public void It_returns_invalid_when_no_checks_are_supplied()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(9182L));
+
+        var result = ProposedCustomViewValueExtractor.Extract([], rootRow);
+
+        result.Should().BeOfType<ProposedCustomViewExtractionResult.InvalidAuthorizationPlan>();
+    }
+
+    private static RootWriteRowBuffer CreateRootRow(FlattenedWriteValue basisValue)
+    {
+        var tableModel = new DbTableModel(
+            _rootTable,
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_CourseTranscript",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    null,
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    _basisColumn,
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    true,
+                    new JsonPathExpression("$.studentReference.studentUniqueId", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+
+        var writePlan = new TableWritePlan(
+            tableModel,
+            InsertSql: "insert into edfi.\"CourseTranscript\" values (@DocumentId, @StudentDocumentId)",
+            UpdateSql: "update edfi.\"CourseTranscript\" set \"StudentDocumentId\" = @StudentDocumentId where \"DocumentId\" = @DocumentId",
+            DeleteByParentSql: null,
+            BulkInsertBatching: new BulkInsertBatchingInfo(100, 2, 1000),
+            ColumnBindings:
+            [
+                new WriteColumnBinding(
+                    tableModel.Columns[0],
+                    new WriteValueSource.DocumentId(),
+                    "DocumentId"
+                ),
+                new WriteColumnBinding(
+                    tableModel.Columns[1],
+                    new WriteValueSource.Scalar(
+                        new JsonPathExpression("$.studentReference.studentUniqueId", []),
+                        new RelationalScalarType(ScalarKind.Int64)
+                    ),
+                    "StudentDocumentId"
+                ),
+            ],
+            KeyUnificationPlans: []
+        );
+
+        return new RootWriteRowBuffer(
+            writePlan,
+            [FlattenedWriteValue.UnresolvedRootDocumentId.Instance, basisValue]
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCustomViewAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCustomViewAuthorizationTests.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// The value-source slices exist so execution never has to re-derive them, but they must never disagree with
+/// the full planned list they came from — that list is the only authority for resolving a <c>cv1</c> payload.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_A_RelationalCustomViewAuthorization
+{
+    private static readonly DbTableName RootTable = new(new DbSchemaName("edfi"), "School");
+    private static readonly DbColumnName DocumentIdColumn = new("DocumentId");
+
+    private static SingleRecordCustomViewAuthorizationCheckSpec Check(
+        int index,
+        CustomViewAuthorizationCheckValueSource valueSource,
+        string strategyName
+    ) =>
+        new(
+            new ConfiguredAuthorizationStrategy(strategyName, 0),
+            index,
+            valueSource,
+            new DbTableName(new DbSchemaName("auth"), strategyName),
+            DocumentIdColumn,
+            [new ColumnPathStep(RootTable, DocumentIdColumn, null, null)],
+            valueSource is CustomViewAuthorizationCheckValueSource.Stored
+                ? new CustomViewAuthorizationCheckTarget.Stored(RootTable, DocumentIdColumn)
+                : new CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable(RootTable),
+            new QualifiedResourceName("Ed-Fi", "School"),
+            [$"{strategyName}Element"],
+            $"You may need a {strategyName} hint."
+        );
+
+    /// <summary>An Update plan: stored checks first, then the proposed pair, indexed request-wide.</summary>
+    private static RelationalCustomViewAuthorization CreateUpdatePlan() =>
+        new([
+            Check(0, CustomViewAuthorizationCheckValueSource.Stored, "SchoolWithATag"),
+            Check(1, CustomViewAuthorizationCheckValueSource.Stored, "SchoolWithAnotherTag"),
+            Check(2, CustomViewAuthorizationCheckValueSource.Proposed, "SchoolWithATag"),
+            Check(3, CustomViewAuthorizationCheckValueSource.Proposed, "SchoolWithAnotherTag"),
+        ]);
+
+    [Test]
+    public void It_keeps_the_full_planned_list_intact()
+    {
+        CreateUpdatePlan().Checks.Select(check => check.Index).Should().Equal(0, 1, 2, 3);
+    }
+
+    [Test]
+    public void It_slices_by_value_source_preserving_request_wide_indexes()
+    {
+        var plan = CreateUpdatePlan();
+
+        plan.StoredChecks.Select(check => check.Index).Should().Equal(0, 1);
+        // The proposed slice starts above zero, which is what lets both slices co-batch without their
+        // payload indexes colliding.
+        plan.ProposedChecks.Select(check => check.Index).Should().Equal(2, 3);
+    }
+
+    [Test]
+    public void It_slices_a_stored_only_plan_to_the_whole_list_and_nothing_proposed()
+    {
+        // GET-by-id and DELETE plan stored values only, so the stored slice is the full list.
+        var plan = new RelationalCustomViewAuthorization([
+            Check(0, CustomViewAuthorizationCheckValueSource.Stored, "SchoolWithATag"),
+        ]);
+
+        plan.StoredChecks.Should().Equal(plan.Checks);
+        plan.ProposedChecks.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_recomputes_both_slices_for_a_different_set_of_checks()
+    {
+        // Producing a different set requires a new instance — Checks is not init-settable, so a copy cannot
+        // carry slices computed from some other list.
+        var storedOnly = new RelationalCustomViewAuthorization([
+            Check(0, CustomViewAuthorizationCheckValueSource.Stored, "SchoolWithATag"),
+        ]);
+        var withProposed = new RelationalCustomViewAuthorization([
+            .. storedOnly.Checks,
+            Check(1, CustomViewAuthorizationCheckValueSource.Proposed, "SchoolWithATag"),
+        ]);
+
+        storedOnly.ProposedChecks.Should().BeEmpty();
+        withProposed.StoredChecks.Select(check => check.Index).Should().Equal(0);
+        withProposed.ProposedChecks.Select(check => check.Index).Should().Equal(1);
+    }
+
+    [Test]
+    public void It_is_unaffected_by_mutating_the_list_it_was_constructed_from()
+    {
+        // IReadOnlyList is a read-only view, not an immutable value, so the constructor copies. Without that
+        // copy a caller could append after construction and leave the slices describing contents Checks no
+        // longer reported — the same stale-slice divergence, reached from outside.
+        List<SingleRecordCustomViewAuthorizationCheckSpec> mutableChecks =
+        [
+            Check(0, CustomViewAuthorizationCheckValueSource.Stored, "SchoolWithATag"),
+        ];
+        var plan = new RelationalCustomViewAuthorization(mutableChecks);
+
+        mutableChecks.Add(Check(1, CustomViewAuthorizationCheckValueSource.Proposed, "SchoolWithATag"));
+        mutableChecks[0] = Check(
+            9,
+            CustomViewAuthorizationCheckValueSource.Stored,
+            "SchoolWithSomethingElse"
+        );
+
+        plan.Checks.Should().ContainSingle();
+        plan.Checks[0].ConfiguredStrategy.StrategyName.Should().Be("SchoolWithATag");
+        plan.Checks[0].Index.Should().Be(0);
+        plan.StoredChecks.Should().Equal(plan.Checks);
+        plan.ProposedChecks.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_rejects_a_missing_check_list()
+    {
+        var act = () => new RelationalCustomViewAuthorization(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -1750,6 +1750,258 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
     private const string CustomViewStrategyName = "SchoolWithATag";
 
+    /// <summary>
+    /// Records the custom-view validation probes a GET-by-id terminal issues.
+    /// </summary>
+    private List<string> GivenCustomViewValidationIsRecorded()
+    {
+        List<string> capturedValidationSql = [];
+
+        A.CallTo(() =>
+                _commandExecutor.ExecuteReaderAsync(
+                    A<RelationalCommand>._,
+                    A<Func<IRelationalCommandReader, CancellationToken, Task<bool>>>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call => capturedValidationSql.Add(call.GetArgument<RelationalCommand>(0)!.CommandText))
+            .Returns(Task.FromResult(true));
+
+        return capturedValidationSql;
+    }
+
+    [Test]
+    public async Task It_validates_a_get_by_id_custom_view_configured_before_a_namespace_no_prefixes_terminal()
+    {
+        // The namespace 403 resolves before any target lookup, but a custom view configured ahead of it
+        // executes first, so a missing or non-conforming view keeps its own 500.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var getRequest = CreateGetRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa01")),
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: []
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_does_not_validate_a_get_by_id_custom_view_configured_after_a_namespace_no_prefixes_terminal()
+    {
+        // The run would have aborted at the namespace position, so a view configured after it never executes
+        // and must not be probed either.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var getRequest = CreateGetRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa02")),
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+            ],
+            namespacePrefixes: []
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>();
+        capturedValidationSql.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_validates_a_get_by_id_custom_view_configured_before_a_no_usable_root_column_terminal()
+    {
+        // The no-usable-root-column 500 resolves before any target lookup, but a custom view configured ahead
+        // of it executes first, so it is probed before that terminal.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var getRequest = CreateGetRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa06")),
+            CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo),
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("no Namespace securable element resolves to a root table column");
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_validates_a_delete_custom_view_configured_before_a_no_usable_root_column_terminal()
+    {
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var deleteRequest = CreateCustomViewDeleteRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa07")),
+            CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo),
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("no Namespace securable element resolves to a root table column");
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_validates_a_delete_custom_view_configured_before_a_namespace_parameterization_terminal()
+    {
+        // An empty prefix cannot be parameterized into a LIKE predicate, so the plan fails as a configuration
+        // error after namespace checks were planned. The view configured ahead of NamespaceBased still runs.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var deleteRequest = CreateCustomViewDeleteRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa08")),
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            namespacePrefixes: [""]
+        );
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>();
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+    }
+
+    /// <summary>
+    /// A DELETE request with a custom view configured ahead of <c>NamespaceBased</c>.
+    /// </summary>
+    private static IDeleteRequest CreateCustomViewDeleteRequest(
+        DocumentUuid documentUuid,
+        MappingSet mappingSet,
+        IReadOnlyList<string> namespacePrefixes
+    )
+    {
+        var deleteRequest = A.Fake<IDeleteRequest>();
+        A.CallTo(() => deleteRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => deleteRequest.MappingSet).Returns(mappingSet);
+        A.CallTo(() => deleteRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => deleteRequest.TraceId).Returns(new TraceId("delete-terminal-trace"));
+        A.CallTo(() => deleteRequest.WritePrecondition).Returns(new WritePrecondition.None());
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], namespacePrefixes));
+
+        return deleteRequest;
+    }
+
+    [Test]
+    public async Task It_validates_a_delete_custom_view_configured_before_a_namespace_no_prefixes_terminal()
+    {
+        // DELETE has the same terminal shape as GET-by-id and the same obligation: a view configured ahead of
+        // the terminal executes first, so it is probed before the 403.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var deleteRequest = A.Fake<IDeleteRequest>();
+        A.CallTo(() => deleteRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => deleteRequest.MappingSet)
+            .Returns(CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo));
+        A.CallTo(() => deleteRequest.DocumentUuid)
+            .Returns(new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa05")));
+        A.CallTo(() => deleteRequest.TraceId).Returns(new TraceId("delete-terminal-trace"));
+        A.CallTo(() => deleteRequest.WritePrecondition).Returns(new WritePrecondition.None());
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], []));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_validates_a_get_by_id_custom_view_configured_before_an_ownership_based_terminal()
+    {
+        // OwnershipBased executes last per auth.md regardless of configured position, so every resolved view
+        // runs before its 501.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var getRequest = CreateGetRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa03")),
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNotImplemented>()
+            .Which.FailureMessage.Should()
+            .Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_validates_a_get_by_id_custom_view_configured_before_an_unknown_strategy_terminal()
+    {
+        // An unrecognized strategy is a 500 from the relationship classifier. A custom view configured ahead of
+        // it executes first, so its own configuration failure must not be masked.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var getRequest = CreateGetRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa04")),
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator("UnknownGetByIdStrategy"),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>();
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+    }
+
     private static CustomViewAuthorizationFailure CreateCustomViewFailure(
         CustomViewAuthorizationFailureKind failureKind = CustomViewAuthorizationFailureKind.NoMatchingRow
     ) =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -8962,6 +8962,31 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_returns_post_security_configuration_failure_for_a_child_collection_custom_view_basis()
+    {
+        // The basis is reachable, but only through a child collection table, so a POST's proposed check has
+        // no root-table value to bind: the designed security-configuration failure, not an unhandled
+        // ArgumentOutOfRangeException from the message builder.
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAwareMappingSetWithChildCollectionStudentBasis(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post child collection basis"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([CreateAuthorizationStrategyEvaluator("StudentWithCTECourseEnrollments")]);
+        A.CallTo(() => upsertRequest.AuthorizationContext).Returns(new RelationalAuthorizationContext([]));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle();
+        failure.Errors[0].Should().Contain("StudentWithCTECourseEnrollments");
+        failure.Errors[0].Should().Contain("child collection table");
+    }
+
+    [Test]
     public async Task It_returns_post_security_configuration_failure_before_known_but_not_enabled_result()
     {
         var upsertRequest = A.Fake<IUpsertRequest>();
@@ -13829,6 +13854,102 @@ public class Given_RelationalDocumentStoreRepositoryTests
             resourceInfo,
             CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(resourceInfo)
         );
+
+    /// <summary>
+    /// A write-aware mapping set whose only route from the subject to the Student basis crosses a child
+    /// collection table, which makes the single-record planner fail a POST/PUT proposed check closed with
+    /// <see cref="RelationshipAuthorizationFailureKind.MissingProposedCustomViewRootBinding"/>.
+    /// </summary>
+    private static MappingSet CreateWriteAwareMappingSetWithChildCollectionStudentBasis(
+        ResourceInfo resourceInfo
+    )
+    {
+        var mappingSet = WithUnreachableStudentBasis(
+            resourceInfo,
+            CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(resourceInfo)
+        );
+        var resource = new QualifiedResourceName(
+            resourceInfo.ProjectName.Value,
+            resourceInfo.ResourceName.Value
+        );
+        var childTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "SchoolStudent"),
+            new JsonPathExpression("$.students[*]", []),
+            new TableKey(
+                "PK_SchoolStudent",
+                [new DbKeyColumn(new DbColumnName("CollectionItemId"), ColumnKind.Scalar)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Student_DocumentId"),
+                    ColumnKind.DocumentFk,
+                    null,
+                    false,
+                    null,
+                    new QualifiedResourceName("Ed-Fi", "Student")
+                ),
+            ],
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Unspecified,
+                [new DbColumnName("CollectionItemId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+        var childBinding = new DocumentReferenceBinding(
+            true,
+            new JsonPathExpression("$.students[*].studentReference", []),
+            childTable.Table,
+            new DbColumnName("Student_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Student"),
+            [
+                new ReferenceIdentityBinding(
+                    new JsonPathExpression("$.studentUniqueId", []),
+                    new JsonPathExpression("$.students[*].studentReference.studentUniqueId", []),
+                    new DbColumnName("Student_StudentUniqueId")
+                ),
+            ],
+            IsRequired: true
+        );
+
+        return mappingSet with
+        {
+            Model = mappingSet.Model with
+            {
+                ConcreteResourcesInNameOrder =
+                [
+                    .. mappingSet.Model.ConcreteResourcesInNameOrder.Select(concreteResource =>
+                        concreteResource.ResourceKey.Resource == resource
+                            ? concreteResource with
+                            {
+                                RelationalModel = concreteResource.RelationalModel with
+                                {
+                                    TablesInDependencyOrder =
+                                    [
+                                        concreteResource.RelationalModel.Root,
+                                        childTable,
+                                    ],
+                                    DocumentReferenceBindings = [childBinding],
+                                },
+                            }
+                            : concreteResource
+                    ),
+                ],
+            },
+        };
+    }
 
     /// <summary>
     /// Adds a minimal Student concrete resource so a <c>StudentWith…</c> basis resolves but has no DocumentId

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -8364,7 +8364,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_post_not_implemented_for_custom_view_authorization_before_any_write_work()
+    public async Task It_plans_a_custom_view_alongside_relationship_authorization_for_a_post()
     {
         var documentUuid = new DocumentUuid(Guid.NewGuid());
         var requestBody = CreateRequestBody("Roosevelt High");
@@ -8388,16 +8388,20 @@ public class Given_RelationalDocumentStoreRepositoryTests
         A.CallTo(() => upsertRequest.AuthorizationContext)
             .Returns(new RelationalAuthorizationContext([255901]));
 
-        var result = await _sut.UpsertDocument(upsertRequest);
+        await _sut.UpsertDocument(upsertRequest);
 
-        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureNotImplemented>().Subject;
-        failure.Reason.Should().Be(UpsertFailureNotImplementedReason.StrategyNotEnabled);
-        failure.FailureMessage.Should().Contain("SchoolWithCustomAuthorization");
-        _capturedExecutorRequests.Should().BeEmpty();
-        A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
-            .MustNotHaveHappened();
-        A.CallTo(() => _referenceResolver.ResolveAsync(A<ReferenceResolverRequest>._, A<CancellationToken>._))
-            .MustNotHaveHappened();
+        // The custom view is an AND filter that composes with the relationship OR group rather than
+        // disabling the write, so both are planned and handed to the executor.
+        var customViewAuthorization = _capturedExecutorRequest.CustomViewAuthorization;
+        customViewAuthorization.Should().NotBeNull();
+        customViewAuthorization!
+            .Checks.Should()
+            .OnlyContain(check => check.ConfiguredStrategy.StrategyName == "SchoolWithCustomAuthorization");
+        customViewAuthorization.StoredChecks.Should().ContainSingle();
+        customViewAuthorization.ProposedChecks.Should().ContainSingle();
+        // The relationship strategy is planned as usual: the custom view is excluded from that bucket, so the
+        // relationship planner cannot downgrade it back to unsupported.
+        _capturedExecutorRequest.PostRelationshipAuthorizationPlans.Should().NotBeNull();
     }
 
     [Test]
@@ -8479,6 +8483,235 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .MustNotHaveHappened();
         A.CallTo(() => _referenceResolver.ResolveAsync(A<ReferenceResolverRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_plans_both_custom_view_value_sources_for_a_post()
+    {
+        // A POST resolves to create or upsert-as-update only in-session, so both sources are planned up front
+        // and the executor applies the stored ones only when a target was captured.
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa01"));
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.InsertSuccess(documentUuid, ComposedWriteResultEtag)
+            )
+        );
+
+        await _sut.UpsertDocument(CreateCustomViewUpsertRequest(documentUuid));
+
+        var customViewAuthorization = _capturedExecutorRequest.CustomViewAuthorization;
+        customViewAuthorization.Should().NotBeNull();
+        customViewAuthorization!.StoredChecks.Select(check => check.Index).Should().Equal(0);
+        // The proposed slice starts above zero, which is what keeps the two sources' cv1 payloads distinct.
+        customViewAuthorization.ProposedChecks.Select(check => check.Index).Should().Equal(1);
+        customViewAuthorization
+            .Checks.Should()
+            .OnlyContain(check => check.ConfiguredStrategy.StrategyName == CustomViewStrategyName);
+    }
+
+    [Test]
+    public async Task It_plans_a_self_basis_proposed_check_carrying_both_execution_branches_for_a_post()
+    {
+        // School is its own basis here, so SQL cannot decide the proposed check: the target's DocumentId does
+        // not exist yet on a create and is immutable on an update. The planner records that rather than
+        // guessing which branch applies.
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa02"));
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.InsertSuccess(documentUuid, ComposedWriteResultEtag)
+            )
+        );
+
+        await _sut.UpsertDocument(CreateCustomViewUpsertRequest(documentUuid));
+
+        _capturedExecutorRequest
+            .CustomViewAuthorization!.ProposedChecks.Should()
+            .ContainSingle()
+            .Which.CheckTarget.Should()
+            .BeOfType<CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable>();
+    }
+
+    [Test]
+    public async Task It_plans_both_custom_view_value_sources_for_a_put()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa03"));
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateSuccess(documentUuid, ComposedWriteResultEtag)
+            )
+        );
+
+        await _sut.UpdateDocumentById(CreateCustomViewUpdateRequest(documentUuid));
+
+        var customViewAuthorization = _capturedExecutorRequest.CustomViewAuthorization;
+        customViewAuthorization.Should().NotBeNull();
+        customViewAuthorization!.StoredChecks.Select(check => check.Index).Should().Equal(0);
+        customViewAuthorization.ProposedChecks.Select(check => check.Index).Should().Equal(1);
+    }
+
+    [Test]
+    public async Task It_plans_no_custom_view_authorization_for_a_write_without_a_configured_custom_view()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa04"));
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateSuccess(documentUuid, ComposedWriteResultEtag)
+            )
+        );
+
+        await _sut.UpdateDocumentById(
+            CreateCustomViewUpdateRequest(
+                documentUuid,
+                strategyNames: [AuthorizationStrategyNameConstants.NamespaceBased]
+            )
+        );
+
+        _capturedExecutorRequest.CustomViewAuthorization.Should().BeNull();
+    }
+
+    [Test]
+    public async Task It_surfaces_a_custom_view_denial_the_write_executor_reports_for_a_put()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa05"));
+        var customViewFailure = CreateCustomViewFailure();
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateFailureCustomViewNotAuthorized(customViewFailure)
+            )
+        );
+
+        var result = await _sut.UpdateDocumentById(CreateCustomViewUpdateRequest(documentUuid));
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.Should()
+            .BeSameAs(customViewFailure);
+    }
+
+    [Test]
+    public async Task It_defers_a_post_relationship_no_claims_denial_when_a_custom_view_is_still_pending()
+    {
+        // A custom view is an AND filter that composes ahead of the relationship OR group, so it has to run
+        // before this denial is reported. Short-circuiting here would skip it entirely: there is no
+        // NamespaceBased strategy to keep the request going to the executor.
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa06"));
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.InsertSuccess(documentUuid, ComposedWriteResultEtag)
+            )
+        );
+
+        var upsertRequest = CreateCustomViewUpsertRequest(
+            documentUuid,
+            strategyNames:
+            [
+                CustomViewStrategyName,
+                AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+            ],
+            namespacePrefixes: [],
+            claimEducationOrganizationIds: []
+        );
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        _capturedExecutorRequests.Should().ContainSingle();
+        _capturedExecutorRequest.CustomViewAuthorization.Should().NotBeNull();
+        _capturedExecutorRequest
+            .ProposedRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.NoClaims>();
+    }
+
+    [Test]
+    public async Task It_carries_the_custom_view_plan_through_the_post_create_new_relationship_branch()
+    {
+        // With claims present the existing-resource plan authorizes, which routes through the create-new
+        // proposed-value planning. Every result that method defers to the executor has to carry the plan, or
+        // the checks are dropped on the way.
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa07"));
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.InsertSuccess(documentUuid, ComposedWriteResultEtag)
+            )
+        );
+
+        var upsertRequest = CreateCustomViewUpsertRequest(
+            documentUuid,
+            strategyNames:
+            [
+                CustomViewStrategyName,
+                AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+            ],
+            claimEducationOrganizationIds: [255901L]
+        );
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        _capturedExecutorRequest.PostRelationshipAuthorizationPlans.Should().NotBeNull();
+        var customViewAuthorization = _capturedExecutorRequest.CustomViewAuthorization;
+        customViewAuthorization.Should().NotBeNull();
+        customViewAuthorization!.StoredChecks.Should().ContainSingle();
+        customViewAuthorization.ProposedChecks.Should().ContainSingle();
+    }
+
+    private void GivenWriteExecutorCaptures(RelationalWriteExecutorResult result) =>
+        A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
+            .Invokes(call =>
+            {
+                _capturedExecutorRequest = call.GetArgument<RelationalWriteExecutorInput>(0)!;
+                _capturedExecutorRequests.Add(_capturedExecutorRequest);
+            })
+            .Returns(Task.FromResult(result));
+
+    private static IUpsertRequest CreateCustomViewUpsertRequest(
+        DocumentUuid documentUuid,
+        string[]? strategyNames = null,
+        string[]? namespacePrefixes = null,
+        long[]? claimEducationOrganizationIds = null
+    )
+    {
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateNamespaceAndRelationshipWriteMappingSet(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Custom View"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                .. (strategyNames ?? [CustomViewStrategyName]).Select(CreateAuthorizationStrategyEvaluator),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(
+                new RelationalAuthorizationContext(
+                    claimEducationOrganizationIds ?? [],
+                    namespacePrefixes ?? ["uri://ed-fi.org/"]
+                )
+            );
+
+        return upsertRequest;
+    }
+
+    private static IUpdateRequest CreateCustomViewUpdateRequest(
+        DocumentUuid documentUuid,
+        string[]? strategyNames = null
+    )
+    {
+        var updateRequest = A.Fake<IUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet)
+            .Returns(CreateNamespaceAndRelationshipWriteMappingSet(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Custom View"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                .. (strategyNames ?? [CustomViewStrategyName]).Select(CreateAuthorizationStrategyEvaluator),
+            ]);
+        A.CallTo(() => updateRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        return updateRequest;
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -8660,6 +8660,269 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_validates_a_post_custom_view_before_a_relationship_security_configuration_terminal()
+    {
+        // The unknown relationship strategy makes this a 500, but the custom view AND-composes ahead of the
+        // relationship bucket, so it executes — and is validated — before that terminal is reported.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post relationship 500"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithStudentsOnly
+                ),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([255901]));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>();
+        capturedValidationSql
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("SchoolWithCustomAuthorization");
+    }
+
+    [Test]
+    public async Task It_validates_a_post_custom_view_when_an_unknown_strategy_stops_before_planning()
+    {
+        // An unknown strategy makes the strategy-level outcome SecurityConfigurationError, the sibling entry
+        // arm to StillUnsupported. It enters the bucket with nothing planned either, so it owes the same.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post unknown strategy"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator("CustomAuthorizationStrategy"),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([255901]));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>();
+        capturedValidationSql
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("SchoolWithCustomAuthorization");
+    }
+
+    [Test]
+    public async Task It_validates_a_post_custom_view_when_an_unsupported_strategy_stops_before_planning()
+    {
+        // OwnershipBased makes the strategy-level outcome StillUnsupported, which enters the relationship
+        // bucket before any custom view has been planned. The view still AND-composes ahead of that 501, so
+        // the bucket has to plan and validate it rather than reporting the terminal over an unchecked view.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post unsupported strategy"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([255901]));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureNotImplemented>();
+        capturedValidationSql
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("SchoolWithCustomAuthorization");
+    }
+
+    [Test]
+    public async Task It_validates_a_put_custom_view_when_an_unsupported_strategy_stops_before_planning()
+    {
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var updateRequest = A.Fake<IUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Put unsupported strategy"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => updateRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([255901]));
+
+        var result = await _sut.UpdateDocumentById(updateRequest);
+
+        result.Should().BeOfType<UpdateResult.UpdateFailureNotImplemented>();
+        capturedValidationSql
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("SchoolWithCustomAuthorization");
+    }
+
+    [Test]
+    public async Task It_validates_a_post_custom_view_configured_before_a_no_usable_root_column_terminal()
+    {
+        // The namespace no-usable-root-column 500 resolves in preflight, but a custom view configured ahead of
+        // it executes first, so it is probed before that terminal is reported.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post no usable root"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("no Namespace securable element resolves to a root table column");
+        capturedValidationSql
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("SchoolWithCustomAuthorization");
+    }
+
+    [Test]
+    public async Task It_validates_a_put_custom_view_configured_before_a_no_usable_root_column_terminal()
+    {
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var updateRequest = A.Fake<IUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Put no usable root"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => updateRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.UpdateDocumentById(updateRequest);
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("no Namespace securable element resolves to a root table column");
+        capturedValidationSql
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("SchoolWithCustomAuthorization");
+    }
+
+    [Test]
+    public async Task It_validates_an_earlier_post_custom_view_before_a_later_no_join_path_failure()
+    {
+        // SchoolWithCustomAuthorization plans; StudentWithNoJoinPath does not. The earlier view executes
+        // first, so it is probed even though the later one cannot plan, and only it is probed.
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAwareMappingSetWithCustomViewBasisButNoJoinPath(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post no join path"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator("StudentWithNoJoinPath"),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext).Returns(new RelationalAuthorizationContext([]));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle();
+        failure.Errors[0].Should().Contain("No DocumentId join path");
+        failure.Errors[0].Should().Contain("StudentWithNoJoinPath");
+        capturedValidationSql
+            .Should()
+            .ContainSingle(sql => sql.Contains("SchoolWithCustomAuthorization", StringComparison.Ordinal));
+        capturedValidationSql
+            .Should()
+            .NotContain(sql => sql.Contains("StudentWithNoJoinPath", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public async Task It_validates_an_earlier_put_custom_view_before_a_later_no_join_path_failure()
+    {
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var updateRequest = A.Fake<IUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet)
+            .Returns(CreateWriteAwareMappingSetWithCustomViewBasisButNoJoinPath(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Put no join path"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator("StudentWithNoJoinPath"),
+            ]);
+        A.CallTo(() => updateRequest.AuthorizationContext).Returns(new RelationalAuthorizationContext([]));
+
+        var result = await _sut.UpdateDocumentById(updateRequest);
+
+        var failure = result.Should().BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle();
+        failure.Errors[0].Should().Contain("No DocumentId join path");
+        failure.Errors[0].Should().Contain("StudentWithNoJoinPath");
+        capturedValidationSql
+            .Should()
+            .ContainSingle(sql => sql.Contains("SchoolWithCustomAuthorization", StringComparison.Ordinal));
+        capturedValidationSql
+            .Should()
+            .NotContain(sql => sql.Contains("StudentWithNoJoinPath", StringComparison.Ordinal));
+    }
+
+    [Test]
     public async Task It_returns_post_security_configuration_failure_before_known_but_not_enabled_result()
     {
         var upsertRequest = A.Fake<IUpsertRequest>();
@@ -13510,13 +13773,35 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
     private static MappingSet CreateQuerySupportedMappingSetWithCustomViewBasisButNoJoinPath(
         ResourceInfo resourceInfo
-    )
+    ) =>
+        WithUnreachableStudentBasis(
+            resourceInfo,
+            CreateQuerySupportedMappingSetWithRootEdOrgSubject(resourceInfo)
+        );
+
+    /// <summary>
+    /// The write-path counterpart: the same unreachable Student basis over a mapping set that also carries a
+    /// write plan, so a POST/PUT reaches custom-view planning instead of failing to resolve one.
+    /// </summary>
+    private static MappingSet CreateWriteAwareMappingSetWithCustomViewBasisButNoJoinPath(
+        ResourceInfo resourceInfo
+    ) =>
+        WithUnreachableStudentBasis(
+            resourceInfo,
+            CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(resourceInfo)
+        );
+
+    /// <summary>
+    /// Adds a minimal Student concrete resource so a <c>StudentWith…</c> basis resolves but has no DocumentId
+    /// join path from the subject, which is what makes the planner report a no-join-path failure rather than
+    /// an unknown strategy.
+    /// </summary>
+    private static MappingSet WithUnreachableStudentBasis(ResourceInfo resourceInfo, MappingSet mappingSet)
     {
         var resource = new QualifiedResourceName(
             resourceInfo.ProjectName.Value,
             resourceInfo.ResourceName.Value
         );
-        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(resourceInfo);
         var concreteResources = mappingSet.Model.ConcreteResourcesInNameOrder.ToList();
 
         if (

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -231,6 +231,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: readAccelerationCoordinator
         );
@@ -2064,7 +2065,14 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     A<CancellationToken>._
                 )
             )
-            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+            .Returns(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                )
+            );
         GivenCustomViewAuthorizationReturns(
             new CustomViewAuthorizationExecutionResult.NotAuthorized(customViewFailure)
         );
@@ -2100,7 +2108,14 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     A<CancellationToken>._
                 )
             )
-            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+            .Returns(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                )
+            );
         GivenCustomViewAuthorizationReturns(
             new CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure("bad payload", null)
         );
@@ -2138,7 +2153,12 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 )
             )
             .ReturnsNextFromSequence(
-                new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L),
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                ),
                 new RelationalReadTargetLookupResult.NotFound()
             );
         GivenCustomViewAuthorizationReturns(new CustomViewAuthorizationExecutionResult.StaleTarget());
@@ -2176,7 +2196,14 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     A<CancellationToken>._
                 )
             )
-            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+            .Returns(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                )
+            );
         GivenCustomViewAuthorizationReturns(
             new CustomViewAuthorizationExecutionResult.NotAuthorized(CreateCustomViewFailure())
         );
@@ -2225,7 +2252,14 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     A<CancellationToken>._
                 )
             )
-            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+            .Returns(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                )
+            );
         GivenNamespaceAuthorizationReturns(
             new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
         );
@@ -2265,7 +2299,14 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     A<CancellationToken>._
                 )
             )
-            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+            .Returns(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                )
+            );
         A.CallTo(() =>
                 _customViewAuthorizationExecutor.ExecuteAsync(
                     A<CustomViewAuthorizationExecutionRequest>._,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -94,6 +94,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     private ISingleRecordRelationshipAuthorizationExecutor _singleRecordRelationshipAuthorizationExecutor =
         null!;
     private INamespaceAuthorizationExecutor _namespaceAuthorizationExecutor = null!;
+    private ICustomViewAuthorizationExecutor _customViewAuthorizationExecutor = null!;
     private RelationalWriteExecutorInput _capturedExecutorRequest = null!;
     private List<RelationalWriteExecutorInput> _capturedExecutorRequests = null!;
 
@@ -120,6 +121,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         _singleRecordRelationshipAuthorizationExecutor =
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>();
         _namespaceAuthorizationExecutor = A.Fake<INamespaceAuthorizationExecutor>();
+        _customViewAuthorizationExecutor = A.Fake<ICustomViewAuthorizationExecutor>();
         _capturedExecutorRequests = [];
         A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
             .Invokes(call =>
@@ -177,6 +179,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -201,6 +204,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -723,6 +727,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -1741,6 +1746,300 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 )
             )
             .MustNotHaveHappened();
+    }
+
+    private const string CustomViewStrategyName = "SchoolWithATag";
+
+    private static CustomViewAuthorizationFailure CreateCustomViewFailure(
+        CustomViewAuthorizationFailureKind failureKind = CustomViewAuthorizationFailureKind.NoMatchingRow
+    ) =>
+        new(
+            failureKind,
+            CustomViewAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            CustomViewStrategyName,
+            ReadableSecurableElements: ["School"],
+            Hint: "You may need a School with A Tag."
+        );
+
+    private void GivenCustomViewAuthorizationReturns(CustomViewAuthorizationExecutionResult result) =>
+        A.CallTo(() =>
+                _customViewAuthorizationExecutor.ExecuteAsync(
+                    A<CustomViewAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(Task.FromResult(result));
+
+    private void GivenNamespaceAuthorizationReturns(NamespaceAuthorizationExecutionResult result) =>
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(Task.FromResult(result));
+
+    private void ThenHydrationMustNotHaveHappened() =>
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+
+    [Test]
+    public async Task It_returns_a_custom_view_403_and_skips_hydration_when_the_stored_basis_is_not_in_the_view()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-cccccccccc01"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var customViewFailure = CreateCustomViewFailure();
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators: [CreateAuthorizationStrategyEvaluator(CustomViewStrategyName)]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        GivenCustomViewAuthorizationReturns(
+            new CustomViewAuthorizationExecutionResult.NotAuthorized(customViewFailure)
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureCustomViewNotAuthorized>()
+            .Subject.CustomViewFailure.Should()
+            .BeSameAs(customViewFailure);
+        // "no reconstitution occurs" is the acceptance criterion, so the denial has to precede hydration.
+        ThenHydrationMustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_security_configuration_500_when_a_custom_view_check_reports_an_unmappable_payload()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-cccccccccc02"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators: [CreateAuthorizationStrategyEvaluator(CustomViewStrategyName)]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        GivenCustomViewAuthorizationReturns(
+            new CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure("bad payload", null)
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureSecurityConfiguration>()
+            .Subject.Errors.Should()
+            .Equal("bad payload");
+        ThenHydrationMustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_reresolves_the_target_and_returns_not_exists_when_a_custom_view_check_reports_a_stale_target()
+    {
+        // The row was deleted between the unlocked target lookup and the check, so the read boundary
+        // re-resolves rather than reporting a denial for a row that no longer exists.
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-cccccccccc03"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators: [CreateAuthorizationStrategyEvaluator(CustomViewStrategyName)]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .ReturnsNextFromSequence(
+                new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L),
+                new RelationalReadTargetLookupResult.NotFound()
+            );
+        GivenCustomViewAuthorizationReturns(new CustomViewAuthorizationExecutionResult.StaleTarget());
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureNotExists>();
+        ThenHydrationMustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_runs_a_custom_view_configured_before_NamespaceBased_first()
+    {
+        // Both are AND filters executing in CMS-configured order and the first failure is reported, so the
+        // namespace check must not run once the earlier custom view has denied.
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-cccccccccc04"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        GivenCustomViewAuthorizationReturns(
+            new CustomViewAuthorizationExecutionResult.NotAuthorized(CreateCustomViewFailure())
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureCustomViewNotAuthorized>();
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_runs_NamespaceBased_first_when_it_is_configured_before_the_custom_view()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-cccccccccc05"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var namespaceFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        GivenNamespaceAuthorizationReturns(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>();
+        A.CallTo(() =>
+                _customViewAuthorizationExecutor.ExecuteAsync(
+                    A<CustomViewAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_passes_the_resolved_target_document_id_and_a_contiguously_indexed_check_list_to_the_custom_view_executor()
+    {
+        // The cv1 payload reports only an index and the failure mapper resolves it positionally, so the
+        // executor must receive a list whose indexes match their positions.
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-cccccccccc06"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators: [CreateAuthorizationStrategyEvaluator(CustomViewStrategyName)]
+        );
+        CustomViewAuthorizationExecutionRequest? observedRequest = null;
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        A.CallTo(() =>
+                _customViewAuthorizationExecutor.ExecuteAsync(
+                    A<CustomViewAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call => observedRequest = call.GetArgument<CustomViewAuthorizationExecutionRequest>(0))
+            .Returns(
+                Task.FromResult<CustomViewAuthorizationExecutionResult>(
+                    new CustomViewAuthorizationExecutionResult.NotAuthorized(CreateCustomViewFailure())
+                )
+            );
+
+        await _sut.GetDocumentById(getRequest);
+
+        observedRequest.Should().NotBeNull();
+        observedRequest!.DocumentId.Should().Be(345L);
+        observedRequest
+            .Checks.Select(check => check.Index)
+            .Should()
+            .Equal(Enumerable.Range(0, observedRequest.Checks.Count));
+        observedRequest
+            .Checks.Should()
+            .AllSatisfy(check =>
+                check.ValueSource.Should().Be(CustomViewAuthorizationCheckValueSource.Stored)
+            );
     }
 
     [Test]
@@ -3916,6 +4215,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -4035,6 +4335,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -4108,6 +4409,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -9612,6 +9914,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -9668,6 +9971,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -9709,6 +10013,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -9765,6 +10070,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -9820,6 +10126,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -9885,6 +10192,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -9985,6 +10293,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -10047,6 +10356,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -10086,6 +10396,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             CreateAuthorizationSubjectSelector(),
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -8693,6 +8693,45 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_defers_a_put_no_claims_denial_into_the_proposed_slot_when_a_custom_view_is_pending()
+    {
+        // A custom view AND-composes before the relationship OR group, and its proposed checks run in the
+        // second command. Keeping NoClaims in the stored slot ends the write at the first phase, so those
+        // proposed checks never execute; the denial has to wait in the proposed slot instead.
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa09"));
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateSuccess(documentUuid, ComposedWriteResultEtag)
+            )
+        );
+        var updateRequest = A.Fake<IUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Put no claims with custom view"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ]);
+        A.CallTo(() => updateRequest.AuthorizationContext).Returns(new RelationalAuthorizationContext([]));
+
+        await _sut.UpdateDocumentById(updateRequest);
+
+        _capturedExecutorRequest.StoredRelationshipAuthorization.Should().BeNull();
+        _capturedExecutorRequest
+            .ProposedRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.NoClaims>();
+        var customViewAuthorization = _capturedExecutorRequest.CustomViewAuthorization;
+        customViewAuthorization.Should().NotBeNull();
+        customViewAuthorization!.ProposedChecks.Should().NotBeEmpty();
+    }
+
+    [Test]
     public async Task It_validates_a_post_custom_view_when_an_unknown_strategy_stops_before_planning()
     {
         // An unknown strategy makes the strategy-level outcome SecurityConfigurationError, the sibling entry

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -6798,6 +6798,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         failure.Errors[0].Should().Contain("StudentWithNoJoinPath");
         failure.Errors[0].Should().Contain("auth.StudentWithNoJoinPath");
         failure.Errors[0].Should().Contain("No DocumentId join path");
+        failure.Errors[0].Should().EndWith("Should a different authorization strategy be used?");
         failure.Diagnostics.Should().ContainSingle();
         failure
             .Diagnostics![0]
@@ -6835,6 +6836,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
         failure.Errors.Should().ContainSingle();
         failure.Errors[0].Should().Contain("No DocumentId join path");
+        failure.Errors[0].Should().EndWith("Should a different authorization strategy be used?");
         failure.Errors[0].Should().Contain("StudentWithNoJoinPath");
         capturedValidationSql
             .Should()
@@ -6868,6 +6870,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
         failure.Errors[0].Should().Contain("No DocumentId join path");
+        failure.Errors[0].Should().EndWith("Should a different authorization strategy be used?");
         capturedValidationSql.Should().BeEmpty();
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/AuthorizationSecurityConfigurationDiagnostics.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/AuthorizationSecurityConfigurationDiagnostics.cs
@@ -29,6 +29,8 @@ internal static class AuthorizationSecurityConfigurationDiagnostics
         "RelationshipAuthorization.InvalidAuthorizationResult";
     public const string RelationshipProposedValueExtractionInvalid =
         "RelationshipAuthorization.ProposedValueExtractionInvalid";
+    public const string CustomViewAuth1PayloadMappingFailed =
+        "CustomViewAuthorization.Auth1.PayloadMappingFailed";
 
     public static SecurityConfigurationFailureDiagnostic[] ForNamespacePrefixParameterization(
         string providerOrPlannerFailureKind
@@ -49,6 +51,24 @@ internal static class AuthorizationSecurityConfigurationDiagnostics
                 ProviderOrPlannerFailureKind: providerOrPlannerFailureKind,
                 ConfiguredStrategyNames: [AuthorizationStrategyNameConstants.NamespaceBased],
                 PhysicalPath: FormatNamespacePhysicalPath(checks)
+            ),
+        ];
+
+    /// <summary>
+    /// Diagnostics for a custom-view AUTH1 payload that could not be mapped to a response. Names every
+    /// configured custom view in the batch and the physical basis paths they authorize against, since the
+    /// payload itself no longer identifies which check it came from.
+    /// </summary>
+    public static SecurityConfigurationFailureDiagnostic[] ForCustomViewAuthorizationAuth1(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+    ) =>
+        [
+            new SecurityConfigurationFailureDiagnostic(
+                ProviderOrPlannerFailureKind: CustomViewAuth1PayloadMappingFailed,
+                ConfiguredStrategyNames: DistinctInFirstOccurrenceOrder(
+                    checks.Select(static check => check.ConfiguredStrategy.StrategyName)
+                ),
+                PhysicalPath: FormatCustomViewPhysicalPath(checks)
             ),
         ];
 
@@ -118,6 +138,24 @@ internal static class AuthorizationSecurityConfigurationDiagnostics
                 )
             ),
         ];
+
+    private static string? FormatCustomViewPhysicalPath(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+    )
+    {
+        var physicalPaths = DistinctInFirstOccurrenceOrder(
+            checks.Select(static check =>
+                $"{check.AuthView}.{check.AuthViewDocumentIdColumn.Value} <- {check.PathToBasisResource[^1].SourceTable}.{check.PathToBasisResource[^1].SourceColumnName.Value}"
+            )
+        );
+
+        return physicalPaths.Length switch
+        {
+            0 => null,
+            1 => physicalPaths[0],
+            _ => string.Join(", ", physicalPaths),
+        };
+    }
 
     private static string? FormatNamespacePhysicalPath(IReadOnlyList<NamespaceAuthorizationCheckSpec> checks)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/AuthorizationSecurityConfigurationDiagnostics.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/AuthorizationSecurityConfigurationDiagnostics.cs
@@ -31,6 +31,8 @@ internal static class AuthorizationSecurityConfigurationDiagnostics
         "RelationshipAuthorization.ProposedValueExtractionInvalid";
     public const string CustomViewAuth1PayloadMappingFailed =
         "CustomViewAuthorization.Auth1.PayloadMappingFailed";
+    public const string CustomViewProposedValueExtractionInvalid =
+        "CustomViewAuthorization.ProposedValueExtractionInvalid";
 
     public static SecurityConfigurationFailureDiagnostic[] ForNamespacePrefixParameterization(
         string providerOrPlannerFailureKind
@@ -65,6 +67,22 @@ internal static class AuthorizationSecurityConfigurationDiagnostics
         [
             new SecurityConfigurationFailureDiagnostic(
                 ProviderOrPlannerFailureKind: CustomViewAuth1PayloadMappingFailed,
+                ConfiguredStrategyNames: DistinctInFirstOccurrenceOrder(
+                    checks.Select(static check => check.ConfiguredStrategy.StrategyName)
+                ),
+                PhysicalPath: FormatCustomViewPhysicalPath(checks)
+            ),
+        ];
+
+    /// <summary>
+    /// Diagnostics for proposed custom-view checks that could not be reconciled with the finalized root row.
+    /// </summary>
+    public static SecurityConfigurationFailureDiagnostic[] ForCustomViewProposedValueExtraction(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+    ) =>
+        [
+            new SecurityConfigurationFailureDiagnostic(
+                ProviderOrPlannerFailureKind: CustomViewProposedValueExtractionInvalid,
                 ConfiguredStrategyNames: DistinctInFirstOccurrenceOrder(
                     checks.Select(static check => check.ConfiguredStrategy.StrategyName)
                 ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationCheckSplitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationCheckSplitter.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Splits a planned custom-view check list into independently executable batches, reindexing each so it can be
+/// compiled and mapped on its own.
+/// </summary>
+/// <remarks>
+/// Reindexing is mandatory, not cosmetic. The SQL compiler requires each check's index to equal its emission
+/// position, and the failure mapper resolves a <c>cv1</c> payload positionally against the list it was given.
+/// A batch therefore has to be handed the same contiguous list that produced it; passing a sliced list with
+/// its original indexes would either fail compilation or resolve a denial to the wrong check.
+/// </remarks>
+internal static class CustomViewAuthorizationCheckSplitter
+{
+    /// <summary>
+    /// Reindexes <paramref name="checks"/> to <c>0..n-1</c> in their current order.
+    /// </summary>
+    public static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Reindex(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+    )
+    {
+        ArgumentNullException.ThrowIfNull(checks);
+
+        return [.. checks.Select(static (check, position) => check with { Index = position })];
+    }
+
+    /// <summary>
+    /// Partitions <paramref name="checks"/} by whether the CMS configured them before
+    /// <paramref name="configuredIndex"/>, reindexing both sides.
+    /// </summary>
+    /// <remarks>
+    /// Custom views and <c>NamespaceBased</c> are AND filters that execute in CMS-configured order, and the
+    /// first failure is the one reported. A namespace check therefore has to run between the custom views
+    /// configured before it and those configured after, which is only possible if each side is its own batch.
+    /// Ties go to the custom view: the namespace planner stamps every namespace check with the earliest index
+    /// at which <c>NamespaceBased</c> appears, so an equal index means the same configured position, and
+    /// ordering within it is arbitrary.
+    /// </remarks>
+    public static (
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Before,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> After
+    ) PartitionByConfiguredIndex(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        int configuredIndex
+    )
+    {
+        ArgumentNullException.ThrowIfNull(checks);
+
+        List<SingleRecordCustomViewAuthorizationCheckSpec> before = [];
+        List<SingleRecordCustomViewAuthorizationCheckSpec> after = [];
+
+        foreach (var check in checks)
+        {
+            if (check.ConfiguredStrategy.RawConfiguredIndex <= configuredIndex)
+            {
+                before.Add(check);
+            }
+            else
+            {
+                after.Add(check);
+            }
+        }
+
+        return (Reindex(before), Reindex(after));
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationCheckSplitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationCheckSplitter.cs
@@ -8,32 +8,20 @@ using EdFi.DataManagementService.Backend.Plans;
 namespace EdFi.DataManagementService.Backend;
 
 /// <summary>
-/// Splits a planned custom-view check list into independently executable batches, reindexing each so it can be
-/// compiled and mapped on its own.
+/// Splits a planned custom-view check list into independently executable batches.
 /// </summary>
 /// <remarks>
-/// Reindexing is mandatory, not cosmetic. The SQL compiler requires each check's index to equal its emission
-/// position, and the failure mapper resolves a <c>cv1</c> payload positionally against the list it was given.
-/// A batch therefore has to be handed the same contiguous list that produced it; passing a sliced list with
-/// its original indexes would either fail compilation or resolve a denial to the wrong check.
+/// Each slice keeps the indexes the planner assigned across the whole request, so an index still identifies
+/// one check no matter which slice raised it. That matters because slices co-batched into one command share a
+/// single provider exception: zero-basing each slice would make two different checks both report index 0. The
+/// compiler accepts a slice whose indexes run contiguously from any starting value, and the failure mapper is
+/// always given the request's full planned list.
 /// </remarks>
 internal static class CustomViewAuthorizationCheckSplitter
 {
     /// <summary>
-    /// Reindexes <paramref name="checks"/> to <c>0..n-1</c> in their current order.
-    /// </summary>
-    public static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Reindex(
-        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
-    )
-    {
-        ArgumentNullException.ThrowIfNull(checks);
-
-        return [.. checks.Select(static (check, position) => check with { Index = position })];
-    }
-
-    /// <summary>
-    /// Partitions <paramref name="checks"/} by whether the CMS configured them before
-    /// <paramref name="configuredIndex"/>, reindexing both sides.
+    /// Partitions <paramref name="checks"/> by whether the CMS configured them at or before
+    /// <paramref name="configuredIndex"/>.
     /// </summary>
     /// <remarks>
     /// Custom views and <c>NamespaceBased</c> are AND filters that execute in CMS-configured order, and the
@@ -68,6 +56,6 @@ internal static class CustomViewAuthorizationCheckSplitter
             }
         }
 
-        return (Reindex(before), Reindex(after));
+        return (before, after);
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationCheckSplitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationCheckSplitter.cs
@@ -37,22 +37,33 @@ internal static class CustomViewAuthorizationCheckSplitter
     ) PartitionByConfiguredIndex(
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
         int configuredIndex
+    ) => PartitionByConfiguredIndex(checks, static check => check, configuredIndex);
+
+    /// <summary>
+    /// Partitions items that carry a check — a check paired with an extracted proposed value, for instance —
+    /// by the same rule, so the tie rule has one definition.
+    /// </summary>
+    public static (IReadOnlyList<T> Before, IReadOnlyList<T> After) PartitionByConfiguredIndex<T>(
+        IReadOnlyList<T> items,
+        Func<T, SingleRecordCustomViewAuthorizationCheckSpec> checkSelector,
+        int configuredIndex
     )
     {
-        ArgumentNullException.ThrowIfNull(checks);
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentNullException.ThrowIfNull(checkSelector);
 
-        List<SingleRecordCustomViewAuthorizationCheckSpec> before = [];
-        List<SingleRecordCustomViewAuthorizationCheckSpec> after = [];
+        List<T> before = [];
+        List<T> after = [];
 
-        foreach (var check in checks)
+        foreach (var item in items)
         {
-            if (check.ConfiguredStrategy.RawConfiguredIndex <= configuredIndex)
+            if (checkSelector(item).ConfiguredStrategy.RawConfiguredIndex <= configuredIndex)
             {
-                before.Add(check);
+                before.Add(item);
             }
             else
             {
-                after.Add(check);
+                after.Add(item);
             }
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationCheckSplitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationCheckSplitter.cs
@@ -14,7 +14,7 @@ namespace EdFi.DataManagementService.Backend;
 /// Each slice keeps the indexes the planner assigned across the whole request, so an index still identifies
 /// one check no matter which slice raised it. That matters because slices co-batched into one command share a
 /// single provider exception: zero-basing each slice would make two different checks both report index 0. The
-/// compiler accepts a slice whose indexes run contiguously from any starting value, and the failure mapper is
+/// compiler accepts a slice whose indexes merely increase from any starting value, and the failure mapper is
 /// always given the request's full planned list.
 /// </remarks>
 internal static class CustomViewAuthorizationCheckSplitter

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
@@ -232,6 +232,23 @@ internal static class CustomViewAuthorizationSqlSpecDefaults
 
 internal static class CustomViewAuthorizationSecurityConfigurationMessages
 {
+    /// <summary>
+    /// A self-basis proposed check is only ever satisfied by the stored check for the same configured
+    /// strategy, which is what authorizes the row whose immutable <c>DocumentId</c> the proposed value reuses.
+    /// Without that pair nothing has been proven, so the plan is a configuration defect.
+    /// </summary>
+    public static string UnpairedSelfBasisProposedCheck(string strategyName) =>
+        $"Relational custom view-based authorization metadata is invalid: strategy '{strategyName}' planned a "
+        + "self-basis proposed check with no paired stored check to authorize the existing row.";
+
+    /// <summary>
+    /// Descriptor writes have no finalized root row to read a bound basis value from, so a proposed check
+    /// whose basis is some other resource cannot be executed on that path.
+    /// </summary>
+    public static string UnsupportedProposedBasisForDescriptorWrite(string strategyName) =>
+        $"Relational custom view-based authorization metadata is invalid: strategy '{strategyName}' requires a "
+        + "proposed basis value from a document reference, which descriptor writes do not bind.";
+
     public const string InvalidAuthorizationMetadata =
         "Relational custom view-based authorization metadata is invalid: the authorization batch reported a "
         + "failure that does not correspond to any planned custom-view check.";

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
@@ -80,16 +80,30 @@ public interface ICustomViewAuthorizationExecutor
 /// <c>urn:ed-fi:api:system</c> 500 rather than as an unhandled provider error. Authorization payloads are
 /// dispatched first, so a denial is never relabelled this way.
 /// </para>
+/// <para>
+/// A failure is not the only way <c>auth.{StrategyName}</c> can break its contract, which is why the run is
+/// preceded by a catalog validation whenever the caller supplies an executor for it. The membership SQL reads
+/// <c>cv.DocumentId</c> from that object directly, so a plain table — or a view whose <c>DocumentId</c> is
+/// merely comparable to <c>bigint</c> — answers it without raising anything, and the request would authorize or
+/// deny against an object auth.md does not accept.
+/// </para>
 /// </remarks>
+/// <param name="validationCommandExecutor">
+/// The executor the pre-run catalog validation uses, or <see langword="null"/> to skip it. It must open its own
+/// connection: a write session's executor runs inside the transaction holding the target lock and would consume
+/// that command stream's results.
+/// </param>
 internal sealed class CustomViewAuthorizationExecutor(
     IRelationalCommandExecutor commandExecutor,
-    IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
+    IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null,
+    IRelationalCommandExecutor? validationCommandExecutor = null
 ) : ICustomViewAuthorizationExecutor
 {
     private readonly IRelationalCommandExecutor _commandExecutor =
         commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
     private readonly IRelationshipAuthorizationProviderFailureExtractor _providerFailureExtractor =
         providerFailureExtractor ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance;
+    private readonly IRelationalCommandExecutor? _validationCommandExecutor = validationCommandExecutor;
 
     public async Task<CustomViewAuthorizationExecutionResult> ExecuteAsync(
         CustomViewAuthorizationExecutionRequest request,
@@ -122,6 +136,24 @@ internal sealed class CustomViewAuthorizationExecutor(
             throw new InvalidOperationException(
                 "Custom view authorization executor cannot execute proposed-value checks without extracted runtime values."
             );
+        }
+
+        // Exactly the checks this run emits, never the whole planned list: validating a view configured after
+        // this run would let its 500 preempt a denial the earlier run is about to report.
+        if (_validationCommandExecutor is not null)
+        {
+            await CustomViewAuthorizationValidator
+                .ValidateSingleRecordAsync(
+                    _validationCommandExecutor,
+                    dialect,
+                    [
+                        .. request.Checks.Where(check =>
+                            sqlPlan.EmittedCheckIndexesInOrder.Contains(check.Index)
+                        ),
+                    ],
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
         }
 
         try

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
@@ -11,15 +11,23 @@ using EdFi.DataManagementService.Core.External.Backend;
 
 namespace EdFi.DataManagementService.Backend;
 
-/// <param name="Checks">
-/// The planned checks that produced the batch. The <c>cv1</c> payload carries only an index and resolution is
-/// positional, so this must be the same list, in the same order, that the compiler was given.
+/// <param name="Checks">The checks this batch executes, in emission order.</param>
+/// <param name="PlannedChecks">
+/// Every custom-view check planned for the request, indexed as the planner assigned them. The <c>cv1</c>
+/// payload carries only an index, so a failure is resolved against this list rather than against the batch —
+/// which is what lets one request run several batches without their indexes colliding. Defaults to
+/// <paramref name="Checks"/> for a request that runs a single batch.
 /// </param>
 public sealed record CustomViewAuthorizationExecutionRequest(
     MappingSet MappingSet,
     long DocumentId,
-    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks
-);
+    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks,
+    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? PlannedChecks = null
+)
+{
+    public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecksOrBatch =>
+        PlannedChecks ?? Checks;
+}
 
 public abstract record CustomViewAuthorizationExecutionResult
 {
@@ -131,7 +139,7 @@ internal sealed class CustomViewAuthorizationExecutor(
                     dialect,
                     ex,
                     _providerFailureExtractor,
-                    request.Checks
+                    request.PlannedChecksOrBatch
                 )
             )
         {
@@ -142,7 +150,7 @@ internal sealed class CustomViewAuthorizationExecutor(
                     dialect,
                     ex,
                     _providerFailureExtractor,
-                    request.Checks,
+                    request.PlannedChecksOrBatch,
                     out var customViewFailure
                 )
             )
@@ -154,13 +162,15 @@ internal sealed class CustomViewAuthorizationExecutor(
                     dialect,
                     ex,
                     _providerFailureExtractor,
-                    request.Checks
+                    request.PlannedChecksOrBatch
                 )
             )
         {
             return new CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure(
                 CustomViewAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata,
-                AuthorizationSecurityConfigurationDiagnostics.ForCustomViewAuthorizationAuth1(request.Checks)
+                AuthorizationSecurityConfigurationDiagnostics.ForCustomViewAuthorizationAuth1(
+                    request.PlannedChecksOrBatch
+                )
             );
         }
         catch (DbException ex)

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <param name="Checks">
+/// The planned checks that produced the batch. The <c>cv1</c> payload carries only an index and resolution is
+/// positional, so this must be the same list, in the same order, that the compiler was given.
+/// </param>
+public sealed record CustomViewAuthorizationExecutionRequest(
+    MappingSet MappingSet,
+    long DocumentId,
+    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks
+);
+
+public abstract record CustomViewAuthorizationExecutionResult
+{
+    private CustomViewAuthorizationExecutionResult() { }
+
+    public sealed record Authorized() : CustomViewAuthorizationExecutionResult;
+
+    public sealed record NotAuthorized(CustomViewAuthorizationFailure Failure)
+        : CustomViewAuthorizationExecutionResult;
+
+    /// <summary>
+    /// The batch carried a custom-view payload this family owns but could not turn into a response. A
+    /// security-configuration defect rather than a denial.
+    /// </summary>
+    public sealed record InvalidAuthorizationFailure(
+        string FailureMessage,
+        SecurityConfigurationFailureDiagnostic[]? Diagnostics = null
+    ) : CustomViewAuthorizationExecutionResult;
+
+    /// <summary>
+    /// The stored target row no longer exists: it was deleted between the unlocked target lookup and the
+    /// stored check. Read callers re-resolve the target and surface the resulting 404.
+    /// </summary>
+    public sealed record StaleTarget : CustomViewAuthorizationExecutionResult;
+}
+
+public interface ICustomViewAuthorizationExecutor
+{
+    Task<CustomViewAuthorizationExecutionResult> ExecuteAsync(
+        CustomViewAuthorizationExecutionRequest request,
+        CancellationToken cancellationToken = default
+    );
+}
+
+/// <summary>
+/// Executes co-batched single-record custom view-based authorization SQL. The batch emits one
+/// <c>SELECT CASE ... END;</c> per check that SQL can decide; the first failing check raises AUTH1 with a
+/// <c>cv1|index|kind</c> payload and aborts the batch. A clean run authorizes the record.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike the namespace and relationship executors, this one can be handed a plan that emits no SQL at all: a
+/// self-basis proposed check is decided in C#. That case authorizes vacuously here and the caller owns the
+/// decision, which is why the compiled plan reports its emitted check indexes.
+/// </para>
+/// <para>
+/// A failure carrying no recognized authorization payload is attributed to the custom view rather than
+/// rethrown. The batch's only object created outside the generated schema is <c>auth.{StrategyName}</c>, which
+/// can be dropped, replaced, or revoked between requests, and auth.md requires that to surface as the
+/// <c>urn:ed-fi:api:system</c> 500 rather than as an unhandled provider error. Authorization payloads are
+/// dispatched first, so a denial is never relabelled this way.
+/// </para>
+/// </remarks>
+internal sealed class CustomViewAuthorizationExecutor(
+    IRelationalCommandExecutor commandExecutor,
+    IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
+) : ICustomViewAuthorizationExecutor
+{
+    private readonly IRelationalCommandExecutor _commandExecutor =
+        commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
+    private readonly IRelationshipAuthorizationProviderFailureExtractor _providerFailureExtractor =
+        providerFailureExtractor ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance;
+
+    public async Task<CustomViewAuthorizationExecutionResult> ExecuteAsync(
+        CustomViewAuthorizationExecutionRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Checks.Count == 0)
+        {
+            return new CustomViewAuthorizationExecutionResult.Authorized();
+        }
+
+        var dialect = request.MappingSet.Key.Dialect;
+        var sqlPlan = new SingleRecordCustomViewAuthorizationSqlCompiler(dialect).Compile(
+            new SingleRecordCustomViewAuthorizationSqlSpec(
+                request.Checks,
+                CustomViewAuthorizationSqlSpecDefaults.DocumentIdParameterName
+            )
+        );
+
+        if (sqlPlan.EmittedCheckIndexesInOrder.Count == 0)
+        {
+            // Every planned check is decided in C#; there is nothing to execute.
+            return new CustomViewAuthorizationExecutionResult.Authorized();
+        }
+
+        if (sqlPlan.ProposedValueParametersInOrder.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Custom view authorization executor cannot execute proposed-value checks without extracted runtime values."
+            );
+        }
+
+        try
+        {
+            return await _commandExecutor
+                .ExecuteReaderAsync(
+                    BuildCommand(sqlPlan, request),
+                    ReadAuthorizedResultAsync,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        catch (DbException ex)
+            when (CustomViewAuthorizationProviderFailureMapper.IsStaleStoredTargetFailure(
+                    dialect,
+                    ex,
+                    _providerFailureExtractor,
+                    request.Checks
+                )
+            )
+        {
+            return new CustomViewAuthorizationExecutionResult.StaleTarget();
+        }
+        catch (DbException ex)
+            when (CustomViewAuthorizationProviderFailureMapper.TryMapCustomViewAuthorizationFailure(
+                    dialect,
+                    ex,
+                    _providerFailureExtractor,
+                    request.Checks,
+                    out var customViewFailure
+                )
+            )
+        {
+            return new CustomViewAuthorizationExecutionResult.NotAuthorized(customViewFailure!);
+        }
+        catch (DbException ex)
+            when (CustomViewAuthorizationProviderFailureMapper.IsUnmappableCustomViewPayload(
+                    dialect,
+                    ex,
+                    _providerFailureExtractor,
+                    request.Checks
+                )
+            )
+        {
+            return new CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure(
+                CustomViewAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata,
+                AuthorizationSecurityConfigurationDiagnostics.ForCustomViewAuthorizationAuth1(request.Checks)
+            );
+        }
+        catch (DbException ex)
+            when (CustomViewAuthorizationProviderFailureMapper.IsUnrecognizedProviderFailure(
+                    dialect,
+                    ex,
+                    _providerFailureExtractor
+                )
+            )
+        {
+            // Attributed to the configured view, so the documented urn:ed-fi:api:system 500 is preserved
+            // instead of an unhandled provider error. Mirrors how DMS-1062 guards the GET-many page query.
+            throw new CustomViewAuthorizationValidationException(ex);
+        }
+    }
+
+    internal static RelationalCommand BuildCommand(
+        SingleRecordCustomViewAuthorizationSqlPlan sqlPlan,
+        CustomViewAuthorizationExecutionRequest request
+    ) =>
+        new(
+            sqlPlan.AuthorizationSql,
+            [.. sqlPlan.ParametersInOrder.Select(parameter => BuildParameter(parameter, request.DocumentId))]
+        );
+
+    private static RelationalParameter BuildParameter(QuerySqlParameter parameter, long documentId)
+    {
+        if (parameter.Binding.Kind is not QuerySqlParameterBindingKind.Scalar)
+        {
+            throw new InvalidOperationException(
+                $"Custom view authorization parameter '{parameter.ParameterName}' must bind as a scalar."
+            );
+        }
+
+        return new RelationalParameter($"@{parameter.ParameterName}", documentId);
+    }
+
+    private static async Task<CustomViewAuthorizationExecutionResult> ReadAuthorizedResultAsync(
+        IRelationalCommandReader reader,
+        CancellationToken cancellationToken
+    )
+    {
+        // Advance through every co-batched statement's result set so each check executes and a
+        // later-statement AUTH1 failure surfaces as a DbException rather than being skipped.
+        var hasMoreResultSets = true;
+        while (hasMoreResultSets)
+        {
+            hasMoreResultSets = await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return new CustomViewAuthorizationExecutionResult.Authorized();
+    }
+}
+
+internal static class CustomViewAuthorizationSqlSpecDefaults
+{
+    public const string DocumentIdParameterName = "documentId";
+}
+
+internal static class CustomViewAuthorizationSecurityConfigurationMessages
+{
+    public const string InvalidAuthorizationMetadata =
+        "Relational custom view-based authorization metadata is invalid: the authorization batch reported a "
+        + "failure that does not correspond to any planned custom-view check.";
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationExecutor.cs
@@ -93,10 +93,16 @@ public interface ICustomViewAuthorizationExecutor
 /// connection: a write session's executor runs inside the transaction holding the target lock and would consume
 /// that command stream's results.
 /// </param>
+/// <param name="writeExceptionClassifier">
+/// Keeps transient provider failures (deadlock victim, lock timeout) out of the custom-view attribution: they
+/// say nothing about the view's contract, so they propagate to the caller's existing transient handling
+/// instead of being wrapped as a validation failure.
+/// </param>
 internal sealed class CustomViewAuthorizationExecutor(
     IRelationalCommandExecutor commandExecutor,
     IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null,
-    IRelationalCommandExecutor? validationCommandExecutor = null
+    IRelationalCommandExecutor? validationCommandExecutor = null,
+    IRelationalWriteExceptionClassifier? writeExceptionClassifier = null
 ) : ICustomViewAuthorizationExecutor
 {
     private readonly IRelationalCommandExecutor _commandExecutor =
@@ -104,6 +110,8 @@ internal sealed class CustomViewAuthorizationExecutor(
     private readonly IRelationshipAuthorizationProviderFailureExtractor _providerFailureExtractor =
         providerFailureExtractor ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance;
     private readonly IRelationalCommandExecutor? _validationCommandExecutor = validationCommandExecutor;
+    private readonly IRelationalWriteExceptionClassifier _writeExceptionClassifier =
+        writeExceptionClassifier ?? new NoOpRelationalWriteExceptionClassifier();
 
     public async Task<CustomViewAuthorizationExecutionResult> ExecuteAsync(
         CustomViewAuthorizationExecutionRequest request,
@@ -206,7 +214,8 @@ internal sealed class CustomViewAuthorizationExecutor(
             );
         }
         catch (DbException ex)
-            when (CustomViewAuthorizationProviderFailureMapper.IsUnrecognizedProviderFailure(
+            when (!_writeExceptionClassifier.IsTransientFailure(ex)
+                && CustomViewAuthorizationProviderFailureMapper.IsUnrecognizedProviderFailure(
                     dialect,
                     ex,
                     _providerFailureExtractor
@@ -215,6 +224,8 @@ internal sealed class CustomViewAuthorizationExecutor(
         {
             // Attributed to the configured view, so the documented urn:ed-fi:api:system 500 is preserved
             // instead of an unhandled provider error. Mirrors how DMS-1062 guards the GET-many page query.
+            // Transient failures are excluded above: they prove nothing about the view and must reach the
+            // caller's retryable-failure handling instead.
             throw new CustomViewAuthorizationValidationException(ex);
         }
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationFailureMessages.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationFailureMessages.cs
@@ -14,16 +14,26 @@ namespace EdFi.DataManagementService.Backend;
 /// </summary>
 internal static class CustomViewAuthorizationFailureMessages
 {
+    /// <summary>
+    /// ODS names the specific basis-entity property missing from the subject entity, because it joins
+    /// custom views on natural keys. DMS joins on DocumentId, so no single missing property exists to name:
+    /// the failure is that no reference path reaches the basis resource at all. The wording therefore states
+    /// the DMS failure rather than ODS's, while keeping ODS's closing question, which is the part an operator
+    /// acts on. See the security-configuration table in auth.md.
+    /// </summary>
     public static string NoJoinPath(RelationshipAuthorizationFailureMetadata failure, string operationLabel)
     {
         ArgumentNullException.ThrowIfNull(failure);
 
-        return $"Relational {operationLabel} authorization metadata is invalid for resource '{RelationalWriteSupport.FormatResource(failure.Resource)}'. "
-            + $"Strategy '{failure.ConfiguredStrategy?.StrategyName}' uses custom auth view '{failure.Location?.AuthorizationObjectName ?? "<unknown>"}', "
-            + "but no DocumentId join path could be resolved from the subject resource to the custom view basis resource."
-            + FormatHintSentence(failure.Hint);
-    }
+        // The planner's hint already names both the subject and the basis resource, so it carries that
+        // detail here rather than being appended after the closing question.
+        var joinPathSentence = string.IsNullOrWhiteSpace(failure.Hint)
+            ? "No DocumentId join path could be resolved from the subject resource to the custom view basis resource."
+            : failure.Hint.Trim();
 
-    private static string FormatHintSentence(string? hint) =>
-        string.IsNullOrWhiteSpace(hint) ? string.Empty : $" {hint}";
+        return $"Relational {operationLabel} authorization metadata is invalid for resource '{RelationalWriteSupport.FormatResource(failure.Resource)}'. "
+            + $"Strategy '{failure.ConfiguredStrategy?.StrategyName}' uses custom auth view '{failure.Location?.AuthorizationObjectName ?? "<unknown>"}'. "
+            + $"{joinPathSentence} "
+            + "Should a different authorization strategy be used?";
+    }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationProviderFailureMapper.cs
@@ -19,9 +19,10 @@ namespace EdFi.DataManagementService.Backend;
 /// <c>1|...</c> or namespace <c>ns1|...</c> payload sharing the same command is never claimed here — the
 /// mirror of the yields those families make for <c>cv1</c>.
 /// <para>
-/// Every method takes the same planned check list that produced the batch. The payload carries only an index,
-/// and resolution is positional, so passing a differently-ordered or differently-indexed list would report a
-/// denial as some other check's category.
+/// Every method takes the request's full planned check list, not just the batch that raised the failure. The
+/// payload carries only an index and resolution is positional, so a request that emits several batches keeps
+/// its indexes unique across all of them and resolves any of their payloads against that one list. Passing a
+/// batch-local or reordered list would report a denial as some other check's category.
 /// </para>
 /// </remarks>
 internal static class CustomViewAuthorizationProviderFailureMapper

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationProviderFailureMapper.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Maps a provider <see cref="DbException"/> carrying a custom-view AUTH1 payload (<c>cv1|index|kind</c>)
+/// back to a cross-boundary <see cref="CustomViewAuthorizationFailure"/>.
+/// </summary>
+/// <remarks>
+/// Routes through the shared <see cref="RelationalAuthorizationAuth1Dispatcher"/>, so a relationship
+/// <c>1|...</c> or namespace <c>ns1|...</c> payload sharing the same command is never claimed here — the
+/// mirror of the yields those families make for <c>cv1</c>.
+/// <para>
+/// Every method takes the same planned check list that produced the batch. The payload carries only an index,
+/// and resolution is positional, so passing a differently-ordered or differently-indexed list would report a
+/// denial as some other check's category.
+/// </para>
+/// </remarks>
+internal static class CustomViewAuthorizationProviderFailureMapper
+{
+    public static bool TryMapCustomViewAuthorizationFailure(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
+        out CustomViewAuthorizationFailure? failure
+    )
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(providerFailureExtractor);
+        ArgumentNullException.ThrowIfNull(plannedChecks);
+
+        failure = null;
+
+        return TryDispatchCustomViewPayload(dialect, exception, providerFailureExtractor, out var payload)
+            && payload is not null
+            && CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(payload, plannedChecks, out failure);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="exception"/> reports that the stored target row no longer exists. The read
+    /// boundary re-resolves the target on this result so a row deleted between the unlocked lookup and the
+    /// check surfaces as a 404 rather than an authorization denial.
+    /// </summary>
+    public static bool IsStaleStoredTargetFailure(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks
+    )
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(providerFailureExtractor);
+        ArgumentNullException.ThrowIfNull(plannedChecks);
+
+        return TryDispatchCustomViewPayload(dialect, exception, providerFailureExtractor, out var payload)
+            && payload is not null
+            && CustomViewAuthorizationFailureMapper.IsStaleStoredTargetFailure(payload, plannedChecks);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="exception"/> carries a custom-view AUTH1 payload that this family owns but
+    /// cannot turn into a response — an out-of-range index, or a kind the indexed check's value source cannot
+    /// produce. Such a payload is a security-configuration defect, not a denial, so the caller reports 500
+    /// rather than inventing a 403.
+    /// </summary>
+    public static bool IsUnmappableCustomViewPayload(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks
+    )
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(providerFailureExtractor);
+        ArgumentNullException.ThrowIfNull(plannedChecks);
+
+        if (!TryDispatchCustomViewPayload(dialect, exception, providerFailureExtractor, out var payload))
+        {
+            return false;
+        }
+
+        return payload is not null
+            && !CustomViewAuthorizationFailureMapper.IsStaleStoredTargetFailure(payload, plannedChecks)
+            && !CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(payload, plannedChecks, out _);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="exception"/> carries no recognized authorization payload at all. A custom-view
+    /// statement references <c>auth.{StrategyName}</c>, which is created outside the schema and can be
+    /// missing, replaced, or revoked, so such a failure is attributed to the view rather than escaping as an
+    /// unhandled provider error.
+    /// </summary>
+    public static bool IsUnrecognizedProviderFailure(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor
+    )
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(providerFailureExtractor);
+
+        var providerFailure = providerFailureExtractor.Extract(exception);
+
+        return !RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            dialect,
+            providerFailure.ErrorCode,
+            providerFailure.Message,
+            out _
+        );
+    }
+
+    private static bool TryDispatchCustomViewPayload(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        out CustomViewAuthorizationAuth1FailurePayload? payload
+    )
+    {
+        payload = null;
+        var providerFailure = providerFailureExtractor.Extract(exception);
+
+        if (
+            !RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+                dialect,
+                providerFailure.ErrorCode,
+                providerFailure.Message,
+                out var dispatchResult
+            )
+        )
+        {
+            return false;
+        }
+
+        if (dispatchResult is RelationalAuthorizationAuth1DispatchResult.CustomView customViewResult)
+        {
+            payload = customViewResult.Payload;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationValidator.cs
@@ -53,6 +53,50 @@ internal static class CustomViewAuthorizationValidator
         }
     }
 
+    /// <summary>
+    /// Validates the views behind single-record checks. Used where a check's answer is decided in C# and no
+    /// membership statement will run: without this, a misconfigured view would be reported as the denial that
+    /// decision produces instead of the documented <c>urn:ed-fi:api:system</c> 500.
+    /// </summary>
+    public static Task ValidateSingleRecordAsync(
+        IRelationalCommandExecutor commandExecutor,
+        SqlDialect dialect,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? checks,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (checks is null || checks.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        return ValidateAsync(
+            commandExecutor,
+            dialect,
+            [.. checks.Select(AdaptForValidation)],
+            cancellationToken
+        );
+    }
+
+    private static PageDocumentIdAuthorizationCustomViewCheck AdaptForValidation(
+        SingleRecordCustomViewAuthorizationCheckSpec check
+    )
+    {
+        // The first path step starts at the subject's root row, so it names the root table and the column the
+        // walk begins from — which is what the validation join needs.
+        var firstStep = check.PathToBasisResource[0];
+
+        return new PageDocumentIdAuthorizationCustomViewCheck(
+            check.ConfiguredStrategy.StrategyName,
+            check.ConfiguredStrategy.RawConfiguredIndex,
+            check.AuthView,
+            check.AuthViewDocumentIdColumn,
+            check.PathToBasisResource,
+            firstStep.SourceTable,
+            firstStep.SourceColumnName
+        );
+    }
+
     internal static string BuildCommandText(
         SqlDialect dialect,
         IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> customViewChecks

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -64,7 +64,9 @@ internal sealed class DefaultRelationalWriteExecutor(
                 ?? throw new ArgumentNullException(nameof(referenceResolverAdapterFactory)),
             relationalParameterConfigurator,
             relationshipAuthorizationProviderFailureExtractor,
-            logger
+            logger,
+            commandBudget: null,
+            customViewValidationCommandExecutor
         );
 
     private readonly RelationalWriteExecutionStateResolver _executionStateResolver = new(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -35,7 +35,8 @@ internal sealed class DefaultRelationalWriteExecutor(
     IDocumentCacheWriterTelemetry? documentCacheWriterTelemetry = null,
     IDataStoreSelection? dataStoreSelection = null,
     IRelationalWriteFirstPhase? writeFirstPhase = null,
-    IRelationalWriteSecondCommandPhase? secondCommandPhase = null
+    IRelationalWriteSecondCommandPhase? secondCommandPhase = null,
+    IRelationalCommandExecutor? customViewValidationCommandExecutor = null
 ) : IRelationalWriteExecutor
 {
     private readonly IRelationalWriteSessionFactory _writeSessionFactory =
@@ -86,7 +87,9 @@ internal sealed class DefaultRelationalWriteExecutor(
         ?? new CompositeRelationalWriteSecondCommand(
             relationalParameterConfigurator,
             relationshipAuthorizationProviderFailureExtractor,
-            logger
+            logger,
+            commandBudget: null,
+            customViewValidationCommandExecutor
         );
 
     private readonly RelationalWriteDatabaseFailureResultMapper _databaseFailureResultMapper = new(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -66,7 +66,8 @@ internal sealed class DefaultRelationalWriteExecutor(
             relationshipAuthorizationProviderFailureExtractor,
             logger,
             commandBudget: null,
-            customViewValidationCommandExecutor
+            customViewValidationCommandExecutor,
+            writeExceptionClassifier
         );
 
     private readonly RelationalWriteExecutionStateResolver _executionStateResolver = new(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -405,10 +405,17 @@ internal sealed class DescriptorReadHandler(
                         request,
                         proceed.CustomViewStrategies,
                         out var customViewChecks,
-                        out var customViewPlanFailure
+                        out var customViewPlanFailure,
+                        out var customViewChecksBeforePlanFailure
                     )
                 )
                 {
+                    await ValidateSingleRecordGetByIdCustomViewsAsync(
+                            request,
+                            customViewChecksBeforePlanFailure,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
                     return new DescriptorGetByIdAuthorizationResult(customViewPlanFailure!, null, null, []);
                 }
 
@@ -990,11 +997,13 @@ internal sealed class DescriptorReadHandler(
         DescriptorGetByIdRequest request,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
         out IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> customViewChecks,
-        out GetResult? securityConfigurationFailure
+        out GetResult? securityConfigurationFailure,
+        out IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checksToValidateBeforeFailure
     )
     {
         customViewChecks = [];
         securityConfigurationFailure = null;
+        checksToValidateBeforeFailure = [];
 
         if (customViewStrategies.Count == 0)
         {
@@ -1022,6 +1031,9 @@ internal sealed class DescriptorReadHandler(
                 failure.Errors,
                 failure.Diagnostics
             );
+            // Views configured ahead of the earliest planning failure planned successfully and execute
+            // first, so they are still validated before this failure is reported.
+            checksToValidateBeforeFailure = SingleRecordChecksBeforeFailure(configurationFailure);
             return false;
         }
 
@@ -1029,6 +1041,42 @@ internal sealed class DescriptorReadHandler(
 
         return true;
     }
+
+    /// <summary>
+    /// The planned single-record checks configured strictly before the earliest planning failure. Those views
+    /// planned successfully and execute first, so they are validated even though a later one cannot plan.
+    /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> SingleRecordChecksBeforeFailure(
+        SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+    )
+    {
+        var earliestFailureIndex = RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+            configurationFailure.Failures
+        );
+
+        return
+        [
+            .. configurationFailure.PlannedChecks.Where(check =>
+                check.ConfiguredStrategy.RawConfiguredIndex < earliestFailureIndex
+            ),
+        ];
+    }
+
+    /// <summary>
+    /// Validates single-record checks that execute ahead of a GET-by-id planning failure. These are
+    /// single-record specs, so they take the single-record validator rather than the page-query one.
+    /// </summary>
+    private Task ValidateSingleRecordGetByIdCustomViewsAsync(
+        DescriptorGetByIdRequest request,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        CancellationToken cancellationToken
+    ) =>
+        CustomViewAuthorizationValidator.ValidateSingleRecordAsync(
+            _commandExecutor,
+            request.MappingSet.Key.Dialect,
+            checks,
+            cancellationToken
+        );
 
     /// <summary>
     /// Validates the views that execute ahead of a GET-by-id terminal. A null or empty list is a no-op, so

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -32,6 +32,7 @@ internal sealed class DescriptorReadHandler(
     IServedEtagComposer servedEtagComposer,
     ILogger<DescriptorReadHandler> logger,
     IDocumentCacheReadAccelerationCoordinator readAccelerationCoordinator,
+    ICustomViewAuthorizationExecutor customViewAuthorizationExecutor,
     ChangeQueryPageOrderingPolicy? orderingPolicy = null
 ) : IDescriptorReadHandler
 {
@@ -56,6 +57,9 @@ internal sealed class DescriptorReadHandler(
         servedEtagComposer ?? throw new ArgumentNullException(nameof(servedEtagComposer));
     private readonly ILogger<DescriptorReadHandler> _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ICustomViewAuthorizationExecutor _customViewAuthorizationExecutor =
+        customViewAuthorizationExecutor
+        ?? throw new ArgumentNullException(nameof(customViewAuthorizationExecutor));
     private readonly ChangeQueryPageOrderingPolicy _orderingPolicy =
         orderingPolicy ?? ChangeQueryPageOrderingPolicy.Default;
     private readonly IDocumentCacheReadAccelerationCoordinator _readAccelerationCoordinator =
@@ -211,7 +215,8 @@ internal sealed class DescriptorReadHandler(
         ArgumentNullException.ThrowIfNull(readSingleOrDefaultAsync);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var authorizationResult = ResolveGetByIdAuthorizationPreflight(request);
+        var authorizationResult = await ResolveGetByIdAuthorizationPreflightAsync(request, cancellationToken)
+            .ConfigureAwait(false);
 
         if (authorizationResult.CompleteResult is not null)
         {
@@ -264,6 +269,32 @@ internal sealed class DescriptorReadHandler(
             return new DescriptorGetByIdReadResult<TRow>.Complete(new GetResult.GetFailureNotExists());
         }
 
+        // Custom views and NamespaceBased are AND filters executing in CMS-configured order, and the first
+        // failure is the one reported. The namespace check is in memory and the custom-view checks are their
+        // own query, so the order is sequenced here rather than by statement position.
+        var (customViewsBeforeNamespace, customViewsAfterNamespace) =
+            CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
+                authorizationResult.CustomViewChecks,
+                authorizationResult.Proceed?.NamespaceChecks.Count > 0
+                    ? authorizationResult.Proceed.NamespaceChecks[0].RawConfiguredIndex
+                    : int.MaxValue
+            );
+
+        if (
+            await ExecuteGetByIdCustomViewsAsync(
+                    request,
+                    descriptorRow.DocumentId,
+                    customViewsBeforeNamespace,
+                    authorizationResult.CustomViewChecks,
+                    cancellationToken
+                )
+                .ConfigureAwait(false) is
+            { } beforeNamespaceDenial
+        )
+        {
+            return new DescriptorGetByIdReadResult<TRow>.Complete(beforeNamespaceDenial);
+        }
+
         if (
             ValidateGetByIdDescriptorCandidate(
                 descriptorRow,
@@ -275,6 +306,21 @@ internal sealed class DescriptorReadHandler(
             return new DescriptorGetByIdReadResult<TRow>.Complete(terminal);
         }
 
+        if (
+            await ExecuteGetByIdCustomViewsAsync(
+                    request,
+                    descriptorRow.DocumentId,
+                    customViewsAfterNamespace,
+                    authorizationResult.CustomViewChecks,
+                    cancellationToken
+                )
+                .ConfigureAwait(false) is
+            { } afterNamespaceDenial
+        )
+        {
+            return new DescriptorGetByIdReadResult<TRow>.Complete(afterNamespaceDenial);
+        }
+
         LogDiscriminatorMismatchIfPresent(request, descriptorRow);
 
         return new DescriptorGetByIdReadResult<TRow>.AuthorizedRow(descriptorRow);
@@ -282,11 +328,14 @@ internal sealed class DescriptorReadHandler(
 
     private sealed record DescriptorGetByIdAuthorizationResult(
         GetResult? CompleteResult,
-        NamespacePrefixParameterization? NamespacePrefixParameterization
+        NamespacePrefixParameterization? NamespacePrefixParameterization,
+        DescriptorReadAuthorizationPreflightOutcome.Proceed? Proceed,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewChecks
     );
 
-    private static DescriptorGetByIdAuthorizationResult ResolveGetByIdAuthorizationPreflight(
-        DescriptorGetByIdRequest request
+    private async Task<DescriptorGetByIdAuthorizationResult> ResolveGetByIdAuthorizationPreflightAsync(
+        DescriptorGetByIdRequest request,
+        CancellationToken cancellationToken
     )
     {
         // StoredDocument reads are internal read-modify-write fetches that bypass per-record
@@ -295,7 +344,7 @@ internal sealed class DescriptorReadHandler(
         // namespace authorization preflight and the in-memory stored-namespace check below.
         if (request.ReadMode == RelationalGetRequestReadMode.StoredDocument)
         {
-            return new DescriptorGetByIdAuthorizationResult(null, null);
+            return new DescriptorGetByIdAuthorizationResult(null, null, null, []);
         }
 
         // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) and
@@ -311,33 +360,69 @@ internal sealed class DescriptorReadHandler(
             "GET"
         );
 
-        // Custom views are implemented for GET-many only, so no GET-by-id terminal may carry checks.
-        // Guard every terminal uniformly rather than one shape, so a future planner change that starts
-        // emitting them here fails loudly instead of silently skipping validation.
-        ThrowIfGetByIdCarriesCustomViewChecks(authorizationPreflight);
-
-        return authorizationPreflight switch
+        switch (authorizationPreflight)
         {
-            DescriptorReadAuthorizationPreflightOutcome.NotImplemented notImplemented => new(
-                new GetResult.GetFailureNotImplemented(notImplemented.FailureMessage),
-                null
-            ),
-            DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError configError => new(
-                new GetResult.GetFailureSecurityConfiguration(configError.Errors, configError.Diagnostics),
-                null
-            ),
-            DescriptorReadAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized => new(
-                new GetResult.GetFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure),
-                null
-            ),
-            DescriptorReadAuthorizationPreflightOutcome.Proceed proceed => new(
-                null,
-                proceed.NamespacePrefixParameterization
-            ),
-            _ => throw new InvalidOperationException(
-                $"Unsupported descriptor GET authorization preflight outcome '{authorizationPreflight.GetType().Name}'."
-            ),
-        };
+            case DescriptorReadAuthorizationPreflightOutcome.NotImplemented notImplemented:
+                // Custom views configured ahead of this terminal execute first, so a missing or
+                // non-conforming view keeps its own 500 rather than being hidden by the terminal.
+                await ValidateGetByIdCustomViewsAsync(
+                        request,
+                        notImplemented.CustomViewChecks,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+                return new DescriptorGetByIdAuthorizationResult(
+                    new GetResult.GetFailureNotImplemented(notImplemented.FailureMessage),
+                    null,
+                    null,
+                    []
+                );
+            case DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError configError:
+                await ValidateGetByIdCustomViewsAsync(request, configError.CustomViewChecks, cancellationToken)
+                    .ConfigureAwait(false);
+                return new DescriptorGetByIdAuthorizationResult(
+                    new GetResult.GetFailureSecurityConfiguration(configError.Errors, configError.Diagnostics),
+                    null,
+                    null,
+                    []
+                );
+            case DescriptorReadAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
+                await ValidateGetByIdCustomViewsAsync(
+                        request,
+                        namespaceNotAuthorized.CustomViewChecks,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+                return new DescriptorGetByIdAuthorizationResult(
+                    new GetResult.GetFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure),
+                    null,
+                    null,
+                    []
+                );
+            case DescriptorReadAuthorizationPreflightOutcome.Proceed proceed:
+                if (
+                    !TryPlanGetByIdCustomViews(
+                        request,
+                        proceed.CustomViewStrategies,
+                        out var customViewChecks,
+                        out var customViewPlanFailure
+                    )
+                )
+                {
+                    return new DescriptorGetByIdAuthorizationResult(customViewPlanFailure!, null, null, []);
+                }
+
+                return new DescriptorGetByIdAuthorizationResult(
+                    null,
+                    proceed.NamespacePrefixParameterization,
+                    proceed,
+                    customViewChecks
+                );
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported descriptor GET authorization preflight outcome '{authorizationPreflight.GetType().Name}'."
+                );
+        }
     }
 
     private static GetResult? ValidateGetByIdDescriptorCandidate(
@@ -898,32 +983,116 @@ internal sealed class DescriptorReadHandler(
     }
 
     /// <summary>
-    /// Fails closed when a GET-by-id preflight terminal carries custom-view checks. GET-by-id has no
-    /// validation step, so silently dropping them would skip a configured authorization filter.
+    /// Plans the single-record custom-view checks descriptor GET-by-id executes, or reports the
+    /// security-configuration failure that stops the read.
     /// </summary>
-    private static void ThrowIfGetByIdCarriesCustomViewChecks(
-        DescriptorReadAuthorizationPreflightOutcome outcome
+    private static bool TryPlanGetByIdCustomViews(
+        DescriptorGetByIdRequest request,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        out IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> customViewChecks,
+        out GetResult? securityConfigurationFailure
     )
     {
-        var customViewChecks = outcome switch
-        {
-            DescriptorReadAuthorizationPreflightOutcome.NotImplemented notImplemented =>
-                notImplemented.CustomViewChecks,
-            DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError configError =>
-                configError.CustomViewChecks,
-            DescriptorReadAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized =>
-                namespaceNotAuthorized.CustomViewChecks,
-            DescriptorReadAuthorizationPreflightOutcome.Proceed proceed => proceed.CustomViewChecks,
-            _ => [],
-        };
+        customViewChecks = [];
+        securityConfigurationFailure = null;
 
-        if (customViewChecks.Count > 0)
+        if (customViewStrategies.Count == 0)
         {
-            throw new InvalidOperationException(
-                $"Descriptor GET-by-id does not support custom view-based authorization, but the preflight "
-                    + $"outcome '{outcome.GetType().Name}' carried {customViewChecks.Count} custom-view check(s)."
-            );
+            return true;
         }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            request.MappingSet,
+            request.MappingSet.GetConcreteResourceModelOrThrow(request.Resource),
+            customViewStrategies,
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            var failure = BuildDescriptorCustomViewSecurityConfigurationFailure(
+                request.Resource,
+                configurationFailure.Failures
+            );
+
+            securityConfigurationFailure = new GetResult.GetFailureSecurityConfiguration(
+                failure.Errors,
+                failure.Diagnostics
+            );
+            return false;
+        }
+
+        customViewChecks = ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Validates the views that execute ahead of a GET-by-id terminal. A null or empty list is a no-op, so
+    /// every terminal can call this unconditionally.
+    /// </summary>
+    private Task ValidateGetByIdCustomViewsAsync(
+        DescriptorGetByIdRequest request,
+        IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck>? customViewChecks,
+        CancellationToken cancellationToken
+    ) =>
+        CustomViewAuthorizationValidator.ValidateAsync(
+            _commandExecutor,
+            request.MappingSet.Key.Dialect,
+            customViewChecks,
+            cancellationToken
+        );
+
+    /// <summary>
+    /// Runs one ordered segment of custom-view membership checks against the fetched row, answering with the
+    /// caller-visible failure or <see langword="null"/> when the segment authorizes.
+    /// </summary>
+    /// <remarks>
+    /// The row has already been read into memory by the time this runs, which is what the in-memory namespace
+    /// check requires too. Denying afterwards discloses nothing: no part of the row reaches the response.
+    /// </remarks>
+    private async Task<GetResult?> ExecuteGetByIdCustomViewsAsync(
+        DescriptorGetByIdRequest request,
+        long documentId,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> runChecks,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
+        CancellationToken cancellationToken
+    )
+    {
+        if (runChecks.Count == 0)
+        {
+            return null;
+        }
+
+        var result = await _customViewAuthorizationExecutor
+            .ExecuteAsync(
+                new CustomViewAuthorizationExecutionRequest(
+                    request.MappingSet,
+                    documentId,
+                    runChecks,
+                    plannedChecks
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return result switch
+        {
+            CustomViewAuthorizationExecutionResult.Authorized => null,
+            CustomViewAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                new GetResult.GetFailureCustomViewNotAuthorized(notAuthorized.Failure),
+            CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure invalid =>
+                new GetResult.GetFailureSecurityConfiguration([invalid.FailureMessage], invalid.Diagnostics),
+            // The row was deleted between this read's SELECT and the membership check, so there is no longer
+            // a record to authorize or to report a denial for.
+            CustomViewAuthorizationExecutionResult.StaleTarget => new GetResult.GetFailureNotExists(),
+            _ => throw new InvalidOperationException(
+                $"Unsupported custom view authorization execution result '{result.GetType().Name}'."
+            ),
+        };
     }
 
     /// <summary>
@@ -1653,9 +1822,9 @@ internal sealed class DescriptorReadHandler(
         return orchestratorOutcome switch
         {
             RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot =>
-                BuildDescriptorNoUsableRootPreflight(mappingSet, resource, operation, noUsableRoot),
+                BuildDescriptorNoUsableRootPreflight(mappingSet, resource, noUsableRoot),
             RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes =>
-                BuildDescriptorNoPrefixesPreflight(mappingSet, resource, operation, noPrefixes),
+                BuildDescriptorNoPrefixesPreflight(mappingSet, resource, noPrefixes),
             RelationalAuthorizationPlanOutcome.Plan plan
                 when operation is NamespaceAuthorizationOperation.ReadMany
                     && RelationalReadGuardrails.HasDescriptorUnsupportedNonNamespaceStrategies(
@@ -1694,7 +1863,6 @@ internal sealed class DescriptorReadHandler(
                 BuildDescriptorReadNotImplemented(
                     mappingSet,
                     resource,
-                    operation,
                     stillUnsupported,
                     RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
                         resource,
@@ -1710,7 +1878,6 @@ internal sealed class DescriptorReadHandler(
                 BuildDescriptorReadSecurityConfigurationError(
                     mappingSet,
                     resource,
-                    operation,
                     securityConfigurationError
                 ),
             _ => throw new InvalidOperationException(
@@ -1722,7 +1889,6 @@ internal sealed class DescriptorReadHandler(
     private static DescriptorReadAuthorizationPreflightOutcome BuildDescriptorNoUsableRootPreflight(
         MappingSet mappingSet,
         QualifiedResourceName resource,
-        NamespaceAuthorizationOperation operation,
         RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot
     )
     {
@@ -1738,7 +1904,6 @@ internal sealed class DescriptorReadHandler(
             TryResolveTerminalCustomViewChecks(
                 mappingSet,
                 resource,
-                operation,
                 noUsableRoot.CustomViewStrategies,
                 noUsableRoot.RawConfiguredIndex,
                 out var customViewChecks
@@ -1759,7 +1924,6 @@ internal sealed class DescriptorReadHandler(
     private static DescriptorReadAuthorizationPreflightOutcome BuildDescriptorNoPrefixesPreflight(
         MappingSet mappingSet,
         QualifiedResourceName resource,
-        NamespaceAuthorizationOperation operation,
         RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes
     )
     {
@@ -1771,7 +1935,6 @@ internal sealed class DescriptorReadHandler(
             TryResolveTerminalCustomViewChecks(
                 mappingSet,
                 resource,
-                operation,
                 noPrefixes.CustomViewStrategies,
                 noPrefixes.RawConfiguredIndex,
                 out var customViewChecks
@@ -1791,7 +1954,6 @@ internal sealed class DescriptorReadHandler(
     private static DescriptorReadAuthorizationPreflightOutcome BuildDescriptorReadSecurityConfigurationError(
         MappingSet mappingSet,
         QualifiedResourceName resource,
-        NamespaceAuthorizationOperation operation,
         RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError
     )
     {
@@ -1808,7 +1970,6 @@ internal sealed class DescriptorReadHandler(
             TryResolveTerminalCustomViewChecks(
                 mappingSet,
                 resource,
-                operation,
                 securityConfigurationError.RelationshipClassification.SupportedCustomViewStrategies,
                 RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
                     securityConfigurationError.RelationshipClassification.SecurityConfigurationFailures
@@ -1838,7 +1999,6 @@ internal sealed class DescriptorReadHandler(
     private static DescriptorReadAuthorizationPreflightOutcome BuildDescriptorReadNotImplemented(
         MappingSet mappingSet,
         QualifiedResourceName resource,
-        NamespaceAuthorizationOperation operation,
         RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported,
         string failureMessage
     )
@@ -1849,7 +2009,6 @@ internal sealed class DescriptorReadHandler(
             TryResolveTerminalCustomViewChecks(
                 mappingSet,
                 resource,
-                operation,
                 stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies,
                 terminalRawConfiguredIndex: null,
                 out var customViewChecks
@@ -1922,7 +2081,6 @@ internal sealed class DescriptorReadHandler(
     private static DescriptorReadAuthorizationPreflightOutcome? TryResolveTerminalCustomViewChecks(
         MappingSet mappingSet,
         QualifiedResourceName resource,
-        NamespaceAuthorizationOperation operation,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> strategies,
         int? terminalRawConfiguredIndex,
         out IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> checks
@@ -1930,12 +2088,9 @@ internal sealed class DescriptorReadHandler(
     {
         checks = [];
 
-        // Custom views are implemented for GET-many only, so every other operation keeps its bare terminal.
-        if (operation is not NamespaceAuthorizationOperation.ReadMany)
-        {
-            return null;
-        }
-
+        // Both read paths execute custom-view checks, so both owe this validation: they plan different check
+        // shapes, but a view that is missing or does not meet the DocumentId contract is the same 500 either
+        // way. The operation is no longer consulted.
         var strategiesToValidate = terminalRawConfiguredIndex is { } rawConfiguredIndex
             ? CustomViewAuthorizationTerminalOrdering.CustomViewsBeforeTerminal(
                 strategies,
@@ -2076,7 +2231,8 @@ internal sealed class DescriptorReadHandler(
         return new DescriptorReadAuthorizationPreflightOutcome.Proceed(
             plan.NamespaceChecks,
             namespacePrefixParameterization,
-            customViewChecks
+            customViewChecks,
+            plan.CustomViewStrategies
         );
     }
 
@@ -2181,13 +2337,18 @@ internal sealed class DescriptorReadHandler(
         /// Dialect-specific prefix parameterization; non-null exactly when namespace authorization
         /// applies. Drives the GET-many SQL emission and the GET-by-id in-memory stored-value check.
         /// </param>
+        /// <param name="CustomViewStrategies">
+        /// The configured custom views, carried unplanned so each caller can plan the shape it executes:
+        /// GET-many compiles them into its page query, GET-by-id into a single-record membership query.
+        /// </param>
         public sealed record Proceed(
             IReadOnlyList<NamespaceAuthorizationCheckSpec> NamespaceChecks,
             NamespacePrefixParameterization? NamespacePrefixParameterization,
-            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecks
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecks,
+            IReadOnlyList<SupportedCustomViewAuthorizationStrategy> CustomViewStrategies
         ) : DescriptorReadAuthorizationPreflightOutcome
         {
-            public static Proceed NoAuthorization { get; } = new([], null, []);
+            public static Proceed NoAuthorization { get; } = new([], null, [], []);
         }
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -1825,11 +1825,14 @@ internal sealed class DescriptorReadHandler(
                 BuildDescriptorNoUsableRootPreflight(mappingSet, resource, noUsableRoot),
             RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes =>
                 BuildDescriptorNoPrefixesPreflight(mappingSet, resource, noPrefixes),
+            // Both read paths route through the same builder, so this terminal carries the custom views
+            // configured ahead of it and its message excludes them from the unsupported list. Gating this on
+            // GET-many left GET-by-id with a bare 501 that skipped validating those views and named the
+            // resolved custom-view strategy as though it were an unsupported blocker.
             RelationalAuthorizationPlanOutcome.Plan plan
-                when operation is NamespaceAuthorizationOperation.ReadMany
-                    && RelationalReadGuardrails.HasDescriptorUnsupportedNonNamespaceStrategies(
-                        plan.NonNamespaceConfiguredStrategies
-                    ) => BuildDescriptorReadPlanPreflight(
+                when RelationalReadGuardrails.HasDescriptorUnsupportedNonNamespaceStrategies(
+                    plan.NonNamespaceConfiguredStrategies
+                ) => BuildDescriptorReadPlanPreflight(
                 mappingSet,
                 resource,
                 authorizationContext,
@@ -1840,17 +1843,6 @@ internal sealed class DescriptorReadHandler(
                     operationLabel,
                     actionLabel,
                     plan.CustomViewStrategies
-                )
-            ),
-            RelationalAuthorizationPlanOutcome.Plan plan
-                when RelationalReadGuardrails.HasDescriptorUnsupportedNonNamespaceStrategies(
-                    plan.NonNamespaceConfiguredStrategies
-                ) => new DescriptorReadAuthorizationPreflightOutcome.NotImplemented(
-                RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
-                    resource,
-                    authorizationStrategyEvaluators,
-                    operationLabel,
-                    actionLabel
                 )
             ),
             RelationalAuthorizationPlanOutcome.Plan plan => BuildDescriptorReadPlanPreflight(
@@ -1869,9 +1861,7 @@ internal sealed class DescriptorReadHandler(
                         authorizationStrategyEvaluators,
                         operationLabel,
                         actionLabel,
-                        operation is NamespaceAuthorizationOperation.ReadMany
-                            ? stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies
-                            : null
+                        stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies
                     )
                 ),
             RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError =>
@@ -1993,8 +1983,8 @@ internal sealed class DescriptorReadHandler(
     /// The known-but-not-enabled 501 terminal. OwnershipBased — the only known-but-not-enabled strategy —
     /// executes last per auth.md "Execution order", regardless of its configured position, so for GET-many
     /// every resolved custom view is validated before the 501 is reported, mirroring the relational query
-    /// path. That lets a missing or non-conforming view surface its own configuration failure.
-    /// Custom views are implemented for GET-many only, so other operations keep the bare 501.
+    /// path. That lets a missing or non-conforming view surface its own configuration failure. GET-by-id
+    /// carries its resolved views the same way, so neither read path reports a bare 501 over them.
     /// </summary>
     private static DescriptorReadAuthorizationPreflightOutcome BuildDescriptorReadNotImplemented(
         MappingSet mappingSet,
@@ -2292,8 +2282,8 @@ internal sealed class DescriptorReadHandler(
     /// <summary>
     /// Descriptor read authorization preflight results. Each terminal carries the custom-view checks that
     /// must be validated before it is reported — custom views are AND filters executing in CMS-configured
-    /// order, so those configured ahead of the terminal still run. The list is empty when nothing needs
-    /// validating, which is always the case outside GET-many since custom views are GET-many only.
+    /// order, so those configured ahead of the terminal still run. The list is empty when no custom view is
+    /// configured ahead of the terminal, which is the only case that needs no validation.
     /// </summary>
     private abstract record DescriptorReadAuthorizationPreflightOutcome
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -378,10 +378,17 @@ internal sealed class DescriptorReadHandler(
                     []
                 );
             case DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError configError:
-                await ValidateGetByIdCustomViewsAsync(request, configError.CustomViewChecks, cancellationToken)
+                await ValidateGetByIdCustomViewsAsync(
+                        request,
+                        configError.CustomViewChecks,
+                        cancellationToken
+                    )
                     .ConfigureAwait(false);
                 return new DescriptorGetByIdAuthorizationResult(
-                    new GetResult.GetFailureSecurityConfiguration(configError.Errors, configError.Diagnostics),
+                    new GetResult.GetFailureSecurityConfiguration(
+                        configError.Errors,
+                        configError.Diagnostics
+                    ),
                     null,
                     null,
                     []

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -1175,7 +1175,8 @@ internal sealed class DescriptorWriteHandler(
         if (lockedCurrentState is DescriptorCurrentStateLoadResult.Loaded)
         {
             // Custom views AND-compose with NamespaceBased in CMS-configured order, so those configured at or
-            // before it run first and those configured after it run once namespace has authorized.
+            // before it run first and those configured after it run once the stored namespace check has
+            // authorized. The whole stored sequence completes before any proposed check runs.
             var preconditionFromEarlyCustomViews = await EvaluateLockedCustomViewAuthorizationAsync(
                     mappingSet,
                     existingTargetContext.DocumentId,
@@ -1209,6 +1210,24 @@ internal sealed class DescriptorWriteHandler(
                 }
             }
 
+            var preconditionFromLateCustomViews = await EvaluateLockedCustomViewAuthorizationAsync(
+                    mappingSet,
+                    existingTargetContext.DocumentId,
+                    customViewsAfterNamespace,
+                    customViewAuthorization,
+                    sessionCommandExecutor,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            if (preconditionFromLateCustomViews is not null)
+            {
+                return preconditionFromLateCustomViews;
+            }
+
+            // Last, because it reads the request's proposed value: every stored check has to have answered
+            // against the locked row first, or a proposed denial would mask the stored custom-view answer
+            // configured after NamespaceBased — including the 500 a nonconforming view behind it owes.
             if (proposedNamespaceAuthorization is not null)
             {
                 var preconditionFromProposed = await EvaluateNamespaceAuthorizationAsync(
@@ -1225,21 +1244,6 @@ internal sealed class DescriptorWriteHandler(
                 {
                     return preconditionFromProposed;
                 }
-            }
-
-            var preconditionFromLateCustomViews = await EvaluateLockedCustomViewAuthorizationAsync(
-                    mappingSet,
-                    existingTargetContext.DocumentId,
-                    customViewsAfterNamespace,
-                    customViewAuthorization,
-                    sessionCommandExecutor,
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
-
-            if (preconditionFromLateCustomViews is not null)
-            {
-                return preconditionFromLateCustomViews;
             }
         }
 
@@ -2955,10 +2959,11 @@ internal sealed class DescriptorWriteHandler(
 
                 case DescriptorCurrentStateLoadResult.Loaded(var persisted, var currentEtag):
                     // AND-compose the configured filters against the locked target before applying any
-                    // change: the custom views configured at or before NamespaceBased, then stored and
-                    // proposed namespace, then the views configured after it. Any denial returns its 403 with
-                    // no INSERT/UPDATE statement, and short-circuits before the no-op or immutable-identity
-                    // checks so 403 wins over those outcomes too.
+                    // change: the stored sequence in configured order — the custom views at or before
+                    // NamespaceBased, the stored namespace check, then the views after it — and only then
+                    // the proposed namespace check. Any denial returns its 403 with no INSERT/UPDATE
+                    // statement, and short-circuits before the no-op or immutable-identity checks so 403
+                    // wins over those outcomes too.
                     var sessionCommandExecutor = writeSession.CreateCommandExecutor();
                     var (customViewsBeforeNamespace, customViewsAfterNamespace) =
                         PartitionDescriptorCustomViewRuns(
@@ -3011,6 +3016,29 @@ internal sealed class DescriptorWriteHandler(
                         }
                     }
 
+                    var lateCustomViewFailure = await EvaluateLockedDescriptorWriteCustomViewsAsync(
+                            request.MappingSet,
+                            documentId,
+                            customViewsAfterNamespace,
+                            customViewAuthorization,
+                            sessionCommandExecutor,
+                            customViewNotAuthorizedFactory,
+                            namespaceAuthorizationInvalidFactory,
+                            namespaceStaleTargetFactory,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
+
+                    if (lateCustomViewFailure is not null)
+                    {
+                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                        return lateCustomViewFailure;
+                    }
+
+                    // Last, because it reads the request's proposed value: every stored check has to have
+                    // answered against the locked row first, or a proposed denial would mask the stored
+                    // custom-view answer configured after NamespaceBased — including the 500 a nonconforming
+                    // view behind it owes.
                     if (proposedNamespaceAuthorization is not null)
                     {
                         var proposedResult = await ExecuteDescriptorNamespaceAuthorizationAsync(
@@ -3035,25 +3063,6 @@ internal sealed class DescriptorWriteHandler(
                             await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
                             return proposedFailure;
                         }
-                    }
-
-                    var lateCustomViewFailure = await EvaluateLockedDescriptorWriteCustomViewsAsync(
-                            request.MappingSet,
-                            documentId,
-                            customViewsAfterNamespace,
-                            customViewAuthorization,
-                            sessionCommandExecutor,
-                            customViewNotAuthorizedFactory,
-                            namespaceAuthorizationInvalidFactory,
-                            namespaceStaleTargetFactory,
-                            cancellationToken
-                        )
-                        .ConfigureAwait(false);
-
-                    if (lateCustomViewFailure is not null)
-                    {
-                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                        return lateCustomViewFailure;
                     }
 
                     // A self-basis proposed check against an existing target is satisfied by the paired stored

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -91,22 +91,41 @@ internal sealed class DescriptorWriteHandler(
         switch (authorizationPreflight)
         {
             case DescriptorWriteAuthorizationPreflightOutcome.NotImplemented notImplemented:
+                await ValidateDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        notImplemented.CustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpsertResult.UpsertFailureNotImplemented(
                     notImplemented.FailureMessage,
                     UpsertFailureNotImplementedReason.StrategyNotEnabled
                 );
             case DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError configError:
+                await ValidateDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        configError.CustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpsertResult.UpsertFailureSecurityConfiguration(
                     configError.Errors,
                     configError.Diagnostics
                 );
             case DescriptorWriteAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
+                await ValidateDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        namespaceNotAuthorized.CustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpsertResult.UpsertFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure);
         }
 
         var proceed = (DescriptorWriteAuthorizationPreflightOutcome.Proceed)authorizationPreflight;
         var storedNamespaceAuthorization = proceed.StoredNamespaceAuthorization;
         var proposedNamespaceAuthorization = proceed.ProposedNamespaceAuthorization;
+        var customViewAuthorization = proceed.CustomViewAuthorization;
 
         var body = DescriptorWriteBodyExtractor.Extract(request.RequestBody, request.Resource);
         var resourceKeyId = RelationalWriteSupport.GetResourceKeyIdOrThrow(
@@ -151,6 +170,7 @@ internal sealed class DescriptorWriteHandler(
                                 documentUuid,
                                 resourceKeyId,
                                 proposedNamespaceAuthorization,
+                                customViewAuthorization,
                                 cancellationToken
                             )
                             .ConfigureAwait(false),
@@ -164,6 +184,7 @@ internal sealed class DescriptorWriteHandler(
                                 resourceKeyId,
                                 storedNamespaceAuthorization,
                                 proposedNamespaceAuthorization,
+                                customViewAuthorization,
                                 cancellationToken
                             )
                             .ConfigureAwait(false),
@@ -188,7 +209,8 @@ internal sealed class DescriptorWriteHandler(
                     request.ProfileName,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
-                    body.Namespace
+                    body.Namespace,
+                    customViewAuthorization
                 )
                 .ConfigureAwait(false);
 
@@ -242,6 +264,20 @@ internal sealed class DescriptorWriteHandler(
                     return new UpsertResult.UpsertFailureSecurityConfiguration(
                         [namespaceFailureMessage],
                         diagnostics
+                    );
+
+                case DescriptorLockedPreconditionResult.CustomViewNotAuthorized(var customViewFailure):
+                    await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    return new UpsertResult.UpsertFailureCustomViewNotAuthorized(customViewFailure);
+
+                case DescriptorLockedPreconditionResult.CustomViewAuthorizationInvalid(
+                    var customViewFailureMessage,
+                    var customViewDiagnostics
+                ):
+                    await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    return new UpsertResult.UpsertFailureSecurityConfiguration(
+                        [customViewFailureMessage],
+                        customViewDiagnostics
                     );
 
                 case DescriptorLockedPreconditionResult.Mismatch(var reason):
@@ -357,19 +393,38 @@ internal sealed class DescriptorWriteHandler(
         switch (authorizationPreflight)
         {
             case DescriptorWriteAuthorizationPreflightOutcome.NotImplemented notImplemented:
+                await ValidateDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        notImplemented.CustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpdateResult.UpdateFailureNotImplemented(notImplemented.FailureMessage);
             case DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError configError:
+                await ValidateDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        configError.CustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpdateResult.UpdateFailureSecurityConfiguration(
                     configError.Errors,
                     configError.Diagnostics
                 );
             case DescriptorWriteAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
+                await ValidateDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        namespaceNotAuthorized.CustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpdateResult.UpdateFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure);
         }
 
         var proceed = (DescriptorWriteAuthorizationPreflightOutcome.Proceed)authorizationPreflight;
         var storedNamespaceAuthorization = proceed.StoredNamespaceAuthorization;
         var proposedNamespaceAuthorization = proceed.ProposedNamespaceAuthorization;
+        var customViewAuthorization = proceed.CustomViewAuthorization;
 
         var body = DescriptorWriteBodyExtractor.Extract(request.RequestBody, request.Resource);
 
@@ -395,7 +450,8 @@ internal sealed class DescriptorWriteHandler(
                         request.ProfileName,
                         storedNamespaceAuthorization,
                         proposedNamespaceAuthorization,
-                        body.Namespace
+                        body.Namespace,
+                        customViewAuthorization
                     )
                     .ConfigureAwait(false);
 
@@ -434,6 +490,20 @@ internal sealed class DescriptorWriteHandler(
                         return new UpdateResult.UpdateFailureSecurityConfiguration(
                             [namespaceFailureMessage],
                             diagnostics
+                        );
+
+                    case DescriptorLockedPreconditionResult.CustomViewNotAuthorized(var customViewFailure):
+                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                        return new UpdateResult.UpdateFailureCustomViewNotAuthorized(customViewFailure);
+
+                    case DescriptorLockedPreconditionResult.CustomViewAuthorizationInvalid(
+                        var customViewFailureMessage,
+                        var customViewDiagnostics
+                    ):
+                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                        return new UpdateResult.UpdateFailureSecurityConfiguration(
+                            [customViewFailureMessage],
+                            customViewDiagnostics
                         );
 
                     case DescriptorLockedPreconditionResult.Mismatch(var reason):
@@ -508,6 +578,7 @@ internal sealed class DescriptorWriteHandler(
                     documentUuid,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
+                    customViewAuthorization,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -979,10 +1050,31 @@ internal sealed class DescriptorWriteHandler(
         {
             // POST with If-Match where no existing document was found normally returns ETagMisMatch,
             // and If-None-Match on the same create proceeds to insert (the caller branches on the
-            // precondition type). Either way a configured proposed-value namespace authorization must
-            // run first so that a denial (403) precedes the precondition outcome. The proposed check is
-            // a single statement against the dialect's namespace authorization SQL and needs no row
-            // lookup.
+            // precondition type). Either way the configured proposed-value filters run before the
+            // precondition outcome, so an authorization denial (403) precedes it. Which of those filters
+            // answers is decided by CMS-configured order, below. The proposed namespace check is a single
+            // statement against the dialect's namespace authorization SQL and needs no row lookup.
+            // Same deterministic denial as the non-precondition create path: no row exists yet, so no view row
+            // can reference it. It and the proposed namespace check run in CMS-configured order, so whichever is
+            // configured first is the one that answers.
+            var createSelfBasisDenial = FindSelfBasisProposedCheck(customViewAuthorization);
+
+            if (
+                createSelfBasisDenial is not null
+                && !NamespacePrecedesSelfBasisDenial(proposedNamespaceAuthorization, createSelfBasisDenial)
+            )
+            {
+                return await BuildSelfBasisCreateDenialResultAsync(
+                        mappingSet,
+                        createSelfBasisDenial,
+                        static failure => new DescriptorLockedPreconditionResult.CustomViewNotAuthorized(
+                            failure
+                        ),
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+            }
+
             if (proposedNamespaceAuthorization is not null)
             {
                 var preconditionFromProposed = await EvaluateNamespaceAuthorizationAsync(
@@ -999,6 +1091,19 @@ internal sealed class DescriptorWriteHandler(
                 {
                     return preconditionFromProposed;
                 }
+            }
+
+            if (createSelfBasisDenial is not null)
+            {
+                return await BuildSelfBasisCreateDenialResultAsync(
+                        mappingSet,
+                        createSelfBasisDenial,
+                        static failure => new DescriptorLockedPreconditionResult.CustomViewNotAuthorized(
+                            failure
+                        ),
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
             }
 
             return new DescriptorLockedPreconditionResult.CreateNew(createDocumentUuid);
@@ -1718,8 +1823,9 @@ internal sealed class DescriptorWriteHandler(
     /// orchestrator. Strategies other than <c>NamespaceBased</c> / <c>NoFurtherAuthorizationRequired</c>
     /// fail closed; the namespace planner terminals (no configured prefixes, no usable root column,
     /// MSSQL prefix cap) short-circuit with no DB roundtrip; otherwise the planner's checks are
-    /// split into stored-value (locked target) and proposed-value (request body) authorizations
-    /// re-indexed from zero, each executed as its own single-record statement inside the write
+    /// split into stored-value (locked target) and proposed-value (request body) namespace authorizations
+    /// re-indexed from zero — custom-view checks keep their request-wide indexes instead, so both value
+    /// sources can share one payload space — each executed as its own single-record statement inside the write
     /// session.
     /// </summary>
     private static DescriptorWriteAuthorizationPreflightOutcome ResolveDescriptorWriteAuthorization(
@@ -1742,7 +1848,8 @@ internal sealed class DescriptorWriteHandler(
 
         return orchestratorOutcome switch
         {
-            RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot =>
+            RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot => WriteTerminal(
+                request,
                 new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError(
                     [
                         NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
@@ -1751,33 +1858,63 @@ internal sealed class DescriptorWriteHandler(
                     ],
                     RelationalReadGuardrails.BuildNoUsableRootColumnDiagnostics(noUsableRoot.Resource)
                 ),
-            RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes =>
+                noUsableRoot.CustomViewStrategies,
+                noUsableRoot.RawConfiguredIndex
+            ),
+            RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes => WriteTerminal(
+                request,
                 new DescriptorWriteAuthorizationPreflightOutcome.NamespaceNotAuthorized(
                     NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
                 ),
+                noPrefixes.CustomViewStrategies,
+                noPrefixes.RawConfiguredIndex
+            ),
             RelationalAuthorizationPlanOutcome.Plan plan
                 when RelationalReadGuardrails.HasDescriptorUnsupportedNonNamespaceStrategies(
                     plan.NonNamespaceConfiguredStrategies
-                ) => new DescriptorWriteAuthorizationPreflightOutcome.NotImplemented(
-                RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
-                    request.Resource,
-                    request.AuthorizationStrategyEvaluators,
-                    operationLabel,
-                    actionLabel
-                )
-            ),
-            RelationalAuthorizationPlanOutcome.Plan plan => BuildDescriptorWritePlanPreflight(request, plan),
-            RelationalAuthorizationPlanOutcome.StillUnsupported =>
+                ) => WriteTerminal(
+                request,
                 new DescriptorWriteAuthorizationPreflightOutcome.NotImplemented(
                     RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
                         request.Resource,
                         request.AuthorizationStrategyEvaluators,
                         operationLabel,
-                        actionLabel
+                        actionLabel,
+                        plan.CustomViewStrategies
                     )
                 ),
+                plan.CustomViewStrategies,
+                // OwnershipBased executes last per auth.md regardless of configured position, so every
+                // resolved view runs before this 501.
+                int.MaxValue
+            ),
+            RelationalAuthorizationPlanOutcome.Plan plan => BuildDescriptorWritePlanPreflight(request, plan),
+            RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported => WriteTerminal(
+                request,
+                new DescriptorWriteAuthorizationPreflightOutcome.NotImplemented(
+                    RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
+                        request.Resource,
+                        request.AuthorizationStrategyEvaluators,
+                        operationLabel,
+                        actionLabel,
+                        stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies
+                    )
+                ),
+                stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies,
+                int.MaxValue
+            ),
             RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError =>
-                BuildDescriptorWriteSecurityConfigurationError(request.Resource, securityConfigurationError),
+                WriteTerminal(
+                    request,
+                    BuildDescriptorWriteSecurityConfigurationError(
+                        request.Resource,
+                        securityConfigurationError
+                    ),
+                    securityConfigurationError.RelationshipClassification.SupportedCustomViewStrategies,
+                    RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                        securityConfigurationError.RelationshipClassification.SecurityConfigurationFailures
+                    )
+                ),
             _ => throw new InvalidOperationException(
                 $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
             ),
@@ -1815,14 +1952,396 @@ internal sealed class DescriptorWriteHandler(
         );
     }
 
+    /// <summary>
+    /// Runs one ordered custom-view segment inside a descriptor write's locked-target boundary, projecting the
+    /// outcome through the caller's result factories so POST and PUT keep their own result types.
+    /// </summary>
+    private async Task<TResult?> EvaluateLockedDescriptorWriteCustomViewsAsync<TResult>(
+        MappingSet mappingSet,
+        long documentId,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> runChecks,
+        RelationalCustomViewAuthorization? customViewAuthorization,
+        IRelationalCommandExecutor sessionCommandExecutor,
+        Func<CustomViewAuthorizationFailure, TResult> customViewNotAuthorizedFactory,
+        Func<string, SecurityConfigurationFailureDiagnostic[]?, TResult> authorizationInvalidFactory,
+        Func<TResult> staleTargetFactory,
+        CancellationToken cancellationToken
+    )
+        where TResult : class
+    {
+        if (runChecks.Count == 0 || customViewAuthorization is null)
+        {
+            return null;
+        }
+
+        var result = await ExecuteDescriptorCustomViewAuthorizationAsync(
+                mappingSet,
+                documentId,
+                runChecks,
+                customViewAuthorization.Checks,
+                sessionCommandExecutor,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return result switch
+        {
+            CustomViewAuthorizationExecutionResult.Authorized => null,
+            CustomViewAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                customViewNotAuthorizedFactory(notAuthorized.Failure),
+            CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure invalid =>
+                authorizationInvalidFactory(invalid.FailureMessage, invalid.Diagnostics),
+            CustomViewAuthorizationExecutionResult.StaleTarget => staleTargetFactory(),
+            _ => throw new InvalidOperationException(
+                $"Unsupported custom view authorization execution result '{result.GetType().Name}'."
+            ),
+        };
+    }
+
+    /// <summary>
+    /// The first self-basis proposed check whose configured strategy planned no stored check, or
+    /// <see langword="null"/> when every one of them is paired. A self-basis proposed check is only satisfied
+    /// by its stored pair, so an unpaired one has proven nothing and must fail closed.
+    /// </summary>
+    private static SingleRecordCustomViewAuthorizationCheckSpec? FindUnpairedSelfBasisProposedCheck(
+        RelationalCustomViewAuthorization? customViewAuthorization
+    )
+    {
+        if (customViewAuthorization is null)
+        {
+            return null;
+        }
+
+        foreach (var check in customViewAuthorization.ProposedChecks)
+        {
+            if (check.CheckTarget is not CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable)
+            {
+                continue;
+            }
+
+            var hasPairedStoredCheck = customViewAuthorization.Checks.Any(planned =>
+                planned.ValueSource is CustomViewAuthorizationCheckValueSource.Stored
+                && planned.ConfiguredStrategy == check.ConfiguredStrategy
+            );
+
+            if (!hasPairedStoredCheck)
+            {
+                return check;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The first proposed check that is not self-basis, or <see langword="null"/> when every one is. Descriptor
+    /// writes have no finalized root row to read a bound basis value from, so such a check cannot be executed
+    /// and must fail closed rather than be skipped.
+    /// </summary>
+    private static SingleRecordCustomViewAuthorizationCheckSpec? FindNonSelfBasisProposedCheck(
+        RelationalCustomViewAuthorization? customViewAuthorization
+    ) =>
+        customViewAuthorization?.ProposedChecks.FirstOrDefault(check =>
+            check.CheckTarget is not CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable
+        );
+
+    /// <summary>
+    /// Whether the proposed namespace check is configured strictly before a self-basis denial, and so still
+    /// runs ahead of it. Custom views and <c>NamespaceBased</c> are AND filters executing in CMS-configured
+    /// order and the first failure is the one reported, so a denial configured at or before the namespace
+    /// position preempts it — matching the tie rule that puts a custom view first at an equal index.
+    /// </summary>
+    private static bool NamespacePrecedesSelfBasisDenial(
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        SingleRecordCustomViewAuthorizationCheckSpec selfBasisDenial
+    ) =>
+        proposedNamespaceAuthorization is { Checks.Count: > 0 } namespaceAuthorization
+        && namespaceAuthorization.Checks[0].RawConfiguredIndex
+            < selfBasisDenial.ConfiguredStrategy.RawConfiguredIndex;
+
+    /// <summary>
+    /// The first self-basis proposed check, or <see langword="null"/> when none is planned.
+    /// </summary>
+    private static SingleRecordCustomViewAuthorizationCheckSpec? FindSelfBasisProposedCheck(
+        RelationalCustomViewAuthorization? customViewAuthorization
+    ) =>
+        customViewAuthorization?.ProposedChecks.FirstOrDefault(check =>
+            check.CheckTarget is CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable
+        );
+
+    /// <summary>
+    /// Validates the denying view, then projects its auth.md §2.4 access-denied failure through the caller's
+    /// result factory. Validating first is what keeps a missing or non-conforming view a 500 rather than being
+    /// reported as this denial.
+    /// </summary>
+    private async Task<TResult> BuildSelfBasisCreateDenialResultAsync<TResult>(
+        MappingSet mappingSet,
+        SingleRecordCustomViewAuthorizationCheckSpec selfBasisDenial,
+        Func<CustomViewAuthorizationFailure, TResult> customViewNotAuthorizedFactory,
+        CancellationToken cancellationToken
+    )
+    {
+        await ValidateDescriptorWriteCustomViewsSingleRecordAsync(
+                mappingSet,
+                [selfBasisDenial],
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return customViewNotAuthorizedFactory(BuildSelfBasisCreateDenial(selfBasisDenial));
+    }
+
+    /// <summary>
+    /// The auth.md §2.4 access-denied failure a self-basis proposed check produces on a create.
+    /// </summary>
+    private static CustomViewAuthorizationFailure BuildSelfBasisCreateDenial(
+        SingleRecordCustomViewAuthorizationCheckSpec check
+    ) =>
+        new(
+            CustomViewAuthorizationFailureKind.NoMatchingRow,
+            CustomViewAuthorizationFailureValueSource.Proposed,
+            check.Index,
+            check.ConfiguredStrategy.StrategyName,
+            [.. check.ReadableSecurableElements],
+            check.FailureHint
+        );
+
+    /// <summary>
+    /// Validates the views behind single-record checks decided in C#, where no membership statement runs.
+    /// </summary>
+    private Task ValidateDescriptorWriteCustomViewsSingleRecordAsync(
+        MappingSet mappingSet,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        CancellationToken cancellationToken
+    ) =>
+        _customViewValidationCommandExecutor is null
+            ? Task.CompletedTask
+            : CustomViewAuthorizationValidator.ValidateSingleRecordAsync(
+                _customViewValidationCommandExecutor,
+                mappingSet.Key.Dialect,
+                checks,
+                cancellationToken
+            );
+
+    /// <summary>
+    /// Builds a write terminal carrying the views configured strictly before <paramref name="terminalIndex"/>,
+    /// so those views are validated before the terminal is reported. A planning failure among them replaces the
+    /// terminal, matching how the descriptor read and DELETE paths order the two.
+    /// </summary>
+    private static DescriptorWriteAuthorizationPreflightOutcome WriteTerminal(
+        DescriptorWriteRequest request,
+        DescriptorWriteAuthorizationPreflightOutcome terminal,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        int terminalIndex
+    )
+    {
+        var strategiesToValidate = CustomViewAuthorizationTerminalOrdering.CustomViewsBeforeTerminal(
+            customViewStrategies,
+            terminalIndex
+        );
+
+        if (strategiesToValidate.Count == 0)
+        {
+            return terminal;
+        }
+
+        var outcome = CustomViewAuthorizationPlanner.Plan(
+            request.MappingSet,
+            request.MappingSet.GetConcreteResourceModelOrThrow(request.Resource),
+            strategiesToValidate
+        );
+
+        if (outcome is CustomViewAuthorizationPlanOutcome.SecurityConfiguration customViewSecurity)
+        {
+            var failure = BuildDescriptorWriteCustomViewSecurityConfigurationFailure(
+                request.Resource,
+                customViewSecurity.Failures
+            );
+
+            return new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError(
+                failure.Errors,
+                failure.Diagnostics,
+                PageDocumentIdCustomViewAdapter.AdaptFromChecks(
+                    CustomViewAuthorizationTerminalOrdering.ChecksBeforeTerminal(
+                        customViewSecurity.PlannedChecks,
+                        RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                            customViewSecurity.Failures
+                        )
+                    )
+                )
+            );
+        }
+
+        var checksToValidate = PageDocumentIdCustomViewAdapter.AdaptFromChecks(
+            ((CustomViewAuthorizationPlanOutcome.Plan)outcome).Checks
+        );
+
+        return terminal switch
+        {
+            DescriptorWriteAuthorizationPreflightOutcome.NotImplemented notImplemented => notImplemented with
+            {
+                CustomViewChecksToValidate = checksToValidate,
+            },
+            DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError configError =>
+                configError with
+                {
+                    CustomViewChecksToValidate = checksToValidate,
+                },
+            DescriptorWriteAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized =>
+                namespaceNotAuthorized with
+                {
+                    CustomViewChecksToValidate = checksToValidate,
+                },
+            _ => throw new InvalidOperationException(
+                $"Descriptor write terminal '{terminal.GetType().Name}' cannot carry custom-view checks."
+            ),
+        };
+    }
+
+    /// <summary>
+    /// A custom-view planning failure reported as a descriptor write security-configuration result.
+    /// <see cref="RelationshipAuthorizationFailureKind.NoCustomViewJoinPath"/> keeps the specific join-path
+    /// message; every other kind keeps the guardrail's unknown-strategy wording.
+    /// </summary>
+    private static RelationalReadSecurityConfigurationFailure BuildDescriptorWriteCustomViewSecurityConfigurationFailure(
+        QualifiedResourceName resource,
+        IReadOnlyList<RelationshipAuthorizationFailureMetadata> failures
+    )
+    {
+        var guardrailFailure = RelationalReadGuardrails.BuildSecurityConfigurationFailure(
+            resource,
+            [],
+            new RelationshipAuthorizationClassification(
+                RelationshipAuthorizationClassificationOutcome.SecurityConfigurationError,
+                [],
+                [],
+                [],
+                [],
+                failures
+            )
+        );
+
+        string[] joinPathErrors =
+        [
+            .. failures
+                .Where(static failure =>
+                    failure.FailureKind is RelationshipAuthorizationFailureKind.NoCustomViewJoinPath
+                )
+                .Select(static failure =>
+                    CustomViewAuthorizationFailureMessages.NoJoinPath(failure, "descriptor write")
+                ),
+        ];
+
+        return joinPathErrors.Length == 0
+            ? guardrailFailure
+            : guardrailFailure with
+            {
+                Errors = joinPathErrors,
+            };
+    }
+
+    /// <summary>
+    /// Plans the single-record custom-view checks a descriptor POST or PUT owes, across both value sources, or
+    /// reports the security-configuration failure that stops the write.
+    /// </summary>
+    private static bool TryPlanDescriptorWriteCustomViews(
+        DescriptorWriteRequest request,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        out RelationalCustomViewAuthorization? customViewAuthorization,
+        out DescriptorWriteAuthorizationPreflightOutcome? securityConfigurationFailure
+    )
+    {
+        customViewAuthorization = null;
+        securityConfigurationFailure = null;
+
+        if (customViewStrategies.Count == 0)
+        {
+            return true;
+        }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            request.MappingSet,
+            request.MappingSet.GetConcreteResourceModelOrThrow(request.Resource),
+            customViewStrategies,
+            NamespaceAuthorizationOperation.Update
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            var failure = BuildDescriptorWriteCustomViewSecurityConfigurationFailure(
+                request.Resource,
+                configurationFailure.Failures
+            );
+
+            securityConfigurationFailure =
+                new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError(
+                    failure.Errors,
+                    failure.Diagnostics
+                );
+            return false;
+        }
+
+        var checks = ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks;
+
+        if (checks.Count == 0)
+        {
+            return true;
+        }
+
+        var planned = new RelationalCustomViewAuthorization(checks);
+
+        // Descriptor writes bind no document references, so there is no finalized root row to read a proposed
+        // basis value from. Only a self-basis proposed check can be settled here; anything else is a
+        // configuration defect this path cannot execute, and must fail closed rather than be skipped. No
+        // shipped ApiSchema produces it — see the pinning test — but nothing in the model builder prevents it.
+        if (FindNonSelfBasisProposedCheck(planned) is { } unsupported)
+        {
+            securityConfigurationFailure =
+                new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError(
+                    [
+                        CustomViewAuthorizationSecurityConfigurationMessages.UnsupportedProposedBasisForDescriptorWrite(
+                            unsupported.ConfiguredStrategy.StrategyName
+                        ),
+                    ],
+                    AuthorizationSecurityConfigurationDiagnostics.ForCustomViewProposedValueExtraction(checks)
+                );
+            return false;
+        }
+
+        customViewAuthorization = planned;
+
+        return true;
+    }
+
     private static DescriptorWriteAuthorizationPreflightOutcome BuildDescriptorWritePlanPreflight(
         DescriptorWriteRequest request,
         RelationalAuthorizationPlanOutcome.Plan plan
     )
     {
+        if (
+            !TryPlanDescriptorWriteCustomViews(
+                request,
+                plan.CustomViewStrategies,
+                out var customViewAuthorization,
+                out var customViewPlanFailure
+            )
+        )
+        {
+            return customViewPlanFailure!;
+        }
+
         if (plan.NamespaceChecks.Count == 0)
         {
-            return DescriptorWriteAuthorizationPreflightOutcome.Proceed.NoAuthorization;
+            return customViewAuthorization is null
+                ? DescriptorWriteAuthorizationPreflightOutcome.Proceed.NoAuthorization
+                : new DescriptorWriteAuthorizationPreflightOutcome.Proceed(
+                    null,
+                    null,
+                    customViewAuthorization
+                );
         }
 
         if (
@@ -1835,9 +2354,14 @@ internal sealed class DescriptorWriteHandler(
             )
         )
         {
-            return new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError(
-                [securityConfigurationMessage],
-                securityConfigurationDiagnostics
+            return WriteTerminal(
+                request,
+                new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError(
+                    [securityConfigurationMessage],
+                    securityConfigurationDiagnostics
+                ),
+                plan.CustomViewStrategies,
+                plan.NamespaceChecks[0].RawConfiguredIndex
             );
         }
 
@@ -1852,30 +2376,67 @@ internal sealed class DescriptorWriteHandler(
             namespacePrefixParameterization
         );
 
-        return new DescriptorWriteAuthorizationPreflightOutcome.Proceed(stored, proposed);
+        return new DescriptorWriteAuthorizationPreflightOutcome.Proceed(
+            stored,
+            proposed,
+            customViewAuthorization
+        );
     }
 
     private abstract record DescriptorWriteAuthorizationPreflightOutcome
     {
         private DescriptorWriteAuthorizationPreflightOutcome() { }
 
-        public sealed record NotImplemented(string FailureMessage)
-            : DescriptorWriteAuthorizationPreflightOutcome;
+        /// <param name="CustomViewChecksToValidate">
+        /// The views configured strictly before this terminal. They execute first, so a missing or
+        /// non-conforming view keeps its own 500 rather than being hidden by the terminal's response.
+        /// </param>
+        public sealed record NotImplemented(
+            string FailureMessage,
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate
+        ) : DescriptorWriteAuthorizationPreflightOutcome
+        {
+            public NotImplemented(string failureMessage)
+                : this(failureMessage, []) { }
+        }
 
+        /// <inheritdoc cref="NotImplemented.CustomViewChecksToValidate"/>
         public sealed record SecurityConfigurationError(
             string[] Errors,
-            SecurityConfigurationFailureDiagnostic[]? Diagnostics = null
-        ) : DescriptorWriteAuthorizationPreflightOutcome;
+            SecurityConfigurationFailureDiagnostic[]? Diagnostics,
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate
+        ) : DescriptorWriteAuthorizationPreflightOutcome
+        {
+            public SecurityConfigurationError(
+                string[] errors,
+                SecurityConfigurationFailureDiagnostic[]? diagnostics = null
+            )
+                : this(errors, diagnostics, []) { }
+        }
 
-        public sealed record NamespaceNotAuthorized(NamespaceAuthorizationFailure Failure)
-            : DescriptorWriteAuthorizationPreflightOutcome;
+        /// <inheritdoc cref="NotImplemented.CustomViewChecksToValidate"/>
+        public sealed record NamespaceNotAuthorized(
+            NamespaceAuthorizationFailure Failure,
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate
+        ) : DescriptorWriteAuthorizationPreflightOutcome
+        {
+            public NamespaceNotAuthorized(NamespaceAuthorizationFailure failure)
+                : this(failure, []) { }
+        }
 
         public sealed record Proceed(
             RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
-            RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization
+            RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization,
+            RelationalCustomViewAuthorization? CustomViewAuthorization
         ) : DescriptorWriteAuthorizationPreflightOutcome
         {
-            public static Proceed NoAuthorization { get; } = new(null, null);
+            public Proceed(
+                RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+                RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization
+            )
+                : this(storedNamespaceAuthorization, proposedNamespaceAuthorization, null) { }
+
+            public static Proceed NoAuthorization { get; } = new(null, null, null);
         }
     }
 
@@ -2115,6 +2676,7 @@ internal sealed class DescriptorWriteHandler(
         short resourceKeyId,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? customViewAuthorization,
         CancellationToken cancellationToken
     ) =>
         ApplyWithLockedDescriptorCurrentStateAsync<UpsertResult>(
@@ -2123,6 +2685,7 @@ internal sealed class DescriptorWriteHandler(
             documentId,
             storedNamespaceAuthorization,
             proposedNamespaceAuthorization,
+            customViewAuthorization,
             static () => new UpsertResult.UpsertFailureWriteConflict(),
             missingDescriptorDocumentId => new UpsertResult.UnknownFailure(
                 BuildMissingDescriptorMessage(request.Resource, missingDescriptorDocumentId)
@@ -2131,6 +2694,9 @@ internal sealed class DescriptorWriteHandler(
             static (failureMessage, diagnostics) =>
                 new UpsertResult.UpsertFailureSecurityConfiguration([failureMessage], diagnostics),
             static () => new UpsertResult.UpsertFailureWriteConflict(),
+            static customViewFailure => new UpsertResult.UpsertFailureCustomViewNotAuthorized(
+                customViewFailure
+            ),
             (persisted, currentEtag, writeSession, ct) =>
                 ApplyLockedDescriptorPostUpsertAsync(
                     request,
@@ -2153,6 +2719,7 @@ internal sealed class DescriptorWriteHandler(
         DocumentUuid documentUuid,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? customViewAuthorization,
         CancellationToken cancellationToken
     ) =>
         ApplyWithLockedDescriptorCurrentStateAsync<UpdateResult>(
@@ -2161,6 +2728,7 @@ internal sealed class DescriptorWriteHandler(
             documentId,
             storedNamespaceAuthorization,
             proposedNamespaceAuthorization,
+            customViewAuthorization,
             static () => new UpdateResult.UpdateFailureNotExists(),
             missingDescriptorDocumentId => new UpdateResult.UnknownFailure(
                 BuildMissingDescriptorMessage(request.Resource, missingDescriptorDocumentId)
@@ -2169,6 +2737,9 @@ internal sealed class DescriptorWriteHandler(
             static (failureMessage, diagnostics) =>
                 new UpdateResult.UpdateFailureSecurityConfiguration([failureMessage], diagnostics),
             static () => new UpdateResult.UpdateFailureNotExists(),
+            static customViewFailure => new UpdateResult.UpdateFailureCustomViewNotAuthorized(
+                customViewFailure
+            ),
             (persisted, currentEtag, writeSession, ct) =>
                 ApplyLockedDescriptorPutAsync(
                     request,
@@ -2189,11 +2760,13 @@ internal sealed class DescriptorWriteHandler(
         long documentId,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? customViewAuthorization,
         Func<TResult> missingDocumentResultFactory,
         Func<long, TResult> missingDescriptorResultFactory,
         Func<NamespaceAuthorizationFailure, TResult> namespaceNotAuthorizedFactory,
         Func<string, SecurityConfigurationFailureDiagnostic[]?, TResult> namespaceAuthorizationInvalidFactory,
         Func<TResult> namespaceStaleTargetFactory,
+        Func<CustomViewAuthorizationFailure, TResult> customViewNotAuthorizedFactory,
         Func<
             PersistedDescriptorState,
             string,
@@ -2232,11 +2805,36 @@ internal sealed class DescriptorWriteHandler(
                     return missingDescriptorResultFactory(documentId);
 
                 case DescriptorCurrentStateLoadResult.Loaded(var persisted, var currentEtag):
-                    // AND-compose stored then proposed namespace authorization against the locked target
-                    // before applying any change. Either denial returns the namespace 403 with no
-                    // INSERT/UPDATE statement, and short-circuits before the no-op or immutable-identity
+                    // AND-compose the configured filters against the locked target before applying any
+                    // change: the custom views configured at or before NamespaceBased, then stored and
+                    // proposed namespace, then the views configured after it. Any denial returns its 403 with
+                    // no INSERT/UPDATE statement, and short-circuits before the no-op or immutable-identity
                     // checks so 403 wins over those outcomes too.
                     var sessionCommandExecutor = writeSession.CreateCommandExecutor();
+                    var (customViewsBeforeNamespace, customViewsAfterNamespace) =
+                        PartitionDescriptorCustomViewRuns(
+                            customViewAuthorization,
+                            storedNamespaceAuthorization
+                        );
+
+                    var earlyCustomViewFailure = await EvaluateLockedDescriptorWriteCustomViewsAsync(
+                            request.MappingSet,
+                            documentId,
+                            customViewsBeforeNamespace,
+                            customViewAuthorization,
+                            sessionCommandExecutor,
+                            customViewNotAuthorizedFactory,
+                            namespaceAuthorizationInvalidFactory,
+                            namespaceStaleTargetFactory,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
+
+                    if (earlyCustomViewFailure is not null)
+                    {
+                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                        return earlyCustomViewFailure;
+                    }
 
                     if (storedNamespaceAuthorization is not null)
                     {
@@ -2290,6 +2888,42 @@ internal sealed class DescriptorWriteHandler(
                         }
                     }
 
+                    var lateCustomViewFailure = await EvaluateLockedDescriptorWriteCustomViewsAsync(
+                            request.MappingSet,
+                            documentId,
+                            customViewsAfterNamespace,
+                            customViewAuthorization,
+                            sessionCommandExecutor,
+                            customViewNotAuthorizedFactory,
+                            namespaceAuthorizationInvalidFactory,
+                            namespaceStaleTargetFactory,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
+
+                    if (lateCustomViewFailure is not null)
+                    {
+                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                        return lateCustomViewFailure;
+                    }
+
+                    // A self-basis proposed check against an existing target is satisfied by the paired stored
+                    // check that just authorized this row: a document's own DocumentId is immutable, so the
+                    // proposed basis value is the value already authorized. Without that pair nothing proved
+                    // it, so the plan fails closed.
+                    var unpairedSelfBasis = FindUnpairedSelfBasisProposedCheck(customViewAuthorization);
+
+                    if (unpairedSelfBasis is not null)
+                    {
+                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                        return namespaceAuthorizationInvalidFactory(
+                            CustomViewAuthorizationSecurityConfigurationMessages.UnpairedSelfBasisProposedCheck(
+                                unpairedSelfBasis.ConfiguredStrategy.StrategyName
+                            ),
+                            null
+                        );
+                    }
+
                     return await applyLoadedAsync(persisted, currentEtag, writeSession, cancellationToken)
                         .ConfigureAwait(false);
 
@@ -2318,9 +2952,30 @@ internal sealed class DescriptorWriteHandler(
         DocumentUuid documentUuid,
         short resourceKeyId,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? customViewAuthorization,
         CancellationToken cancellationToken
     )
     {
+        // A self-basis proposed check on a create has no DocumentId to prove membership for — the row does not
+        // exist yet, so no view row can reference it. The denial is deterministic, so when nothing is configured
+        // ahead of it no session is opened at all; the view is still validated so a misconfigured view keeps its
+        // own 500.
+        var selfBasisDenial = FindSelfBasisProposedCheck(customViewAuthorization);
+
+        if (
+            selfBasisDenial is not null
+            && !NamespacePrecedesSelfBasisDenial(proposedNamespaceAuthorization, selfBasisDenial)
+        )
+        {
+            return await BuildSelfBasisCreateDenialResultAsync(
+                    request.MappingSet,
+                    selfBasisDenial,
+                    static failure => new UpsertResult.UpsertFailureCustomViewNotAuthorized(failure),
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+
         await using var writeSession = await _writeSessionFactory
             .CreateAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -2354,6 +3009,21 @@ internal sealed class DescriptorWriteHandler(
                     await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
                     return proposedFailure;
                 }
+            }
+
+            // The namespace check was configured first and authorized, so the denial configured after it is now
+            // the first failure.
+            if (selfBasisDenial is not null)
+            {
+                await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+
+                return await BuildSelfBasisCreateDenialResultAsync(
+                        request.MappingSet,
+                        selfBasisDenial,
+                        static failure => new UpsertResult.UpsertFailureCustomViewNotAuthorized(failure),
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
             }
 
             var insertResult = await InsertDescriptorAsync(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -1673,7 +1673,8 @@ internal sealed class DescriptorWriteHandler(
     /// <remarks>
     /// The executor is bound to the write session, not to a fresh connection: the target row is locked inside
     /// this transaction, so a check issued on any other connection would either block or read a row the
-    /// transaction has not committed.
+    /// transaction has not committed. Its validation probe is the opposite — it reads the catalog rather than the
+    /// locked row, so it takes the fresh executor the terminals already validate on.
     /// </remarks>
     private Task<CustomViewAuthorizationExecutionResult> ExecuteDescriptorCustomViewAuthorizationAsync(
         MappingSet mappingSet,
@@ -1685,7 +1686,8 @@ internal sealed class DescriptorWriteHandler(
     ) =>
         new CustomViewAuthorizationExecutor(
             sessionCommandExecutor,
-            _relationshipAuthorizationProviderFailureExtractor
+            _relationshipAuthorizationProviderFailureExtractor,
+            _customViewValidationCommandExecutor
         ).ExecuteAsync(
             new CustomViewAuthorizationExecutionRequest(mappingSet, documentId, runChecks, plannedChecks),
             cancellationToken

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -108,6 +108,12 @@ internal sealed class DescriptorWriteHandler(
                         cancellationToken
                     )
                     .ConfigureAwait(false);
+                await ValidateSingleRecordDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        configError.SingleRecordCustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpsertResult.UpsertFailureSecurityConfiguration(
                     configError.Errors,
                     configError.Diagnostics
@@ -407,6 +413,12 @@ internal sealed class DescriptorWriteHandler(
                         cancellationToken
                     )
                     .ConfigureAwait(false);
+                await ValidateSingleRecordDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        configError.SingleRecordCustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpdateResult.UpdateFailureSecurityConfiguration(
                     configError.Errors,
                     configError.Diagnostics
@@ -654,6 +666,12 @@ internal sealed class DescriptorWriteHandler(
             await ValidateDescriptorWriteCustomViewsAsync(
                     request.MappingSet,
                     stop.CustomViewChecksToValidate,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            await ValidateSingleRecordDescriptorWriteCustomViewsAsync(
+                    request.MappingSet,
+                    stop.SingleRecordCustomViewChecksToValidate,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -1406,11 +1424,13 @@ internal sealed class DescriptorWriteHandler(
         DescriptorDeleteRequest request,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
         out RelationalCustomViewAuthorization? customViewAuthorization,
-        out DeleteResult? securityConfigurationFailure
+        out DeleteResult? securityConfigurationFailure,
+        out IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checksToValidateBeforeFailure
     )
     {
         customViewAuthorization = null;
         securityConfigurationFailure = null;
+        checksToValidateBeforeFailure = [];
 
         if (customViewStrategies.Count == 0)
         {
@@ -1433,6 +1453,9 @@ internal sealed class DescriptorWriteHandler(
                 request.Resource,
                 configurationFailure.Failures
             );
+            // Views configured ahead of the earliest planning failure planned successfully and execute
+            // first, so they are still validated before this failure is reported.
+            checksToValidateBeforeFailure = SingleRecordChecksBeforeFailure(configurationFailure);
             return false;
         }
 
@@ -1544,6 +1567,61 @@ internal sealed class DescriptorWriteHandler(
     /// Validates the views a terminal carries. A null or empty list is a no-op, so every terminal can route
     /// through this unconditionally.
     /// </summary>
+    /// <summary>
+    /// The planned single-record checks configured strictly before the earliest planning failure. Those views
+    /// planned successfully and execute first, so they are validated even though a later one cannot plan.
+    /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> SingleRecordChecksBeforeFailure(
+        SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+    )
+    {
+        var earliestFailureIndex = RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+            configurationFailure.Failures
+        );
+
+        return
+        [
+            .. configurationFailure.PlannedChecks.Where(check =>
+                check.ConfiguredStrategy.RawConfiguredIndex < earliestFailureIndex
+            ),
+        ];
+    }
+
+    /// <summary>
+    /// Carries single-record checks on a write planning failure so the async caller validates them before
+    /// reporting it. Only the security-configuration outcome can carry them, which is the only outcome the
+    /// single-record planner produces on failure.
+    /// </summary>
+    private static DescriptorWriteAuthorizationPreflightOutcome WithSingleRecordChecksToValidate(
+        DescriptorWriteAuthorizationPreflightOutcome outcome,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+    ) =>
+        outcome is DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError configurationError
+            ? configurationError with
+            {
+                SingleRecordCustomViewChecksToValidate = checks,
+            }
+            : outcome;
+
+    /// <summary>
+    /// Validates single-record checks that execute ahead of a descriptor write planning failure. These are
+    /// single-record specs, so they take the single-record validator rather than the page-query one. A null
+    /// validation executor keeps the existing no-op behavior.
+    /// </summary>
+    private Task ValidateSingleRecordDescriptorWriteCustomViewsAsync(
+        MappingSet mappingSet,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        CancellationToken cancellationToken
+    ) =>
+        _customViewValidationCommandExecutor is null
+            ? Task.CompletedTask
+            : CustomViewAuthorizationValidator.ValidateSingleRecordAsync(
+                _customViewValidationCommandExecutor,
+                mappingSet.Key.Dialect,
+                checks,
+                cancellationToken
+            );
+
     private Task ValidateDescriptorWriteCustomViewsAsync(
         MappingSet mappingSet,
         IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck>? customViewChecks,
@@ -1711,11 +1789,16 @@ internal sealed class DescriptorWriteHandler(
                 request,
                 plan.CustomViewStrategies,
                 out var customViewAuthorization,
-                out var customViewPlanFailure
+                out var customViewPlanFailure,
+                out var customViewChecksBeforePlanFailure
             )
         )
         {
-            return new DescriptorDeleteAuthorizationPreflightResult.Stop(customViewPlanFailure!);
+            return new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                customViewPlanFailure!,
+                [],
+                customViewChecksBeforePlanFailure
+            );
         }
 
         if (plan.NamespaceChecks.Count == 0)
@@ -1799,13 +1882,24 @@ internal sealed class DescriptorWriteHandler(
         /// The views configured ahead of this terminal. They execute before it, so a missing or non-conforming
         /// view keeps its own 500 rather than being hidden by the terminal's response.
         /// </param>
+        /// <param name="SingleRecordCustomViewChecksToValidate">
+        /// Checks planned by the single-record planner, which the terminals reached through the page planner
+        /// never carry. They take the single-record validator rather than the page-query one.
+        /// </param>
         public sealed record Stop(
             DeleteResult Result,
-            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate,
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> SingleRecordCustomViewChecksToValidate
         ) : DescriptorDeleteAuthorizationPreflightResult
         {
             public Stop(DeleteResult result)
-                : this(result, []) { }
+                : this(result, [], []) { }
+
+            public Stop(
+                DeleteResult result,
+                IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> customViewChecksToValidate
+            )
+                : this(result, customViewChecksToValidate, []) { }
         }
 
         public sealed record Proceed(
@@ -2248,11 +2342,13 @@ internal sealed class DescriptorWriteHandler(
         DescriptorWriteRequest request,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
         out RelationalCustomViewAuthorization? customViewAuthorization,
-        out DescriptorWriteAuthorizationPreflightOutcome? securityConfigurationFailure
+        out DescriptorWriteAuthorizationPreflightOutcome? securityConfigurationFailure,
+        out IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checksToValidateBeforeFailure
     )
     {
         customViewAuthorization = null;
         securityConfigurationFailure = null;
+        checksToValidateBeforeFailure = [];
 
         if (customViewStrategies.Count == 0)
         {
@@ -2326,11 +2422,15 @@ internal sealed class DescriptorWriteHandler(
                 request,
                 plan.CustomViewStrategies,
                 out var customViewAuthorization,
-                out var customViewPlanFailure
+                out var customViewPlanFailure,
+                out var customViewChecksBeforePlanFailure
             )
         )
         {
-            return customViewPlanFailure!;
+            return WithSingleRecordChecksToValidate(
+                customViewPlanFailure!,
+                customViewChecksBeforePlanFailure
+            );
         }
 
         if (plan.NamespaceChecks.Count == 0)
@@ -2401,17 +2501,26 @@ internal sealed class DescriptorWriteHandler(
         }
 
         /// <inheritdoc cref="NotImplemented.CustomViewChecksToValidate"/>
+        /// <inheritdoc cref="DescriptorDeleteAuthorizationPreflightResult.Stop.SingleRecordCustomViewChecksToValidate"/>
         public sealed record SecurityConfigurationError(
             string[] Errors,
             SecurityConfigurationFailureDiagnostic[]? Diagnostics,
-            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate,
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> SingleRecordCustomViewChecksToValidate
         ) : DescriptorWriteAuthorizationPreflightOutcome
         {
             public SecurityConfigurationError(
                 string[] errors,
                 SecurityConfigurationFailureDiagnostic[]? diagnostics = null
             )
-                : this(errors, diagnostics, []) { }
+                : this(errors, diagnostics, [], []) { }
+
+            public SecurityConfigurationError(
+                string[] errors,
+                SecurityConfigurationFailureDiagnostic[]? diagnostics,
+                IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> customViewChecksToValidate
+            )
+                : this(errors, diagnostics, customViewChecksToValidate, []) { }
         }
 
         /// <inheritdoc cref="NotImplemented.CustomViewChecksToValidate"/>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -1691,7 +1691,8 @@ internal sealed class DescriptorWriteHandler(
         new CustomViewAuthorizationExecutor(
             sessionCommandExecutor,
             _relationshipAuthorizationProviderFailureExtractor,
-            _customViewValidationCommandExecutor
+            _customViewValidationCommandExecutor,
+            _writeExceptionClassifier
         ).ExecuteAsync(
             new CustomViewAuthorizationExecutionRequest(mappingSet, documentId, runChecks, plannedChecks),
             cancellationToken

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -97,6 +97,12 @@ internal sealed class DescriptorWriteHandler(
                         cancellationToken
                     )
                     .ConfigureAwait(false);
+                await ValidateSingleRecordDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        notImplemented.SingleRecordCustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpsertResult.UpsertFailureNotImplemented(
                     notImplemented.FailureMessage,
                     UpsertFailureNotImplementedReason.StrategyNotEnabled
@@ -122,6 +128,12 @@ internal sealed class DescriptorWriteHandler(
                 await ValidateDescriptorWriteCustomViewsAsync(
                         request.MappingSet,
                         namespaceNotAuthorized.CustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+                await ValidateSingleRecordDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        namespaceNotAuthorized.SingleRecordCustomViewChecksToValidate,
                         cancellationToken
                     )
                     .ConfigureAwait(false);
@@ -405,6 +417,12 @@ internal sealed class DescriptorWriteHandler(
                         cancellationToken
                     )
                     .ConfigureAwait(false);
+                await ValidateSingleRecordDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        notImplemented.SingleRecordCustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
                 return new UpdateResult.UpdateFailureNotImplemented(notImplemented.FailureMessage);
             case DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError configError:
                 await ValidateDescriptorWriteCustomViewsAsync(
@@ -427,6 +445,12 @@ internal sealed class DescriptorWriteHandler(
                 await ValidateDescriptorWriteCustomViewsAsync(
                         request.MappingSet,
                         namespaceNotAuthorized.CustomViewChecksToValidate,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+                await ValidateSingleRecordDescriptorWriteCustomViewsAsync(
+                        request.MappingSet,
+                        namespaceNotAuthorized.SingleRecordCustomViewChecksToValidate,
                         cancellationToken
                     )
                     .ConfigureAwait(false);
@@ -1564,9 +1588,12 @@ internal sealed class DescriptorWriteHandler(
     }
 
     /// <summary>
-    /// Validates the views a terminal carries. A null or empty list is a no-op, so every terminal can route
-    /// through this unconditionally.
+    /// Every planned single-record check, for terminals that all resolved views execute ahead of.
     /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> AllSingleRecordChecks(
+        RelationalCustomViewAuthorization? customViewAuthorization
+    ) => customViewAuthorization?.Checks ?? [];
+
     /// <summary>
     /// The planned single-record checks configured strictly before the earliest planning failure. Those views
     /// planned successfully and execute first, so they are validated even though a later one cannot plan.
@@ -1622,6 +1649,10 @@ internal sealed class DescriptorWriteHandler(
                 cancellationToken
             );
 
+    /// <summary>
+    /// Validates the views a terminal carries. A null or empty list is a no-op, so every terminal can route
+    /// through this unconditionally.
+    /// </summary>
     private Task ValidateDescriptorWriteCustomViewsAsync(
         MappingSet mappingSet,
         IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck>? customViewChecks,
@@ -2239,52 +2270,43 @@ internal sealed class DescriptorWriteHandler(
             return terminal;
         }
 
-        var outcome = CustomViewAuthorizationPlanner.Plan(
-            request.MappingSet,
-            request.MappingSet.GetConcreteResourceModelOrThrow(request.Resource),
-            strategiesToValidate
-        );
-
-        if (outcome is CustomViewAuthorizationPlanOutcome.SecurityConfiguration customViewSecurity)
+        // Planned through the same single-record descriptor-write path the Plan outcome uses, not the page
+        // planner: these checks execute on a descriptor write, so they owe the non-self proposed-basis guard
+        // that path enforces. Page planning bypassed it, so a view this path cannot execute was attached to
+        // the terminal and validated as though it were runnable.
+        if (
+            !TryPlanDescriptorWriteCustomViews(
+                request,
+                strategiesToValidate,
+                out var customViewAuthorization,
+                out var customViewPlanFailure,
+                out var customViewChecksBeforePlanFailure
+            )
+        )
         {
-            var failure = BuildDescriptorWriteCustomViewSecurityConfigurationFailure(
-                request.Resource,
-                customViewSecurity.Failures
-            );
-
-            return new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError(
-                failure.Errors,
-                failure.Diagnostics,
-                PageDocumentIdCustomViewAdapter.AdaptFromChecks(
-                    CustomViewAuthorizationTerminalOrdering.ChecksBeforeTerminal(
-                        customViewSecurity.PlannedChecks,
-                        RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
-                            customViewSecurity.Failures
-                        )
-                    )
-                )
+            return WithSingleRecordChecksToValidate(
+                customViewPlanFailure!,
+                customViewChecksBeforePlanFailure
             );
         }
 
-        var checksToValidate = PageDocumentIdCustomViewAdapter.AdaptFromChecks(
-            ((CustomViewAuthorizationPlanOutcome.Plan)outcome).Checks
-        );
+        var checksToValidate = AllSingleRecordChecks(customViewAuthorization);
 
         return terminal switch
         {
             DescriptorWriteAuthorizationPreflightOutcome.NotImplemented notImplemented => notImplemented with
             {
-                CustomViewChecksToValidate = checksToValidate,
+                SingleRecordCustomViewChecksToValidate = checksToValidate,
             },
             DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError configError =>
                 configError with
                 {
-                    CustomViewChecksToValidate = checksToValidate,
+                    SingleRecordCustomViewChecksToValidate = checksToValidate,
                 },
             DescriptorWriteAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized =>
                 namespaceNotAuthorized with
                 {
-                    CustomViewChecksToValidate = checksToValidate,
+                    SingleRecordCustomViewChecksToValidate = checksToValidate,
                 },
             _ => throw new InvalidOperationException(
                 $"Descriptor write terminal '{terminal.GetType().Name}' cannot carry custom-view checks."
@@ -2377,6 +2399,9 @@ internal sealed class DescriptorWriteHandler(
                     failure.Errors,
                     failure.Diagnostics
                 );
+            // Views configured ahead of the earliest planning failure planned successfully and execute first,
+            // so they are still validated before this failure is reported.
+            checksToValidateBeforeFailure = SingleRecordChecksBeforeFailure(configurationFailure);
             return false;
         }
 
@@ -2404,6 +2429,15 @@ internal sealed class DescriptorWriteHandler(
                     ],
                     AuthorizationSecurityConfigurationDiagnostics.ForCustomViewProposedValueExtraction(checks)
                 );
+            // Every view configured before the unsupported one planned and executes first, so they are
+            // validated before this failure is reported.
+            checksToValidateBeforeFailure =
+            [
+                .. checks.Where(check =>
+                    check.ConfiguredStrategy.RawConfiguredIndex
+                    < unsupported.ConfiguredStrategy.RawConfiguredIndex
+                ),
+            ];
             return false;
         }
 
@@ -2491,13 +2525,15 @@ internal sealed class DescriptorWriteHandler(
         /// The views configured strictly before this terminal. They execute first, so a missing or
         /// non-conforming view keeps its own 500 rather than being hidden by the terminal's response.
         /// </param>
+        /// <inheritdoc cref="DescriptorDeleteAuthorizationPreflightResult.Stop.SingleRecordCustomViewChecksToValidate"/>
         public sealed record NotImplemented(
             string FailureMessage,
-            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate,
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> SingleRecordCustomViewChecksToValidate
         ) : DescriptorWriteAuthorizationPreflightOutcome
         {
             public NotImplemented(string failureMessage)
-                : this(failureMessage, []) { }
+                : this(failureMessage, [], []) { }
         }
 
         /// <inheritdoc cref="NotImplemented.CustomViewChecksToValidate"/>
@@ -2524,13 +2560,15 @@ internal sealed class DescriptorWriteHandler(
         }
 
         /// <inheritdoc cref="NotImplemented.CustomViewChecksToValidate"/>
+        /// <inheritdoc cref="DescriptorDeleteAuthorizationPreflightResult.Stop.SingleRecordCustomViewChecksToValidate"/>
         public sealed record NamespaceNotAuthorized(
             NamespaceAuthorizationFailure Failure,
-            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate,
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> SingleRecordCustomViewChecksToValidate
         ) : DescriptorWriteAuthorizationPreflightOutcome
         {
             public NamespaceNotAuthorized(NamespaceAuthorizationFailure failure)
-                : this(failure, []) { }
+                : this(failure, [], []) { }
         }
 
         public sealed record Proceed(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -30,7 +30,8 @@ internal sealed class DescriptorWriteHandler(
     IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
         null,
     IDocumentCacheWriterTelemetry? documentCacheWriterTelemetry = null,
-    IDataStoreSelection? dataStoreSelection = null
+    IDataStoreSelection? dataStoreSelection = null,
+    IRelationalCommandExecutor? customViewValidationCommandExecutor = null
 ) : IDescriptorWriteHandler
 {
     private readonly IRelationalWriteTargetLookupService _targetLookupService =
@@ -43,6 +44,15 @@ internal sealed class DescriptorWriteHandler(
         writeSessionFactory ?? throw new ArgumentNullException(nameof(writeSessionFactory));
     private readonly ILogger<DescriptorWriteHandler> _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <summary>
+    /// Validates <c>auth.{StrategyName}</c> for views that execute ahead of a preflight terminal. Terminals
+    /// resolve before the write session opens, so the probe cannot use the session: opening one just to read a
+    /// catalog would take locks the denied request never needed. Null skips validation rather than probing on a
+    /// session that does not exist yet.
+    /// </summary>
+    private readonly IRelationalCommandExecutor? _customViewValidationCommandExecutor =
+        customViewValidationCommandExecutor;
     private readonly IServedEtagComposer _servedEtagComposer =
         servedEtagComposer ?? throw new ArgumentNullException(nameof(servedEtagComposer));
     private readonly IRelationshipAuthorizationProviderFailureExtractor _relationshipAuthorizationProviderFailureExtractor =
@@ -568,12 +578,25 @@ internal sealed class DescriptorWriteHandler(
 
         if (authorizationPreflight is DescriptorDeleteAuthorizationPreflightResult.Stop stop)
         {
+            // Views configured ahead of this terminal execute first, so a missing or non-conforming view keeps
+            // its own 500 rather than being hidden by the terminal's response.
+            await ValidateDescriptorWriteCustomViewsAsync(
+                    request.MappingSet,
+                    stop.CustomViewChecksToValidate,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
             return stop.Result;
         }
 
-        var storedNamespaceAuthorization = (
-            (DescriptorDeleteAuthorizationPreflightResult.Proceed)authorizationPreflight
-        ).StoredNamespaceAuthorization;
+        var proceed = (DescriptorDeleteAuthorizationPreflightResult.Proceed)authorizationPreflight;
+        var storedNamespaceAuthorization = proceed.StoredNamespaceAuthorization;
+        var customViewAuthorization = proceed.CustomViewAuthorization;
+        var (customViewsBeforeNamespace, customViewsAfterNamespace) = PartitionDescriptorCustomViewRuns(
+            customViewAuthorization,
+            storedNamespaceAuthorization
+        );
 
         // Scope the DELETE by ResourceKeyId so a UUID belonging to a different descriptor
         // (or a non-descriptor document) cannot be deleted through this resource endpoint.
@@ -634,7 +657,7 @@ internal sealed class DescriptorWriteHandler(
                     // change Namespace/CodeValue identity. Deleting by the same DocumentUuid plus
                     // ResourceKeyId after authorizing the locked row therefore does not allow an
                     // unauthorized replacement-delete path.
-                    if (storedNamespaceAuthorization is not null)
+                    if (storedNamespaceAuthorization is not null || customViewAuthorization is not null)
                     {
                         var resolvedDeleteTarget = await RelationalDocumentUuidLookupSupport
                             .TryResolveDeleteTargetAsync(
@@ -666,20 +689,42 @@ internal sealed class DescriptorWriteHandler(
                         }
                         else
                         {
-                            var namespaceFailure = MapDeleteNamespaceAuthorizationResult(
-                                await ExecuteDescriptorNamespaceAuthorizationAsync(
-                                        request.MappingSet,
+                            // Configured order: the views configured at or before NamespaceBased, then the
+                            // namespace check, then the rest. The first failure is the one reported.
+                            outcome =
+                                await AuthorizeLockedDescriptorDeleteCustomViewsAsync(
+                                        request,
                                         resolvedDeleteTarget.DocumentId,
-                                        storedNamespaceAuthorization,
-                                        proposedNamespace: null,
+                                        customViewsBeforeNamespace,
+                                        customViewAuthorization,
                                         sessionCommandExecutor,
                                         cancellationToken
                                     )
                                     .ConfigureAwait(false)
-                            );
-
-                            outcome =
-                                namespaceFailure
+                                ?? (
+                                    storedNamespaceAuthorization is null
+                                        ? null
+                                        : MapDeleteNamespaceAuthorizationResult(
+                                            await ExecuteDescriptorNamespaceAuthorizationAsync(
+                                                    request.MappingSet,
+                                                    resolvedDeleteTarget.DocumentId,
+                                                    storedNamespaceAuthorization,
+                                                    proposedNamespace: null,
+                                                    sessionCommandExecutor,
+                                                    cancellationToken
+                                                )
+                                                .ConfigureAwait(false)
+                                        )
+                                )
+                                ?? await AuthorizeLockedDescriptorDeleteCustomViewsAsync(
+                                        request,
+                                        resolvedDeleteTarget.DocumentId,
+                                        customViewsAfterNamespace,
+                                        customViewAuthorization,
+                                        sessionCommandExecutor,
+                                        cancellationToken
+                                    )
+                                    .ConfigureAwait(false)
                                 ?? await ExecuteDescriptorDeleteCommandAsync(
                                         request,
                                         resourceKeyId,
@@ -713,7 +758,8 @@ internal sealed class DescriptorWriteHandler(
                             cancellationToken,
                             // DELETE has no profile lens, so the current etag is unprofiled.
                             profileName: null,
-                            storedNamespaceAuthorization: storedNamespaceAuthorization
+                            storedNamespaceAuthorization: storedNamespaceAuthorization,
+                            customViewAuthorization: customViewAuthorization
                         )
                         .ConfigureAwait(false);
 
@@ -735,6 +781,15 @@ internal sealed class DescriptorWriteHandler(
                         DescriptorLockedPreconditionResult.NamespaceNotAuthorized(var namespaceFailure) =>
                             new DeleteResult.DeleteFailureNamespaceNotAuthorized(namespaceFailure),
                         DescriptorLockedPreconditionResult.NamespaceAuthorizationInvalid(
+                            var failureMessage,
+                            var diagnostics
+                        ) => new DeleteResult.DeleteFailureSecurityConfiguration(
+                            [failureMessage],
+                            diagnostics
+                        ),
+                        DescriptorLockedPreconditionResult.CustomViewNotAuthorized(var customViewFailure) =>
+                            new DeleteResult.DeleteFailureCustomViewNotAuthorized(customViewFailure),
+                        DescriptorLockedPreconditionResult.CustomViewAuthorizationInvalid(
                             var failureMessage,
                             var diagnostics
                         ) => new DeleteResult.DeleteFailureSecurityConfiguration(
@@ -836,9 +891,14 @@ internal sealed class DescriptorWriteHandler(
         string? profileName = null,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null,
-        string? proposedNamespace = null
+        string? proposedNamespace = null,
+        RelationalCustomViewAuthorization? customViewAuthorization = null
     )
     {
+        var (customViewsBeforeNamespace, customViewsAfterNamespace) = PartitionDescriptorCustomViewRuns(
+            customViewAuthorization,
+            storedNamespaceAuthorization
+        );
         ArgumentNullException.ThrowIfNull(mappingSet);
         ArgumentNullException.ThrowIfNull(precondition);
         ArgumentNullException.ThrowIfNull(writeSession);
@@ -967,6 +1027,23 @@ internal sealed class DescriptorWriteHandler(
         // falls through to the existing not-found/not-exists handling.
         if (lockedCurrentState is DescriptorCurrentStateLoadResult.Loaded)
         {
+            // Custom views AND-compose with NamespaceBased in CMS-configured order, so those configured at or
+            // before it run first and those configured after it run once namespace has authorized.
+            var preconditionFromEarlyCustomViews = await EvaluateLockedCustomViewAuthorizationAsync(
+                    mappingSet,
+                    existingTargetContext.DocumentId,
+                    customViewsBeforeNamespace,
+                    customViewAuthorization,
+                    sessionCommandExecutor,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            if (preconditionFromEarlyCustomViews is not null)
+            {
+                return preconditionFromEarlyCustomViews;
+            }
+
             if (storedNamespaceAuthorization is not null)
             {
                 var preconditionFromStored = await EvaluateNamespaceAuthorizationAsync(
@@ -1001,6 +1078,21 @@ internal sealed class DescriptorWriteHandler(
                 {
                     return preconditionFromProposed;
                 }
+            }
+
+            var preconditionFromLateCustomViews = await EvaluateLockedCustomViewAuthorizationAsync(
+                    mappingSet,
+                    existingTargetContext.DocumentId,
+                    customViewsAfterNamespace,
+                    customViewAuthorization,
+                    sessionCommandExecutor,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            if (preconditionFromLateCustomViews is not null)
+            {
+                return preconditionFromLateCustomViews;
             }
         }
 
@@ -1125,60 +1217,381 @@ internal sealed class DescriptorWriteHandler(
 
         return orchestratorOutcome switch
         {
-            RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot =>
-                new DescriptorDeleteAuthorizationPreflightResult.Stop(
-                    new DeleteResult.DeleteFailureSecurityConfiguration(
-                        [
-                            NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
-                                RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
-                            ),
-                        ],
-                        RelationalReadGuardrails.BuildNoUsableRootColumnDiagnostics(noUsableRoot.Resource)
-                    )
+            RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot => DeleteTerminal(
+                request,
+                new DeleteResult.DeleteFailureSecurityConfiguration(
+                    [
+                        NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                            RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                        ),
+                    ],
+                    RelationalReadGuardrails.BuildNoUsableRootColumnDiagnostics(noUsableRoot.Resource)
                 ),
-            RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes =>
-                new DescriptorDeleteAuthorizationPreflightResult.Stop(
-                    new DeleteResult.DeleteFailureNamespaceNotAuthorized(
-                        NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
-                    )
+                noUsableRoot.CustomViewStrategies,
+                noUsableRoot.RawConfiguredIndex
+            ),
+            RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes => DeleteTerminal(
+                request,
+                new DeleteResult.DeleteFailureNamespaceNotAuthorized(
+                    NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
                 ),
+                noPrefixes.CustomViewStrategies,
+                noPrefixes.RawConfiguredIndex
+            ),
             RelationalAuthorizationPlanOutcome.Plan plan
                 when RelationalReadGuardrails.HasDescriptorUnsupportedNonNamespaceStrategies(
                     plan.NonNamespaceConfiguredStrategies
-                ) => new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                ) => DeleteTerminal(
+                request,
                 new DeleteResult.DeleteFailureNotImplemented(
                     RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
                         request.Resource,
                         request.AuthorizationStrategyEvaluators,
                         "descriptor DELETE",
-                        "DELETE"
+                        "DELETE",
+                        plan.CustomViewStrategies
                     )
-                )
+                ),
+                plan.CustomViewStrategies,
+                // OwnershipBased executes last per auth.md regardless of configured position, so every
+                // resolved view runs before this 501.
+                int.MaxValue
             ),
             RelationalAuthorizationPlanOutcome.Plan plan => AuthorizeDescriptorDeletePlanPreflight(
                 request,
                 plan
             ),
-            RelationalAuthorizationPlanOutcome.StillUnsupported =>
-                new DescriptorDeleteAuthorizationPreflightResult.Stop(
-                    new DeleteResult.DeleteFailureNotImplemented(
-                        RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
-                            request.Resource,
-                            request.AuthorizationStrategyEvaluators,
-                            "descriptor DELETE",
-                            "DELETE"
-                        )
+            RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported => DeleteTerminal(
+                request,
+                new DeleteResult.DeleteFailureNotImplemented(
+                    RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
+                        request.Resource,
+                        request.AuthorizationStrategyEvaluators,
+                        "descriptor DELETE",
+                        "DELETE",
+                        stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies
                     )
                 ),
+                stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies,
+                int.MaxValue
+            ),
             RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError =>
-                new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                DeleteTerminal(
+                    request,
                     BuildDescriptorDeleteSecurityConfigurationError(
                         request.Resource,
                         securityConfigurationError
+                    ),
+                    securityConfigurationError.RelationshipClassification.SupportedCustomViewStrategies,
+                    RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                        securityConfigurationError.RelationshipClassification.SecurityConfigurationFailures
                     )
                 ),
             _ => throw new InvalidOperationException(
                 $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+            ),
+        };
+    }
+
+    /// <summary>
+    /// Plans the single-record stored custom-view checks descriptor DELETE executes, or reports the
+    /// security-configuration failure that stops the delete.
+    /// </summary>
+    private static bool TryPlanDescriptorDeleteCustomViews(
+        DescriptorDeleteRequest request,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        out RelationalCustomViewAuthorization? customViewAuthorization,
+        out DeleteResult? securityConfigurationFailure
+    )
+    {
+        customViewAuthorization = null;
+        securityConfigurationFailure = null;
+
+        if (customViewStrategies.Count == 0)
+        {
+            return true;
+        }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            request.MappingSet,
+            request.MappingSet.GetConcreteResourceModelOrThrow(request.Resource),
+            customViewStrategies,
+            NamespaceAuthorizationOperation.Delete
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            securityConfigurationFailure = BuildDescriptorDeleteCustomViewSecurityConfigurationFailure(
+                request.Resource,
+                configurationFailure.Failures
+            );
+            return false;
+        }
+
+        var checks = ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks;
+
+        if (checks.Count > 0)
+        {
+            customViewAuthorization = new RelationalCustomViewAuthorization(checks);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the DELETE terminal carrying the views configured strictly before
+    /// <paramref name="terminalIndex"/>, so those views are validated before the terminal is reported. A
+    /// planning failure among them replaces the terminal, matching how the descriptor read path orders the two.
+    /// </summary>
+    private static DescriptorDeleteAuthorizationPreflightResult DeleteTerminal(
+        DescriptorDeleteRequest request,
+        DeleteResult result,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        int terminalIndex
+    )
+    {
+        var strategiesToValidate = CustomViewAuthorizationTerminalOrdering.CustomViewsBeforeTerminal(
+            customViewStrategies,
+            terminalIndex
+        );
+
+        if (strategiesToValidate.Count == 0)
+        {
+            return new DescriptorDeleteAuthorizationPreflightResult.Stop(result);
+        }
+
+        var outcome = CustomViewAuthorizationPlanner.Plan(
+            request.MappingSet,
+            request.MappingSet.GetConcreteResourceModelOrThrow(request.Resource),
+            strategiesToValidate
+        );
+
+        if (outcome is CustomViewAuthorizationPlanOutcome.SecurityConfiguration customViewSecurity)
+        {
+            return new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                BuildDescriptorDeleteCustomViewSecurityConfigurationFailure(
+                    request.Resource,
+                    customViewSecurity.Failures
+                ),
+                PageDocumentIdCustomViewAdapter.AdaptFromChecks(
+                    CustomViewAuthorizationTerminalOrdering.ChecksBeforeTerminal(
+                        customViewSecurity.PlannedChecks,
+                        RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                            customViewSecurity.Failures
+                        )
+                    )
+                )
+            );
+        }
+
+        return new DescriptorDeleteAuthorizationPreflightResult.Stop(
+            result,
+            PageDocumentIdCustomViewAdapter.AdaptFromChecks(
+                ((CustomViewAuthorizationPlanOutcome.Plan)outcome).Checks
+            )
+        );
+    }
+
+    /// <summary>
+    /// A custom-view planning failure reported as a descriptor DELETE security-configuration result.
+    /// <see cref="RelationshipAuthorizationFailureKind.NoCustomViewJoinPath"/> keeps the specific join-path
+    /// message; every other kind keeps the guardrail's unknown-strategy wording.
+    /// </summary>
+    private static DeleteResult.DeleteFailureSecurityConfiguration BuildDescriptorDeleteCustomViewSecurityConfigurationFailure(
+        QualifiedResourceName resource,
+        IReadOnlyList<RelationshipAuthorizationFailureMetadata> failures
+    )
+    {
+        var guardrailFailure = RelationalReadGuardrails.BuildSecurityConfigurationFailure(
+            resource,
+            [],
+            new RelationshipAuthorizationClassification(
+                RelationshipAuthorizationClassificationOutcome.SecurityConfigurationError,
+                [],
+                [],
+                [],
+                [],
+                failures
+            )
+        );
+
+        string[] joinPathErrors =
+        [
+            .. failures
+                .Where(static failure =>
+                    failure.FailureKind is RelationshipAuthorizationFailureKind.NoCustomViewJoinPath
+                )
+                .Select(static failure =>
+                    CustomViewAuthorizationFailureMessages.NoJoinPath(failure, "descriptor DELETE")
+                ),
+        ];
+
+        return new DeleteResult.DeleteFailureSecurityConfiguration(
+            joinPathErrors.Length == 0 ? guardrailFailure.Errors : joinPathErrors,
+            guardrailFailure.Diagnostics
+        );
+    }
+
+    /// <summary>
+    /// Validates the views a terminal carries. A null or empty list is a no-op, so every terminal can route
+    /// through this unconditionally.
+    /// </summary>
+    private Task ValidateDescriptorWriteCustomViewsAsync(
+        MappingSet mappingSet,
+        IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck>? customViewChecks,
+        CancellationToken cancellationToken
+    ) =>
+        _customViewValidationCommandExecutor is null
+            ? Task.CompletedTask
+            : CustomViewAuthorizationValidator.ValidateAsync(
+                _customViewValidationCommandExecutor,
+                mappingSet.Key.Dialect,
+                customViewChecks,
+                cancellationToken
+            );
+
+    /// <summary>
+    /// Runs one ordered segment of stored custom-view membership checks against the locked target.
+    /// </summary>
+    /// <remarks>
+    /// The executor is bound to the write session, not to a fresh connection: the target row is locked inside
+    /// this transaction, so a check issued on any other connection would either block or read a row the
+    /// transaction has not committed.
+    /// </remarks>
+    private Task<CustomViewAuthorizationExecutionResult> ExecuteDescriptorCustomViewAuthorizationAsync(
+        MappingSet mappingSet,
+        long documentId,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> runChecks,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
+        IRelationalCommandExecutor sessionCommandExecutor,
+        CancellationToken cancellationToken
+    ) =>
+        new CustomViewAuthorizationExecutor(
+            sessionCommandExecutor,
+            _relationshipAuthorizationProviderFailureExtractor
+        ).ExecuteAsync(
+            new CustomViewAuthorizationExecutionRequest(mappingSet, documentId, runChecks, plannedChecks),
+            cancellationToken
+        );
+
+    /// <summary>
+    /// Splits a delete's planned custom-view checks around the namespace check's configured position. Both are
+    /// AND filters executing in CMS-configured order, and the first failure is the one reported.
+    /// </summary>
+    private static (
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Before,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> After
+    ) PartitionDescriptorCustomViewRuns(
+        RelationalCustomViewAuthorization? customViewAuthorization,
+        RelationalWriteNamespaceAuthorization? namespaceAuthorization
+    )
+    {
+        if (customViewAuthorization is null)
+        {
+            return ([], []);
+        }
+
+        return namespaceAuthorization is { Checks.Count: > 0 } namespaceChecks
+            ? CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
+                customViewAuthorization.StoredChecks,
+                namespaceChecks.Checks[0].RawConfiguredIndex
+            )
+            : (customViewAuthorization.StoredChecks, []);
+    }
+
+    /// <summary>
+    /// Runs one ordered custom-view segment inside a descriptor DELETE's locked-target boundary, answering
+    /// with the caller-visible failure or <see langword="null"/> when the segment authorizes.
+    /// </summary>
+    private async Task<DeleteResult?> AuthorizeLockedDescriptorDeleteCustomViewsAsync(
+        DescriptorDeleteRequest request,
+        long documentId,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> runChecks,
+        RelationalCustomViewAuthorization? customViewAuthorization,
+        IRelationalCommandExecutor sessionCommandExecutor,
+        CancellationToken cancellationToken
+    )
+    {
+        if (runChecks.Count == 0 || customViewAuthorization is null)
+        {
+            return null;
+        }
+
+        var result = await ExecuteDescriptorCustomViewAuthorizationAsync(
+                request.MappingSet,
+                documentId,
+                runChecks,
+                customViewAuthorization.Checks,
+                sessionCommandExecutor,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return result switch
+        {
+            CustomViewAuthorizationExecutionResult.Authorized => null,
+            CustomViewAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                new DeleteResult.DeleteFailureCustomViewNotAuthorized(notAuthorized.Failure),
+            CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure invalid =>
+                new DeleteResult.DeleteFailureSecurityConfiguration(
+                    [invalid.FailureMessage],
+                    invalid.Diagnostics
+                ),
+            // The target was deleted between the resolve and this check, so there is nothing left to delete.
+            CustomViewAuthorizationExecutionResult.StaleTarget => new DeleteResult.DeleteFailureNotExists(),
+            _ => throw new InvalidOperationException(
+                $"Unsupported custom view authorization execution result '{result.GetType().Name}'."
+            ),
+        };
+    }
+
+    /// <summary>
+    /// The locked-precondition counterpart of
+    /// <see cref="AuthorizeLockedDescriptorDeleteCustomViewsAsync"/>, shared by the verbs that authorize
+    /// through the If-Match precondition helper.
+    /// </summary>
+    private async Task<DescriptorLockedPreconditionResult?> EvaluateLockedCustomViewAuthorizationAsync(
+        MappingSet mappingSet,
+        long documentId,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> runChecks,
+        RelationalCustomViewAuthorization? customViewAuthorization,
+        IRelationalCommandExecutor sessionCommandExecutor,
+        CancellationToken cancellationToken
+    )
+    {
+        if (runChecks.Count == 0 || customViewAuthorization is null)
+        {
+            return null;
+        }
+
+        var result = await ExecuteDescriptorCustomViewAuthorizationAsync(
+                mappingSet,
+                documentId,
+                runChecks,
+                customViewAuthorization.Checks,
+                sessionCommandExecutor,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return result switch
+        {
+            CustomViewAuthorizationExecutionResult.Authorized => null,
+            CustomViewAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                new DescriptorLockedPreconditionResult.CustomViewNotAuthorized(notAuthorized.Failure),
+            CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure invalid =>
+                new DescriptorLockedPreconditionResult.CustomViewAuthorizationInvalid(
+                    invalid.FailureMessage,
+                    invalid.Diagnostics
+                ),
+            CustomViewAuthorizationExecutionResult.StaleTarget => DescriptorLockedPreconditionResult
+                .NotFound
+                .Instance,
+            _ => throw new InvalidOperationException(
+                $"Unsupported custom view authorization execution result '{result.GetType().Name}'."
             ),
         };
     }
@@ -1188,9 +1601,21 @@ internal sealed class DescriptorWriteHandler(
         RelationalAuthorizationPlanOutcome.Plan plan
     )
     {
+        if (
+            !TryPlanDescriptorDeleteCustomViews(
+                request,
+                plan.CustomViewStrategies,
+                out var customViewAuthorization,
+                out var customViewPlanFailure
+            )
+        )
+        {
+            return new DescriptorDeleteAuthorizationPreflightResult.Stop(customViewPlanFailure!);
+        }
+
         if (plan.NamespaceChecks.Count == 0)
         {
-            return new DescriptorDeleteAuthorizationPreflightResult.Proceed(null);
+            return new DescriptorDeleteAuthorizationPreflightResult.Proceed(null, customViewAuthorization);
         }
 
         if (
@@ -1203,16 +1628,20 @@ internal sealed class DescriptorWriteHandler(
             )
         )
         {
-            return new DescriptorDeleteAuthorizationPreflightResult.Stop(
+            return DeleteTerminal(
+                request,
                 new DeleteResult.DeleteFailureSecurityConfiguration(
                     [securityConfigurationMessage],
                     securityConfigurationDiagnostics
-                )
+                ),
+                plan.CustomViewStrategies,
+                plan.NamespaceChecks[0].RawConfiguredIndex
             );
         }
 
         return new DescriptorDeleteAuthorizationPreflightResult.Proceed(
-            new RelationalWriteNamespaceAuthorization(plan.NamespaceChecks, namespacePrefixParameterization)
+            new RelationalWriteNamespaceAuthorization(plan.NamespaceChecks, namespacePrefixParameterization),
+            customViewAuthorization
         );
     }
 
@@ -1261,10 +1690,27 @@ internal sealed class DescriptorWriteHandler(
     {
         private DescriptorDeleteAuthorizationPreflightResult() { }
 
-        public sealed record Stop(DeleteResult Result) : DescriptorDeleteAuthorizationPreflightResult;
+        /// <param name="CustomViewChecksToValidate">
+        /// The views configured ahead of this terminal. They execute before it, so a missing or non-conforming
+        /// view keeps its own 500 rather than being hidden by the terminal's response.
+        /// </param>
+        public sealed record Stop(
+            DeleteResult Result,
+            IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck> CustomViewChecksToValidate
+        ) : DescriptorDeleteAuthorizationPreflightResult
+        {
+            public Stop(DeleteResult result)
+                : this(result, []) { }
+        }
 
-        public sealed record Proceed(RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization)
-            : DescriptorDeleteAuthorizationPreflightResult;
+        public sealed record Proceed(
+            RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
+            RelationalCustomViewAuthorization? CustomViewAuthorization
+        ) : DescriptorDeleteAuthorizationPreflightResult
+        {
+            public Proceed(RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization)
+                : this(storedNamespaceAuthorization, null) { }
+        }
     }
 
     /// <summary>
@@ -2436,6 +2882,14 @@ internal sealed class DescriptorWriteHandler(
             : DescriptorLockedPreconditionResult;
 
         public sealed record NamespaceAuthorizationInvalid(
+            string FailureMessage,
+            SecurityConfigurationFailureDiagnostic[]? Diagnostics = null
+        ) : DescriptorLockedPreconditionResult;
+
+        public sealed record CustomViewNotAuthorized(CustomViewAuthorizationFailure Failure)
+            : DescriptorLockedPreconditionResult;
+
+        public sealed record CustomViewAuthorizationInvalid(
             string FailureMessage,
             SecurityConfigurationFailureDiagnostic[]? Diagnostics = null
         ) : DescriptorLockedPreconditionResult;

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
@@ -117,7 +117,13 @@ internal static class NamespaceAuthorizationProviderFailureMapper
                 AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidStaleTargetPayload,
             RelationalAuthorizationAuth1DispatchResult.Namespace =>
                 AuthorizationSecurityConfigurationDiagnostics.NamespaceAuth1PayloadMappingFailed,
+            // A payload belonging to another AUTH1 family shares the transport but is not ours to
+            // classify. Yield so the codec that owns the discriminator reports it. Without this,
+            // a command carrying both namespace and custom-view statements would turn a custom-view
+            // 403 into a namespace invalid-metadata 500, because the catch-all below claims anything
+            // it does not recognize.
             RelationalAuthorizationAuth1DispatchResult.Relationship => string.Empty,
+            RelationalAuthorizationAuth1DispatchResult.CustomView => string.Empty,
             _ => AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuthorizationMetadata,
         };
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedCustomViewAuthorizationCommand.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedCustomViewAuthorizationCommand.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// One emitted run of proposed custom view-based authorization: the checks in this run paired with the basis
+/// values read from the finalized root row, plus the request's full planned list for failure mapping.
+/// </summary>
+/// <param name="PlannedChecks">
+/// Every custom-view check planned for the request, across both value sources, indexed as the planner assigned
+/// them. A <c>cv1</c> payload carries only an index, so it is always resolved against this list and never
+/// against the run — one request can emit several runs, and their indexes must not collide.
+/// </param>
+/// <param name="Values">The checks this run emits, in emission order, each with its bound basis value.</param>
+internal sealed record ProposedCustomViewAuthorizationRuntimeCheck(
+    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks,
+    IReadOnlyList<ProposedCustomViewRuntimeValue> Values
+)
+{
+    public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks =>
+        [.. Values.Select(static value => value.Check)];
+}
+
+/// <param name="Command">The compiled statement.</param>
+/// <param name="ResultSetCount">One result set per emitted check.</param>
+internal sealed record ProposedCustomViewAuthorizationStatement(
+    RelationalCommand Command,
+    int ResultSetCount
+);
+
+/// <summary>
+/// Builds and reads the proposed custom view-based authorization statement. Unlike the stored variant, each
+/// check binds a basis value taken from the finalized merged root row rather than the target's
+/// <c>DocumentId</c>, so nothing here depends on a captured target.
+/// </summary>
+internal static class ProposedCustomViewAuthorizationCommand
+{
+    /// <summary>
+    /// Builds the run's statement, or <see langword="null"/> when it emits none. A run holds no self-basis
+    /// check, so an empty result means the run itself was empty.
+    /// </summary>
+    public static ProposedCustomViewAuthorizationStatement? Build(
+        MappingSet mappingSet,
+        ProposedCustomViewAuthorizationRuntimeCheck runtimeCheck
+    )
+    {
+        ArgumentNullException.ThrowIfNull(mappingSet);
+        ArgumentNullException.ThrowIfNull(runtimeCheck);
+
+        var sqlPlan = new SingleRecordCustomViewAuthorizationSqlCompiler(mappingSet.Key.Dialect).Compile(
+            new SingleRecordCustomViewAuthorizationSqlSpec(
+                runtimeCheck.Checks,
+                CustomViewAuthorizationSqlSpecDefaults.DocumentIdParameterName
+            )
+        );
+
+        if (sqlPlan.EmittedCheckIndexesInOrder.Count == 0)
+        {
+            return null;
+        }
+
+        return new ProposedCustomViewAuthorizationStatement(
+            new RelationalCommand(sqlPlan.AuthorizationSql, BuildParameters(sqlPlan, runtimeCheck)),
+            sqlPlan.EmittedCheckIndexesInOrder.Count
+        );
+    }
+
+    /// <summary>
+    /// Binds one parameter per proposed basis value. A proposed-only run binds no stored <c>DocumentId</c>, so
+    /// any parameter the compiler did not tag as a proposed value has no value to take and is a planning
+    /// defect rather than something to guess at.
+    /// </summary>
+    private static IReadOnlyList<RelationalParameter> BuildParameters(
+        SingleRecordCustomViewAuthorizationSqlPlan sqlPlan,
+        ProposedCustomViewAuthorizationRuntimeCheck runtimeCheck
+    )
+    {
+        var valuesByCheckIndex = runtimeCheck.Values.ToDictionary(
+            static value => value.Check.Index,
+            static value => value.BasisValue
+        );
+        var checkIndexByParameterName = sqlPlan.ProposedValueParametersInOrder.ToDictionary(
+            static parameter => parameter.ParameterName,
+            static parameter => parameter.CheckIndex,
+            StringComparer.Ordinal
+        );
+
+        List<RelationalParameter> parameters = new(sqlPlan.ParametersInOrder.Count);
+
+        foreach (var parameter in sqlPlan.ParametersInOrder)
+        {
+            if (parameter.Binding.Kind is not QuerySqlParameterBindingKind.Scalar)
+            {
+                throw new InvalidOperationException(
+                    $"Proposed custom view authorization parameter '{parameter.ParameterName}' must bind as a scalar."
+                );
+            }
+
+            if (!checkIndexByParameterName.TryGetValue(parameter.ParameterName, out var checkIndex))
+            {
+                throw new InvalidOperationException(
+                    $"Proposed custom view authorization parameter '{parameter.ParameterName}' is not a proposed basis value; a proposed-value run binds no other parameter."
+                );
+            }
+
+            if (!valuesByCheckIndex.TryGetValue(checkIndex, out var basisValue))
+            {
+                throw new InvalidOperationException(
+                    $"Proposed custom view authorization has no extracted basis value for check '{checkIndex}'."
+                );
+            }
+
+            parameters.Add(new RelationalParameter($"@{parameter.ParameterName}", basisValue));
+        }
+
+        return parameters;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedCustomViewValueExtractor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedCustomViewValueExtractor.cs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// One proposed custom-view check paired with the basis value read for it, when SQL decides it.
+/// </summary>
+/// <param name="Check">The planned check.</param>
+/// <param name="BasisValue">
+/// The finalized root row's value for the check's bound column. <see langword="null"/> when the row carries no
+/// value, which the SQL maps to the auth.md §2.8 proposed-value-missing failure rather than being rejected
+/// here — a missing value is a client outcome, not a planning defect.
+/// </param>
+internal sealed record ProposedCustomViewRuntimeValue(
+    SingleRecordCustomViewAuthorizationCheckSpec Check,
+    object? BasisValue
+);
+
+/// <summary>
+/// The proposed custom-view work for one write, split by how each check is decided.
+/// </summary>
+/// <param name="SqlValues">
+/// Checks SQL decides, each with its bound basis value, in planned order.
+/// </param>
+/// <param name="SelfBasisChecks">
+/// Checks whose basis is the subject itself, in planned order. SQL cannot decide them: on a create the
+/// document has no <c>DocumentId</c> yet, and on an update the value is the immutable one the paired stored
+/// check already authorized. The caller resolves them against the target context.
+/// </param>
+internal sealed record ProposedCustomViewRuntimeWork(
+    IReadOnlyList<ProposedCustomViewRuntimeValue> SqlValues,
+    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> SelfBasisChecks
+);
+
+internal abstract record ProposedCustomViewExtractionResult
+{
+    private ProposedCustomViewExtractionResult() { }
+
+    public sealed record Ready(ProposedCustomViewRuntimeWork Work) : ProposedCustomViewExtractionResult;
+
+    /// <summary>
+    /// The planned checks could not be reconciled with the finalized root row. The write fails closed as a
+    /// security-configuration failure, matching the namespace and relationship proposed-value siblings.
+    /// </summary>
+    public sealed record InvalidAuthorizationPlan(string FailureMessage) : ProposedCustomViewExtractionResult;
+}
+
+/// <summary>
+/// Reads each proposed custom-view check's basis value from the finalized merged root row, using the root
+/// table's <see cref="TableWritePlan.ColumnBindings"/> to locate the bound column. Authorization never reads
+/// the raw request body: the merged row is what will be persisted, so it is what must be authorized.
+/// </summary>
+internal static class ProposedCustomViewValueExtractor
+{
+    public static ProposedCustomViewExtractionResult Extract(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> proposedChecks,
+        RootWriteRowBuffer rootRow
+    )
+    {
+        ArgumentNullException.ThrowIfNull(proposedChecks);
+        ArgumentNullException.ThrowIfNull(rootRow);
+
+        if (proposedChecks.Count == 0)
+        {
+            return Invalid("Proposed custom view authorization requires at least one check spec.");
+        }
+
+        var rootTable = rootRow.TableWritePlan.TableModel.Table;
+        List<ProposedCustomViewRuntimeValue> sqlValues = [];
+        List<SingleRecordCustomViewAuthorizationCheckSpec> selfBasisChecks = [];
+
+        foreach (var check in proposedChecks)
+        {
+            if (check.ValueSource is not CustomViewAuthorizationCheckValueSource.Proposed)
+            {
+                return Invalid(
+                    $"Proposed custom view authorization cannot extract check '{check.Index}' because it uses value source '{check.ValueSource}'."
+                );
+            }
+
+            switch (check.CheckTarget)
+            {
+                case CustomViewAuthorizationCheckTarget.ProposedSelfBasisUnavailable selfBasis:
+                    if (!selfBasis.RootTable.Equals(rootTable))
+                    {
+                        return Invalid(
+                            $"Proposed custom view authorization check '{check.Index}' targets root table '{selfBasis.RootTable}', but the finalized root row is for '{rootTable}'."
+                        );
+                    }
+
+                    selfBasisChecks.Add(check);
+                    continue;
+
+                case CustomViewAuthorizationCheckTarget.Proposed proposed:
+                    if (!proposed.RootTable.Equals(rootTable))
+                    {
+                        return Invalid(
+                            $"Proposed custom view authorization check '{check.Index}' targets root table '{proposed.RootTable}', but the finalized root row is for '{rootTable}'."
+                        );
+                    }
+
+                    // RootTable and Binding.Table are independent contract fields, so a malformed plan can
+                    // name the right root table and a foreign binding table. Without this check a same-named
+                    // column on the root would be read as if it were the foreign table's column.
+                    if (!proposed.Binding.Table.Equals(rootTable))
+                    {
+                        return Invalid(
+                            $"Proposed custom view authorization check '{check.Index}' binds basis column '{proposed.Binding.Column.Value}' on table '{proposed.Binding.Table}', but the finalized root row is for '{rootTable}'."
+                        );
+                    }
+
+                    if (!TryFindBindingIndex(rootRow, proposed.Binding.Column, out var bindingIndex))
+                    {
+                        // The strategy is configured but the write plan binds no column for its basis
+                        // reference — a profile-shaped body that dropped the reference, for instance. Failing
+                        // closed is required: skipping the check would serve a write the strategy restricts.
+                        return Invalid(
+                            $"Proposed custom view authorization could not locate a root binding for basis column '{proposed.Binding.Column.Value}' required by strategy '{check.ConfiguredStrategy.StrategyName}'."
+                        );
+                    }
+
+                    sqlValues.Add(
+                        new ProposedCustomViewRuntimeValue(
+                            check,
+                            GetBoundSqlValue(rootRow.Values[bindingIndex])
+                        )
+                    );
+                    continue;
+
+                default:
+                    return Invalid(
+                        $"Proposed custom view authorization check '{check.Index}' does not use a proposed-value target."
+                    );
+            }
+        }
+
+        return new ProposedCustomViewExtractionResult.Ready(
+            new ProposedCustomViewRuntimeWork(sqlValues, selfBasisChecks)
+        );
+    }
+
+    private static bool TryFindBindingIndex(
+        RootWriteRowBuffer rootRow,
+        External.DbColumnName column,
+        out int bindingIndex
+    )
+    {
+        var bindings = rootRow.TableWritePlan.ColumnBindings;
+
+        for (var index = 0; index < bindings.Length; index++)
+        {
+            if (bindings[index].Column.ColumnName.Equals(column))
+            {
+                bindingIndex = index;
+                return true;
+            }
+        }
+
+        bindingIndex = -1;
+        return false;
+    }
+
+    private static object? GetBoundSqlValue(FlattenedWriteValue value) =>
+        value is FlattenedWriteValue.Literal { Value: { } literalValue } && literalValue is not DBNull
+            ? literalValue
+            : null;
+
+    private static ProposedCustomViewExtractionResult Invalid(string failureMessage) =>
+        new ProposedCustomViewExtractionResult.InvalidAuthorizationPlan(failureMessage);
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -239,6 +239,9 @@ public static class ReferenceResolverServiceCollectionExtensions
             ServiceDescriptor.Scoped<INamespaceAuthorizationExecutor, NamespaceAuthorizationExecutor>()
         );
         services.TryAdd(
+            ServiceDescriptor.Scoped<ICustomViewAuthorizationExecutor, CustomViewAuthorizationExecutor>()
+        );
+        services.TryAdd(
             ServiceDescriptor.Scoped<
                 IRelationshipAuthorizationProviderFailureExtractor,
                 DefaultRelationshipAuthorizationProviderFailureExtractor

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -239,7 +239,15 @@ public static class ReferenceResolverServiceCollectionExtensions
             ServiceDescriptor.Scoped<INamespaceAuthorizationExecutor, NamespaceAuthorizationExecutor>()
         );
         services.TryAdd(
-            ServiceDescriptor.Scoped<ICustomViewAuthorizationExecutor, CustomViewAuthorizationExecutor>()
+            ServiceDescriptor.Scoped<ICustomViewAuthorizationExecutor>(
+                static serviceProvider => new CustomViewAuthorizationExecutor(
+                    serviceProvider.GetRequiredService<IRelationalCommandExecutor>(),
+                    serviceProvider.GetService<IRelationshipAuthorizationProviderFailureExtractor>(),
+                    // The same executor validates the run's views: it opens a connection per command, so it is
+                    // never the write session's, which is what the validation probe must avoid.
+                    serviceProvider.GetRequiredService<IRelationalCommandExecutor>()
+                )
+            )
         );
         services.TryAdd(
             ServiceDescriptor.Scoped<

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -245,7 +245,8 @@ public static class ReferenceResolverServiceCollectionExtensions
                     serviceProvider.GetService<IRelationshipAuthorizationProviderFailureExtractor>(),
                     // The same executor validates the run's views: it opens a connection per command, so it is
                     // never the write session's, which is what the validation probe must avoid.
-                    serviceProvider.GetRequiredService<IRelationalCommandExecutor>()
+                    serviceProvider.GetRequiredService<IRelationalCommandExecutor>(),
+                    serviceProvider.GetService<IRelationalWriteExceptionClassifier>()
                 )
             )
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCompositeStoredAuthorization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCompositeStoredAuthorization.cs
@@ -53,6 +53,19 @@ internal sealed record StoredNamespaceStatementPlan(
     NamespacePrefixParameterization PrefixParameterization
 );
 
+/// <summary>
+/// What emitted stored custom-view checks need in order to map their provider failure back.
+/// </summary>
+/// <remarks>
+/// Holds the request's whole planned list rather than the appended runs. A request can append custom views
+/// both before and after the namespace statement, and every statement in the command shares one provider
+/// exception, so a <c>cv1</c> index is resolved against the full list — which is exactly what keeps the two
+/// runs' indexes from colliding.
+/// </remarks>
+internal sealed record StoredCustomViewStatementPlan(
+    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks
+);
+
 /// <summary>The stored relationship check's decoded success row.</summary>
 internal sealed record StoredRelationshipAuthorizationRow(int AuthorizationResult, long ContentVersion);
 
@@ -69,6 +82,9 @@ internal abstract record StoredAuthorizationDenial
     public sealed record StaleTarget : StoredAuthorizationDenial;
 
     public sealed record NamespaceNotAuthorized(NamespaceAuthorizationFailure Failure)
+        : StoredAuthorizationDenial;
+
+    public sealed record CustomViewNotAuthorized(CustomViewAuthorizationFailure Failure)
         : StoredAuthorizationDenial;
 
     public sealed record RelationshipNotAuthorized(RelationshipAuthorizationFailure Failure)
@@ -101,6 +117,7 @@ internal abstract record StoredAuthorizationDenial
 internal static class RelationalCompositeStoredAuthorization
 {
     public const string NamespaceLabel = "stored-namespace-authorization";
+    public const string CustomViewLabel = "stored-custom-view-authorization";
     public const string RelationshipLabel = "stored-relationship-authorization";
 
     /// <summary>
@@ -247,6 +264,97 @@ internal static class RelationalCompositeStoredAuthorization
     }
 
     /// <summary>
+    /// Appends one run of stored custom-view checks behind the carrier's row guard.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Callers append up to two runs — the custom views the CMS configured before <c>NamespaceBased</c> and
+    /// those configured after — so that the AND filters execute in configured order and the first failure is
+    /// the one reported. Both runs carry indexes from the request's single planned list, so the
+    /// <see cref="StoredCustomViewStatementPlan"/> a caller keeps is the same regardless of how many runs
+    /// were appended.
+    /// </para>
+    /// <para>
+    /// No parameter-budget fallback exists, and none is reachable: a stored custom-view statement's only
+    /// parameter is the target <c>DocumentId</c>, which the carrier substitutes away, leaving the statement
+    /// with none. A run that did not fit would have to become an ordered segment running <em>after</em> this
+    /// command, which would place it after the namespace check it may be configured before — silently
+    /// inverting the order that decides which denial the caller sees. So a non-fit throws instead: it is a
+    /// defect in the budget accounting, not a case to degrade into.
+    /// </para>
+    /// </remarks>
+    public static void AppendCustomViewRun(
+        RelationalCompositeCommandBuilder builder,
+        IRelationalCompositeTargetCarrier carrier,
+        MappingSet mappingSet,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> runChecks
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(carrier);
+        ArgumentNullException.ThrowIfNull(mappingSet);
+        ArgumentNullException.ThrowIfNull(runChecks);
+
+        if (runChecks.Count == 0)
+        {
+            return;
+        }
+
+        var sqlPlan = new SingleRecordCustomViewAuthorizationSqlCompiler(mappingSet.Key.Dialect).Compile(
+            new SingleRecordCustomViewAuthorizationSqlSpec(
+                runChecks,
+                CustomViewAuthorizationSqlSpecDefaults.DocumentIdParameterName,
+                RowGuardPredicateSql: carrier.CapturedTargetPresentPredicate
+            )
+        );
+
+        if (sqlPlan.EmittedCheckIndexesInOrder.Count == 0)
+        {
+            // Every check in the run is decided in C# — only reachable for a proposed self-basis check, which
+            // a stored run never contains.
+            return;
+        }
+
+        var command = CustomViewAuthorizationExecutor.BuildCommand(
+            sqlPlan,
+            new CustomViewAuthorizationExecutionRequest(mappingSet, DocumentId: 0L, runChecks)
+        );
+        var parametersAfterSubstitution = CountParametersAfterSubstitution(
+            command,
+            CustomViewAuthorizationSqlSpecDefaults.DocumentIdParameterName
+        );
+
+        if (parametersAfterSubstitution != 0 || !builder.Fits(parametersAfterSubstitution))
+        {
+            throw new InvalidOperationException(
+                $"Stored custom view authorization statements must bind no parameters after carrier substitution, but {parametersAfterSubstitution} remained; a run that cannot be co-batched would have to execute after the namespace check it may precede."
+            );
+        }
+
+        var rewritten = RelationalCompositeStatementRewriter.Rewrite(
+            command,
+            builder.Allocator,
+            builder.NextOrdinal,
+            BuildCarrierSubstitutions(
+                carrier,
+                CustomViewAuthorizationSqlSpecDefaults.DocumentIdParameterName,
+                carrier.CapturedTargetIdExpression
+            )
+        );
+        var resultSetCount = sqlPlan.EmittedCheckIndexesInOrder.Count;
+
+        builder.Append(
+            CustomViewLabel,
+            rewritten.Sql,
+            rewritten.Parameters,
+            RelationalCompositeResultShape.Rows,
+            (reader, readCancellation) =>
+                RelationalCompositeResultSetSpan.ConsumeAsync(reader, resultSetCount, readCancellation),
+            resultSetCount
+        );
+    }
+
+    /// <summary>
     /// Appends the stored relationship check when its disposition is
     /// <see cref="StoredRelationshipDisposition.Emitted"/> and it fits, and reports whether it did.
     /// </summary>
@@ -374,12 +482,62 @@ internal static class RelationalCompositeStoredAuthorization
         StoredRelationshipStatementPlan? relationshipPlan,
         int emittedAuth1Index,
         IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
-        ILogger logger
+        ILogger logger,
+        StoredCustomViewStatementPlan? customViewPlan = null
     )
     {
         ArgumentNullException.ThrowIfNull(exception);
         ArgumentNullException.ThrowIfNull(providerFailureExtractor);
         ArgumentNullException.ThrowIfNull(logger);
+
+        // Which family raised the abort is decided by the payload's discriminator, not by the order these
+        // arms are tried: each family yields on a payload it does not own. Statement order in the command is
+        // what enforces the configured AND precedence, and the command aborts at its first failure, so only
+        // one family can ever have a payload to claim.
+        if (customViewPlan is not null)
+        {
+            if (
+                CustomViewAuthorizationProviderFailureMapper.IsStaleStoredTargetFailure(
+                    dialect,
+                    exception,
+                    providerFailureExtractor,
+                    customViewPlan.PlannedChecks
+                )
+            )
+            {
+                return new StoredAuthorizationDenial.StaleTarget();
+            }
+
+            if (
+                CustomViewAuthorizationProviderFailureMapper.TryMapCustomViewAuthorizationFailure(
+                    dialect,
+                    exception,
+                    providerFailureExtractor,
+                    customViewPlan.PlannedChecks,
+                    out var customViewFailure
+                )
+            )
+            {
+                return new StoredAuthorizationDenial.CustomViewNotAuthorized(customViewFailure!);
+            }
+
+            if (
+                CustomViewAuthorizationProviderFailureMapper.IsUnmappableCustomViewPayload(
+                    dialect,
+                    exception,
+                    providerFailureExtractor,
+                    customViewPlan.PlannedChecks
+                )
+            )
+            {
+                return new StoredAuthorizationDenial.SecurityConfiguration(
+                    [CustomViewAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata],
+                    AuthorizationSecurityConfigurationDiagnostics.ForCustomViewAuthorizationAuth1(
+                        customViewPlan.PlannedChecks
+                    )
+                );
+            }
+        }
 
         if (namespacePlan is not null)
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
@@ -26,8 +26,11 @@ internal sealed record RelationalDeleteCommandRequest(
     RelationshipAuthorizationResult StoredRelationshipAuthorization
 )
 {
-    /// <summary>The stored custom-view checks, or <see langword="null"/> when none are configured.</summary>
-    public RelationalCustomViewAuthorization? StoredCustomViewAuthorization { get; init; }
+    /// <summary>
+    /// Every custom-view check planned for this delete, or <see langword="null"/> when none are configured.
+    /// DELETE authorizes stored values only, so the proposed source is always empty here.
+    /// </summary>
+    public RelationalCustomViewAuthorization? CustomViewAuthorization { get; init; }
 
     public WritePrecondition WritePrecondition { get; init; } = new WritePrecondition.None();
 
@@ -332,12 +335,12 @@ internal sealed class CompositeRelationalDeleteCommand(
             ? (IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>)[]
             : customViewsAfterNamespace;
         var customViewPlan =
-            request.StoredCustomViewAuthorization is { } storedCustomViewAuthorization
+            request.CustomViewAuthorization is { } customViewAuthorization
             && (
                 customViewsBeforeNamespace.Count > 0
                 || (namespaceEmitted && customViewsAfterNamespace.Count > 0)
             )
-                ? new StoredCustomViewStatementPlan(storedCustomViewAuthorization.Checks)
+                ? new StoredCustomViewStatementPlan(customViewAuthorization.Checks)
                 : null;
         var relationshipPlan = classifiedRelationship;
         var relationshipEmitted =
@@ -396,17 +399,17 @@ internal sealed class CompositeRelationalDeleteCommand(
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> After
     ) PartitionCustomViewRuns(RelationalDeleteCommandRequest request)
     {
-        if (request.StoredCustomViewAuthorization is not { } storedCustomViewAuthorization)
+        if (request.CustomViewAuthorization is not { } customViewAuthorization)
         {
             return ([], []);
         }
 
         return request.StoredNamespaceAuthorization is { } storedNamespaceAuthorization
             ? CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
-                storedCustomViewAuthorization.Checks,
+                customViewAuthorization.StoredChecks,
                 storedNamespaceAuthorization.Checks[0].RawConfiguredIndex
             )
-            : (storedCustomViewAuthorization.Checks, []);
+            : (customViewAuthorization.StoredChecks, []);
     }
 
     private static bool CanCoBatchDeletes(
@@ -466,7 +469,7 @@ internal sealed class CompositeRelationalDeleteCommand(
         CancellationToken cancellationToken
     )
     {
-        if (segmentChecks.Count == 0 || request.StoredCustomViewAuthorization is null)
+        if (segmentChecks.Count == 0 || request.CustomViewAuthorization is null)
         {
             return null;
         }
@@ -480,7 +483,7 @@ internal sealed class CompositeRelationalDeleteCommand(
                     request.MappingSet,
                     documentId,
                     segmentChecks,
-                    request.StoredCustomViewAuthorization.Checks
+                    request.CustomViewAuthorization.Checks
                 ),
                 cancellationToken
             )

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
@@ -511,7 +511,8 @@ internal sealed class CompositeRelationalDeleteCommand(
         var executionResult = await new CustomViewAuthorizationExecutor(
             writeSession.CreateCommandExecutor(),
             _providerFailureExtractor,
-            _customViewValidationCommandExecutor
+            _customViewValidationCommandExecutor,
+            _exceptionClassifier
         )
             .ExecuteAsync(
                 new CustomViewAuthorizationExecutionRequest(
@@ -839,8 +840,10 @@ internal sealed class CompositeRelationalDeleteCommand(
             // outside the generated schema is auth.{StrategyName}, which can be dropped, replaced, or revoked
             // between requests, and auth.md requires that to surface as the urn:ed-fi:api:system 500 rather
             // than as a generic delete failure. Authorization payloads are classified above, so a denial is
-            // never relabelled.
-            _ when IsAttributableToCustomView(customViewPlan, failureContext) =>
+            // never relabelled — and a transient provider failure (deadlock victim, lock timeout) proves
+            // nothing about the view's contract, so it keeps the retryable write-conflict mapping below.
+            _ when IsAttributableToCustomView(customViewPlan, failureContext)
+                    && !_exceptionClassifier.IsTransientFailure(exception) =>
                 throw new CustomViewAuthorizationValidationException(exception),
             _ => RelationalDeleteExecution.MapFailure(
                 exception,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
@@ -66,7 +66,8 @@ internal sealed class CompositeRelationalDeleteCommand(
     IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
         null,
     ILogger? logger = null,
-    RelationalCommandBudget? commandBudget = null
+    RelationalCommandBudget? commandBudget = null,
+    IRelationalCommandExecutor? customViewValidationCommandExecutor = null
 )
 {
     private const string ResourceRootDeleteLabel = "resource-root-delete";
@@ -103,6 +104,14 @@ internal sealed class CompositeRelationalDeleteCommand(
 
     private readonly RelationalCommandBudget? _commandBudget = commandBudget;
 
+    /// <summary>
+    /// The fresh-connection executor the custom-view catalog validation runs on, or <see langword="null"/> to
+    /// skip validation. Never the write session's: the probe reads the catalog, and issuing it on the session
+    /// would run inside the transaction holding the target lock and consume that command's results.
+    /// </summary>
+    private readonly IRelationalCommandExecutor? _customViewValidationCommandExecutor =
+        customViewValidationCommandExecutor;
+
     /// <param name="NamespacePlan">
     /// The namespace checks the opening command carried, or <see langword="null"/> when it carried none —
     /// so a provider failure is mapped only against checks that command actually sent.
@@ -131,10 +140,16 @@ internal sealed class CompositeRelationalDeleteCommand(
         public StoredCustomViewStatementPlan? CustomViewPlan { get; init; }
 
         /// <summary>
-        /// The custom-view checks still owed as their own ordered segment, empty when none are. Only the run
-        /// configured after <c>NamespaceBased</c> can land here, and only when the namespace check itself was
-        /// pushed onto a segment: the run has to follow that check, so it cannot ride the opening command
-        /// which precedes it.
+        /// Exactly the custom-view checks the opening command carries statements for, so their views are
+        /// validated before it runs and no other view's contract can preempt what it decides.
+        /// </summary>
+        public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewCommandChecks { get; init; } =
+        [];
+
+        /// <summary>
+        /// The custom-view checks owed as their own ordered segment, empty when none are. Only the run
+        /// configured after <c>NamespaceBased</c> lands here: it has to follow that check, and its views may
+        /// only be validated once the check has passed, which the opening command cannot express.
         /// </summary>
         public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewSegmentChecks { get; init; } =
         [];
@@ -153,6 +168,12 @@ internal sealed class CompositeRelationalDeleteCommand(
             request.StoredRelationshipAuthorization
         );
         var plan = BuildPlan(request, relationshipPlan);
+
+        // Ahead of the command, because the views it carries run ahead of the namespace check inside it: a
+        // table masquerading as auth.{StrategyName} answers the membership SQL without raising anything, so
+        // nothing later in the command would reveal it.
+        await ValidateCommandCustomViewsAsync(request, plan.CustomViewCommandChecks, cancellationToken)
+            .ConfigureAwait(false);
 
         IReadOnlyList<RelationalCompositeStatementOutcome> outcomes;
         var execution = new RelationalCompositeCommandExecution();
@@ -279,8 +300,16 @@ internal sealed class CompositeRelationalDeleteCommand(
     /// silently never sent.
     /// </para>
     /// <para>
+    /// A custom-view run configured after <c>NamespaceBased</c> is a fourth: it owes an ordered segment so its
+    /// views are validated only after that check passes, and the deletes wait for it exactly as they do for any
+    /// other segmented check.
+    /// </para>
+    /// <para>
     /// A namespace check that does not fit also forces the relationship check onto a segment: emitting the
     /// relationship into this command would place it ahead of the namespace check whose denial outranks it.
+    /// An owed custom-view segment forces it the same way and for the same reason — relationship
+    /// authorization runs after every configured AND filter, so a relationship denial riding this command
+    /// would answer before the segment those views are still owed, and the segment would never run.
     /// </para>
     /// </remarks>
     private DeleteCommandPlan BuildPlan(
@@ -296,10 +325,10 @@ internal sealed class CompositeRelationalDeleteCommand(
 
         AppendCaptureTarget(builder, request);
 
-        // Custom views and NamespaceBased are AND filters executing in CMS-configured order, and the
-        // command aborts at its first failure, so the namespace statement is emitted between the views
-        // configured before it and those configured after. Both runs' indexes come from one planned list, so
-        // a cv1 payload still identifies exactly one check.
+        // Custom views and NamespaceBased are AND filters executing in CMS-configured order, and the command
+        // aborts at its first failure, so only the views configured before the namespace statement can ride it.
+        // Both runs' indexes come from one planned list, so a cv1 payload still identifies exactly one check
+        // whichever command raised it.
         var (customViewsBeforeNamespace, customViewsAfterNamespace) = PartitionCustomViewRuns(request);
 
         RelationalCompositeStoredAuthorization.AppendCustomViewRun(
@@ -317,34 +346,20 @@ internal sealed class CompositeRelationalDeleteCommand(
             out var namespacePlan
         );
 
-        // The after-run may only ride this command when the namespace check it must follow rides it too.
-        // Otherwise the namespace check runs as a later segment, and appending the run here would place it
-        // ahead of the check it is configured after — so it becomes a segment of its own instead of being
-        // dropped, which would delete a row without enforcing a configured view.
-        if (namespaceEmitted)
-        {
-            RelationalCompositeStoredAuthorization.AppendCustomViewRun(
-                builder,
-                carrier,
-                request.MappingSet,
-                customViewsAfterNamespace
-            );
-        }
-
-        var customViewSegmentChecks = namespaceEmitted
-            ? (IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>)[]
-            : customViewsAfterNamespace;
+        // The after-run always takes an ordered segment of its own rather than riding this command behind the
+        // namespace statement. Its views have to be validated, and only once the namespace check has passed:
+        // co-batched, the run would either be validated too early — reporting a view's 500 over a namespace
+        // denial configured ahead of it — or validated after the deletes this command carries had already run.
+        var customViewSegmentChecks = customViewsAfterNamespace;
         var customViewPlan =
             request.CustomViewAuthorization is { } customViewAuthorization
-            && (
-                customViewsBeforeNamespace.Count > 0
-                || (namespaceEmitted && customViewsAfterNamespace.Count > 0)
-            )
+            && customViewsBeforeNamespace.Count > 0
                 ? new StoredCustomViewStatementPlan(customViewAuthorization.Checks)
                 : null;
         var relationshipPlan = classifiedRelationship;
         var relationshipEmitted =
             namespaceEmitted
+            && customViewSegmentChecks.Count == 0
             && RelationalCompositeStoredAuthorization.TryAppendRelationship(
                 builder,
                 carrier,
@@ -386,9 +401,28 @@ internal sealed class CompositeRelationalDeleteCommand(
         )
         {
             CustomViewPlan = customViewPlan,
+            CustomViewCommandChecks = customViewsBeforeNamespace,
             CustomViewSegmentChecks = customViewSegmentChecks,
         };
     }
+
+    /// <summary>
+    /// Validates the views behind the custom-view statements the opening command carries. Empty checks or a null
+    /// validation executor are a no-op, so the call site can route through this unconditionally.
+    /// </summary>
+    private Task ValidateCommandCustomViewsAsync(
+        RelationalDeleteCommandRequest request,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        CancellationToken cancellationToken
+    ) =>
+        _customViewValidationCommandExecutor is null
+            ? Task.CompletedTask
+            : CustomViewAuthorizationValidator.ValidateSingleRecordAsync(
+                _customViewValidationCommandExecutor,
+                request.MappingSet.Key.Dialect,
+                checks,
+                cancellationToken
+            );
 
     /// <summary>
     /// Splits the planned custom-view checks around the configured position of <c>NamespaceBased</c>. With no
@@ -456,10 +490,10 @@ internal sealed class CompositeRelationalDeleteCommand(
     }
 
     /// <summary>
-    /// Runs the custom-view checks configured after <c>NamespaceBased</c> as their own ordered segment, for
-    /// the case where the namespace check they follow could not fit the opening command. Authorization
-    /// therefore still executes in configured order and strictly precedes the relationship check and any
-    /// deletion, at the cost of one more command on that path.
+    /// Runs the custom-view checks configured after <c>NamespaceBased</c> as their own ordered segment, which
+    /// is what lets their views be validated only once that check has passed. Authorization therefore still
+    /// executes in configured order and strictly precedes the relationship check and any deletion, at the cost
+    /// of one more command on that path.
     /// </summary>
     private async Task<DeleteResult?> ExecuteSegmentedCustomViewAsync(
         RelationalDeleteCommandRequest request,
@@ -476,7 +510,8 @@ internal sealed class CompositeRelationalDeleteCommand(
 
         var executionResult = await new CustomViewAuthorizationExecutor(
             writeSession.CreateCommandExecutor(),
-            _providerFailureExtractor
+            _providerFailureExtractor,
+            _customViewValidationCommandExecutor
         )
             .ExecuteAsync(
                 new CustomViewAuthorizationExecutionRequest(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
@@ -26,6 +26,9 @@ internal sealed record RelationalDeleteCommandRequest(
     RelationshipAuthorizationResult StoredRelationshipAuthorization
 )
 {
+    /// <summary>The stored custom-view checks, or <see langword="null"/> when none are configured.</summary>
+    public RelationalCustomViewAuthorization? StoredCustomViewAuthorization { get; init; }
+
     public WritePrecondition WritePrecondition { get; init; } = new WritePrecondition.None();
 
     /// <summary>
@@ -116,7 +119,23 @@ internal sealed class CompositeRelationalDeleteCommand(
         RelationalWriteNamespaceAuthorization? NamespaceSegmentAuthorization,
         StoredRelationshipStatementPlan RelationshipPlan,
         int? DocumentDeleteOrdinal
-    );
+    )
+    {
+        /// <summary>
+        /// The custom-view checks the command carried, or <see langword="null"/> when it carried none — so a
+        /// provider failure is mapped only against checks that command actually sent.
+        /// </summary>
+        public StoredCustomViewStatementPlan? CustomViewPlan { get; init; }
+
+        /// <summary>
+        /// The custom-view checks still owed as their own ordered segment, empty when none are. Only the run
+        /// configured after <c>NamespaceBased</c> can land here, and only when the namespace check itself was
+        /// pushed onto a segment: the run has to follow that check, so it cannot ride the opening command
+        /// which precedes it.
+        /// </summary>
+        public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewSegmentChecks { get; init; } =
+        [];
+    }
 
     public async Task<DeleteResult> ExecuteAsync(
         RelationalDeleteCommandRequest request,
@@ -133,16 +152,24 @@ internal sealed class CompositeRelationalDeleteCommand(
         var plan = BuildPlan(request, relationshipPlan);
 
         IReadOnlyList<RelationalCompositeStatementOutcome> outcomes;
+        var execution = new RelationalCompositeCommandExecution();
 
         try
         {
-            outcomes = await new RelationalCompositeCommandExecution()
+            outcomes = await execution
                 .ExecuteAsync(writeSession, plan.Command, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (DbException exception)
         {
-            return MapProviderFailure(request, plan.NamespacePlan, plan.RelationshipPlan, exception);
+            return MapProviderFailure(
+                request,
+                plan.NamespacePlan,
+                plan.CustomViewPlan,
+                plan.RelationshipPlan,
+                exception,
+                execution.Failure
+            );
         }
 
         if (outcomes[0].Value is not RelationalCompositeCapturedTarget capturedTarget)
@@ -163,6 +190,21 @@ internal sealed class CompositeRelationalDeleteCommand(
         )
         {
             return namespaceResult;
+        }
+
+        if (
+            await ExecuteSegmentedCustomViewAsync(
+                    request,
+                    plan.CustomViewSegmentChecks,
+                    capturedTarget.DocumentId,
+                    writeSession,
+                    cancellationToken
+                )
+                .ConfigureAwait(false) is
+            { } customViewResult
+        )
+        {
+            return customViewResult;
         }
 
         if (
@@ -251,6 +293,19 @@ internal sealed class CompositeRelationalDeleteCommand(
 
         AppendCaptureTarget(builder, request);
 
+        // Custom views and NamespaceBased are AND filters executing in CMS-configured order, and the
+        // command aborts at its first failure, so the namespace statement is emitted between the views
+        // configured before it and those configured after. Both runs' indexes come from one planned list, so
+        // a cv1 payload still identifies exactly one check.
+        var (customViewsBeforeNamespace, customViewsAfterNamespace) = PartitionCustomViewRuns(request);
+
+        RelationalCompositeStoredAuthorization.AppendCustomViewRun(
+            builder,
+            carrier,
+            request.MappingSet,
+            customViewsBeforeNamespace
+        );
+
         var namespaceEmitted = RelationalCompositeStoredAuthorization.TryAppendNamespace(
             builder,
             carrier,
@@ -258,6 +313,32 @@ internal sealed class CompositeRelationalDeleteCommand(
             request.StoredNamespaceAuthorization,
             out var namespacePlan
         );
+
+        // The after-run may only ride this command when the namespace check it must follow rides it too.
+        // Otherwise the namespace check runs as a later segment, and appending the run here would place it
+        // ahead of the check it is configured after — so it becomes a segment of its own instead of being
+        // dropped, which would delete a row without enforcing a configured view.
+        if (namespaceEmitted)
+        {
+            RelationalCompositeStoredAuthorization.AppendCustomViewRun(
+                builder,
+                carrier,
+                request.MappingSet,
+                customViewsAfterNamespace
+            );
+        }
+
+        var customViewSegmentChecks = namespaceEmitted
+            ? (IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>)[]
+            : customViewsAfterNamespace;
+        var customViewPlan =
+            request.StoredCustomViewAuthorization is { } storedCustomViewAuthorization
+            && (
+                customViewsBeforeNamespace.Count > 0
+                || (namespaceEmitted && customViewsAfterNamespace.Count > 0)
+            )
+                ? new StoredCustomViewStatementPlan(storedCustomViewAuthorization.Checks)
+                : null;
         var relationshipPlan = classifiedRelationship;
         var relationshipEmitted =
             namespaceEmitted
@@ -283,7 +364,11 @@ internal sealed class CompositeRelationalDeleteCommand(
 
         int? documentDeleteOrdinal = null;
 
-        if (namespaceEmitted && CanCoBatchDeletes(request, relationshipPlan.Disposition))
+        if (
+            namespaceEmitted
+            && customViewSegmentChecks.Count == 0
+            && CanCoBatchDeletes(request, relationshipPlan.Disposition)
+        )
         {
             AppendResourceRootDelete(builder, carrier, request);
             documentDeleteOrdinal = AppendDocumentDelete(builder, carrier, request.MappingSet.Key.Dialect);
@@ -295,7 +380,33 @@ internal sealed class CompositeRelationalDeleteCommand(
             namespaceEmitted ? null : request.StoredNamespaceAuthorization,
             relationshipPlan,
             documentDeleteOrdinal
-        );
+        )
+        {
+            CustomViewPlan = customViewPlan,
+            CustomViewSegmentChecks = customViewSegmentChecks,
+        };
+    }
+
+    /// <summary>
+    /// Splits the planned custom-view checks around the configured position of <c>NamespaceBased</c>. With no
+    /// namespace check every view runs ahead of the relationship group, so the whole list is the first run.
+    /// </summary>
+    private static (
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Before,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> After
+    ) PartitionCustomViewRuns(RelationalDeleteCommandRequest request)
+    {
+        if (request.StoredCustomViewAuthorization is not { } storedCustomViewAuthorization)
+        {
+            return ([], []);
+        }
+
+        return request.StoredNamespaceAuthorization is { } storedNamespaceAuthorization
+            ? CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
+                storedCustomViewAuthorization.Checks,
+                storedNamespaceAuthorization.Checks[0].RawConfiguredIndex
+            )
+            : (storedCustomViewAuthorization.Checks, []);
     }
 
     private static bool CanCoBatchDeletes(
@@ -339,6 +450,58 @@ internal sealed class CompositeRelationalDeleteCommand(
                 cancellationToken
             )
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the custom-view checks configured after <c>NamespaceBased</c> as their own ordered segment, for
+    /// the case where the namespace check they follow could not fit the opening command. Authorization
+    /// therefore still executes in configured order and strictly precedes the relationship check and any
+    /// deletion, at the cost of one more command on that path.
+    /// </summary>
+    private async Task<DeleteResult?> ExecuteSegmentedCustomViewAsync(
+        RelationalDeleteCommandRequest request,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> segmentChecks,
+        long documentId,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        if (segmentChecks.Count == 0 || request.StoredCustomViewAuthorization is null)
+        {
+            return null;
+        }
+
+        var executionResult = await new CustomViewAuthorizationExecutor(
+            writeSession.CreateCommandExecutor(),
+            _providerFailureExtractor
+        )
+            .ExecuteAsync(
+                new CustomViewAuthorizationExecutionRequest(
+                    request.MappingSet,
+                    documentId,
+                    segmentChecks,
+                    request.StoredCustomViewAuthorization.Checks
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            CustomViewAuthorizationExecutionResult.Authorized => null,
+            CustomViewAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                new DeleteResult.DeleteFailureCustomViewNotAuthorized(notAuthorized.Failure),
+            CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                new DeleteResult.DeleteFailureSecurityConfiguration(
+                    [invalidFailure.FailureMessage],
+                    invalidFailure.Diagnostics
+                ),
+            // Unreachable while the capture lock holds; the same defensive mapping the namespace segment uses.
+            CustomViewAuthorizationExecutionResult.StaleTarget => new DeleteResult.DeleteFailureNotExists(),
+            _ => throw new InvalidOperationException(
+                $"Unsupported custom view authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
     }
 
     /// <summary>
@@ -606,8 +769,10 @@ internal sealed class CompositeRelationalDeleteCommand(
     private DeleteResult MapProviderFailure(
         RelationalDeleteCommandRequest request,
         StoredNamespaceStatementPlan? namespacePlan,
+        StoredCustomViewStatementPlan? customViewPlan,
         StoredRelationshipStatementPlan relationshipPlan,
-        DbException exception
+        DbException exception,
+        RelationalCompositeFailureContext? failureContext
     ) =>
         RelationalCompositeStoredAuthorization.TryClassifyDenial(
             request.MappingSet.Key.Dialect,
@@ -616,7 +781,8 @@ internal sealed class CompositeRelationalDeleteCommand(
             relationshipPlan,
             RelationshipAuthorizationAuth1Index,
             _providerFailureExtractor,
-            _logger
+            _logger,
+            customViewPlan
         ) switch
         {
             // Stale is unreachable while the capture lock holds; kept as the same defensive mapping the
@@ -624,10 +790,20 @@ internal sealed class CompositeRelationalDeleteCommand(
             StoredAuthorizationDenial.StaleTarget => new DeleteResult.DeleteFailureNotExists(),
             StoredAuthorizationDenial.NamespaceNotAuthorized(var failure) =>
                 new DeleteResult.DeleteFailureNamespaceNotAuthorized(failure),
+            StoredAuthorizationDenial.CustomViewNotAuthorized(var failure) =>
+                new DeleteResult.DeleteFailureCustomViewNotAuthorized(failure),
             StoredAuthorizationDenial.RelationshipNotAuthorized(var failure) =>
                 new DeleteResult.DeleteFailureRelationshipNotAuthorized(failure),
             StoredAuthorizationDenial.SecurityConfiguration(var messages, var diagnostics) =>
                 new DeleteResult.DeleteFailureSecurityConfiguration(messages, diagnostics),
+            // A failure in a command carrying custom-view statements that arrives without an AUTH1 payload is
+            // attributed to the configured view. The only object those statements reference that is created
+            // outside the generated schema is auth.{StrategyName}, which can be dropped, replaced, or revoked
+            // between requests, and auth.md requires that to surface as the urn:ed-fi:api:system 500 rather
+            // than as a generic delete failure. Authorization payloads are classified above, so a denial is
+            // never relabelled.
+            _ when IsAttributableToCustomView(customViewPlan, failureContext) =>
+                throw new CustomViewAuthorizationValidationException(exception),
             _ => RelationalDeleteExecution.MapFailure(
                 exception,
                 _exceptionClassifier,
@@ -639,6 +815,42 @@ internal sealed class CompositeRelationalDeleteCommand(
                 DeleteTargetKind.Document
             ),
         };
+
+    /// <summary>
+    /// Whether a provider failure with no authorization payload should be attributed to a configured custom
+    /// view rather than to the delete.
+    /// </summary>
+    /// <remarks>
+    /// An explicit custom-view label settles it. Otherwise the stage decides: a failure raised while opening
+    /// the reader, or one that is unattributable, cannot name a statement — PostgreSQL prepares the whole
+    /// batch before executing any of it, so a missing view surfaces there, nominally against statement 0. A
+    /// failure genuinely attributed to some other statement is left alone.
+    /// </remarks>
+    private static bool IsAttributableToCustomView(
+        StoredCustomViewStatementPlan? customViewPlan,
+        RelationalCompositeFailureContext? failureContext
+    )
+    {
+        if (customViewPlan is null)
+        {
+            return false;
+        }
+
+        if (
+            string.Equals(
+                failureContext?.Label,
+                RelationalCompositeStoredAuthorization.CustomViewLabel,
+                StringComparison.Ordinal
+            )
+        )
+        {
+            return true;
+        }
+
+        return failureContext?.Stage
+            is RelationalCompositeFailureStage.OpeningReader
+                or RelationalCompositeFailureStage.Unattributable;
+    }
 
     /// <summary>
     /// Whether the <c>dms.Document</c> delete returned a row, which is how delete success is decided; the

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -36,6 +36,7 @@ public sealed class RelationalDocumentStoreRepository(
     RelationalEdOrgAuthorizationSubjectSelector edOrgAuthorizationSubjectSelector,
     ISingleRecordRelationshipAuthorizationExecutor singleRecordRelationshipAuthorizationExecutor,
     INamespaceAuthorizationExecutor namespaceAuthorizationExecutor,
+    ICustomViewAuthorizationExecutor customViewAuthorizationExecutor,
     IRelationalCommandExecutor commandExecutor,
     IDocumentCacheReadAccelerationCoordinator readAccelerationCoordinator,
     IRelationalParameterConfigurator? relationalParameterConfigurator = null,
@@ -82,6 +83,9 @@ public sealed class RelationalDocumentStoreRepository(
     private readonly INamespaceAuthorizationExecutor _namespaceAuthorizationExecutor =
         namespaceAuthorizationExecutor
         ?? throw new ArgumentNullException(nameof(namespaceAuthorizationExecutor));
+    private readonly ICustomViewAuthorizationExecutor _customViewAuthorizationExecutor =
+        customViewAuthorizationExecutor
+        ?? throw new ArgumentNullException(nameof(customViewAuthorizationExecutor));
 
     // The read executor. Custom view-based GET-many validation runs on it rather than on a write session:
     // each call takes a separate read connection and round trip, but a read never opens a write
@@ -2867,6 +2871,7 @@ public sealed class RelationalDocumentStoreRepository(
                             relationalGetRequest,
                             mappingSet,
                             proceed.StoredNamespaceAuthorization,
+                            proceed.StoredCustomViewAuthorization,
                             proceed.StoredRelationshipAuthorization,
                             existingDocument.DocumentId,
                             existingDocument.ContentVersion,
@@ -3311,18 +3316,24 @@ public sealed class RelationalDocumentStoreRepository(
                 );
 
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
+                // Validating the custom views configured ahead of this terminal needs the eager view
+                // probe, which no single-record path has yet, so the terminal is reported as-is.
                 return AuthorizeGetByIdRelationshipPreflight(
                     mappingSet,
                     resource,
+                    null,
                     null,
                     securityConfigurationError.NonNamespaceConfiguredStrategies,
                     authorizationContext
                 );
 
             case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
+                // Validating the custom views configured ahead of this terminal needs the eager view
+                // probe, which no single-record path has yet, so the terminal is reported as-is.
                 return AuthorizeGetByIdRelationshipPreflight(
                     mappingSet,
                     resource,
+                    null,
                     null,
                     stillUnsupported.NonNamespaceConfiguredStrategies,
                     authorizationContext
@@ -3345,12 +3356,26 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalAuthorizationContext authorizationContext
     )
     {
+        if (
+            !TryPlanGetByIdCustomViewAuthorization(
+                mappingSet,
+                resource,
+                plan.CustomViewStrategies,
+                out var storedCustomViewAuthorization,
+                out var customViewSecurityConfigurationFailure
+            )
+        )
+        {
+            return new GetByIdAuthorizationPreflightResult.Stop(customViewSecurityConfigurationFailure!);
+        }
+
         if (plan.NamespaceChecks.Count == 0)
         {
             return AuthorizeGetByIdRelationshipPreflight(
                 mappingSet,
                 resource,
                 null,
+                storedCustomViewAuthorization,
                 plan.NonNamespaceConfiguredStrategies,
                 authorizationContext
             );
@@ -3383,15 +3408,66 @@ public sealed class RelationalDocumentStoreRepository(
             mappingSet,
             resource,
             storedNamespaceAuthorization,
+            storedCustomViewAuthorization,
             plan.NonNamespaceConfiguredStrategies,
             authorizationContext
         );
+    }
+
+    /// <summary>
+    /// Plans the stored custom-view checks, or reports the security-configuration failure that stops the read.
+    /// </summary>
+    private static bool TryPlanGetByIdCustomViewAuthorization(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        out RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        out GetResult? securityConfigurationFailure
+    )
+    {
+        storedCustomViewAuthorization = null;
+        securityConfigurationFailure = null;
+
+        if (customViewStrategies.Count == 0)
+        {
+            return true;
+        }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            customViewStrategies,
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            securityConfigurationFailure = BuildGetAuthorizationSecurityConfigurationFailure(
+                mappingSet,
+                resource,
+                configurationFailure.Failures
+            );
+            return false;
+        }
+
+        var checks = ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks;
+
+        if (checks.Count > 0)
+        {
+            storedCustomViewAuthorization = new RelationalCustomViewAuthorization(checks);
+        }
+
+        return true;
     }
 
     private GetByIdAuthorizationPreflightResult AuthorizeGetByIdRelationshipPreflight(
         MappingSet mappingSet,
         QualifiedResourceName resource,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? storedCustomViewAuthorization,
         IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
         RelationalAuthorizationContext authorizationContext
     )
@@ -3423,6 +3499,7 @@ public sealed class RelationalDocumentStoreRepository(
 
             _ => new GetByIdAuthorizationPreflightResult.Proceed(
                 storedNamespaceAuthorization,
+                storedCustomViewAuthorization,
                 storedRelationshipAuthorization
             ),
         };
@@ -3432,6 +3509,7 @@ public sealed class RelationalDocumentStoreRepository(
         IGetRequest relationalGetRequest,
         MappingSet mappingSet,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? storedCustomViewAuthorization,
         RelationshipAuthorizationResult storedRelationshipAuthorization,
         long documentId,
         long storedContentVersion,
@@ -3439,41 +3517,20 @@ public sealed class RelationalDocumentStoreRepository(
     )
     {
         var authorizationContext = relationalGetRequest.AuthorizationContext;
+        var andFilterOutcome = await AuthorizeGetAndFiltersAsync(
+                mappingSet,
+                documentId,
+                storedNamespaceAuthorization,
+                storedCustomViewAuthorization
+            )
+            .ConfigureAwait(false);
 
-        if (storedNamespaceAuthorization is not null)
+        if (andFilterOutcome is not null)
         {
-            var namespaceOutcome = await ExecuteGetNamespaceAuthorizationAsync(
-                    mappingSet,
-                    documentId,
-                    storedNamespaceAuthorization,
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
-
-            if (namespaceOutcome is not null)
-            {
-                return namespaceOutcome;
-            }
-
-            var relationshipOutcome = await AuthorizeGetRelationshipAsync(
-                    mappingSet,
-                    storedRelationshipAuthorization,
-                    authorizationContext,
-                    documentId,
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
-
-            // Namespace authorization read the stored row but does not report a content version, so
-            // its decision must be pinned to the stored content version that drove this attempt. The
-            // served representation, the relationship boundary, and the post-hydration boundary must
-            // all agree on that one version; otherwise a mutation that interleaved with the
-            // authorization sequence could change the namespace and serve a representation the
-            // namespace check never validated.
-            return AnchorNamespaceReadBoundary(relationshipOutcome, storedContentVersion);
+            return andFilterOutcome;
         }
 
-        return await AuthorizeGetRelationshipAsync(
+        var relationshipOutcome = await AuthorizeGetRelationshipAsync(
                 mappingSet,
                 storedRelationshipAuthorization,
                 authorizationContext,
@@ -3481,6 +3538,128 @@ public sealed class RelationalDocumentStoreRepository(
                 cancellationToken
             )
             .ConfigureAwait(false);
+
+        if (storedNamespaceAuthorization is null && storedCustomViewAuthorization is null)
+        {
+            return relationshipOutcome;
+        }
+
+        // The AND checks read the stored row but report no content version, so their decisions are only
+        // valid for the version that drove this attempt. The served representation, the relationship
+        // boundary, and the post-hydration boundary must all agree on that one version; otherwise a
+        // mutation interleaving with the authorization sequence could change a namespace or a basis value
+        // and serve a representation those checks never validated.
+        return AnchorStoredAndFilterReadBoundary(relationshipOutcome, storedContentVersion);
+    }
+
+    /// <summary>
+    /// Runs the AND-combined stored checks in CMS-configured order, returning the first failing outcome or
+    /// <see langword="null"/> when all of them authorize.
+    /// </summary>
+    /// <remarks>
+    /// Custom views and <c>NamespaceBased</c> interleave by configured index, and the first failure is the one
+    /// reported, so custom views configured before the namespace check must run before it and those configured
+    /// after must run after. A compiled custom-view batch is one command, so honoring that order costs one
+    /// command per contiguous run — two only when custom views straddle the namespace index, which is why the
+    /// list is partitioned rather than executed check by check.
+    /// </remarks>
+    private async Task<GetAuthorizationOutcome?> AuthorizeGetAndFiltersAsync(
+        MappingSet mappingSet,
+        long documentId,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? storedCustomViewAuthorization
+    )
+    {
+        if (storedNamespaceAuthorization is null)
+        {
+            return storedCustomViewAuthorization is null
+                ? null
+                : await ExecuteGetCustomViewAuthorizationAsync(
+                        mappingSet,
+                        documentId,
+                        storedCustomViewAuthorization.Checks
+                    )
+                    .ConfigureAwait(false);
+        }
+
+        var (customViewsBeforeNamespace, customViewsAfterNamespace) = storedCustomViewAuthorization is null
+            ? ((IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>)[], [])
+            : CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
+                storedCustomViewAuthorization.Checks,
+                storedNamespaceAuthorization.Checks[0].RawConfiguredIndex
+            );
+
+        if (customViewsBeforeNamespace.Count > 0)
+        {
+            var beforeOutcome = await ExecuteGetCustomViewAuthorizationAsync(
+                    mappingSet,
+                    documentId,
+                    customViewsBeforeNamespace
+                )
+                .ConfigureAwait(false);
+
+            if (beforeOutcome is not null)
+            {
+                return beforeOutcome;
+            }
+        }
+
+        var namespaceOutcome = await ExecuteGetNamespaceAuthorizationAsync(
+                mappingSet,
+                documentId,
+                storedNamespaceAuthorization
+            )
+            .ConfigureAwait(false);
+
+        if (namespaceOutcome is not null)
+        {
+            return namespaceOutcome;
+        }
+
+        return customViewsAfterNamespace.Count == 0
+            ? null
+            : await ExecuteGetCustomViewAuthorizationAsync(mappingSet, documentId, customViewsAfterNamespace)
+                .ConfigureAwait(false);
+    }
+
+    private async Task<GetAuthorizationOutcome?> ExecuteGetCustomViewAuthorizationAsync(
+        MappingSet mappingSet,
+        long documentId,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+    )
+    {
+        var executionResult = await _customViewAuthorizationExecutor
+            .ExecuteAsync(new CustomViewAuthorizationExecutionRequest(mappingSet, documentId, checks))
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            CustomViewAuthorizationExecutionResult.Authorized => null,
+            CustomViewAuthorizationExecutionResult.NotAuthorized notAuthorized => new GetAuthorizationOutcome(
+                new GetResult.GetFailureCustomViewNotAuthorized(notAuthorized.Failure),
+                null,
+                false
+            ),
+            CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                new GetAuthorizationOutcome(
+                    new GetResult.GetFailureSecurityConfiguration(
+                        [invalidFailure.FailureMessage],
+                        invalidFailure.Diagnostics
+                    ),
+                    null,
+                    false
+                ),
+            // The stored target row was deleted between the unlocked target lookup and this check. Retry so
+            // the read boundary re-resolves the target; a target still gone on the next attempt is a 404.
+            CustomViewAuthorizationExecutionResult.StaleTarget => new GetAuthorizationOutcome(
+                null,
+                null,
+                RetryTargetResolution: true
+            ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported custom view authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
     }
 
     private async Task<GetAuthorizationOutcome> AuthorizeGetRelationshipAsync(
@@ -3538,7 +3717,7 @@ public sealed class RelationalDocumentStoreRepository(
         }
     }
 
-    private static GetAuthorizationOutcome AnchorNamespaceReadBoundary(
+    private static GetAuthorizationOutcome AnchorStoredAndFilterReadBoundary(
         GetAuthorizationOutcome relationshipOutcome,
         long storedContentVersion
     )
@@ -3550,11 +3729,10 @@ public sealed class RelationalDocumentStoreRepository(
             return relationshipOutcome;
         }
 
-        // The namespace check ran against the stored row but reports no version, so its decision is
-        // only valid for the stored content version. When the relationship boundary either reported
-        // no version (a no-op OR group) or reported the same stored version, pin the read boundary to
-        // that version so hydration and the post-hydration boundary serve exactly the namespace-checked
-        // representation.
+        // The AND checks ran against the stored row but report no version, so their decisions are only
+        // valid for the stored content version. When the relationship boundary either reported no version
+        // (a no-op OR group) or reported the same stored version, pin the read boundary to that version so
+        // hydration and the post-hydration boundary serve exactly the representation those checks saw.
         if (
             authorized.ObservedContentVersion is null
             || authorized.ObservedContentVersion == storedContentVersion
@@ -3563,10 +3741,10 @@ public sealed class RelationalDocumentStoreRepository(
             return authorized with { ObservedContentVersion = storedContentVersion };
         }
 
-        // The relationship boundary observed a different content version than the one the namespace
-        // check authorized, so a mutation interleaved with the authorization sequence and the
-        // namespace decision can no longer be trusted for the version that would be served. Force a
-        // retry so the entire authorization sequence re-runs against the current row.
+        // The relationship boundary observed a different content version than the one the AND checks
+        // authorized, so a mutation interleaved with the authorization sequence and those decisions can no
+        // longer be trusted for the version that would be served. Force a retry so the entire
+        // authorization sequence re-runs against the current row.
         return authorized with
         {
             RetryTargetResolution = true,
@@ -3741,6 +3919,7 @@ public sealed class RelationalDocumentStoreRepository(
         // StoredNamespaceAuthorization is null when only relationship strategies must be evaluated.
         public sealed record Proceed(
             RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
+            RelationalCustomViewAuthorization? StoredCustomViewAuthorization,
             RelationshipAuthorizationResult StoredRelationshipAuthorization
         ) : GetByIdAuthorizationPreflightResult;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -691,6 +691,58 @@ public sealed class RelationalDocumentStoreRepository(
         );
     }
 
+    /// <summary>
+    /// The write counterpart of <see cref="DeleteTerminal"/>. Every POST/PUT preflight terminal that can be
+    /// preceded by a custom view routes through this, so attaching the views is not a per-arm decision.
+    /// </summary>
+    private static WriteGuardRailPreflightResult<TResult> WriteTerminal<TResult>(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        TResult result,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        int terminalIndex,
+        Func<IReadOnlyList<RelationshipAuthorizationFailureMetadata>, TResult> securityConfigurationFactory
+    )
+    {
+        var strategiesToValidate = CustomViewAuthorizationTerminalOrdering.CustomViewsBeforeTerminal(
+            customViewStrategies,
+            terminalIndex
+        );
+
+        if (strategiesToValidate.Count == 0)
+        {
+            return new WriteGuardRailPreflightResult<TResult>.Stop(result);
+        }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            strategiesToValidate,
+            NamespaceAuthorizationOperation.Update
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            return new WriteGuardRailPreflightResult<TResult>.Stop(
+                securityConfigurationFactory(configurationFailure.Failures),
+                SingleRecordChecksBeforeTerminal(
+                    configurationFailure.PlannedChecks,
+                    RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                        configurationFailure.Failures
+                    )
+                )
+            );
+        }
+
+        return new WriteGuardRailPreflightResult<TResult>.Stop(
+            result,
+            ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks
+        );
+    }
+
     private DeleteAuthorizationPreflightResult AuthorizeDeletePreflight(
         IDeleteRequest relationalDeleteRequest,
         MappingSet mappingSet,
@@ -858,11 +910,13 @@ public sealed class RelationalDocumentStoreRepository(
         QualifiedResourceName resource,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
         out RelationalCustomViewAuthorization? customViewAuthorization,
-        out IReadOnlyList<RelationshipAuthorizationFailureMetadata>? securityConfigurationFailures
+        out IReadOnlyList<RelationshipAuthorizationFailureMetadata>? securityConfigurationFailures,
+        out IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checksToValidateBeforeFailure
     )
     {
         customViewAuthorization = null;
         securityConfigurationFailures = null;
+        checksToValidateBeforeFailure = [];
 
         if (customViewStrategies.Count == 0)
         {
@@ -882,6 +936,14 @@ public sealed class RelationalDocumentStoreRepository(
         )
         {
             securityConfigurationFailures = configurationFailure.Failures;
+            // Views configured ahead of the earliest planning failure planned successfully and execute
+            // first, so they are still validated before this failure is reported.
+            checksToValidateBeforeFailure = SingleRecordChecksBeforeTerminal(
+                configurationFailure.PlannedChecks,
+                RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                    configurationFailure.Failures
+                )
+            );
             return false;
         }
 
@@ -2249,7 +2311,9 @@ public sealed class RelationalDocumentStoreRepository(
         switch (orchestratorOutcome)
         {
             case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
-                return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                return WriteTerminal<UpsertResult>(
+                    mappingSet,
+                    resource,
                     new UpsertResult.UpsertFailureSecurityConfiguration(
                         [
                             NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
@@ -2257,14 +2321,22 @@ public sealed class RelationalDocumentStoreRepository(
                             ),
                         ],
                         RelationalReadGuardrails.BuildNoUsableRootColumnDiagnostics(noUsableRoot.Resource)
-                    )
+                    ),
+                    noUsableRoot.CustomViewStrategies,
+                    noUsableRoot.RawConfiguredIndex,
+                    failures => BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, failures)
                 );
 
             case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
-                return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                return WriteTerminal<UpsertResult>(
+                    mappingSet,
+                    resource,
                     new UpsertResult.UpsertFailureNamespaceNotAuthorized(
                         NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
-                    )
+                    ),
+                    noPrefixes.CustomViewStrategies,
+                    noPrefixes.RawConfiguredIndex,
+                    failures => BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, failures)
                 );
 
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
@@ -2275,7 +2347,10 @@ public sealed class RelationalDocumentStoreRepository(
                     securityConfigurationError.NonNamespaceConfiguredStrategies,
                     authorizationContext,
                     storedNamespaceAuthorization: null,
-                    proposedNamespaceAuthorization: null
+                    proposedNamespaceAuthorization: null,
+                    supportedCustomViewStrategies: securityConfigurationError
+                        .RelationshipClassification
+                        .SupportedCustomViewStrategies
                 );
 
             case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
@@ -2286,7 +2361,10 @@ public sealed class RelationalDocumentStoreRepository(
                     stillUnsupported.NonNamespaceConfiguredStrategies,
                     authorizationContext,
                     storedNamespaceAuthorization: null,
-                    proposedNamespaceAuthorization: null
+                    proposedNamespaceAuthorization: null,
+                    supportedCustomViewStrategies: stillUnsupported
+                        .RelationshipClassification
+                        .SupportedCustomViewStrategies
                 );
 
             case RelationalAuthorizationPlanOutcome.Plan plan:
@@ -2315,12 +2393,14 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 plan.CustomViewStrategies,
                 out var customViewAuthorization,
-                out var customViewFailures
+                out var customViewFailures,
+                out var customViewChecksBeforeFailure
             )
         )
         {
             return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
-                BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, customViewFailures!)
+                BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, customViewFailures!),
+                customViewChecksBeforeFailure
             );
         }
 
@@ -2352,7 +2432,8 @@ public sealed class RelationalDocumentStoreRepository(
                 new UpsertResult.UpsertFailureSecurityConfiguration(
                     [securityConfigurationMessage],
                     securityConfigurationDiagnostics
-                )
+                ),
+                CustomViewChecksBeforeNamespaceCheck(customViewAuthorization, plan.NamespaceChecks)
             );
         }
 
@@ -2409,9 +2490,35 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalAuthorizationContext authorizationContext,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
-        RelationalCustomViewAuthorization? customViewAuthorization = null
+        RelationalCustomViewAuthorization? customViewAuthorization = null,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? supportedCustomViewStrategies = null
     )
     {
+        supportedCustomViewStrategies ??= [];
+
+        // The strategy-level SecurityConfigurationError and StillUnsupported arms reach this bucket before
+        // any custom view has been planned, so plan them here rather than at each terminal below: every Stop
+        // in this method then carries the views that execute ahead of it. Callers that already planned pass
+        // customViewAuthorization instead and skip this.
+        if (
+            customViewAuthorization is null
+            && supportedCustomViewStrategies.Count > 0
+            && !TryPlanWriteCustomViewAuthorization(
+                mappingSet,
+                resource,
+                supportedCustomViewStrategies,
+                out customViewAuthorization,
+                out var customViewFailures,
+                out var customViewChecksBeforeFailure
+            )
+        )
+        {
+            return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, customViewFailures!),
+                customViewChecksBeforeFailure
+            );
+        }
+
         var existingResourcePlan = _relationshipAuthorizationPlanner.PlanUpdateValues(
             mappingSet,
             resource,
@@ -2425,7 +2532,8 @@ public sealed class RelationalDocumentStoreRepository(
         if (securityConfigurationFailures.Count > 0)
         {
             return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
-                BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, securityConfigurationFailures)
+                BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, securityConfigurationFailures),
+                ChecksBeforeRelationshipFailure(customViewAuthorization, securityConfigurationFailures)
             );
         }
 
@@ -2438,7 +2546,8 @@ public sealed class RelationalDocumentStoreRepository(
                         existingResourcePlan.KnownButNotEnabledFailures
                     ),
                     UpsertFailureNotImplementedReason.StrategyNotEnabled
-                )
+                ),
+                AllCustomViewChecks(customViewAuthorization)
             );
         }
 
@@ -2491,13 +2600,18 @@ public sealed class RelationalDocumentStoreRepository(
                             knownButNotEnabled.Failures
                         ),
                         UpsertFailureNotImplementedReason.StrategyNotEnabled
-                    )
+                    ),
+                    AllCustomViewChecks(customViewAuthorization)
                 ),
 
             RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError =>
                 new WriteGuardRailPreflightResult<UpsertResult>.Stop(
                     BuildPostAuthorizationSecurityConfigurationFailure(
                         mappingSet,
+                        securityConfigurationError.Failures
+                    ),
+                    ChecksBeforeRelationshipFailure(
+                        customViewAuthorization,
                         securityConfigurationError.Failures
                     )
                 ),
@@ -2571,7 +2685,8 @@ public sealed class RelationalDocumentStoreRepository(
                             knownButNotEnabled.Failures
                         ),
                         UpsertFailureNotImplementedReason.StrategyNotEnabled
-                    )
+                    ),
+                    AllCustomViewChecks(customViewAuthorization)
                 ),
 
             RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError =>
@@ -2614,7 +2729,9 @@ public sealed class RelationalDocumentStoreRepository(
         switch (orchestratorOutcome)
         {
             case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
-                return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
+                return WriteTerminal<UpdateResult>(
+                    mappingSet,
+                    resource,
                     new UpdateResult.UpdateFailureSecurityConfiguration(
                         [
                             NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
@@ -2622,14 +2739,22 @@ public sealed class RelationalDocumentStoreRepository(
                             ),
                         ],
                         RelationalReadGuardrails.BuildNoUsableRootColumnDiagnostics(noUsableRoot.Resource)
-                    )
+                    ),
+                    noUsableRoot.CustomViewStrategies,
+                    noUsableRoot.RawConfiguredIndex,
+                    failures => BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, failures)
                 );
 
             case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
-                return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
+                return WriteTerminal<UpdateResult>(
+                    mappingSet,
+                    resource,
                     new UpdateResult.UpdateFailureNamespaceNotAuthorized(
                         NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
-                    )
+                    ),
+                    noPrefixes.CustomViewStrategies,
+                    noPrefixes.RawConfiguredIndex,
+                    failures => BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, failures)
                 );
 
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
@@ -2640,7 +2765,10 @@ public sealed class RelationalDocumentStoreRepository(
                     securityConfigurationError.NonNamespaceConfiguredStrategies,
                     authorizationContext,
                     storedNamespaceAuthorization: null,
-                    proposedNamespaceAuthorization: null
+                    proposedNamespaceAuthorization: null,
+                    supportedCustomViewStrategies: securityConfigurationError
+                        .RelationshipClassification
+                        .SupportedCustomViewStrategies
                 );
 
             case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
@@ -2651,7 +2779,10 @@ public sealed class RelationalDocumentStoreRepository(
                     stillUnsupported.NonNamespaceConfiguredStrategies,
                     authorizationContext,
                     storedNamespaceAuthorization: null,
-                    proposedNamespaceAuthorization: null
+                    proposedNamespaceAuthorization: null,
+                    supportedCustomViewStrategies: stillUnsupported
+                        .RelationshipClassification
+                        .SupportedCustomViewStrategies
                 );
 
             case RelationalAuthorizationPlanOutcome.Plan plan:
@@ -2678,12 +2809,14 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 plan.CustomViewStrategies,
                 out var customViewAuthorization,
-                out var customViewFailures
+                out var customViewFailures,
+                out var customViewChecksBeforeFailure
             )
         )
         {
             return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
-                BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, customViewFailures!)
+                BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, customViewFailures!),
+                customViewChecksBeforeFailure
             );
         }
 
@@ -2715,7 +2848,8 @@ public sealed class RelationalDocumentStoreRepository(
                 new UpdateResult.UpdateFailureSecurityConfiguration(
                     [securityConfigurationMessage],
                     securityConfigurationDiagnostics
-                )
+                ),
+                CustomViewChecksBeforeNamespaceCheck(customViewAuthorization, plan.NamespaceChecks)
             );
         }
 
@@ -2744,9 +2878,35 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalAuthorizationContext authorizationContext,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
-        RelationalCustomViewAuthorization? customViewAuthorization = null
+        RelationalCustomViewAuthorization? customViewAuthorization = null,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? supportedCustomViewStrategies = null
     )
     {
+        supportedCustomViewStrategies ??= [];
+
+        // The strategy-level SecurityConfigurationError and StillUnsupported arms reach this bucket before
+        // any custom view has been planned, so plan them here rather than at each terminal below: every Stop
+        // in this method then carries the views that execute ahead of it. Callers that already planned pass
+        // customViewAuthorization instead and skip this.
+        if (
+            customViewAuthorization is null
+            && supportedCustomViewStrategies.Count > 0
+            && !TryPlanWriteCustomViewAuthorization(
+                mappingSet,
+                resource,
+                supportedCustomViewStrategies,
+                out customViewAuthorization,
+                out var customViewFailures,
+                out var customViewChecksBeforeFailure
+            )
+        )
+        {
+            return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
+                BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, customViewFailures!),
+                customViewChecksBeforeFailure
+            );
+        }
+
         var relationshipAuthorizationPlan = _relationshipAuthorizationPlanner.PlanUpdateValues(
             mappingSet,
             resource,
@@ -2760,7 +2920,8 @@ public sealed class RelationalDocumentStoreRepository(
         if (securityConfigurationFailures.Count > 0)
         {
             return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
-                BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, securityConfigurationFailures)
+                BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, securityConfigurationFailures),
+                ChecksBeforeRelationshipFailure(customViewAuthorization, securityConfigurationFailures)
             );
         }
 
@@ -2772,7 +2933,8 @@ public sealed class RelationalDocumentStoreRepository(
                 new UpdateResult.UpdateFailureNotImplemented(
                     BuildKnownButNotEnabledPutAuthorizationMessage(resource, knownButNotEnabledFailures),
                     UpdateFailureNotImplementedReason.StrategyNotEnabled
-                )
+                ),
+                AllCustomViewChecks(customViewAuthorization)
             );
         }
 
@@ -2943,6 +3105,13 @@ public sealed class RelationalDocumentStoreRepository(
                     break;
 
                 case WriteGuardRailPreflightResult<TResult>.Stop stopResult:
+                    // Views configured ahead of this terminal execute first, so a missing or non-conforming
+                    // one keeps its own failure instead of being masked by the terminal's result.
+                    await ValidateSingleRecordCustomViewsAsync(
+                            mappingSet,
+                            stopResult.CustomViewChecksToValidate
+                        )
+                        .ConfigureAwait(false);
                     return stopResult.Result;
 
                 default:
@@ -3125,7 +3294,15 @@ public sealed class RelationalDocumentStoreRepository(
             }
         }
 
-        public sealed record Stop(TResult Result) : WriteGuardRailPreflightResult<TResult>;
+        /// <inheritdoc cref="GetByIdAuthorizationPreflightResult.Stop.CustomViewChecksToValidate"/>
+        public sealed record Stop(
+            TResult Result,
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewChecksToValidate
+        ) : WriteGuardRailPreflightResult<TResult>
+        {
+            public Stop(TResult result)
+                : this(result, []) { }
+        }
     }
 
     private async Task<GetResult> GetDocumentByIdAsync(
@@ -3647,6 +3824,46 @@ public sealed class RelationalDocumentStoreRepository(
             ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks
         );
     }
+
+    /// <summary>
+    /// The already-planned custom-view checks configured strictly before the earliest relationship
+    /// security-configuration failure. Custom views AND-compose ahead of relationship strategies, so the ones
+    /// configured before the failure still execute and must be validated before it is reported.
+    /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> ChecksBeforeRelationshipFailure(
+        RelationalCustomViewAuthorization? customViewAuthorization,
+        IReadOnlyList<RelationshipAuthorizationFailureMetadata> failures
+    ) =>
+        customViewAuthorization is null
+            ? []
+            : SingleRecordChecksBeforeTerminal(
+                customViewAuthorization.Checks,
+                RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(failures)
+            );
+
+    /// <summary>
+    /// Every planned custom-view check. Known-but-not-enabled relationship strategies execute last per
+    /// auth.md "Execution order" whatever their configured position, so every resolved view runs ahead of the
+    /// 501 rather than only those configured before it.
+    /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> AllCustomViewChecks(
+        RelationalCustomViewAuthorization? customViewAuthorization
+    ) => customViewAuthorization?.Checks ?? [];
+
+    /// <summary>
+    /// The already-planned custom-view checks configured strictly before the namespace check, for terminals
+    /// that fail after custom-view planning succeeded.
+    /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewChecksBeforeNamespaceCheck(
+        RelationalCustomViewAuthorization? customViewAuthorization,
+        IReadOnlyList<NamespaceAuthorizationCheckSpec> namespaceChecks
+    ) =>
+        customViewAuthorization is null || namespaceChecks.Count == 0
+            ? []
+            : SingleRecordChecksBeforeTerminal(
+                customViewAuthorization.Checks,
+                namespaceChecks[0].RawConfiguredIndex
+            );
 
     /// <summary>
     /// The planned single-record checks configured strictly before <paramref name="terminalRawConfiguredIndex"/>.

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -766,9 +766,51 @@ public sealed class RelationalDocumentStoreRepository(
     }
 
     /// <summary>
-    /// Plans the stored custom-view checks, or reports the security-configuration failure that stops the
-    /// delete.
+    /// Plans the custom-view checks a POST or PUT owes, across both value sources, or reports the
+    /// security-configuration failures that stop the write.
     /// </summary>
+    private static bool TryPlanWriteCustomViewAuthorization(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        out RelationalCustomViewAuthorization? customViewAuthorization,
+        out IReadOnlyList<RelationshipAuthorizationFailureMetadata>? securityConfigurationFailures
+    )
+    {
+        customViewAuthorization = null;
+        securityConfigurationFailures = null;
+
+        if (customViewStrategies.Count == 0)
+        {
+            return true;
+        }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            customViewStrategies,
+            NamespaceAuthorizationOperation.Update
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            securityConfigurationFailures = configurationFailure.Failures;
+            return false;
+        }
+
+        var checks = ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks;
+
+        if (checks.Count > 0)
+        {
+            customViewAuthorization = new RelationalCustomViewAuthorization(checks);
+        }
+
+        return true;
+    }
+
     private static bool TryPlanDeleteCustomViewAuthorization(
         MappingSet mappingSet,
         QualifiedResourceName resource,
@@ -2126,6 +2168,23 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalAuthorizationContext authorizationContext
     )
     {
+        // A POST may resolve to create or upsert-as-update in-session, so both value sources are planned
+        // here; the executor applies the stored checks only when the write resolves to an existing target.
+        if (
+            !TryPlanWriteCustomViewAuthorization(
+                mappingSet,
+                resource,
+                plan.CustomViewStrategies,
+                out var customViewAuthorization,
+                out var customViewFailures
+            )
+        )
+        {
+            return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, customViewFailures!)
+            );
+        }
+
         if (plan.NamespaceChecks.Count == 0)
         {
             return AuthorizePostRelationshipBucket(
@@ -2135,7 +2194,8 @@ public sealed class RelationalDocumentStoreRepository(
                 plan.NonNamespaceConfiguredStrategies,
                 authorizationContext,
                 storedNamespaceAuthorization: null,
-                proposedNamespaceAuthorization: null
+                proposedNamespaceAuthorization: null,
+                customViewAuthorization: customViewAuthorization
             );
         }
 
@@ -2169,7 +2229,8 @@ public sealed class RelationalDocumentStoreRepository(
             plan.NonNamespaceConfiguredStrategies,
             authorizationContext,
             storedNamespaceAuthorization,
-            proposedNamespaceAuthorization
+            proposedNamespaceAuthorization,
+            customViewAuthorization
         );
     }
 
@@ -2208,7 +2269,8 @@ public sealed class RelationalDocumentStoreRepository(
         IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
         RelationalAuthorizationContext authorizationContext,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
-        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? customViewAuthorization = null
     )
     {
         var existingResourcePlan = _relationshipAuthorizationPlanner.PlanUpdateValues(
@@ -2249,7 +2311,8 @@ public sealed class RelationalDocumentStoreRepository(
                     null,
                     null,
                     storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization
+                    proposedNamespaceAuthorization,
+                    customViewAuthorization: customViewAuthorization
                 ),
 
             RelationshipAuthorizationResult.Authorized => CreatePostRelationshipAuthorizationContinue(
@@ -2260,22 +2323,25 @@ public sealed class RelationalDocumentStoreRepository(
                 writePlan,
                 existingResourcePlan,
                 storedNamespaceAuthorization,
-                proposedNamespaceAuthorization
+                proposedNamespaceAuthorization,
+                customViewAuthorization
             ),
 
-            // NamespaceBased AND-composes before relationship OR strategies (auth.md). When a
-            // proposed namespace check is also planned, defer NoClaims through Continue so the
-            // namespace check gets to deny first; the write path's second command
-            // emits the NoClaims failure if namespace authorized. With no namespace check planned,
-            // short-circuit at preflight to avoid a needless executor roundtrip.
+            // NamespaceBased and custom view-based both AND-compose before relationship OR strategies
+            // (auth.md). When any of them is planned, defer NoClaims through Continue so those filters get to
+            // deny first; the write path's second command emits the NoClaims failure only once they have
+            // authorized. With no AND filter planned at all, short-circuit at preflight to avoid a needless
+            // executor roundtrip.
             RelationshipAuthorizationResult.NoClaims noClaims => proposedNamespaceAuthorization is null
             && storedNamespaceAuthorization is null
+            && customViewAuthorization is null
                 ? BuildNoClaimsPostRelationshipAuthorizationFailure(noClaims, authorizationContext)
                 : new WriteGuardRailPreflightResult<UpsertResult>.Continue(
                     null,
                     noClaims,
                     storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization
+                    proposedNamespaceAuthorization,
+                    customViewAuthorization: customViewAuthorization
                 ),
 
             RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled =>
@@ -2311,7 +2377,8 @@ public sealed class RelationalDocumentStoreRepository(
         ResourceWritePlan writePlan,
         RelationshipAuthorizationUpdatePlan existingResourcePlan,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
-        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? customViewAuthorization = null
     )
     {
         var createNewProposedValues = _relationshipAuthorizationPlanner.PlanProposedValues(
@@ -2322,36 +2389,40 @@ public sealed class RelationalDocumentStoreRepository(
             writePlan
         );
 
+        // Every deferral out of this method owes the executor the same namespace and custom-view plans, and
+        // only the create-new relationship result varies. Building them here rather than at each arm keeps a
+        // new arm from silently dropping a planned check by omitting a trailing argument.
+        WriteGuardRailPreflightResult<UpsertResult> DeferToExecutor(
+            RelationshipAuthorizationResult? createNewProposedRelationshipAuthorization,
+            RelationalWriteExecutorResult? createNewImmediateResult = null
+        ) =>
+            new WriteGuardRailPreflightResult<UpsertResult>.Continue(
+                null,
+                null,
+                storedNamespaceAuthorization,
+                proposedNamespaceAuthorization,
+                new PostRelationshipAuthorizationPlans(
+                    existingResourcePlan,
+                    createNewProposedRelationshipAuthorization,
+                    createNewImmediateResult
+                ),
+                customViewAuthorization
+            );
+
         return createNewProposedValues switch
         {
             RelationshipAuthorizationResult.NoAuthorizationRequired
-            or RelationshipAuthorizationResult.NoFurtherAuthorizationRequired =>
-                new WriteGuardRailPreflightResult<UpsertResult>.Continue(
-                    null,
-                    null,
-                    storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization,
-                    new PostRelationshipAuthorizationPlans(existingResourcePlan, null, null)
-                ),
+            or RelationshipAuthorizationResult.NoFurtherAuthorizationRequired => DeferToExecutor(null),
 
-            RelationshipAuthorizationResult.Authorized createNewAuthorized =>
-                new WriteGuardRailPreflightResult<UpsertResult>.Continue(
-                    null,
-                    null,
-                    storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization,
-                    new PostRelationshipAuthorizationPlans(existingResourcePlan, createNewAuthorized, null)
-                ),
+            RelationshipAuthorizationResult.Authorized createNewAuthorized => DeferToExecutor(
+                createNewAuthorized
+            ),
 
+            // A pending custom view is an AND filter too, so it has to run before this denial is reported.
             RelationshipAuthorizationResult.NoClaims noClaims => proposedNamespaceAuthorization is null
+            && customViewAuthorization is null
                 ? BuildNoClaimsPostRelationshipAuthorizationFailure(noClaims, authorizationContext)
-                : new WriteGuardRailPreflightResult<UpsertResult>.Continue(
-                    null,
-                    null,
-                    storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization,
-                    new PostRelationshipAuthorizationPlans(existingResourcePlan, noClaims, null)
-                ),
+                : DeferToExecutor(noClaims),
 
             RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled =>
                 new WriteGuardRailPreflightResult<UpsertResult>.Stop(
@@ -2365,19 +2436,12 @@ public sealed class RelationalDocumentStoreRepository(
                 ),
 
             RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError =>
-                new WriteGuardRailPreflightResult<UpsertResult>.Continue(
+                DeferToExecutor(
                     null,
-                    null,
-                    storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization,
-                    new PostRelationshipAuthorizationPlans(
-                        existingResourcePlan,
-                        null,
-                        new RelationalWriteExecutorResult.Upsert(
-                            BuildPostAuthorizationSecurityConfigurationFailure(
-                                mappingSet,
-                                securityConfigurationError.Failures
-                            )
+                    new RelationalWriteExecutorResult.Upsert(
+                        BuildPostAuthorizationSecurityConfigurationFailure(
+                            mappingSet,
+                            securityConfigurationError.Failures
                         )
                     )
                 ),
@@ -2469,6 +2533,21 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalAuthorizationContext authorizationContext
     )
     {
+        if (
+            !TryPlanWriteCustomViewAuthorization(
+                mappingSet,
+                resource,
+                plan.CustomViewStrategies,
+                out var customViewAuthorization,
+                out var customViewFailures
+            )
+        )
+        {
+            return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
+                BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, customViewFailures!)
+            );
+        }
+
         if (plan.NamespaceChecks.Count == 0)
         {
             return AuthorizePutRelationshipBucket(
@@ -2478,7 +2557,8 @@ public sealed class RelationalDocumentStoreRepository(
                 plan.NonNamespaceConfiguredStrategies,
                 authorizationContext,
                 storedNamespaceAuthorization: null,
-                proposedNamespaceAuthorization: null
+                proposedNamespaceAuthorization: null,
+                customViewAuthorization: customViewAuthorization
             );
         }
 
@@ -2512,7 +2592,8 @@ public sealed class RelationalDocumentStoreRepository(
             plan.NonNamespaceConfiguredStrategies,
             authorizationContext,
             storedNamespaceAuthorization,
-            proposedNamespaceAuthorization
+            proposedNamespaceAuthorization,
+            customViewAuthorization
         );
     }
 
@@ -2523,7 +2604,8 @@ public sealed class RelationalDocumentStoreRepository(
         IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
         RelationalAuthorizationContext authorizationContext,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
-        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? customViewAuthorization = null
     )
     {
         var relationshipAuthorizationPlan = _relationshipAuthorizationPlanner.PlanUpdateValues(
@@ -2563,7 +2645,8 @@ public sealed class RelationalDocumentStoreRepository(
                     null,
                     null,
                     storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization
+                    proposedNamespaceAuthorization,
+                    customViewAuthorization: customViewAuthorization
                 ),
 
             // NamespaceBased AND-composes before the relationship OR group (auth.md,
@@ -2579,13 +2662,15 @@ public sealed class RelationalDocumentStoreRepository(
                     noClaims,
                     null,
                     storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization
+                    proposedNamespaceAuthorization,
+                    customViewAuthorization: customViewAuthorization
                 )
                 : new WriteGuardRailPreflightResult<UpdateResult>.Continue(
                     null,
                     noClaims,
                     storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization
+                    proposedNamespaceAuthorization,
+                    customViewAuthorization: customViewAuthorization
                 ),
 
             RelationshipAuthorizationResult.Authorized authorized =>
@@ -2594,7 +2679,8 @@ public sealed class RelationalDocumentStoreRepository(
                     relationshipAuthorizationPlan.ProposedValues
                         as RelationshipAuthorizationResult.Authorized,
                     storedNamespaceAuthorization,
-                    proposedNamespaceAuthorization
+                    proposedNamespaceAuthorization,
+                    customViewAuthorization: customViewAuthorization
                 ),
 
             _ => throw new InvalidOperationException(
@@ -2700,6 +2786,7 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null;
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null;
         PostRelationshipAuthorizationPlans? postRelationshipAuthorizationPlans = null;
+        RelationalCustomViewAuthorization? customViewAuthorization = null;
 
         if (preflight is not null)
         {
@@ -2713,6 +2800,7 @@ public sealed class RelationalDocumentStoreRepository(
                     storedNamespaceAuthorization = continueResult.StoredNamespaceAuthorization;
                     proposedNamespaceAuthorization = continueResult.ProposedNamespaceAuthorization;
                     postRelationshipAuthorizationPlans = continueResult.PostRelationshipAuthorizationPlans;
+                    customViewAuthorization = continueResult.CustomViewAuthorization;
                     break;
 
                 case WriteGuardRailPreflightResult<TResult>.Stop stopResult:
@@ -2765,6 +2853,7 @@ public sealed class RelationalDocumentStoreRepository(
                     )
                     {
                         PostRelationshipAuthorizationPlans = postRelationshipAuthorizationPlans,
+                        CustomViewAuthorization = customViewAuthorization,
                     }
                 )
                 .ConfigureAwait(false);
@@ -2826,7 +2915,8 @@ public sealed class RelationalDocumentStoreRepository(
                 RelationshipAuthorizationResult? proposedRelationshipAuthorization,
                 RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null,
                 RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null,
-                PostRelationshipAuthorizationPlans? postRelationshipAuthorizationPlans = null
+                PostRelationshipAuthorizationPlans? postRelationshipAuthorizationPlans = null,
+                RelationalCustomViewAuthorization? customViewAuthorization = null
             )
             {
                 ValidateStoredRelationshipAuthorization(storedRelationshipAuthorization);
@@ -2836,6 +2926,7 @@ public sealed class RelationalDocumentStoreRepository(
                 StoredNamespaceAuthorization = storedNamespaceAuthorization;
                 ProposedNamespaceAuthorization = proposedNamespaceAuthorization;
                 PostRelationshipAuthorizationPlans = postRelationshipAuthorizationPlans;
+                CustomViewAuthorization = customViewAuthorization;
             }
 
             public RelationshipAuthorizationResult? StoredRelationshipAuthorization { get; }
@@ -2845,6 +2936,12 @@ public sealed class RelationalDocumentStoreRepository(
             public RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization { get; }
 
             public RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization { get; }
+
+            /// <summary>
+            /// Every custom-view check planned for this write, across both value sources. Null when no custom
+            /// view participates.
+            /// </summary>
+            public RelationalCustomViewAuthorization? CustomViewAuthorization { get; }
 
             public PostRelationshipAuthorizationPlans? PostRelationshipAuthorizationPlans { get; }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -435,6 +435,7 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 writePrecondition,
                 proceed.StoredNamespaceAuthorization,
+                proceed.StoredCustomViewAuthorization,
                 proceed.StoredRelationshipAuthorization
             ),
             _ => throw new InvalidOperationException(
@@ -449,6 +450,7 @@ public sealed class RelationalDocumentStoreRepository(
         QualifiedResourceName resource,
         WritePrecondition writePrecondition,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? storedCustomViewAuthorization,
         RelationshipAuthorizationResult storedRelationshipAuthorization
     )
     {
@@ -507,6 +509,7 @@ public sealed class RelationalDocumentStoreRepository(
                             storedRelationshipAuthorization
                         )
                         {
+                            StoredCustomViewAuthorization = storedCustomViewAuthorization,
                             WritePrecondition = writePrecondition,
                             DeferredRelationshipDenial = BuildDeferredDeleteRelationshipDenial(
                                 storedRelationshipAuthorization,
@@ -659,18 +662,24 @@ public sealed class RelationalDocumentStoreRepository(
                 );
 
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
+                // Validating the custom views configured ahead of this terminal needs the eager view
+                // probe, which no single-record path has yet, so the terminal is reported as-is.
                 return AuthorizeDeleteRelationshipPreflight(
                     mappingSet,
                     resource,
+                    null,
                     null,
                     securityConfigurationError.NonNamespaceConfiguredStrategies,
                     relationalDeleteRequest.AuthorizationContext
                 );
 
             case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
+                // Validating the custom views configured ahead of this terminal needs the eager view
+                // probe, which no single-record path has yet, so the terminal is reported as-is.
                 return AuthorizeDeleteRelationshipPreflight(
                     mappingSet,
                     resource,
+                    null,
                     null,
                     stillUnsupported.NonNamespaceConfiguredStrategies,
                     relationalDeleteRequest.AuthorizationContext
@@ -698,12 +707,26 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalAuthorizationContext authorizationContext
     )
     {
+        if (
+            !TryPlanDeleteCustomViewAuthorization(
+                mappingSet,
+                resource,
+                plan.CustomViewStrategies,
+                out var storedCustomViewAuthorization,
+                out var customViewSecurityConfigurationFailure
+            )
+        )
+        {
+            return new DeleteAuthorizationPreflightResult.Stop(customViewSecurityConfigurationFailure!);
+        }
+
         if (plan.NamespaceChecks.Count == 0)
         {
             return AuthorizeDeleteRelationshipPreflight(
                 mappingSet,
                 resource,
                 null,
+                storedCustomViewAuthorization,
                 plan.NonNamespaceConfiguredStrategies,
                 authorizationContext
             );
@@ -736,15 +759,67 @@ public sealed class RelationalDocumentStoreRepository(
             mappingSet,
             resource,
             storedNamespaceAuthorization,
+            storedCustomViewAuthorization,
             plan.NonNamespaceConfiguredStrategies,
             authorizationContext
         );
+    }
+
+    /// <summary>
+    /// Plans the stored custom-view checks, or reports the security-configuration failure that stops the
+    /// delete.
+    /// </summary>
+    private static bool TryPlanDeleteCustomViewAuthorization(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        out RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        out DeleteResult? securityConfigurationFailure
+    )
+    {
+        storedCustomViewAuthorization = null;
+        securityConfigurationFailure = null;
+
+        if (customViewStrategies.Count == 0)
+        {
+            return true;
+        }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            customViewStrategies,
+            NamespaceAuthorizationOperation.Delete
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            securityConfigurationFailure = BuildDeleteAuthorizationSecurityConfigurationFailure(
+                mappingSet,
+                resource,
+                configurationFailure.Failures
+            );
+            return false;
+        }
+
+        var checks = ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks;
+
+        if (checks.Count > 0)
+        {
+            storedCustomViewAuthorization = new RelationalCustomViewAuthorization(checks);
+        }
+
+        return true;
     }
 
     private DeleteAuthorizationPreflightResult AuthorizeDeleteRelationshipPreflight(
         MappingSet mappingSet,
         QualifiedResourceName resource,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? storedCustomViewAuthorization,
         IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
         RelationalAuthorizationContext authorizationContext
     )
@@ -779,6 +854,7 @@ public sealed class RelationalDocumentStoreRepository(
 
             _ => new DeleteAuthorizationPreflightResult.Proceed(
                 storedNamespaceAuthorization,
+                storedCustomViewAuthorization,
                 storedRelationshipAuthorization
             ),
         };
@@ -792,6 +868,7 @@ public sealed class RelationalDocumentStoreRepository(
 
         public sealed record Proceed(
             RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
+            RelationalCustomViewAuthorization? StoredCustomViewAuthorization,
             RelationshipAuthorizationResult StoredRelationshipAuthorization
         ) : DeleteAuthorizationPreflightResult;
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -428,7 +428,12 @@ public sealed class RelationalDocumentStoreRepository(
 
         return authorizationPreflight switch
         {
-            DeleteAuthorizationPreflightResult.Stop stop => Task.FromResult(stop.Result),
+            // Views configured ahead of the terminal execute first, so a missing or non-conforming view keeps
+            // its own 500 rather than being hidden by the terminal's response.
+            DeleteAuthorizationPreflightResult.Stop stop => ValidateThenReportDeleteTerminalAsync(
+                mappingSet,
+                stop
+            ),
             DeleteAuthorizationPreflightResult.Proceed proceed => DeleteDocumentByIdAsync(
                 deleteRequest,
                 mappingSet,
@@ -623,6 +628,69 @@ public sealed class RelationalDocumentStoreRepository(
         return new DeleteResult.DeleteFailureRelationshipNotAuthorized(noClaimsFailure);
     }
 
+    private async Task<DeleteResult> ValidateThenReportDeleteTerminalAsync(
+        MappingSet mappingSet,
+        DeleteAuthorizationPreflightResult.Stop stop
+    )
+    {
+        await ValidateSingleRecordCustomViewsAsync(mappingSet, stop.CustomViewChecksToValidate)
+            .ConfigureAwait(false);
+
+        return stop.Result;
+    }
+
+    /// <inheritdoc cref="GetByIdTerminal"/>
+    private static DeleteAuthorizationPreflightResult DeleteTerminal(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        DeleteResult result,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        int terminalIndex
+    )
+    {
+        var strategiesToValidate = CustomViewAuthorizationTerminalOrdering.CustomViewsBeforeTerminal(
+            customViewStrategies,
+            terminalIndex
+        );
+
+        if (strategiesToValidate.Count == 0)
+        {
+            return new DeleteAuthorizationPreflightResult.Stop(result);
+        }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            strategiesToValidate,
+            NamespaceAuthorizationOperation.Delete
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            return new DeleteAuthorizationPreflightResult.Stop(
+                BuildDeleteAuthorizationSecurityConfigurationFailure(
+                    mappingSet,
+                    resource,
+                    configurationFailure.Failures
+                ),
+                SingleRecordChecksBeforeTerminal(
+                    configurationFailure.PlannedChecks,
+                    RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                        configurationFailure.Failures
+                    )
+                )
+            );
+        }
+
+        return new DeleteAuthorizationPreflightResult.Stop(
+            result,
+            ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks
+        );
+    }
+
     private DeleteAuthorizationPreflightResult AuthorizeDeletePreflight(
         IDeleteRequest relationalDeleteRequest,
         MappingSet mappingSet,
@@ -643,7 +711,9 @@ public sealed class RelationalDocumentStoreRepository(
         switch (orchestratorOutcome)
         {
             case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
-                return new DeleteAuthorizationPreflightResult.Stop(
+                return DeleteTerminal(
+                    mappingSet,
+                    resource,
                     new DeleteResult.DeleteFailureSecurityConfiguration(
                         [
                             NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
@@ -651,36 +721,40 @@ public sealed class RelationalDocumentStoreRepository(
                             ),
                         ],
                         RelationalReadGuardrails.BuildNoUsableRootColumnDiagnostics(noUsableRoot.Resource)
-                    )
+                    ),
+                    noUsableRoot.CustomViewStrategies,
+                    noUsableRoot.RawConfiguredIndex
                 );
 
             case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
-                return new DeleteAuthorizationPreflightResult.Stop(
+                return DeleteTerminal(
+                    mappingSet,
+                    resource,
                     new DeleteResult.DeleteFailureNamespaceNotAuthorized(
                         NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
-                    )
+                    ),
+                    noPrefixes.CustomViewStrategies,
+                    noPrefixes.RawConfiguredIndex
                 );
 
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
-                // Validating the custom views configured ahead of this terminal needs the eager view
-                // probe, which no single-record path has yet, so the terminal is reported as-is.
                 return AuthorizeDeleteRelationshipPreflight(
                     mappingSet,
                     resource,
                     null,
                     null,
+                    securityConfigurationError.RelationshipClassification.SupportedCustomViewStrategies,
                     securityConfigurationError.NonNamespaceConfiguredStrategies,
                     relationalDeleteRequest.AuthorizationContext
                 );
 
             case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
-                // Validating the custom views configured ahead of this terminal needs the eager view
-                // probe, which no single-record path has yet, so the terminal is reported as-is.
                 return AuthorizeDeleteRelationshipPreflight(
                     mappingSet,
                     resource,
                     null,
                     null,
+                    stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies,
                     stillUnsupported.NonNamespaceConfiguredStrategies,
                     relationalDeleteRequest.AuthorizationContext
                 );
@@ -713,11 +787,15 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 plan.CustomViewStrategies,
                 out var storedCustomViewAuthorization,
-                out var customViewSecurityConfigurationFailure
+                out var customViewSecurityConfigurationFailure,
+                out var customViewChecksToValidate
             )
         )
         {
-            return new DeleteAuthorizationPreflightResult.Stop(customViewSecurityConfigurationFailure!);
+            return new DeleteAuthorizationPreflightResult.Stop(
+                customViewSecurityConfigurationFailure!,
+                customViewChecksToValidate
+            );
         }
 
         if (plan.NamespaceChecks.Count == 0)
@@ -727,6 +805,7 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 null,
                 storedCustomViewAuthorization,
+                null,
                 plan.NonNamespaceConfiguredStrategies,
                 authorizationContext
             );
@@ -742,11 +821,15 @@ public sealed class RelationalDocumentStoreRepository(
             )
         )
         {
-            return new DeleteAuthorizationPreflightResult.Stop(
+            return DeleteTerminal(
+                mappingSet,
+                resource,
                 new DeleteResult.DeleteFailureSecurityConfiguration(
                     [securityConfigurationMessage],
                     securityConfigurationDiagnostics
-                )
+                ),
+                plan.CustomViewStrategies,
+                plan.NamespaceChecks[0].RawConfiguredIndex
             );
         }
 
@@ -760,6 +843,7 @@ public sealed class RelationalDocumentStoreRepository(
             resource,
             storedNamespaceAuthorization,
             storedCustomViewAuthorization,
+            null,
             plan.NonNamespaceConfiguredStrategies,
             authorizationContext
         );
@@ -816,11 +900,13 @@ public sealed class RelationalDocumentStoreRepository(
         QualifiedResourceName resource,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
         out RelationalCustomViewAuthorization? storedCustomViewAuthorization,
-        out DeleteResult? securityConfigurationFailure
+        out DeleteResult? securityConfigurationFailure,
+        out IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checksToValidateBeforeFailure
     )
     {
         storedCustomViewAuthorization = null;
         securityConfigurationFailure = null;
+        checksToValidateBeforeFailure = [];
 
         if (customViewStrategies.Count == 0)
         {
@@ -844,6 +930,14 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 configurationFailure.Failures
             );
+            // Views configured ahead of the earliest planning failure planned successfully and execute first,
+            // so they are still validated before this failure is reported.
+            checksToValidateBeforeFailure = SingleRecordChecksBeforeTerminal(
+                configurationFailure.PlannedChecks,
+                RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                    configurationFailure.Failures
+                )
+            );
             return false;
         }
 
@@ -862,6 +956,7 @@ public sealed class RelationalDocumentStoreRepository(
         QualifiedResourceName resource,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? customViewStrategiesToValidate,
         IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
         RelationalAuthorizationContext authorizationContext
     )
@@ -875,24 +970,60 @@ public sealed class RelationalDocumentStoreRepository(
 
         return storedRelationshipAuthorization switch
         {
+            // OwnershipBased executes last per auth.md regardless of configured position, so every resolved
+            // view runs before this 501.
             RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled =>
-                new DeleteAuthorizationPreflightResult.Stop(
-                    new DeleteResult.DeleteFailureNotImplemented(
-                        BuildKnownButNotEnabledDeleteAuthorizationMessage(
-                            resource,
-                            knownButNotEnabled.Failures
-                        )
+                storedCustomViewAuthorization is { } plannedForNotImplemented
+                    ? new DeleteAuthorizationPreflightResult.Stop(
+                        new DeleteResult.DeleteFailureNotImplemented(
+                            BuildKnownButNotEnabledDeleteAuthorizationMessage(
+                                resource,
+                                knownButNotEnabled.Failures
+                            )
+                        ),
+                        plannedForNotImplemented.Checks
                     )
-                ),
-
-            RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError =>
-                new DeleteAuthorizationPreflightResult.Stop(
-                    BuildDeleteAuthorizationSecurityConfigurationFailure(
+                    : DeleteTerminal(
                         mappingSet,
                         resource,
-                        securityConfigurationError.Failures
+                        new DeleteResult.DeleteFailureNotImplemented(
+                            BuildKnownButNotEnabledDeleteAuthorizationMessage(
+                                resource,
+                                knownButNotEnabled.Failures
+                            )
+                        ),
+                        customViewStrategiesToValidate ?? [],
+                        int.MaxValue
+                    ),
+
+            RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError =>
+                storedCustomViewAuthorization is { } plannedForConfigError
+                    ? new DeleteAuthorizationPreflightResult.Stop(
+                        BuildDeleteAuthorizationSecurityConfigurationFailure(
+                            mappingSet,
+                            resource,
+                            securityConfigurationError.Failures
+                        ),
+                        SingleRecordChecksBeforeTerminal(
+                            plannedForConfigError.Checks,
+                            RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                                securityConfigurationError.Failures
+                            )
+                        )
                     )
-                ),
+                    : DeleteTerminal(
+                        mappingSet,
+                        resource,
+                        BuildDeleteAuthorizationSecurityConfigurationFailure(
+                            mappingSet,
+                            resource,
+                            securityConfigurationError.Failures
+                        ),
+                        customViewStrategiesToValidate ?? [],
+                        RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                            securityConfigurationError.Failures
+                        )
+                    ),
 
             _ => new DeleteAuthorizationPreflightResult.Proceed(
                 storedNamespaceAuthorization,
@@ -906,7 +1037,15 @@ public sealed class RelationalDocumentStoreRepository(
     {
         private DeleteAuthorizationPreflightResult() { }
 
-        public sealed record Stop(DeleteResult Result) : DeleteAuthorizationPreflightResult;
+        /// <inheritdoc cref="GetByIdAuthorizationPreflightResult.Stop.CustomViewChecksToValidate"/>
+        public sealed record Stop(
+            DeleteResult Result,
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewChecksToValidate
+        ) : DeleteAuthorizationPreflightResult
+        {
+            public Stop(DeleteResult result)
+                : this(result, []) { }
+        }
 
         public sealed record Proceed(
             RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
@@ -3006,6 +3145,9 @@ public sealed class RelationalDocumentStoreRepository(
 
         if (authorizationPreflight is GetByIdAuthorizationPreflightResult.Stop preflightStop)
         {
+            await ValidateSingleRecordCustomViewsAsync(mappingSet, preflightStop.CustomViewChecksToValidate)
+                .ConfigureAwait(false);
+
             return preflightStop.Result;
         }
 
@@ -3446,6 +3588,88 @@ public sealed class RelationalDocumentStoreRepository(
         return currentDocument.ContentVersion != observedContentVersion.Value;
     }
 
+    /// <summary>
+    /// Builds a GET-by-id terminal carrying the views configured strictly before
+    /// <paramref name="terminalIndex"/>, so those views are validated before the terminal is reported. A
+    /// planning failure among them replaces the terminal, matching how the descriptor paths order the two.
+    /// </summary>
+    /// <remarks>
+    /// Every terminal on this path routes through here rather than constructing <c>Stop</c> directly, so a
+    /// terminal added later cannot quietly skip validation.
+    /// </remarks>
+    private static GetByIdAuthorizationPreflightResult GetByIdTerminal(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        GetResult result,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
+        int terminalIndex
+    )
+    {
+        var strategiesToValidate = CustomViewAuthorizationTerminalOrdering.CustomViewsBeforeTerminal(
+            customViewStrategies,
+            terminalIndex
+        );
+
+        if (strategiesToValidate.Count == 0)
+        {
+            return new GetByIdAuthorizationPreflightResult.Stop(result);
+        }
+
+        var outcome = SingleRecordCustomViewAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            strategiesToValidate,
+            NamespaceAuthorizationOperation.ReadSingle
+        );
+
+        if (
+            outcome
+            is SingleRecordCustomViewAuthorizationPlanOutcome.SecurityConfiguration configurationFailure
+        )
+        {
+            return new GetByIdAuthorizationPreflightResult.Stop(
+                BuildGetAuthorizationSecurityConfigurationFailure(
+                    mappingSet,
+                    resource,
+                    configurationFailure.Failures
+                ),
+                SingleRecordChecksBeforeTerminal(
+                    configurationFailure.PlannedChecks,
+                    RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                        configurationFailure.Failures
+                    )
+                )
+            );
+        }
+
+        return new GetByIdAuthorizationPreflightResult.Stop(
+            result,
+            ((SingleRecordCustomViewAuthorizationPlanOutcome.Plan)outcome).Checks
+        );
+    }
+
+    /// <summary>
+    /// The planned single-record checks configured strictly before <paramref name="terminalRawConfiguredIndex"/>.
+    /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> SingleRecordChecksBeforeTerminal(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        int terminalRawConfiguredIndex
+    ) => [.. checks.Where(check => check.ConfiguredStrategy.RawConfiguredIndex < terminalRawConfiguredIndex)];
+
+    /// <summary>
+    /// Validates the views a GET-by-id terminal carries. Empty is a no-op, so every terminal can route
+    /// through this unconditionally.
+    /// </summary>
+    private Task ValidateSingleRecordCustomViewsAsync(
+        MappingSet mappingSet,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+    ) =>
+        CustomViewAuthorizationValidator.ValidateSingleRecordAsync(
+            _commandExecutor,
+            mappingSet.Key.Dialect,
+            checks
+        );
+
     private GetByIdAuthorizationPreflightResult AuthorizeGetByIdPreflight(
         IGetRequest relationalGetRequest,
         MappingSet mappingSet,
@@ -3472,7 +3696,9 @@ public sealed class RelationalDocumentStoreRepository(
         switch (orchestratorOutcome)
         {
             case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
-                return new GetByIdAuthorizationPreflightResult.Stop(
+                return GetByIdTerminal(
+                    mappingSet,
+                    resource,
                     new GetResult.GetFailureSecurityConfiguration(
                         [
                             NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
@@ -3480,38 +3706,42 @@ public sealed class RelationalDocumentStoreRepository(
                             ),
                         ],
                         RelationalReadGuardrails.BuildNoUsableRootColumnDiagnostics(noUsableRoot.Resource)
-                    )
+                    ),
+                    noUsableRoot.CustomViewStrategies,
+                    noUsableRoot.RawConfiguredIndex
                 );
 
             case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
-                return new GetByIdAuthorizationPreflightResult.Stop(
+                return GetByIdTerminal(
+                    mappingSet,
+                    resource,
                     new GetResult.GetFailureNamespaceNotAuthorized(
                         NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
-                    )
+                    ),
+                    noPrefixes.CustomViewStrategies,
+                    noPrefixes.RawConfiguredIndex
                 );
 
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
-                // Validating the custom views configured ahead of this terminal needs the eager view
-                // probe, which no single-record path has yet, so the terminal is reported as-is.
                 return AuthorizeGetByIdRelationshipPreflight(
                     mappingSet,
                     resource,
                     null,
                     null,
                     securityConfigurationError.NonNamespaceConfiguredStrategies,
-                    authorizationContext
+                    authorizationContext,
+                    securityConfigurationError.RelationshipClassification.SupportedCustomViewStrategies
                 );
 
             case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
-                // Validating the custom views configured ahead of this terminal needs the eager view
-                // probe, which no single-record path has yet, so the terminal is reported as-is.
                 return AuthorizeGetByIdRelationshipPreflight(
                     mappingSet,
                     resource,
                     null,
                     null,
                     stillUnsupported.NonNamespaceConfiguredStrategies,
-                    authorizationContext
+                    authorizationContext,
+                    stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies
                 );
 
             case RelationalAuthorizationPlanOutcome.Plan plan:
@@ -3537,11 +3767,15 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 plan.CustomViewStrategies,
                 out var storedCustomViewAuthorization,
-                out var customViewSecurityConfigurationFailure
+                out var customViewSecurityConfigurationFailure,
+                out var customViewChecksToValidate
             )
         )
         {
-            return new GetByIdAuthorizationPreflightResult.Stop(customViewSecurityConfigurationFailure!);
+            return new GetByIdAuthorizationPreflightResult.Stop(
+                customViewSecurityConfigurationFailure!,
+                customViewChecksToValidate
+            );
         }
 
         if (plan.NamespaceChecks.Count == 0)
@@ -3566,11 +3800,15 @@ public sealed class RelationalDocumentStoreRepository(
             )
         )
         {
-            return new GetByIdAuthorizationPreflightResult.Stop(
+            return GetByIdTerminal(
+                mappingSet,
+                resource,
                 new GetResult.GetFailureSecurityConfiguration(
                     [securityConfigurationMessage],
                     securityConfigurationDiagnostics
-                )
+                ),
+                plan.CustomViewStrategies,
+                plan.NamespaceChecks[0].RawConfiguredIndex
             );
         }
 
@@ -3597,11 +3835,13 @@ public sealed class RelationalDocumentStoreRepository(
         QualifiedResourceName resource,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> customViewStrategies,
         out RelationalCustomViewAuthorization? storedCustomViewAuthorization,
-        out GetResult? securityConfigurationFailure
+        out GetResult? securityConfigurationFailure,
+        out IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checksToValidateBeforeFailure
     )
     {
         storedCustomViewAuthorization = null;
         securityConfigurationFailure = null;
+        checksToValidateBeforeFailure = [];
 
         if (customViewStrategies.Count == 0)
         {
@@ -3625,6 +3865,14 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 configurationFailure.Failures
             );
+            // Views configured ahead of the earliest planning failure planned successfully and execute first,
+            // so they are still validated before this failure is reported.
+            checksToValidateBeforeFailure = SingleRecordChecksBeforeTerminal(
+                configurationFailure.PlannedChecks,
+                RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                    configurationFailure.Failures
+                )
+            );
             return false;
         }
 
@@ -3644,7 +3892,8 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalCustomViewAuthorization? storedCustomViewAuthorization,
         IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
-        RelationalAuthorizationContext authorizationContext
+        RelationalAuthorizationContext authorizationContext,
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? customViewStrategiesToValidate = null
     )
     {
         var storedRelationshipAuthorization = _relationshipAuthorizationPlanner.PlanStoredValues(
@@ -3654,23 +3903,66 @@ public sealed class RelationalDocumentStoreRepository(
             authorizationContext
         );
 
+        // Reached either from a planner terminal, which carries the strategies it never got to plan, or from
+        // the Plan path, where the views planned successfully and are carried on the authorization instead.
+        var terminalCustomViewStrategies = customViewStrategiesToValidate ?? [];
+
         return storedRelationshipAuthorization switch
         {
+            // OwnershipBased executes last per auth.md regardless of configured position, so every resolved
+            // view runs before this 501.
             RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled =>
-                new GetByIdAuthorizationPreflightResult.Stop(
-                    new GetResult.GetFailureNotImplemented(
-                        BuildKnownButNotEnabledGetAuthorizationMessage(resource, knownButNotEnabled.Failures)
+                storedCustomViewAuthorization is { } plannedForNotImplemented
+                    ? new GetByIdAuthorizationPreflightResult.Stop(
+                        new GetResult.GetFailureNotImplemented(
+                            BuildKnownButNotEnabledGetAuthorizationMessage(
+                                resource,
+                                knownButNotEnabled.Failures
+                            )
+                        ),
+                        plannedForNotImplemented.Checks
                     )
-                ),
-
-            RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError =>
-                new GetByIdAuthorizationPreflightResult.Stop(
-                    BuildGetAuthorizationSecurityConfigurationFailure(
+                    : GetByIdTerminal(
                         mappingSet,
                         resource,
-                        securityConfigurationError.Failures
+                        new GetResult.GetFailureNotImplemented(
+                            BuildKnownButNotEnabledGetAuthorizationMessage(
+                                resource,
+                                knownButNotEnabled.Failures
+                            )
+                        ),
+                        terminalCustomViewStrategies,
+                        int.MaxValue
+                    ),
+
+            RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError =>
+                storedCustomViewAuthorization is { } plannedForConfigError
+                    ? new GetByIdAuthorizationPreflightResult.Stop(
+                        BuildGetAuthorizationSecurityConfigurationFailure(
+                            mappingSet,
+                            resource,
+                            securityConfigurationError.Failures
+                        ),
+                        SingleRecordChecksBeforeTerminal(
+                            plannedForConfigError.Checks,
+                            RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                                securityConfigurationError.Failures
+                            )
+                        )
                     )
-                ),
+                    : GetByIdTerminal(
+                        mappingSet,
+                        resource,
+                        BuildGetAuthorizationSecurityConfigurationFailure(
+                            mappingSet,
+                            resource,
+                            securityConfigurationError.Failures
+                        ),
+                        terminalCustomViewStrategies,
+                        RelationalAuthorizationPlanner.EarliestSecurityConfigurationFailureIndex(
+                            securityConfigurationError.Failures
+                        )
+                    ),
 
             _ => new GetByIdAuthorizationPreflightResult.Proceed(
                 storedNamespaceAuthorization,
@@ -4098,7 +4390,19 @@ public sealed class RelationalDocumentStoreRepository(
 
         // A document-independent namespace planner terminal (no usable root column, no prefixes, or
         // prefix cap exceeded) denied or failed the request before any target lookup.
-        public sealed record Stop(GetResult Result) : GetByIdAuthorizationPreflightResult;
+        /// <param name="CustomViewChecksToValidate">
+        /// The views configured strictly before this terminal. They are AND filters executing in
+        /// CMS-configured order, so they run first and a missing or non-conforming view keeps its own 500
+        /// rather than being hidden by the terminal's response.
+        /// </param>
+        public sealed record Stop(
+            GetResult Result,
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewChecksToValidate
+        ) : GetByIdAuthorizationPreflightResult
+        {
+            public Stop(GetResult result)
+                : this(result, []) { }
+        }
 
         // Document-dependent authorization remains and runs per attempt against the resolved target.
         // StoredNamespaceAuthorization is null when only relationship strategies must be evaluated.

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -3577,6 +3577,7 @@ public sealed class RelationalDocumentStoreRepository(
                 : await ExecuteGetCustomViewAuthorizationAsync(
                         mappingSet,
                         documentId,
+                        storedCustomViewAuthorization.Checks,
                         storedCustomViewAuthorization.Checks
                     )
                     .ConfigureAwait(false);
@@ -3594,7 +3595,8 @@ public sealed class RelationalDocumentStoreRepository(
             var beforeOutcome = await ExecuteGetCustomViewAuthorizationAsync(
                     mappingSet,
                     documentId,
-                    customViewsBeforeNamespace
+                    customViewsBeforeNamespace,
+                    storedCustomViewAuthorization!.Checks
                 )
                 .ConfigureAwait(false);
 
@@ -3618,18 +3620,26 @@ public sealed class RelationalDocumentStoreRepository(
 
         return customViewsAfterNamespace.Count == 0
             ? null
-            : await ExecuteGetCustomViewAuthorizationAsync(mappingSet, documentId, customViewsAfterNamespace)
+            : await ExecuteGetCustomViewAuthorizationAsync(
+                    mappingSet,
+                    documentId,
+                    customViewsAfterNamespace,
+                    storedCustomViewAuthorization!.Checks
+                )
                 .ConfigureAwait(false);
     }
 
     private async Task<GetAuthorizationOutcome?> ExecuteGetCustomViewAuthorizationAsync(
         MappingSet mappingSet,
         long documentId,
-        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks
     )
     {
         var executionResult = await _customViewAuthorizationExecutor
-            .ExecuteAsync(new CustomViewAuthorizationExecutionRequest(mappingSet, documentId, checks))
+            .ExecuteAsync(
+                new CustomViewAuthorizationExecutionRequest(mappingSet, documentId, checks, plannedChecks)
+            )
             .ConfigureAwait(false);
 
         return executionResult switch

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -5201,6 +5201,14 @@ public sealed class RelationalDocumentStoreRepository(
                     + $"Strategy '{failure.ConfiguredStrategy?.StrategyName}' requires proposed-value EducationOrganization subject "
                     + $"{FormatSecurableElementDetail(failure.Location?.ReadableName, failure.Location?.JsonPath) ?? "from relationship authorization metadata"}, "
                     + $"but root column '{failure.Location?.Table}.{failure.Location?.Column?.Value}' does not have a matching root write binding.",
+            RelationshipAuthorizationFailureKind.MissingProposedCustomViewRootBinding =>
+                $"Relational {operationLabel} authorization metadata is invalid for resource '{RelationalWriteSupport.FormatResource(failure.Resource)}'. "
+                    + $"Strategy '{failure.ConfiguredStrategy?.StrategyName}' uses custom auth view '{failure.Location?.AuthorizationObjectName ?? "<unknown>"}'. "
+                    + (
+                        string.IsNullOrWhiteSpace(failure.Hint)
+                            ? "The custom view basis resource is reached only through a child collection table, so no root-table value can authorize proposed data for a write."
+                            : failure.Hint.Trim()
+                    ),
             _ => throw new ArgumentOutOfRangeException(
                 nameof(failure),
                 failure.FailureKind,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -502,7 +502,10 @@ public sealed class RelationalDocumentStoreRepository(
                     _deleteConstraintResolver,
                     _relationalParameterConfigurator,
                     _relationshipAuthorizationProviderFailureExtractor,
-                    _logger
+                    _logger,
+                    // Opens a connection per command, so the custom-view validation probe never joins the write
+                    // session's transaction.
+                    customViewValidationCommandExecutor: _commandExecutor
                 )
                     .ExecuteAsync(
                         new RelationalDeleteCommandRequest(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -3308,6 +3308,7 @@ public sealed class RelationalDocumentStoreRepository(
                             relationalGetRequest,
                             mappingSet,
                             proceed.StoredNamespaceAuthorization,
+                            proceed.StoredCustomViewAuthorization,
                             proceed.StoredRelationshipAuthorization,
                             existingDocument.DocumentId,
                             existingDocument.ContentVersion,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -509,7 +509,7 @@ public sealed class RelationalDocumentStoreRepository(
                             storedRelationshipAuthorization
                         )
                         {
-                            StoredCustomViewAuthorization = storedCustomViewAuthorization,
+                            CustomViewAuthorization = storedCustomViewAuthorization,
                             WritePrecondition = writePrecondition,
                             DeferredRelationshipDenial = BuildDeferredDeleteRelationshipDenial(
                                 storedRelationshipAuthorization,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -2950,15 +2950,17 @@ public sealed class RelationalDocumentStoreRepository(
                     customViewAuthorization: customViewAuthorization
                 ),
 
-            // NamespaceBased AND-composes before the relationship OR group (auth.md,
-            // 08-namespace-auth-strategy.md). When a namespace check is planned, defer the stored
-            // relationship NoClaims denial into the proposed-relationship slot so the stored-then-proposed
-            // namespace checks get to deny first; the write path's second command emits the
-            // NoClaims denial only after the proposed namespace check authorizes. With no namespace check
-            // planned, keep NoClaims in the stored slot so the stored boundary emits it after the target
-            // lock, preserving the existing 404-over-403 ordering for a missing PUT target.
+            // NamespaceBased and custom view-based both AND-compose before the relationship OR group
+            // (auth.md, 08-namespace-auth-strategy.md). When either is planned, defer the stored relationship
+            // NoClaims denial into the proposed-relationship slot so those filters get to deny first; the
+            // write path's second command emits the NoClaims denial only after they authorize. Leaving it in
+            // the stored slot with custom views pending ends the write at the first phase, before the proposed
+            // custom-view checks run at all. With no AND filter planned, keep NoClaims in the stored slot so
+            // the stored boundary emits it after the target lock, preserving the existing 404-over-403
+            // ordering for a missing PUT target.
             RelationshipAuthorizationResult.NoClaims noClaims => storedNamespaceAuthorization is null
             && proposedNamespaceAuthorization is null
+            && customViewAuthorization is null
                 ? new WriteGuardRailPreflightResult<UpdateResult>.Continue(
                     noClaims,
                     null,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalReadGuardrails.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalReadGuardrails.cs
@@ -139,7 +139,7 @@ internal static class RelationalReadGuardrails
 
     /// <param name="supportedCustomViewStrategies">
     /// Custom view-based strategies this operation resolved and will apply. Custom views are supported
-    /// AND filters on GET-many, so they are neither reported as unsupported effective strategies nor
+    /// AND filters on both read paths, so they are neither reported as unsupported effective strategies nor
     /// omitted from the supported-strategy sentence. Empty (the default) for every operation that does
     /// not implement custom views, which keeps that operation's wording unchanged.
     /// </param>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -776,6 +776,13 @@ public sealed record RelationalWriteExecutorRequest
     public RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization { get; init; }
 
     /// <summary>
+    /// Stored-value custom view-based authorization for existing-target writes. Evaluated inside the
+    /// locked-target boundary before any precondition, interleaved with the namespace checks by configured
+    /// index. Null when no custom view participates.
+    /// </summary>
+    public RelationalCustomViewAuthorization? StoredCustomViewAuthorization { get; init; }
+
+    /// <summary>
     /// POST-specific relationship authorization plans for target-dependent create-new vs upsert-as-update
     /// selection inside the executor's write session.
     /// </summary>
@@ -881,6 +888,9 @@ public sealed record RelationalWriteExecutorInput
     /// <inheritdoc cref="RelationalWriteExecutorRequest.StoredNamespaceAuthorization"/>
     public RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization { get; init; }
 
+    /// <inheritdoc cref="RelationalWriteExecutorRequest.StoredCustomViewAuthorization"/>
+    public RelationalCustomViewAuthorization? StoredCustomViewAuthorization { get; init; }
+
     /// <inheritdoc cref="RelationalWriteExecutorRequest.ProposedNamespaceAuthorization"/>
     public RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization { get; init; }
 
@@ -912,6 +922,7 @@ public sealed record RelationalWriteExecutorInput
         )
         {
             PostRelationshipAuthorizationPlans = PostRelationshipAuthorizationPlans,
+            StoredCustomViewAuthorization = StoredCustomViewAuthorization,
         };
 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -776,11 +776,12 @@ public sealed record RelationalWriteExecutorRequest
     public RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization { get; init; }
 
     /// <summary>
-    /// Stored-value custom view-based authorization for existing-target writes. Evaluated inside the
-    /// locked-target boundary before any precondition, interleaved with the namespace checks by configured
-    /// index. Null when no custom view participates.
+    /// Every custom view-based check planned for this write, across both value sources. Stored checks are
+    /// evaluated inside the locked-target boundary before any precondition, interleaved with the namespace
+    /// checks by configured index; proposed checks after merge finalizes the root row. Null when no custom
+    /// view participates.
     /// </summary>
-    public RelationalCustomViewAuthorization? StoredCustomViewAuthorization { get; init; }
+    public RelationalCustomViewAuthorization? CustomViewAuthorization { get; init; }
 
     /// <summary>
     /// POST-specific relationship authorization plans for target-dependent create-new vs upsert-as-update
@@ -888,8 +889,8 @@ public sealed record RelationalWriteExecutorInput
     /// <inheritdoc cref="RelationalWriteExecutorRequest.StoredNamespaceAuthorization"/>
     public RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization { get; init; }
 
-    /// <inheritdoc cref="RelationalWriteExecutorRequest.StoredCustomViewAuthorization"/>
-    public RelationalCustomViewAuthorization? StoredCustomViewAuthorization { get; init; }
+    /// <inheritdoc cref="RelationalWriteExecutorRequest.CustomViewAuthorization"/>
+    public RelationalCustomViewAuthorization? CustomViewAuthorization { get; init; }
 
     /// <inheritdoc cref="RelationalWriteExecutorRequest.ProposedNamespaceAuthorization"/>
     public RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization { get; init; }
@@ -922,7 +923,7 @@ public sealed record RelationalWriteExecutorInput
         )
         {
             PostRelationshipAuthorizationPlans = PostRelationshipAuthorizationPlans,
-            StoredCustomViewAuthorization = StoredCustomViewAuthorization,
+            CustomViewAuthorization = CustomViewAuthorization,
         };
 }
 
@@ -943,26 +944,69 @@ public sealed record RelationalWriteNamespaceAuthorization(
 );
 
 /// <summary>
-/// The planned custom view-based checks for one value source of one operation.
+/// Every custom view-based check planned for one request, across both value sources.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Stored and proposed checks travel as separate instances. A compiled batch's row guard applies to every
-/// statement in it, so a create path needs its stored checks vacuous while its proposed checks still run —
-/// which is only expressible as separate batches.
+/// <see cref="Checks"/> is the request's single full planned list, and the only list a <c>cv1</c> failure may
+/// be mapped against. Execution slices it — by value source, and within the stored source by configured
+/// position relative to <c>NamespaceBased</c> — but no slice is ever the authority for resolving a payload.
+/// Indexes are request-wide for that reason: batches sharing a command also share one provider exception, so a
+/// per-slice index would leave two checks both reporting index 0. Each emitted slice need only be contiguous
+/// from its own starting index, which is all the compiler enforces.
 /// </para>
 /// <para>
-/// Indexes are request-wide, not per instance. A request can emit several batches — the views configured
-/// before and after a <c>NamespaceBased</c> check, and a stored batch and a proposed one — and batches sharing
-/// a command also share one provider exception, so a per-batch index would leave two checks both reporting
-/// index 0. Each emitted slice must be contiguous from its own starting index, which is all the compiler
-/// enforces, and every failure is mapped against the request's full planned list rather than against the
-/// slice that raised it.
+/// Stored and proposed checks must be compiled and executed as separate batches. A compiled batch's row guard
+/// applies to every statement in it, so a create path needs its stored checks vacuous while its proposed
+/// checks still run — which one batch cannot express.
 /// </para>
 /// </remarks>
-public sealed record RelationalCustomViewAuthorization(
-    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks
-);
+public sealed record RelationalCustomViewAuthorization
+{
+    public RelationalCustomViewAuthorization(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+    )
+    {
+        ArgumentNullException.ThrowIfNull(checks);
+
+        // Copied, not aliased: IReadOnlyList is a read-only view, so a caller holding the underlying List
+        // could otherwise append or replace entries after construction and leave the slices describing
+        // contents this instance no longer reports.
+        Checks = [.. checks];
+        StoredChecks =
+        [
+            .. Checks.Where(static check =>
+                check.ValueSource is CustomViewAuthorizationCheckValueSource.Stored
+            ),
+        ];
+        ProposedChecks =
+        [
+            .. Checks.Where(static check =>
+                check.ValueSource is CustomViewAuthorizationCheckValueSource.Proposed
+            ),
+        ];
+    }
+
+    /// <summary>
+    /// The request's full planned list, and the only list a <c>cv1</c> failure may be mapped against.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>init</c>-settable, and neither are the slices. A positional record would allow
+    /// <c>with { Checks = ... }</c> to replace this list while the copy constructor carried over slices
+    /// computed from the previous one, leaving them describing checks the instance no longer holds — which
+    /// would silently skip or mis-slice checks at execution. The constructor also copies its argument, since
+    /// a read-only view over a caller's mutable list would let the same divergence happen from outside.
+    /// Producing a different set therefore requires constructing a new instance, which recomputes both
+    /// slices from it.
+    /// </remarks>
+    public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks { get; }
+
+    /// <summary>The stored-value checks, in planned order. Always derived from <see cref="Checks"/>.</summary>
+    public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> StoredChecks { get; }
+
+    /// <summary>The proposed-value checks, in planned order. Always derived from <see cref="Checks"/>.</summary>
+    public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> ProposedChecks { get; }
+}
 
 /// <summary>
 /// Backend-local classification of one executor attempt.

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -946,11 +946,19 @@ public sealed record RelationalWriteNamespaceAuthorization(
 /// The planned custom view-based checks for one value source of one operation.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Stored and proposed checks travel as separate instances. A compiled batch's row guard applies to every
 /// statement in it, so a create path needs its stored checks vacuous while its proposed checks still run —
-/// which is only expressible as separate batches. Splitting also means each instance's indexes must be
-/// contiguous from zero, since the compiler enforces index-equals-position and the failure mapper resolves the
-/// <c>cv1</c> payload positionally against the very list that produced the batch.
+/// which is only expressible as separate batches.
+/// </para>
+/// <para>
+/// Indexes are request-wide, not per instance. A request can emit several batches — the views configured
+/// before and after a <c>NamespaceBased</c> check, and a stored batch and a proposed one — and batches sharing
+/// a command also share one provider exception, so a per-batch index would leave two checks both reporting
+/// index 0. Each emitted slice must be contiguous from its own starting index, which is all the compiler
+/// enforces, and every failure is mapped against the request's full planned list rather than against the
+/// slice that raised it.
+/// </para>
 /// </remarks>
 public sealed record RelationalCustomViewAuthorization(
     IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -952,8 +952,9 @@ public sealed record RelationalWriteNamespaceAuthorization(
 /// be mapped against. Execution slices it — by value source, and within the stored source by configured
 /// position relative to <c>NamespaceBased</c> — but no slice is ever the authority for resolving a payload.
 /// Indexes are request-wide for that reason: batches sharing a command also share one provider exception, so a
-/// per-slice index would leave two checks both reporting index 0. Each emitted slice need only be contiguous
-/// from its own starting index, which is all the compiler enforces.
+/// per-slice index would leave two checks both reporting index 0. Each emitted slice need only carry
+/// nonnegative, strictly increasing indexes, which is all the compiler enforces — a slice may skip an index a
+/// check settled in C# holds.
 /// </para>
 /// <para>
 /// Stored and proposed checks must be compiled and executed as separate batches. A compiled batch's row guard

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -932,6 +932,20 @@ public sealed record RelationalWriteNamespaceAuthorization(
 );
 
 /// <summary>
+/// The planned custom view-based checks for one value source of one operation.
+/// </summary>
+/// <remarks>
+/// Stored and proposed checks travel as separate instances. A compiled batch's row guard applies to every
+/// statement in it, so a create path needs its stored checks vacuous while its proposed checks still run —
+/// which is only expressible as separate batches. Splitting also means each instance's indexes must be
+/// contiguous from zero, since the compiler enforces index-equals-position and the failure mapper resolves the
+/// <c>cv1</c> payload positionally against the very list that produced the batch.
+/// </remarks>
+public sealed record RelationalCustomViewAuthorization(
+    IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Checks
+);
+
+/// <summary>
 /// Backend-local classification of one executor attempt.
 /// </summary>
 public abstract record RelationalWriteExecutorAttemptOutcome

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
@@ -84,6 +84,25 @@ internal static class RelationalWriteExecutorResults
         };
     }
 
+    public static RelationalWriteExecutorResult BuildCustomViewAuthorizationFailureResult(
+        RelationalWriteOperationKind operationKind,
+        CustomViewAuthorizationFailure customViewFailure
+    )
+    {
+        ArgumentNullException.ThrowIfNull(customViewFailure);
+
+        return operationKind switch
+        {
+            RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.UpsertFailureCustomViewNotAuthorized(customViewFailure)
+            ),
+            RelationalWriteOperationKind.Put => new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateFailureCustomViewNotAuthorized(customViewFailure)
+            ),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, null),
+        };
+    }
+
     /// <summary>
     /// Maps a stale-target namespace authorization result to a write conflict (POST) or not-exists (PUT)
     /// outcome, mirroring the single-record relationship authorization stale-target mapping. Locked write

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
@@ -194,7 +194,14 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         StoredRelationshipStatementPlan RelationshipPlan,
         ReferenceStatementPlan? ReferencePlan,
         HydrationStatementPlan? HydrationPlan
-    );
+    )
+    {
+        /// <summary>
+        /// The custom-view checks the command carried, or <see langword="null"/> when it carried none — so a
+        /// provider failure is mapped only against checks that command actually sent.
+        /// </summary>
+        public StoredCustomViewStatementPlan? CustomViewPlan { get; init; }
+    }
 
     public async Task<RelationalWriteFirstPhaseResolution> ResolveAsync(
         RelationalWriteExecutorInput input,
@@ -250,6 +257,20 @@ internal sealed class CompositeRelationalWriteFirstPhase(
 
         AppendCaptureTarget(builder, input);
 
+        // Custom views and NamespaceBased are AND filters executing in CMS-configured order, and the command
+        // aborts at its first failure, so the namespace statement is emitted between the views configured
+        // before it and those configured after. Both runs' indexes come from one planned list, so a cv1
+        // payload still identifies exactly one check. This path is all-or-nothing — a namespace check that
+        // does not fit sends the whole request to ordered segments — so no run can be stranded here.
+        var (customViewsBeforeNamespace, customViewsAfterNamespace) = PartitionCustomViewRuns(input);
+
+        RelationalCompositeStoredAuthorization.AppendCustomViewRun(
+            builder,
+            carrier,
+            input.MappingSet,
+            customViewsBeforeNamespace
+        );
+
         if (
             !RelationalCompositeStoredAuthorization.TryAppendNamespace(
                 builder,
@@ -262,6 +283,19 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         {
             return null;
         }
+
+        RelationalCompositeStoredAuthorization.AppendCustomViewRun(
+            builder,
+            carrier,
+            input.MappingSet,
+            customViewsAfterNamespace
+        );
+
+        var customViewPlan =
+            input.StoredCustomViewAuthorization is { } storedCustomViewAuthorization
+            && (customViewsBeforeNamespace.Count > 0 || customViewsAfterNamespace.Count > 0)
+                ? new StoredCustomViewStatementPlan(storedCustomViewAuthorization.Checks)
+                : null;
 
         if (
             !RelationalCompositeStoredAuthorization.TryAppendRelationship(
@@ -291,7 +325,10 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             relationshipPlan,
             referencePlan,
             hydrationPlan
-        );
+        )
+        {
+            CustomViewPlan = customViewPlan,
+        };
     }
 
     private async Task<RelationalWriteFirstPhaseResolution> ExecuteSingleCompositePlanAsync(
@@ -307,16 +344,27 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         var hydrationPlan = plan.HydrationPlan;
 
         IReadOnlyList<RelationalCompositeStatementOutcome> outcomes;
+        var execution = new RelationalCompositeCommandExecution();
 
         try
         {
-            outcomes = await new RelationalCompositeCommandExecution()
+            outcomes = await execution
                 .ExecuteAsync(writeSession, plan.Command, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (DbException exception)
         {
-            if (TryMapAuthorizationFailure(input, namespacePlan, relationshipPlan, exception) is { } mapped)
+            if (
+                TryMapAuthorizationFailure(
+                    input,
+                    namespacePlan,
+                    plan.CustomViewPlan,
+                    relationshipPlan,
+                    exception,
+                    execution.Failure
+                ) is
+                { } mapped
+            )
             {
                 return RelationalWriteFirstPhaseResolution.Immediate(mapped);
             }
@@ -448,6 +496,25 @@ internal sealed class CompositeRelationalWriteFirstPhase(
 
         if (capturedTarget is not null)
         {
+            // Same configured order the co-batched path emits, now as separate segments: the views
+            // configured before NamespaceBased, then the namespace check, then the views configured after it.
+            var (segmentedViewsBefore, segmentedViewsAfter) = PartitionCustomViewRuns(input);
+
+            if (
+                await ExecuteStandaloneStoredCustomViewAsync(
+                        executionRequest,
+                        segmentedViewsBefore,
+                        capturedTarget.DocumentId,
+                        writeSession,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false) is
+                { } customViewBeforeResult
+            )
+            {
+                return RelationalWriteFirstPhaseResolution.Immediate(customViewBeforeResult);
+            }
+
             var storedNamespaceResult = await ExecuteStandaloneStoredNamespaceAsync(
                     executionRequest,
                     capturedTarget.DocumentId,
@@ -459,6 +526,21 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             if (storedNamespaceResult is not null)
             {
                 return RelationalWriteFirstPhaseResolution.Immediate(storedNamespaceResult);
+            }
+
+            if (
+                await ExecuteStandaloneStoredCustomViewAsync(
+                        executionRequest,
+                        segmentedViewsAfter,
+                        capturedTarget.DocumentId,
+                        writeSession,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false) is
+                { } customViewAfterResult
+            )
+            {
+                return RelationalWriteFirstPhaseResolution.Immediate(customViewAfterResult);
             }
 
             var storedRelationshipResult = await ResolveStandaloneStoredRelationshipDispositionAsync(
@@ -528,6 +610,62 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             ),
             null
         );
+    }
+
+    /// <summary>
+    /// Runs one custom-view run as its own ordered segment on the write session, for the ordered-segments
+    /// path. Mapping uses the request's full planned list so a run carrying request-wide indexes still
+    /// resolves its payload to the right check.
+    /// </summary>
+    private async Task<RelationalWriteExecutorResult?> ExecuteStandaloneStoredCustomViewAsync(
+        RelationalWriteExecutorRequest executionRequest,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> segmentChecks,
+        long targetDocumentId,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        if (segmentChecks.Count == 0 || executionRequest.StoredCustomViewAuthorization is null)
+        {
+            return null;
+        }
+
+        var executionResult = await new CustomViewAuthorizationExecutor(
+            writeSession.CreateCommandExecutor(),
+            _providerFailureExtractor
+        )
+            .ExecuteAsync(
+                new CustomViewAuthorizationExecutionRequest(
+                    executionRequest.MappingSet,
+                    targetDocumentId,
+                    segmentChecks,
+                    executionRequest.StoredCustomViewAuthorization.Checks
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            CustomViewAuthorizationExecutionResult.Authorized => null,
+            CustomViewAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                RelationalWriteExecutorResults.BuildCustomViewAuthorizationFailureResult(
+                    executionRequest.OperationKind,
+                    notAuthorized.Failure
+                ),
+            CustomViewAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
+                    executionRequest.OperationKind,
+                    [invalidFailure.FailureMessage],
+                    invalidFailure.Diagnostics
+                ),
+            // Unreachable while the capture lock holds; the same defensive mapping the namespace segment uses.
+            CustomViewAuthorizationExecutionResult.StaleTarget =>
+                RelationalWriteExecutorResults.BuildStaleTargetResult(executionRequest.OperationKind),
+            _ => throw new InvalidOperationException(
+                $"Unsupported custom view authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
     }
 
     private async Task<RelationalWriteExecutorResult?> ExecuteStandaloneStoredNamespaceAsync(
@@ -783,8 +921,10 @@ internal sealed class CompositeRelationalWriteFirstPhase(
     private RelationalWriteExecutorResult? TryMapAuthorizationFailure(
         RelationalWriteExecutorInput input,
         StoredNamespaceStatementPlan? namespacePlan,
+        StoredCustomViewStatementPlan? customViewPlan,
         StoredRelationshipStatementPlan relationshipPlan,
-        DbException exception
+        DbException exception,
+        RelationalCompositeFailureContext? failureContext
     ) =>
         RelationalCompositeStoredAuthorization.TryClassifyDenial(
             input.MappingSet.Key.Dialect,
@@ -793,7 +933,8 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             relationshipPlan,
             RelationalWriteExecutorResults.GetRelationshipAuthorizationAuth1Index(input.OperationKind),
             _providerFailureExtractor,
-            _logger
+            _logger,
+            customViewPlan
         ) switch
         {
             // Stale is unreachable while the capture lock holds; kept as the same defensive mapping the
@@ -803,6 +944,11 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             ),
             StoredAuthorizationDenial.NamespaceNotAuthorized(var failure) =>
                 RelationalWriteExecutorResults.BuildNamespaceAuthorizationFailureResult(
+                    input.OperationKind,
+                    failure
+                ),
+            StoredAuthorizationDenial.CustomViewNotAuthorized(var failure) =>
+                RelationalWriteExecutorResults.BuildCustomViewAuthorizationFailureResult(
                     input.OperationKind,
                     failure
                 ),
@@ -817,8 +963,63 @@ internal sealed class CompositeRelationalWriteFirstPhase(
                     messages,
                     diagnostics
                 ),
+            // A failure with no authorization payload in a command carrying custom-view statements is
+            // attributed to the configured view, so a dropped or revoked auth.{StrategyName} keeps the
+            // documented urn:ed-fi:api:system 500 rather than escaping as an unhandled provider error. The
+            // statement label alone cannot decide it: PostgreSQL prepares the whole batch before executing
+            // any of it, so a missing view surfaces at reader-open nominally against statement 0.
+            _ when IsAttributableToCustomView(customViewPlan, failureContext) =>
+                throw new CustomViewAuthorizationValidationException(exception),
             _ => null,
         };
+
+    private static bool IsAttributableToCustomView(
+        StoredCustomViewStatementPlan? customViewPlan,
+        RelationalCompositeFailureContext? failureContext
+    )
+    {
+        if (customViewPlan is null)
+        {
+            return false;
+        }
+
+        if (
+            string.Equals(
+                failureContext?.Label,
+                RelationalCompositeStoredAuthorization.CustomViewLabel,
+                StringComparison.Ordinal
+            )
+        )
+        {
+            return true;
+        }
+
+        return failureContext?.Stage
+            is RelationalCompositeFailureStage.OpeningReader
+                or RelationalCompositeFailureStage.Unattributable;
+    }
+
+    /// <summary>
+    /// Splits the planned custom-view checks around the configured position of <c>NamespaceBased</c>. With no
+    /// namespace check every view runs ahead of the relationship group, so the whole list is the first run.
+    /// </summary>
+    private static (
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> Before,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> After
+    ) PartitionCustomViewRuns(RelationalWriteExecutorInput input)
+    {
+        if (input.StoredCustomViewAuthorization is not { } storedCustomViewAuthorization)
+        {
+            return ([], []);
+        }
+
+        return input.StoredNamespaceAuthorization is { } storedNamespaceAuthorization
+            ? CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
+                storedCustomViewAuthorization.Checks,
+                storedNamespaceAuthorization.Checks[0].RawConfiguredIndex
+            )
+            : (storedCustomViewAuthorization.Checks, []);
+    }
 
     /// <summary>
     /// Shapes a PUT whose in-transaction target observation found nothing. RFC 9110 §13.1.1 If-Match:

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
@@ -168,7 +168,8 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         null,
     ILogger? logger = null,
     RelationalCommandBudget? commandBudget = null,
-    IRelationalCommandExecutor? customViewValidationCommandExecutor = null
+    IRelationalCommandExecutor? customViewValidationCommandExecutor = null,
+    IRelationalWriteExceptionClassifier? writeExceptionClassifier = null
 ) : IRelationalWriteFirstPhase
 {
     private const string ReferenceResolutionLabel = "reference-resolution";
@@ -196,6 +197,13 @@ internal sealed class CompositeRelationalWriteFirstPhase(
     /// </summary>
     private readonly IRelationalCommandExecutor? _customViewValidationCommandExecutor =
         customViewValidationCommandExecutor;
+
+    /// <summary>
+    /// Keeps transient provider failures (deadlock victim, lock timeout) out of the custom-view attribution:
+    /// they say nothing about the view's contract and must keep their retryable write-conflict classification.
+    /// </summary>
+    private readonly IRelationalWriteExceptionClassifier _writeExceptionClassifier =
+        writeExceptionClassifier ?? new NoOpRelationalWriteExceptionClassifier();
 
     private sealed record CompositeFirstPhasePlan(
         RelationalCompositeCommand Command,
@@ -665,7 +673,8 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         var executionResult = await new CustomViewAuthorizationExecutor(
             writeSession.CreateCommandExecutor(),
             _providerFailureExtractor,
-            _customViewValidationCommandExecutor
+            _customViewValidationCommandExecutor,
+            _writeExceptionClassifier
         )
             .ExecuteAsync(
                 new CustomViewAuthorizationExecutionRequest(
@@ -1000,10 +1009,32 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             // attributed to the configured view, so a dropped or revoked auth.{StrategyName} keeps the
             // documented urn:ed-fi:api:system 500 rather than escaping as an unhandled provider error. The
             // statement label alone cannot decide it: PostgreSQL prepares the whole batch before executing
-            // any of it, so a missing view surfaces at reader-open nominally against statement 0.
+            // any of it, so a missing view surfaces at reader-open nominally against statement 0. A transient
+            // provider failure (deadlock victim, lock timeout) proves nothing about the view's contract, so it
+            // maps to the same retryable write-conflict result the executor's failure mapper would produce.
             _ when IsAttributableToCustomView(customViewPlan, failureContext) =>
-                throw new CustomViewAuthorizationValidationException(exception),
+                _writeExceptionClassifier.IsTransientFailure(exception)
+                    ? BuildTransientWriteConflictResult(input.OperationKind)
+                    : throw new CustomViewAuthorizationValidationException(exception),
             _ => null,
+        };
+
+    /// <summary>
+    /// The transient-failure result for the operation, mirroring the write executor's database failure
+    /// mapping so a deadlock in the opening command answers the same retryable 409 as one in the DML.
+    /// </summary>
+    private static RelationalWriteExecutorResult BuildTransientWriteConflictResult(
+        RelationalWriteOperationKind operationKind
+    ) =>
+        operationKind switch
+        {
+            RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.UpsertFailureWriteConflict()
+            ),
+            RelationalWriteOperationKind.Put => new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateFailureWriteConflict()
+            ),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, null),
         };
 
     private static bool IsAttributableToCustomView(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
@@ -291,10 +291,12 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             customViewsAfterNamespace
         );
 
+        // Mapping uses the request's full planned list, never the emitted slices, so a payload from either
+        // run resolves to the check the planner assigned that index to.
         var customViewPlan =
-            input.StoredCustomViewAuthorization is { } storedCustomViewAuthorization
+            input.CustomViewAuthorization is { } customViewAuthorization
             && (customViewsBeforeNamespace.Count > 0 || customViewsAfterNamespace.Count > 0)
-                ? new StoredCustomViewStatementPlan(storedCustomViewAuthorization.Checks)
+                ? new StoredCustomViewStatementPlan(customViewAuthorization.Checks)
                 : null;
 
         if (
@@ -625,7 +627,7 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         CancellationToken cancellationToken
     )
     {
-        if (segmentChecks.Count == 0 || executionRequest.StoredCustomViewAuthorization is null)
+        if (segmentChecks.Count == 0 || executionRequest.CustomViewAuthorization is null)
         {
             return null;
         }
@@ -639,7 +641,7 @@ internal sealed class CompositeRelationalWriteFirstPhase(
                     executionRequest.MappingSet,
                     targetDocumentId,
                     segmentChecks,
-                    executionRequest.StoredCustomViewAuthorization.Checks
+                    executionRequest.CustomViewAuthorization.Checks
                 ),
                 cancellationToken
             )
@@ -1008,17 +1010,19 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> After
     ) PartitionCustomViewRuns(RelationalWriteExecutorInput input)
     {
-        if (input.StoredCustomViewAuthorization is not { } storedCustomViewAuthorization)
+        if (input.CustomViewAuthorization is not { } customViewAuthorization)
         {
             return ([], []);
         }
 
+        // Only the stored source belongs in this phase; the proposed source runs after merge finalizes the
+        // root row.
         return input.StoredNamespaceAuthorization is { } storedNamespaceAuthorization
             ? CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
-                storedCustomViewAuthorization.Checks,
+                customViewAuthorization.StoredChecks,
                 storedNamespaceAuthorization.Checks[0].RawConfiguredIndex
             )
-            : (storedCustomViewAuthorization.Checks, []);
+            : (customViewAuthorization.StoredChecks, []);
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
@@ -167,7 +167,8 @@ internal sealed class CompositeRelationalWriteFirstPhase(
     IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
         null,
     ILogger? logger = null,
-    RelationalCommandBudget? commandBudget = null
+    RelationalCommandBudget? commandBudget = null,
+    IRelationalCommandExecutor? customViewValidationCommandExecutor = null
 ) : IRelationalWriteFirstPhase
 {
     private const string ReferenceResolutionLabel = "reference-resolution";
@@ -188,6 +189,14 @@ internal sealed class CompositeRelationalWriteFirstPhase(
 
     private readonly RelationalCommandBudget? _commandBudget = commandBudget;
 
+    /// <summary>
+    /// The fresh-connection executor the custom-view catalog validation runs on, or <see langword="null"/> to
+    /// skip validation. Never the write session's: the probe reads the catalog, and issuing it on the session
+    /// would run inside the transaction holding the target lock and consume that command's results.
+    /// </summary>
+    private readonly IRelationalCommandExecutor? _customViewValidationCommandExecutor =
+        customViewValidationCommandExecutor;
+
     private sealed record CompositeFirstPhasePlan(
         RelationalCompositeCommand Command,
         StoredNamespaceStatementPlan? NamespacePlan,
@@ -201,6 +210,13 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         /// provider failure is mapped only against checks that command actually sent.
         /// </summary>
         public StoredCustomViewStatementPlan? CustomViewPlan { get; init; }
+
+        /// <summary>
+        /// Exactly the custom-view checks the command carries statements for, so their views are validated
+        /// before it runs and no other view's contract can preempt what it decides.
+        /// </summary>
+        public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewCommandChecks { get; init; } =
+        [];
     }
 
     public async Task<RelationalWriteFirstPhaseResolution> ResolveAsync(
@@ -258,11 +274,16 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         AppendCaptureTarget(builder, input);
 
         // Custom views and NamespaceBased are AND filters executing in CMS-configured order, and the command
-        // aborts at its first failure, so the namespace statement is emitted between the views configured
-        // before it and those configured after. Both runs' indexes come from one planned list, so a cv1
-        // payload still identifies exactly one check. This path is all-or-nothing — a namespace check that
-        // does not fit sends the whole request to ordered segments — so no run can be stranded here.
+        // aborts at its first failure, so only the views configured before the namespace statement can ride it.
+        // A run configured after that check owes its own ordered segment, because its views may be validated
+        // only once the check has passed — so the whole request takes the ordered-segments path, where every run
+        // is already executed and validated in configured order.
         var (customViewsBeforeNamespace, customViewsAfterNamespace) = PartitionCustomViewRuns(input);
+
+        if (customViewsAfterNamespace.Count > 0)
+        {
+            return null;
+        }
 
         RelationalCompositeStoredAuthorization.AppendCustomViewRun(
             builder,
@@ -284,18 +305,11 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             return null;
         }
 
-        RelationalCompositeStoredAuthorization.AppendCustomViewRun(
-            builder,
-            carrier,
-            input.MappingSet,
-            customViewsAfterNamespace
-        );
-
-        // Mapping uses the request's full planned list, never the emitted slices, so a payload from either
-        // run resolves to the check the planner assigned that index to.
+        // Mapping uses the request's full planned list, never the emitted slice, so a payload resolves to the
+        // check the planner assigned that index to.
         var customViewPlan =
             input.CustomViewAuthorization is { } customViewAuthorization
-            && (customViewsBeforeNamespace.Count > 0 || customViewsAfterNamespace.Count > 0)
+            && customViewsBeforeNamespace.Count > 0
                 ? new StoredCustomViewStatementPlan(customViewAuthorization.Checks)
                 : null;
 
@@ -330,6 +344,7 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         )
         {
             CustomViewPlan = customViewPlan,
+            CustomViewCommandChecks = customViewsBeforeNamespace,
         };
     }
 
@@ -344,6 +359,21 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         var relationshipPlan = plan.RelationshipPlan;
         var referencePlan = plan.ReferencePlan;
         var hydrationPlan = plan.HydrationPlan;
+
+        // Ahead of the command, because the views it carries run ahead of the namespace check inside it: a table
+        // masquerading as auth.{StrategyName} answers the membership SQL without raising anything, so nothing
+        // later in the command would reveal it.
+        if (_customViewValidationCommandExecutor is not null)
+        {
+            await CustomViewAuthorizationValidator
+                .ValidateSingleRecordAsync(
+                    _customViewValidationCommandExecutor,
+                    input.MappingSet.Key.Dialect,
+                    plan.CustomViewCommandChecks,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
 
         IReadOnlyList<RelationalCompositeStatementOutcome> outcomes;
         var execution = new RelationalCompositeCommandExecution();
@@ -634,7 +664,8 @@ internal sealed class CompositeRelationalWriteFirstPhase(
 
         var executionResult = await new CustomViewAuthorizationExecutor(
             writeSession.CreateCommandExecutor(),
-            _providerFailureExtractor
+            _providerFailureExtractor,
+            _customViewValidationCommandExecutor
         )
             .ExecuteAsync(
                 new CustomViewAuthorizationExecutionRequest(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
@@ -750,6 +750,22 @@ internal sealed class CompositeRelationalWriteSecondCommand(
 
             return this;
         }
+
+        /// <summary>
+        /// The emitted checks the CMS configured at or before <paramref name="namespaceConfiguredIndex"/> —
+        /// exactly the ones whose statements precede the namespace statement in this command. A check
+        /// configured after it is emitted behind that statement, so an abort there never reached it, and
+        /// probing its view would report a contract failure ahead of the namespace answer configured first.
+        /// </summary>
+        public EmittedCustomViewRuns BeforeNamespace(int namespaceConfiguredIndex) =>
+            this with
+            {
+                // The same splitter the runs were partitioned with, so "before the namespace position" —
+                // including its tie rule — has one definition.
+                EmittedChecks = CustomViewAuthorizationCheckSplitter
+                    .PartitionByConfiguredIndex(EmittedChecks, namespaceConfiguredIndex)
+                    .Before,
+            };
     }
 
     private sealed record CommandRun(
@@ -2201,6 +2217,19 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 .Checks.Select(static check => check.ValueSource)
                 .ToArray();
 
+            // The custom-view statements this command emitted ahead of the namespace one. They already
+            // answered — a table masquerading as auth.{StrategyName} satisfies the membership SQL silently —
+            // so a namespace answer is the caller's answer only once the views configured before it are known
+            // to conform. Every namespace disposition validates them, because each one returns in their place.
+            var reachedBeforeNamespace = customViewRuns?.BeforeNamespace(
+                namespacePlan.Checks[0].RawConfiguredIndex
+            );
+
+            Task ValidateReachedCustomViewsAsync() =>
+                reachedBeforeNamespace is null
+                    ? Task.CompletedTask
+                    : ValidateEmittedCustomViewsAsync(request, reachedBeforeNamespace, cancellationToken);
+
             if (
                 NamespaceAuthorizationProviderFailureMapper.TryMapNamespaceAuthorizationFailure(
                     dialect,
@@ -2212,6 +2241,8 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 )
             )
             {
+                await ValidateReachedCustomViewsAsync().ConfigureAwait(false);
+
                 return RelationalWriteExecutorResults.BuildNamespaceAuthorizationFailureResult(
                     request.OperationKind,
                     namespaceFailure!
@@ -2229,6 +2260,8 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 )
             )
             {
+                await ValidateReachedCustomViewsAsync().ConfigureAwait(false);
+
                 return RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
                     request.OperationKind,
                     [NamespaceAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata],
@@ -2243,6 +2276,16 @@ internal sealed class CompositeRelationalWriteSecondCommand(
 
         if (runtimeCheck is not null)
         {
+            // The relationship statement is emitted last — after the namespace check and after both
+            // custom-view runs — so every view this command emitted ran ahead of it and owes its
+            // urn:ed-fi:api:system 500 before this denial. The whole emitted set is probed for that reason,
+            // where a namespace denial probes only the runs configured before it.
+            if (customViewRuns is not null && IsRelationshipFamilyFailure(dialect, runtimeCheck, exception))
+            {
+                await ValidateEmittedCustomViewsAsync(request, customViewRuns, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
             // Throws the authorization exceptions the executor already maps to results, or rethrows the
             // provider failure unchanged when it is not an authorization denial.
             ProposedRelationshipAuthorizationCommand.ThrowMappedFailure(
@@ -2256,4 +2299,23 @@ internal sealed class CompositeRelationalWriteSecondCommand(
 
         throw exception;
     }
+
+    /// <summary>
+    /// Whether the failure carries a payload the relationship family owns — a denial, or one it recognizes but
+    /// cannot map. A failure carrying no recognized payload at all has already been probed as an
+    /// unattributable failure, so asking here is what keeps that probe from running a second time.
+    /// </summary>
+    private bool IsRelationshipFamilyFailure(
+        SqlDialect dialect,
+        ProposedRelationshipAuthorizationRuntimeCheck runtimeCheck,
+        DbException exception
+    ) =>
+        ProposedRelationshipAuthorizationCommand.TryMapFailure(
+            dialect,
+            _providerFailureExtractor,
+            runtimeCheck,
+            exception,
+            out _,
+            out var invalidFailureDiagnostic
+        ) || invalidFailureDiagnostic is not null;
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
@@ -162,15 +162,25 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         ArgumentNullException.ThrowIfNull(mergeResult);
         ArgumentNullException.ThrowIfNull(writeSession);
 
-        if (TryPlanNamespace(request, mergeResult, out var namespacePlan) is { } namespacePlanFailure)
-        {
-            // The plan could not be reconciled with the finalized root row, which is decided before any
-            // statement is built, so nothing is sent.
-            return new RelationalWriteSecondCommandResolution(mergeResult, null, namespacePlanFailure);
-        }
+        // A namespace planning failure is not returned yet. The plan could not be reconciled with the
+        // finalized root row, so nothing is sent for it, but custom views configured before NamespaceBased
+        // execute ahead of that position and still get to deny — or to surface a missing view — first.
+        var namespacePlanFailure = TryPlanNamespace(request, mergeResult, out var namespacePlan);
+
+        // Partitioning needs the namespace position even when planning failed and left no plan to read it
+        // from; without it every view would count as preceding and the ones configured after NamespaceBased
+        // would run before a failure that precedes them.
+        var namespaceConfiguredIndex =
+            namespacePlan?.Checks[0].RawConfiguredIndex ?? ProposedNamespaceConfiguredIndex(request);
 
         if (
-            TryPlanCustomView(request, mergeResult, namespacePlan, out var customViewPlan) is
+            TryPlanCustomView(
+                request,
+                mergeResult,
+                namespaceConfiguredIndex,
+                namespacePlanFailure is not null,
+                out var customViewPlan
+            ) is
             { } customViewPlanFailure
         )
         {
@@ -184,7 +194,13 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             namespacePlan = null;
         }
 
-        if (customViewPlan?.SelfBasisDenial is not null)
+        // With the namespace plan intact this is unchanged. When namespace planning failed, the denial
+        // outranks that failure only if it is configured at or before NamespaceBased, which is exactly what
+        // suppression records; a denial configured after it cannot preempt a failure that precedes it.
+        if (
+            customViewPlan?.SelfBasisDenial is not null
+            && (namespacePlanFailure is null || customViewPlan.SuppressNamespace)
+        )
         {
             // The denial is decided in C#, so no statement can carry it and nothing may be co-batched behind
             // it. Only the filters configured before it can outrank it, and those are the only ones planned.
@@ -199,6 +215,27 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                         cancellationToken
                     )
                     .ConfigureAwait(false)
+            );
+        }
+
+        if (namespacePlanFailure is not null)
+        {
+            // Only the views configured before NamespaceBased may outrank it. The ones after it never run:
+            // the check they follow could not be built, so their turn never comes.
+            var precedingCustomViewDenial = await RunCustomViewOnlyAsync(
+                    request,
+                    customViewPlan,
+                    customViewPlan?.BeforeNamespace,
+                    ProposedCustomViewAuthorizationLabel,
+                    writeSession,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            return new RelationalWriteSecondCommandResolution(
+                mergeResult,
+                null,
+                precedingCustomViewDenial ?? namespacePlanFailure
             );
         }
 
@@ -1460,10 +1497,21 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     /// into the runs the configured order requires. Returns the security-configuration failure when the plan
     /// cannot be reconciled with that row.
     /// </summary>
+    /// <param name="namespaceConfiguredIndex">
+    /// The configured position of the proposed namespace check, or null when none is configured. Taken from
+    /// the request rather than the plan when namespace planning failed, so partitioning still knows where
+    /// NamespaceBased sits.
+    /// </param>
+    /// <param name="namespacePlanFailed">
+    /// When the namespace plan could not be reconciled with the finalized root row, only the checks
+    /// configured before it may still run, so only those are extracted. Extracting the later ones would let
+    /// an invalid basis among them report a failure ahead of the namespace failure that precedes them.
+    /// </param>
     private static RelationalWriteExecutorResult? TryPlanCustomView(
         RelationalWriteExecutorRequest request,
         RelationalWriteMergeResult mergeResult,
-        NamespaceStatementPlan? namespacePlan,
+        int? namespaceConfiguredIndex,
+        bool namespacePlanFailed,
         out CustomViewStatementPlan? statementPlan
     )
     {
@@ -1475,8 +1523,25 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         }
 
         var plannedChecks = customViewAuthorization.Checks;
+        var proposedChecks = customViewAuthorization.ProposedChecks;
+
+        if (namespacePlanFailed && namespaceConfiguredIndex is { } pendingFailureIndex)
+        {
+            // Same splitter the runs use, so "before the namespace position" means one thing here too.
+            proposedChecks = CustomViewAuthorizationCheckSplitter
+                .PartitionByConfiguredIndex(proposedChecks, static check => check, pendingFailureIndex)
+                .Before;
+
+            if (proposedChecks.Count == 0)
+            {
+                // Nothing configured before the failure, so no custom-view statement is built and the
+                // namespace failure stands on its own.
+                return null;
+            }
+        }
+
         var extraction = ProposedCustomViewValueExtractor.Extract(
-            customViewAuthorization.ProposedChecks,
+            proposedChecks,
             RelationalWriteFinalizedRootRow.Build(request, mergeResult)
         );
 
@@ -1504,17 +1569,16 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             // change the answer and none of it is emitted.
             sqlValues = [.. sqlValues.Where(value => IsConfiguredBefore(value.Check, selfBasisDenial))];
             suppressNamespace =
-                namespacePlan is not null
-                && namespacePlan.Checks[0].RawConfiguredIndex
-                    >= selfBasisDenial.ConfiguredStrategy.RawConfiguredIndex;
+                namespaceConfiguredIndex is { } suppressionIndex
+                && suppressionIndex >= selfBasisDenial.ConfiguredStrategy.RawConfiguredIndex;
         }
 
         var (beforeNamespace, afterNamespace) =
-            namespacePlan is not null && !suppressNamespace
+            namespaceConfiguredIndex is { } partitionIndex && !suppressNamespace
                 ? CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
                     sqlValues,
                     static value => value.Check,
-                    namespacePlan.Checks[0].RawConfiguredIndex
+                    partitionIndex
                 )
                 : (sqlValues, (IReadOnlyList<ProposedCustomViewRuntimeValue>)[]);
 
@@ -1788,6 +1852,15 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         NamespacePrefixParameterization PrefixParameterization,
         string? ProposedNamespace
     );
+
+    /// <summary>
+    /// The configured position of the proposed namespace check, read from the request so it survives a
+    /// namespace planning failure.
+    /// </summary>
+    private static int? ProposedNamespaceConfiguredIndex(RelationalWriteExecutorRequest request) =>
+        request.ProposedNamespaceAuthorization is { Checks.Count: > 0 } namespaceAuthorization
+            ? namespaceAuthorization.Checks[0].RawConfiguredIndex
+            : null;
 
     /// <summary>
     /// Extracts the proposed namespace value from the finalized merged root row — never the raw request

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
@@ -104,6 +104,20 @@ internal sealed class CompositeRelationalWriteSecondCommand(
 {
     private const string ProposedNamespaceAuthorizationLabel = "proposed-namespace-authorization";
     private const string ProposedRelationshipAuthorizationLabel = "proposed-relationship-authorization";
+
+    /// <summary>
+    /// The proposed custom-view run holding the views the CMS configured at or before <c>NamespaceBased</c>.
+    /// Also the only run when no namespace check participates.
+    /// </summary>
+    private const string ProposedCustomViewAuthorizationLabel = "proposed-custom-view-authorization";
+
+    /// <summary>
+    /// The proposed custom-view run holding the views configured after <c>NamespaceBased</c>. A separate label
+    /// because the two runs are separate statements with the namespace check between them, and the packer keys
+    /// units by label.
+    /// </summary>
+    private const string ProposedCustomViewAuthorizationAfterNamespaceLabel =
+        "proposed-custom-view-authorization-after-namespace";
     private const string DocumentInsertLabel = "document-insert";
     private const string ContentVersionReadLabel = "content-version-read";
 
@@ -146,6 +160,39 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             return new RelationalWriteSecondCommandResolution(mergeResult, null, namespacePlanFailure);
         }
 
+        if (
+            TryPlanCustomView(request, mergeResult, namespacePlan, out var customViewPlan) is
+            { } customViewPlanFailure
+        )
+        {
+            return new RelationalWriteSecondCommandResolution(mergeResult, null, customViewPlanFailure);
+        }
+
+        if (customViewPlan?.SuppressNamespace is true)
+        {
+            // A self-basis create denial is configured at or before NamespaceBased, so the namespace check
+            // never runs: the batch would have aborted at the earlier position.
+            namespacePlan = null;
+        }
+
+        if (customViewPlan?.SelfBasisDenial is not null)
+        {
+            // The denial is decided in C#, so no statement can carry it and nothing may be co-batched behind
+            // it. Only the filters configured before it can outrank it, and those are the only ones planned.
+            return new RelationalWriteSecondCommandResolution(
+                mergeResult,
+                null,
+                await ResolveSelfBasisDenialAsync(
+                        request,
+                        customViewPlan,
+                        namespacePlan,
+                        writeSession,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false)
+            );
+        }
+
         var relationshipPlan = PlanRelationship(request, mergeResult);
         mergeResult = relationshipPlan.MergeResult;
 
@@ -156,8 +203,9 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             // denial. So that check runs alone and nothing else is sent: no reserved collection key and no
             // data-modifying statement, which is what keeps a constraint violation from preempting the
             // authorization failure the caller must see, and keeps a denied create from leaving a row.
-            var namespaceDenial = await RunNamespaceOnlyAsync(
+            var precedingDenial = await RunProposedFiltersOnlyAsync(
                     request,
+                    customViewPlan,
                     namespacePlan,
                     writeSession,
                     cancellationToken
@@ -167,13 +215,14 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             return new RelationalWriteSecondCommandResolution(
                 mergeResult,
                 null,
-                namespaceDenial ?? deferredResult
+                precedingDenial ?? deferredResult
             );
         }
 
         if (
             mode is RelationalWriteSecondCommandMode.AuthorizationOnly
             && namespacePlan is null
+            && customViewPlan is null
             && relationshipPlan.RuntimeCheck is null
         )
         {
@@ -186,6 +235,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 mergeResult,
                 mode,
                 namespacePlan,
+                customViewPlan,
                 relationshipPlan.RuntimeCheck,
                 writeSession,
                 cancellationToken
@@ -224,13 +274,155 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 request,
                 builder,
                 namespacePlan,
+                customViewPlannedChecks: null,
                 runtimeCheck: null,
-                writeSession,
-                cancellationToken
+                writeSession: writeSession,
+                cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
 
         return run.Denial;
+    }
+
+    /// <summary>
+    /// Runs the proposed AND filters that carry statements as commands of their own, in CMS-configured order,
+    /// answering with the first denial or <see langword="null"/>. Selected wherever a later statement must not
+    /// share the command: the relationship check could not be co-batched, or the request is already denied and
+    /// only these filters' precedence over that denial remains to be settled.
+    /// </summary>
+    private async Task<RelationalWriteExecutorResult?> RunProposedFiltersOnlyAsync(
+        RelationalWriteExecutorRequest request,
+        CustomViewStatementPlan? customViewPlan,
+        NamespaceStatementPlan? namespacePlan,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        if (
+            await RunCustomViewOnlyAsync(
+                    request,
+                    customViewPlan,
+                    customViewPlan?.BeforeNamespace,
+                    ProposedCustomViewAuthorizationLabel,
+                    writeSession,
+                    cancellationToken
+                )
+                .ConfigureAwait(false) is
+            { } beforeDenial
+        )
+        {
+            return beforeDenial;
+        }
+
+        if (
+            await RunNamespaceOnlyAsync(request, namespacePlan, writeSession, cancellationToken)
+                .ConfigureAwait(false) is
+            { } namespaceDenial
+        )
+        {
+            return namespaceDenial;
+        }
+
+        return await RunCustomViewOnlyAsync(
+                request,
+                customViewPlan,
+                customViewPlan?.AfterNamespace,
+                ProposedCustomViewAuthorizationAfterNamespaceLabel,
+                writeSession,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    private async Task<RelationalWriteExecutorResult?> RunCustomViewOnlyAsync(
+        RelationalWriteExecutorRequest request,
+        CustomViewStatementPlan? customViewPlan,
+        IReadOnlyList<ProposedCustomViewRuntimeValue>? runValues,
+        string label,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        if (customViewPlan is null || runValues is null || runValues.Count == 0)
+        {
+            return null;
+        }
+
+        var builder = CreateBuilder(request);
+        var runtimeCheck = new ProposedCustomViewAuthorizationRuntimeCheck(
+            customViewPlan.PlannedChecks,
+            runValues
+        );
+        TryAppendCustomView(builder, request, runtimeCheck, label);
+
+        var run = await RunAsync(
+                request,
+                builder,
+                namespacePlan: null,
+                customViewPlannedChecks: customViewPlan.PlannedChecks,
+                runtimeCheck: null,
+                writeSession: writeSession,
+                cancellationToken: cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return run.Denial;
+    }
+
+    /// <summary>
+    /// Settles a self-basis proposed check on a create. Everything configured before it runs first, because an
+    /// earlier failure outranks this one; then the view itself is validated, so a missing or nonconforming view
+    /// keeps its <c>urn:ed-fi:api:system</c> 500 rather than being reported as this denial.
+    /// </summary>
+    private async Task<RelationalWriteExecutorResult> ResolveSelfBasisDenialAsync(
+        RelationalWriteExecutorRequest request,
+        CustomViewStatementPlan customViewPlan,
+        NamespaceStatementPlan? namespacePlan,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        var denyingCheck =
+            customViewPlan.SelfBasisDenial
+            ?? throw new InvalidOperationException(
+                "Self-basis denial resolution requires a denying self-basis check."
+            );
+
+        if (
+            await RunProposedFiltersOnlyAsync(
+                    request,
+                    customViewPlan,
+                    namespacePlan,
+                    writeSession,
+                    cancellationToken
+                )
+                .ConfigureAwait(false) is
+            { } precedingDenial
+        )
+        {
+            return precedingDenial;
+        }
+
+        await CustomViewAuthorizationValidator
+            .ValidateSingleRecordAsync(
+                writeSession.CreateCommandExecutor(),
+                request.MappingSet.Key.Dialect,
+                [denyingCheck],
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return RelationalWriteExecutorResults.BuildCustomViewAuthorizationFailureResult(
+            request.OperationKind,
+            new CustomViewAuthorizationFailure(
+                CustomViewAuthorizationFailureKind.NoMatchingRow,
+                CustomViewAuthorizationFailureValueSource.Proposed,
+                denyingCheck.Index,
+                denyingCheck.ConfiguredStrategy.StrategyName,
+                [.. denyingCheck.ReadableSecurableElements],
+                denyingCheck.FailureHint
+            )
+        );
     }
 
     private sealed record SecondCommandExecution(
@@ -243,6 +435,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         RelationalWriteMergeResult mergeResult,
         RelationalWriteSecondCommandMode mode,
         NamespaceStatementPlan? namespacePlan,
+        CustomViewStatementPlan? customViewPlan,
         ProposedRelationshipAuthorizationRuntimeCheck? runtimeCheck,
         IRelationalWriteSession writeSession,
         CancellationToken cancellationToken
@@ -263,6 +456,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                     request,
                     mergeResult,
                     namespacePlan,
+                    customViewPlan,
                     runtimeCheck,
                     relationshipCommand,
                     writeSession,
@@ -272,18 +466,34 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         }
 
         var builder = CreateBuilder(request);
+        // Configured order, with the namespace check between the two custom-view runs.
+        var customViewBefore = TryAppendCustomViewRun(
+            builder,
+            request,
+            customViewPlan,
+            customViewPlan?.BeforeNamespace,
+            ProposedCustomViewAuthorizationLabel
+        );
         var namespaceEmitted = TryAppendNamespace(builder, request, namespacePlan);
+        var customViewAfter = TryAppendCustomViewRun(
+            builder,
+            request,
+            customViewPlan,
+            customViewPlan?.AfterNamespace,
+            ProposedCustomViewAuthorizationAfterNamespaceLabel
+        );
         var relationshipEmitted =
             relationshipCommand is not null
             && CanCoBatchRelationshipInto(builder, runtimeCheck!, relationshipCommand)
             && TryAppendRelationship(builder, relationshipCommand);
 
-        if (namespaceEmitted || relationshipEmitted)
+        if (namespaceEmitted || relationshipEmitted || customViewBefore || customViewAfter)
         {
             var run = await RunAsync(
                     request,
                     builder,
                     namespaceEmitted ? namespacePlan : null,
+                    customViewBefore || customViewAfter ? customViewPlan!.PlannedChecks : null,
                     relationshipEmitted ? runtimeCheck : null,
                     writeSession,
                     cancellationToken
@@ -325,6 +535,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         RelationalWriteExecutorRequest request,
         RelationalWriteMergeResult mergeResult,
         NamespaceStatementPlan? namespacePlan,
+        CustomViewStatementPlan? customViewPlan,
         ProposedRelationshipAuthorizationRuntimeCheck? runtimeCheck,
         RelationalCommand? relationshipCommand,
         IRelationalWriteSession writeSession,
@@ -348,12 +559,18 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             // Create artifacts only after proposed authorization: a check that cannot join the command has
             // to run, and pass, before the data-modifying statements are built at all.
             if (
-                await RunNamespaceOnlyAsync(request, namespacePlan, writeSession, cancellationToken)
+                await RunProposedFiltersOnlyAsync(
+                        request,
+                        customViewPlan,
+                        namespacePlan,
+                        writeSession,
+                        cancellationToken
+                    )
                     .ConfigureAwait(false) is
-                { } namespaceDenial
+                { } precedingDenial
             )
             {
-                return new SecondCommandExecution(null, namespaceDenial);
+                return new SecondCommandExecution(null, precedingDenial);
             }
 
             var standaloneDenial = await ExecuteStandaloneRelationshipAsync(
@@ -371,11 +588,19 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             }
 
             namespacePlan = null;
+            customViewPlan = null;
             relationshipCommand = null;
             runtimeCheck = null;
         }
 
-        var units = BuildDmlUnits(request, preparation, namespacePlan, runtimeCheck, relationshipCommand);
+        var units = BuildDmlUnits(
+            request,
+            preparation,
+            namespacePlan,
+            customViewPlan,
+            runtimeCheck,
+            relationshipCommand
+        );
         var packedCommands = RelationalCompositeCommandPacker.Pack(
             [.. units.Select(static unit => unit.PackUnit)],
             budget
@@ -408,6 +633,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                     request,
                     builder,
                     context.EmittedNamespacePlan,
+                    context.EmittedCustomViewPlannedChecks,
                     context.EmittedRuntimeCheck,
                     writeSession,
                     cancellationToken
@@ -455,6 +681,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         RelationalWriteExecutorRequest request,
         RelationalCompositeCommandBuilder builder,
         NamespaceStatementPlan? namespacePlan,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? customViewPlannedChecks,
         ProposedRelationshipAuthorizationRuntimeCheck? runtimeCheck,
         IRelationalWriteSession writeSession,
         CancellationToken cancellationToken
@@ -473,7 +700,13 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         {
             return new CommandRun(
                 [],
-                MapAuthorizationFailure(request, namespacePlan, runtimeCheck, exception)
+                MapAuthorizationFailure(
+                    request,
+                    namespacePlan,
+                    customViewPlannedChecks,
+                    runtimeCheck,
+                    exception
+                )
             );
         }
     }
@@ -588,6 +821,12 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         public NamespaceStatementPlan? EmittedNamespacePlan { get; set; }
 
         public ProposedRelationshipAuthorizationRuntimeCheck? EmittedRuntimeCheck { get; set; }
+
+        /// <summary>
+        /// The request's full planned custom-view list, set once either run is emitted into this command. A
+        /// <c>cv1</c> payload is resolved against the whole list, so which run emitted it does not matter.
+        /// </summary>
+        public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? EmittedCustomViewPlannedChecks { get; set; }
     }
 
     /// <summary>
@@ -642,6 +881,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         RelationalWriteExecutorRequest request,
         DmlPreparation preparation,
         NamespaceStatementPlan? namespacePlan,
+        CustomViewStatementPlan? customViewPlan,
         ProposedRelationshipAuthorizationRuntimeCheck? runtimeCheck,
         RelationalCommand? relationshipCommand
     )
@@ -649,6 +889,14 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         var targetContext = RequireTargetContext(request);
         var dialect = request.MappingSet.Key.Dialect;
         List<DmlEmitUnit> units = [];
+
+        AddCustomViewUnit(
+            units,
+            request,
+            customViewPlan,
+            customViewPlan?.BeforeNamespace,
+            ProposedCustomViewAuthorizationLabel
+        );
 
         if (namespacePlan is not null)
         {
@@ -668,6 +916,14 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 )
             );
         }
+
+        AddCustomViewUnit(
+            units,
+            request,
+            customViewPlan,
+            customViewPlan?.AfterNamespace,
+            ProposedCustomViewAuthorizationAfterNamespaceLabel
+        );
 
         if (relationshipCommand is not null)
         {
@@ -1082,7 +1338,13 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         }
         catch (DbException exception)
         {
-            return MapAuthorizationFailure(request, namespacePlan: null, runtimeCheck, exception);
+            return MapAuthorizationFailure(
+                request,
+                namespacePlan: null,
+                customViewPlannedChecks: null,
+                runtimeCheck,
+                exception
+            );
         }
     }
 
@@ -1128,6 +1390,301 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     ) =>
         CanCoBatchRelationshipShape(runtimeCheck)
         && relationshipCommand.Parameters.Count <= budget.MaxParametersPerCommand;
+
+    /// <param name="PlannedChecks">
+    /// The request's full planned custom-view list across both value sources. Every <c>cv1</c> payload is
+    /// resolved against this list, never against an emitted run.
+    /// </param>
+    /// <param name="BeforeNamespace">
+    /// The runs' checks configured at or before <c>NamespaceBased</c>, with their extracted basis values.
+    /// </param>
+    /// <param name="AfterNamespace">The checks configured after <c>NamespaceBased</c>.</param>
+    /// <param name="SelfBasisDenial">
+    /// The earliest self-basis check that denies, when the write resolved to a create. Decided in C#, so it
+    /// carries no statement and nothing configured at or after it is emitted.
+    /// </param>
+    /// <param name="SuppressNamespace">
+    /// Whether the namespace check is preempted by <paramref name="SelfBasisDenial"/>. True only when the
+    /// denial is configured at or before the namespace position, matching the tie rule that puts a custom view
+    /// first at an equal configured index.
+    /// </param>
+    private sealed record CustomViewStatementPlan(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks,
+        IReadOnlyList<ProposedCustomViewRuntimeValue> BeforeNamespace,
+        IReadOnlyList<ProposedCustomViewRuntimeValue> AfterNamespace,
+        SingleRecordCustomViewAuthorizationCheckSpec? SelfBasisDenial,
+        bool SuppressNamespace
+    );
+
+    /// <summary>
+    /// Extracts each proposed custom-view basis value from the finalized merged root row and splits the checks
+    /// into the runs the configured order requires. Returns the security-configuration failure when the plan
+    /// cannot be reconciled with that row.
+    /// </summary>
+    private static RelationalWriteExecutorResult? TryPlanCustomView(
+        RelationalWriteExecutorRequest request,
+        RelationalWriteMergeResult mergeResult,
+        NamespaceStatementPlan? namespacePlan,
+        out CustomViewStatementPlan? statementPlan
+    )
+    {
+        statementPlan = null;
+
+        if (request.CustomViewAuthorization is not { ProposedChecks.Count: > 0 } customViewAuthorization)
+        {
+            return null;
+        }
+
+        var plannedChecks = customViewAuthorization.Checks;
+        var extraction = ProposedCustomViewValueExtractor.Extract(
+            customViewAuthorization.ProposedChecks,
+            RelationalWriteFinalizedRootRow.Build(request, mergeResult)
+        );
+
+        if (extraction is ProposedCustomViewExtractionResult.InvalidAuthorizationPlan invalid)
+        {
+            return InvalidCustomViewPlan(request, plannedChecks, invalid.FailureMessage);
+        }
+
+        var work = ((ProposedCustomViewExtractionResult.Ready)extraction).Work;
+
+        if (
+            ResolveSelfBasisChecks(request, plannedChecks, work.SelfBasisChecks, out var selfBasisDenial) is
+            { } selfBasisFailure
+        )
+        {
+            return selfBasisFailure;
+        }
+
+        var sqlValues = work.SqlValues;
+        var suppressNamespace = false;
+
+        if (selfBasisDenial is not null)
+        {
+            // The denial is deterministic at its configured position, so nothing configured at or after it can
+            // change the answer and none of it is emitted.
+            sqlValues = [.. sqlValues.Where(value => IsConfiguredBefore(value.Check, selfBasisDenial))];
+            suppressNamespace =
+                namespacePlan is not null
+                && namespacePlan.Checks[0].RawConfiguredIndex
+                    >= selfBasisDenial.ConfiguredStrategy.RawConfiguredIndex;
+        }
+
+        var (beforeNamespace, afterNamespace) =
+            namespacePlan is not null && !suppressNamespace
+                ? CustomViewAuthorizationCheckSplitter.PartitionByConfiguredIndex(
+                    sqlValues,
+                    static value => value.Check,
+                    namespacePlan.Checks[0].RawConfiguredIndex
+                )
+                : (sqlValues, (IReadOnlyList<ProposedCustomViewRuntimeValue>)[]);
+
+        statementPlan = new CustomViewStatementPlan(
+            plannedChecks,
+            beforeNamespace,
+            afterNamespace,
+            selfBasisDenial,
+            suppressNamespace
+        );
+
+        return null;
+    }
+
+    /// <summary>
+    /// Settles the self-basis checks that SQL cannot decide, reporting the earliest one that denies. A create
+    /// denies; an existing target is satisfied, but only when the same configured strategy also planned a
+    /// stored check — that check is what authorized the row whose immutable <c>DocumentId</c> is being reused
+    /// as the proposed basis value, so without it nothing has been proven and the plan fails closed.
+    /// </summary>
+    private static RelationalWriteExecutorResult? ResolveSelfBasisChecks(
+        RelationalWriteExecutorRequest request,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> selfBasisChecks,
+        out SingleRecordCustomViewAuthorizationCheckSpec? denial
+    )
+    {
+        denial = null;
+
+        if (selfBasisChecks.Count == 0)
+        {
+            return null;
+        }
+
+        if (request.TargetContext is null)
+        {
+            return InvalidCustomViewPlan(
+                request,
+                plannedChecks,
+                "Proposed custom view authorization cannot settle a self-basis check without an executor-resolved target context."
+            );
+        }
+
+        if (request.TargetContext is RelationalWriteTargetContext.CreateNew)
+        {
+            foreach (var check in selfBasisChecks)
+            {
+                if (denial is null || IsConfiguredBefore(check, denial))
+                {
+                    denial = check;
+                }
+            }
+
+            return null;
+        }
+
+        foreach (var check in selfBasisChecks)
+        {
+            var hasPairedStoredCheck = plannedChecks.Any(planned =>
+                planned.ValueSource is CustomViewAuthorizationCheckValueSource.Stored
+                && planned.ConfiguredStrategy == check.ConfiguredStrategy
+            );
+
+            if (!hasPairedStoredCheck)
+            {
+                return InvalidCustomViewPlan(
+                    request,
+                    plannedChecks,
+                    $"Proposed custom view authorization cannot treat self-basis check '{check.Index}' as satisfied: strategy '{check.ConfiguredStrategy.StrategyName}' planned no stored check to authorize the existing row."
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Orders two checks the way the CMS configured them, breaking an equal configured index by planned index
+    /// so a tie resolves the same way every time.
+    /// </summary>
+    private static bool IsConfiguredBefore(
+        SingleRecordCustomViewAuthorizationCheckSpec left,
+        SingleRecordCustomViewAuthorizationCheckSpec right
+    ) =>
+        (left.ConfiguredStrategy.RawConfiguredIndex, left.Index).CompareTo(
+            (right.ConfiguredStrategy.RawConfiguredIndex, right.Index)
+        ) < 0;
+
+    private static RelationalWriteExecutorResult InvalidCustomViewPlan(
+        RelationalWriteExecutorRequest request,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
+        string failureMessage
+    ) =>
+        RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
+            request.OperationKind,
+            [failureMessage],
+            AuthorizationSecurityConfigurationDiagnostics.ForCustomViewProposedValueExtraction(plannedChecks)
+        );
+
+    /// <summary>
+    /// Appends one proposed custom-view run and reports whether it emitted a statement.
+    /// </summary>
+    private static bool TryAppendCustomViewRun(
+        RelationalCompositeCommandBuilder builder,
+        RelationalWriteExecutorRequest request,
+        CustomViewStatementPlan? customViewPlan,
+        IReadOnlyList<ProposedCustomViewRuntimeValue>? runValues,
+        string label
+    )
+    {
+        if (customViewPlan is null || runValues is null || runValues.Count == 0)
+        {
+            return false;
+        }
+
+        return TryAppendCustomView(
+            builder,
+            request,
+            new ProposedCustomViewAuthorizationRuntimeCheck(customViewPlan.PlannedChecks, runValues),
+            label
+        );
+    }
+
+    private static bool TryAppendCustomView(
+        RelationalCompositeCommandBuilder builder,
+        RelationalWriteExecutorRequest request,
+        ProposedCustomViewAuthorizationRuntimeCheck runtimeCheck,
+        string label
+    )
+    {
+        if (
+            ProposedCustomViewAuthorizationCommand.Build(request.MappingSet, runtimeCheck)
+            is not { } statement
+        )
+        {
+            return false;
+        }
+
+        AppendCustomViewStatement(builder, statement, label);
+
+        return true;
+    }
+
+    private static void AppendCustomViewStatement(
+        RelationalCompositeCommandBuilder builder,
+        ProposedCustomViewAuthorizationStatement statement,
+        string label
+    )
+    {
+        var rewritten = RelationalCompositeStatementRewriter.Rewrite(
+            statement.Command,
+            builder.Allocator,
+            builder.NextOrdinal
+        );
+        var resultSetCount = statement.ResultSetCount;
+
+        builder.Append(
+            label,
+            rewritten.Sql,
+            rewritten.Parameters,
+            RelationalCompositeResultShape.Rows,
+            (reader, readCancellation) =>
+                RelationalCompositeResultSetSpan.ConsumeAsync(reader, resultSetCount, readCancellation),
+            resultSetCount
+        );
+    }
+
+    private static void AddCustomViewUnit(
+        List<DmlEmitUnit> units,
+        RelationalWriteExecutorRequest request,
+        CustomViewStatementPlan? customViewPlan,
+        IReadOnlyList<ProposedCustomViewRuntimeValue>? runValues,
+        string label
+    )
+    {
+        if (customViewPlan is null || runValues is null || runValues.Count == 0)
+        {
+            return;
+        }
+
+        var runtimeCheck = new ProposedCustomViewAuthorizationRuntimeCheck(
+            customViewPlan.PlannedChecks,
+            runValues
+        );
+
+        if (
+            ProposedCustomViewAuthorizationCommand.Build(request.MappingSet, runtimeCheck)
+            is not { } statement
+        )
+        {
+            return;
+        }
+
+        units.Add(
+            new DmlEmitUnit(
+                new RelationalCompositePackUnit(
+                    label,
+                    RowCount: 0,
+                    ParametersPerRow: 0,
+                    FixedParameterCount: statement.Command.Parameters.Count
+                ),
+                (context, _, _) =>
+                {
+                    AppendCustomViewStatement(context.Builder, statement, label);
+                    context.EmittedCustomViewPlannedChecks = customViewPlan.PlannedChecks;
+                }
+            )
+        );
+    }
 
     private sealed record NamespaceStatementPlan(
         IReadOnlyList<NamespaceAuthorizationCheckSpec> Checks,
@@ -1345,11 +1902,59 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     private RelationalWriteExecutorResult MapAuthorizationFailure(
         RelationalWriteExecutorRequest request,
         NamespaceStatementPlan? namespacePlan,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? customViewPlannedChecks,
         ProposedRelationshipAuthorizationRuntimeCheck? runtimeCheck,
         DbException exception
     )
     {
         var dialect = request.MappingSet.Key.Dialect;
+
+        // Custom views are dispatched first because only they claim a cv1 payload; a payload from another
+        // family reaches its own mapper untouched. Mapping always uses the request's full planned list, so a
+        // payload from either emitted run resolves to the check the planner assigned that index to.
+        if (customViewPlannedChecks is not null)
+        {
+            if (
+                CustomViewAuthorizationProviderFailureMapper.TryMapCustomViewAuthorizationFailure(
+                    dialect,
+                    exception,
+                    _providerFailureExtractor,
+                    customViewPlannedChecks,
+                    out var customViewFailure
+                )
+            )
+            {
+                return RelationalWriteExecutorResults.BuildCustomViewAuthorizationFailureResult(
+                    request.OperationKind,
+                    customViewFailure!
+                );
+            }
+
+            if (
+                CustomViewAuthorizationProviderFailureMapper.IsUnmappableCustomViewPayload(
+                    dialect,
+                    exception,
+                    _providerFailureExtractor,
+                    customViewPlannedChecks
+                )
+            )
+            {
+                return RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
+                    request.OperationKind,
+                    [CustomViewAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata],
+                    AuthorizationSecurityConfigurationDiagnostics.ForCustomViewAuthorizationAuth1(
+                        customViewPlannedChecks
+                    )
+                );
+            }
+
+            // Proposed-value checks bind no stored DocumentId, so the stale stored-target kind cannot be
+            // raised here. A failure carrying no custom-view payload is deliberately NOT attributed to the
+            // view either: this command can also carry the document insert and the resource tables'
+            // statements, and PostgreSQL reports a batch-prepare failure without a usable statement
+            // position, so attributing by position would relabel a constraint violation as a security
+            // configuration error. Such failures fall through to the executor's existing handling.
+        }
 
         if (namespacePlan is not null)
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
@@ -1658,9 +1658,6 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         );
 
     /// <summary>
-    /// Appends one proposed custom-view run and reports whether it emitted a statement.
-    /// </summary>
-    /// <summary>
     /// Appends one proposed custom-view run, answering with the checks it emitted or <see langword="null"/>
     /// when it emitted none.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
@@ -99,7 +99,8 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
         null,
     ILogger? logger = null,
-    RelationalCommandBudget? commandBudget = null
+    RelationalCommandBudget? commandBudget = null,
+    IRelationalCommandExecutor? customViewValidationCommandExecutor = null
 ) : IRelationalWriteSecondCommandPhase
 {
     private const string ProposedNamespaceAuthorizationLabel = "proposed-namespace-authorization";
@@ -140,6 +141,14 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     private readonly ILogger _logger = logger ?? NullLogger.Instance;
 
     private readonly RelationalCommandBudget? _commandBudget = commandBudget;
+
+    /// <summary>
+    /// Executes the custom-view validation probe. Every implementation opens its own connection per command,
+    /// which is what makes it usable after a provider failure has already aborted the write session's
+    /// transaction. Null leaves the failure unattributed rather than probing on the aborted session.
+    /// </summary>
+    private readonly IRelationalCommandExecutor? _customViewValidationCommandExecutor =
+        customViewValidationCommandExecutor;
 
     public async Task<RelationalWriteSecondCommandResolution> ResolveAsync(
         RelationalWriteExecutorRequest request,
@@ -274,7 +283,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 request,
                 builder,
                 namespacePlan,
-                customViewPlannedChecks: null,
+                customViewRuns: null,
                 runtimeCheck: null,
                 writeSession: writeSession,
                 cancellationToken: cancellationToken
@@ -353,13 +362,15 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             customViewPlan.PlannedChecks,
             runValues
         );
-        TryAppendCustomView(builder, request, runtimeCheck, label);
+        var emittedChecks = TryAppendCustomView(builder, request, runtimeCheck, label);
 
         var run = await RunAsync(
                 request,
                 builder,
                 namespacePlan: null,
-                customViewPlannedChecks: customViewPlan.PlannedChecks,
+                customViewRuns: emittedChecks is null
+                    ? null
+                    : new EmittedCustomViewRuns(customViewPlan.PlannedChecks, emittedChecks),
                 runtimeCheck: null,
                 writeSession: writeSession,
                 cancellationToken: cancellationToken
@@ -487,13 +498,15 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             && CanCoBatchRelationshipInto(builder, runtimeCheck!, relationshipCommand)
             && TryAppendRelationship(builder, relationshipCommand);
 
-        if (namespaceEmitted || relationshipEmitted || customViewBefore || customViewAfter)
+        var customViewRuns = ComposeEmittedCustomViewRuns(customViewPlan, customViewBefore, customViewAfter);
+
+        if (namespaceEmitted || relationshipEmitted || customViewRuns is not null)
         {
             var run = await RunAsync(
                     request,
                     builder,
                     namespaceEmitted ? namespacePlan : null,
-                    customViewBefore || customViewAfter ? customViewPlan!.PlannedChecks : null,
+                    customViewRuns,
                     relationshipEmitted ? runtimeCheck : null,
                     writeSession,
                     cancellationToken
@@ -633,7 +646,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                     request,
                     builder,
                     context.EmittedNamespacePlan,
-                    context.EmittedCustomViewPlannedChecks,
+                    context.EmittedCustomViewRuns,
                     context.EmittedRuntimeCheck,
                     writeSession,
                     cancellationToken
@@ -668,6 +681,19 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     private RelationalCompositeCommandBuilder CreateBuilder(RelationalWriteExecutorRequest request) =>
         new(IRelationalCompositeCommandDialect.Create(request.MappingSet.Key.Dialect), _commandBudget);
 
+    /// <param name="PlannedChecks">
+    /// The request's full planned custom-view list. Mapping resolves a <c>cv1</c> payload against this, since
+    /// the payload carries only an index and several runs can share one command.
+    /// </param>
+    /// <param name="EmittedChecks">
+    /// Exactly the checks whose statements this command carries. Validation probes these views and no others,
+    /// so a failure is never attributed to a view the command never touched.
+    /// </param>
+    private sealed record EmittedCustomViewRuns(
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> EmittedChecks
+    );
+
     private sealed record CommandRun(
         IReadOnlyList<RelationalCompositeStatementOutcome> Outcomes,
         RelationalWriteExecutorResult? Denial
@@ -681,7 +707,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         RelationalWriteExecutorRequest request,
         RelationalCompositeCommandBuilder builder,
         NamespaceStatementPlan? namespacePlan,
-        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? customViewPlannedChecks,
+        EmittedCustomViewRuns? customViewRuns,
         ProposedRelationshipAuthorizationRuntimeCheck? runtimeCheck,
         IRelationalWriteSession writeSession,
         CancellationToken cancellationToken
@@ -700,13 +726,15 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         {
             return new CommandRun(
                 [],
-                MapAuthorizationFailure(
-                    request,
-                    namespacePlan,
-                    customViewPlannedChecks,
-                    runtimeCheck,
-                    exception
-                )
+                await MapAuthorizationFailureAsync(
+                        request,
+                        namespacePlan,
+                        customViewRuns,
+                        runtimeCheck,
+                        exception,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false)
             );
         }
     }
@@ -823,10 +851,19 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         public ProposedRelationshipAuthorizationRuntimeCheck? EmittedRuntimeCheck { get; set; }
 
         /// <summary>
-        /// The request's full planned custom-view list, set once either run is emitted into this command. A
-        /// <c>cv1</c> payload is resolved against the whole list, so which run emitted it does not matter.
+        /// The custom-view runs emitted into this command. Both runs can land in one command, so a run's
+        /// checks are added to whatever is already recorded rather than replacing it.
         /// </summary>
-        public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? EmittedCustomViewPlannedChecks { get; set; }
+        public EmittedCustomViewRuns? EmittedCustomViewRuns { get; private set; }
+
+        public void RecordEmittedCustomViewRun(
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
+            IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> emittedChecks
+        ) =>
+            EmittedCustomViewRuns = new EmittedCustomViewRuns(
+                plannedChecks,
+                [.. EmittedCustomViewRuns?.EmittedChecks ?? [], .. emittedChecks]
+            );
     }
 
     /// <summary>
@@ -1338,13 +1375,15 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         }
         catch (DbException exception)
         {
-            return MapAuthorizationFailure(
-                request,
-                namespacePlan: null,
-                customViewPlannedChecks: null,
-                runtimeCheck,
-                exception
-            );
+            return await MapAuthorizationFailureAsync(
+                    request,
+                    namespacePlan: null,
+                    customViewRuns: null,
+                    runtimeCheck,
+                    exception,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
         }
     }
 
@@ -1564,6 +1603,49 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             (right.ConfiguredStrategy.RawConfiguredIndex, right.Index)
         ) < 0;
 
+    /// <summary>
+    /// Probes the views this command's custom-view statements referenced, and throws
+    /// <see cref="CustomViewAuthorizationValidationException"/> when one is missing or does not meet the
+    /// <c>DocumentId</c> contract. <c>auth.{StrategyName}</c> is the only object a request touches that lives
+    /// outside the generated schema, so it can be dropped, replaced, or revoked between requests, and auth.md
+    /// requires that to surface as the <c>urn:ed-fi:api:system</c> 500 rather than as an unhandled provider
+    /// error.
+    /// </summary>
+    /// <remarks>
+    /// The probe runs on a command executor that opens its own connection, never on the write session: the
+    /// failure being classified has already aborted that session's transaction, so a statement issued there
+    /// could only fail for that reason and would prove nothing about the view.
+    /// </remarks>
+    private async Task ThrowIfEmittedCustomViewsAreInvalidAsync(
+        RelationalWriteExecutorRequest request,
+        EmittedCustomViewRuns customViewRuns,
+        DbException exception,
+        CancellationToken cancellationToken
+    )
+    {
+        if (
+            _customViewValidationCommandExecutor is null
+            || customViewRuns.EmittedChecks.Count == 0
+            || !CustomViewAuthorizationProviderFailureMapper.IsUnrecognizedProviderFailure(
+                request.MappingSet.Key.Dialect,
+                exception,
+                _providerFailureExtractor
+            )
+        )
+        {
+            return;
+        }
+
+        await CustomViewAuthorizationValidator
+            .ValidateSingleRecordAsync(
+                _customViewValidationCommandExecutor,
+                request.MappingSet.Key.Dialect,
+                customViewRuns.EmittedChecks,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
     private static RelationalWriteExecutorResult InvalidCustomViewPlan(
         RelationalWriteExecutorRequest request,
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
@@ -1578,7 +1660,11 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     /// <summary>
     /// Appends one proposed custom-view run and reports whether it emitted a statement.
     /// </summary>
-    private static bool TryAppendCustomViewRun(
+    /// <summary>
+    /// Appends one proposed custom-view run, answering with the checks it emitted or <see langword="null"/>
+    /// when it emitted none.
+    /// </summary>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? TryAppendCustomViewRun(
         RelationalCompositeCommandBuilder builder,
         RelationalWriteExecutorRequest request,
         CustomViewStatementPlan? customViewPlan,
@@ -1588,7 +1674,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     {
         if (customViewPlan is null || runValues is null || runValues.Count == 0)
         {
-            return false;
+            return null;
         }
 
         return TryAppendCustomView(
@@ -1599,7 +1685,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         );
     }
 
-    private static bool TryAppendCustomView(
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? TryAppendCustomView(
         RelationalCompositeCommandBuilder builder,
         RelationalWriteExecutorRequest request,
         ProposedCustomViewAuthorizationRuntimeCheck runtimeCheck,
@@ -1611,12 +1697,12 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             is not { } statement
         )
         {
-            return false;
+            return null;
         }
 
         AppendCustomViewStatement(builder, statement, label);
 
-        return true;
+        return runtimeCheck.Checks;
     }
 
     private static void AppendCustomViewStatement(
@@ -1641,6 +1727,20 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 RelationalCompositeResultSetSpan.ConsumeAsync(reader, resultSetCount, readCancellation),
             resultSetCount
         );
+    }
+
+    private static EmittedCustomViewRuns? ComposeEmittedCustomViewRuns(
+        CustomViewStatementPlan? customViewPlan,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? before,
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? after
+    )
+    {
+        if (customViewPlan is null || (before is null && after is null))
+        {
+            return null;
+        }
+
+        return new EmittedCustomViewRuns(customViewPlan.PlannedChecks, [.. before ?? [], .. after ?? []]);
     }
 
     private static void AddCustomViewUnit(
@@ -1680,7 +1780,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 (context, _, _) =>
                 {
                     AppendCustomViewStatement(context.Builder, statement, label);
-                    context.EmittedCustomViewPlannedChecks = customViewPlan.PlannedChecks;
+                    context.RecordEmittedCustomViewRun(customViewPlan.PlannedChecks, runtimeCheck.Checks);
                 }
             )
         );
@@ -1899,12 +1999,13 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     /// A failure that is no authorization denial at all propagates to the executor's database failure
     /// handling unchanged.
     /// </summary>
-    private RelationalWriteExecutorResult MapAuthorizationFailure(
+    private async Task<RelationalWriteExecutorResult> MapAuthorizationFailureAsync(
         RelationalWriteExecutorRequest request,
         NamespaceStatementPlan? namespacePlan,
-        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec>? customViewPlannedChecks,
+        EmittedCustomViewRuns? customViewRuns,
         ProposedRelationshipAuthorizationRuntimeCheck? runtimeCheck,
-        DbException exception
+        DbException exception,
+        CancellationToken cancellationToken
     )
     {
         var dialect = request.MappingSet.Key.Dialect;
@@ -1912,14 +2013,14 @@ internal sealed class CompositeRelationalWriteSecondCommand(
         // Custom views are dispatched first because only they claim a cv1 payload; a payload from another
         // family reaches its own mapper untouched. Mapping always uses the request's full planned list, so a
         // payload from either emitted run resolves to the check the planner assigned that index to.
-        if (customViewPlannedChecks is not null)
+        if (customViewRuns is not null)
         {
             if (
                 CustomViewAuthorizationProviderFailureMapper.TryMapCustomViewAuthorizationFailure(
                     dialect,
                     exception,
                     _providerFailureExtractor,
-                    customViewPlannedChecks,
+                    customViewRuns.PlannedChecks,
                     out var customViewFailure
                 )
             )
@@ -1935,7 +2036,7 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                     dialect,
                     exception,
                     _providerFailureExtractor,
-                    customViewPlannedChecks
+                    customViewRuns.PlannedChecks
                 )
             )
             {
@@ -1943,17 +2044,27 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                     request.OperationKind,
                     [CustomViewAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata],
                     AuthorizationSecurityConfigurationDiagnostics.ForCustomViewAuthorizationAuth1(
-                        customViewPlannedChecks
+                        customViewRuns.PlannedChecks
                     )
                 );
             }
 
             // Proposed-value checks bind no stored DocumentId, so the stale stored-target kind cannot be
-            // raised here. A failure carrying no custom-view payload is deliberately NOT attributed to the
-            // view either: this command can also carry the document insert and the resource tables'
-            // statements, and PostgreSQL reports a batch-prepare failure without a usable statement
-            // position, so attributing by position would relabel a constraint violation as a security
-            // configuration error. Such failures fall through to the executor's existing handling.
+            // raised here.
+            //
+            // A failure carrying no authorization payload cannot be attributed by position: this command can
+            // also carry the document insert and the resource tables' statements, and PostgreSQL reports a
+            // batch-prepare failure without a usable statement position, so a constraint violation would be
+            // relabelled as a security configuration error. Instead the emitted views are probed directly.
+            // Only a view that actually fails its contract produces the documented 500; anything else leaves
+            // the original failure to the executor's existing handling.
+            await ThrowIfEmittedCustomViewsAreInvalidAsync(
+                    request,
+                    customViewRuns,
+                    exception,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
         }
 
         if (namespacePlan is not null)

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
@@ -729,7 +729,28 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     private sealed record EmittedCustomViewRuns(
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks,
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> EmittedChecks
-    );
+    )
+    {
+        /// <summary>
+        /// The emitted checks up to and including the one a <c>cv1</c> payload named. The command aborts at
+        /// its first <c>AUTH1</c>, so nothing emitted after that check ran: probing a later view would report
+        /// its contract failure ahead of the namespace or custom-view answer configured before it. An index
+        /// this command did not emit leaves the run unchanged, which only a payload naming an unemitted check
+        /// could produce.
+        /// </summary>
+        public EmittedCustomViewRuns ThroughDeniedCheck(int deniedCheckIndex)
+        {
+            for (var position = 0; position < EmittedChecks.Count; position++)
+            {
+                if (EmittedChecks[position].Index == deniedCheckIndex)
+                {
+                    return this with { EmittedChecks = [.. EmittedChecks.Take(position + 1)] };
+                }
+            }
+
+            return this;
+        }
+    }
 
     private sealed record CommandRun(
         IReadOnlyList<RelationalCompositeStatementOutcome> Outcomes,
@@ -752,12 +773,21 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     {
         try
         {
-            return new CommandRun(
-                await new RelationalCompositeCommandExecution()
-                    .ExecuteAsync(writeSession, builder.Seal(), cancellationToken)
-                    .ConfigureAwait(false),
-                null
-            );
+            var outcomes = await new RelationalCompositeCommandExecution()
+                .ExecuteAsync(writeSession, builder.Seal(), cancellationToken)
+                .ConfigureAwait(false);
+
+            // A clean run means every emitted check answered, so validating their views here cannot preempt a
+            // denial: a table masquerading as auth.{StrategyName} satisfies the membership SQL silently, and the
+            // command's own failure paths never see it. Only the runs this command emitted are probed, and the
+            // write is still uncommitted, so the documented 500 leaves nothing behind.
+            if (customViewRuns is not null)
+            {
+                await ValidateEmittedCustomViewsAsync(request, customViewRuns, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return new CommandRun(outcomes, null);
         }
         catch (DbException exception)
         {
@@ -1700,15 +1730,30 @@ internal sealed class CompositeRelationalWriteSecondCommand(
             return;
         }
 
-        await CustomViewAuthorizationValidator
-            .ValidateSingleRecordAsync(
+        await ValidateEmittedCustomViewsAsync(request, customViewRuns, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Probes the views the command's custom-view statements referenced, throwing
+    /// <see cref="CustomViewAuthorizationValidationException"/> when one is missing or does not meet the
+    /// <c>DocumentId</c> contract. Exactly the emitted runs are probed, never the whole planned list: a view
+    /// behind a check this command never carried has not been reached, and blaming it would replace an answer
+    /// configured ahead of it.
+    /// </summary>
+    private Task ValidateEmittedCustomViewsAsync(
+        RelationalWriteExecutorRequest request,
+        EmittedCustomViewRuns customViewRuns,
+        CancellationToken cancellationToken
+    ) =>
+        _customViewValidationCommandExecutor is null
+            ? Task.CompletedTask
+            : CustomViewAuthorizationValidator.ValidateSingleRecordAsync(
                 _customViewValidationCommandExecutor,
                 request.MappingSet.Key.Dialect,
                 customViewRuns.EmittedChecks,
                 cancellationToken
-            )
-            .ConfigureAwait(false);
-    }
+            );
 
     private static RelationalWriteExecutorResult InvalidCustomViewPlan(
         RelationalWriteExecutorRequest request,
@@ -2095,6 +2140,19 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 )
             )
             {
+                // A cv1 no-match is only a denial once the object behind it is a conforming view. A table
+                // masquerading as auth.{StrategyName} answers the membership SQL, and its rows simply not
+                // matching arrives here as that same ordinary payload — indistinguishable from a real denial
+                // without probing. Validating first is what keeps the documented urn:ed-fi:api:system 500
+                // from being served as a 403, and it mirrors the post-success validation a clean command
+                // already performs for the case where such an object authorizes instead.
+                await ValidateEmittedCustomViewsAsync(
+                        request,
+                        customViewRuns.ThroughDeniedCheck(customViewFailure!.EmittedAuth1Index),
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
                 return RelationalWriteExecutorResults.BuildCustomViewAuthorizationFailureResult(
                     request.OperationKind,
                     customViewFailure!

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationshipAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationshipAuthorizationProviderFailureMapper.cs
@@ -85,6 +85,17 @@ internal static class RelationshipAuthorizationProviderFailureMapper
             return false;
         }
 
+        // A payload belonging to another AUTH1 family shares the transport but is not ours. Yield with no
+        // diagnostic so the codec that owns the discriminator claims it. Without this, a command carrying
+        // both relationship and custom-view statements would report a custom-view 403 as a relationship
+        // invalid-payload 500, because an unparseable payload below is treated as our own malformed one.
+        // Only *known* foreign discriminators yield: undecodable text with no discriminator still takes the
+        // parse-failure path, so a genuinely corrupt payload stays a loud security-configuration error.
+        if (IsForeignAuthorizationPayload(payloadText))
+        {
+            return false;
+        }
+
         if (
             !RelationshipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(payloadText, out var payload)
             || payload is null
@@ -153,6 +164,21 @@ internal static class RelationshipAuthorizationProviderFailureMapper
             diagnostic.MappingFailureCategory
         );
     }
+
+    /// <summary>
+    /// Whether <paramref name="payloadText"/> carries the discriminator of an AUTH1 family other than
+    /// relationship. Namespace payloads lead with <c>ns1|</c> and custom view-based payloads with
+    /// <c>cv1|</c>; the relationship family leads with its own payload version.
+    /// </summary>
+    private static bool IsForeignAuthorizationPayload(string payloadText) =>
+        payloadText.StartsWith(
+            NamespaceAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
+            StringComparison.Ordinal
+        )
+        || payloadText.StartsWith(
+            CustomViewAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
+            StringComparison.Ordinal
+        );
 
     private static RelationshipAuthorizationProviderFailureDiagnostic BuildDiagnostic(
         SqlDialect dialect,

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/CustomViewAuthorizationFailure.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/CustomViewAuthorizationFailure.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Backend;
+
+/// <summary>
+/// Identifies the authorization value family evaluated by a custom view-based authorization check.
+/// </summary>
+public enum CustomViewAuthorizationFailureValueSource
+{
+    Stored,
+    Proposed,
+}
+
+/// <summary>
+/// Identifies the failed custom view-based authorization condition.
+/// </summary>
+/// <remarks>
+/// The stale-stored-target condition the SQL batch can also raise is deliberately absent: it is a retry
+/// signal that resolves to a 404, never a response of its own. A missing or non-conforming
+/// <c>auth.{StrategyName}</c> view is likewise absent — that is a security-configuration problem carrying the
+/// <c>urn:ed-fi:api:system</c> 500 rather than an authorization denial.
+/// </remarks>
+public enum CustomViewAuthorizationFailureKind
+{
+    /// <summary>
+    /// The basis resource's DocumentId resolved but is not present in the custom authorization view.
+    /// auth.md §2.4 — authorization denied, without the EdOrg-claims relationship wording.
+    /// </summary>
+    NoMatchingRow,
+
+    /// <summary>
+    /// The stored basis value is null, so the existing item can never be authorized by this strategy.
+    /// auth.md §2.7 — custom view, invalid data, element uninitialized.
+    /// </summary>
+    StoredValueUninitialized,
+
+    /// <summary>
+    /// The proposed basis value is absent, so the request body supplies nothing to authorize.
+    /// auth.md §2.8 — custom view, access denied, element required.
+    /// </summary>
+    ProposedValueMissing,
+}
+
+/// <summary>
+/// Cross-boundary metadata for a failed custom view-based authorization check.
+/// </summary>
+/// <param name="FailureKind">Which of §2.4 / §2.7 / §2.8 applies.</param>
+/// <param name="ValueSource">Whether the stored row or the proposed request body was evaluated.</param>
+/// <param name="EmittedAuth1Index">The failing check's index within the request's custom-view check list.</param>
+/// <param name="StrategyName">The configured custom view-based strategy name.</param>
+/// <param name="ReadableSecurableElements">
+/// User-facing names of the securable element the check decided on. More than one only for a
+/// composite-identity basis resource, which is what §2.4's multiple-element phrasing covers.
+/// </param>
+/// <param name="Hint">
+/// The §"Authorization Failure Hints" sentence for this strategy, with no <c>Hint:</c> prefix; the response
+/// formatter supplies that prefix.
+/// </param>
+public sealed record CustomViewAuthorizationFailure(
+    CustomViewAuthorizationFailureKind FailureKind,
+    CustomViewAuthorizationFailureValueSource ValueSource,
+    int EmittedAuth1Index,
+    string StrategyName,
+    string[] ReadableSecurableElements,
+    string? Hint
+);

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/DeleteResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/DeleteResult.cs
@@ -49,6 +49,13 @@ public abstract record DeleteResult
         : DeleteResult();
 
     /// <summary>
+    /// A failure because stored custom view-based authorization denied the delete. Carries the custom-view
+    /// failure metadata so Core can build the §2.4/§2.7/§2.8 ProblemDetails response.
+    /// </summary>
+    public record DeleteFailureCustomViewNotAuthorized(CustomViewAuthorizationFailure CustomViewFailure)
+        : DeleteResult();
+
+    /// <summary>
     /// A failure because the requested delete operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/GetResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/GetResult.cs
@@ -52,6 +52,13 @@ public record GetResult
         : GetResult();
 
     /// <summary>
+    /// A failure because custom view-based authorization denied access to the document. Carries the
+    /// custom-view failure metadata so Core can build the §2.4/§2.7/§2.8 ProblemDetails response.
+    /// </summary>
+    public record GetFailureCustomViewNotAuthorized(CustomViewAuthorizationFailure CustomViewFailure)
+        : GetResult();
+
+    /// <summary>
     /// A failure because the requested read operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/SecurityConfigurationResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/SecurityConfigurationResponse.cs
@@ -30,13 +30,6 @@ public static class SecurityConfigurationFailureMessages
     public static string UnknownAuthorizationStrategies(IEnumerable<string> unavailableStrategyNames) =>
         $"Could not find authorization strategy implementations for the following strategy names: {FormatQuotedCsv(DistinctInFirstOccurrenceOrder(unavailableStrategyNames))}.";
 
-    public static string CustomViewBasisPropertyUnavailable(
-        string targetEntityName,
-        string propertyName,
-        string basisEntityName
-    ) =>
-        $"Unable to find a property on the authorization subject entity type '{targetEntityName}' corresponding to the '{propertyName}' property on the custom authorization view's basis entity type '{basisEntityName}' in order to perform authorization. Should a different authorization strategy be used?";
-
     private static string FormatBracketedQuotedList(IEnumerable<string> values) =>
         $"[{FormatQuotedCsv(values)}]";
 

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpdateResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpdateResult.cs
@@ -114,6 +114,13 @@ public record UpdateResult
         : UpdateResult();
 
     /// <summary>
+    /// A failure because stored or proposed custom view-based authorization denied the PUT/update. Carries
+    /// the custom-view failure metadata so Core can build the §2.4/§2.7/§2.8 ProblemDetails response.
+    /// </summary>
+    public record UpdateFailureCustomViewNotAuthorized(CustomViewAuthorizationFailure CustomViewFailure)
+        : UpdateResult();
+
+    /// <summary>
     /// A failure because the requested PUT/update operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpsertResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpsertResult.cs
@@ -114,6 +114,13 @@ public record UpsertResult
         : UpsertResult();
 
     /// <summary>
+    /// A failure because stored or proposed custom view-based authorization denied the POST/upsert. Carries
+    /// the custom-view failure metadata so Core can build the §2.4/§2.7/§2.8 ProblemDetails response.
+    /// </summary>
+    public record UpsertFailureCustomViewNotAuthorized(CustomViewAuthorizationFailure CustomViewFailure)
+        : UpsertResult();
+
+    /// <summary>
     /// A failure because the requested POST/upsert operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ApiSchema/DescriptorDocumentReferenceContractTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ApiSchema/DescriptorDocumentReferenceContractTests.cs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.ApiSchema;
+
+/// <summary>
+/// Pins the ApiSchema fact the descriptor write authorization path depends on: no descriptor resource declares
+/// a document reference.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Descriptor writes bind no document references, so there is no finalized root row for a proposed custom-view
+/// basis value to be read from. Only a self-basis proposed check can be settled on that path; anything else
+/// fails closed as a security-configuration error rather than being skipped.
+/// </para>
+/// <para>
+/// That fail-closed branch is unreachable today only because of this data fact —
+/// <c>ReferenceBindingPass</c> applies whatever <c>documentPathsMapping</c> yields and has no storage-kind
+/// guard. If a future Data Standard or extension gives a descriptor a document reference, this test fails and
+/// the descriptor write path needs a real proposed-value extractor rather than the fail-closed branch.
+/// </para>
+/// </remarks>
+[TestFixture]
+[Parallelizable]
+public class Given_The_Shipped_ApiSchema_Descriptor_Resources
+{
+    [Test]
+    public void They_declare_no_document_references()
+    {
+        var packages = LoadShippedApiSchemaPackages();
+
+        // A relocated or renamed package directory would otherwise make this test vacuously pass.
+        packages.Should().NotBeEmpty("the shipped ApiSchema packages must be discoverable to pin this fact");
+
+        var descriptorsWithReferences = new List<string>();
+        var descriptorCount = 0;
+
+        foreach (var (packageName, document) in packages)
+        {
+            foreach (var project in EnumerateProjectSchemas(document.RootElement))
+            {
+                if (!project.TryGetProperty("resourceSchemas", out var resourceSchemas))
+                {
+                    continue;
+                }
+
+                foreach (var resource in resourceSchemas.EnumerateObject())
+                {
+                    if (
+                        !resource.Value.TryGetProperty("isDescriptor", out var isDescriptor)
+                        || !isDescriptor.GetBoolean()
+                    )
+                    {
+                        continue;
+                    }
+
+                    descriptorCount++;
+
+                    if (DeclaresDocumentReference(resource.Value))
+                    {
+                        descriptorsWithReferences.Add($"{packageName}:{resource.Name}");
+                    }
+                }
+            }
+        }
+
+        descriptorCount.Should().BePositive("the shipped packages must contain descriptor resources");
+        descriptorsWithReferences.Should().BeEmpty();
+    }
+
+    private static bool DeclaresDocumentReference(JsonElement resourceSchema) =>
+        resourceSchema.TryGetProperty("documentPathsMapping", out var documentPathsMapping)
+        && documentPathsMapping
+            .EnumerateObject()
+            .Any(mapping =>
+                mapping.Value.TryGetProperty("isReference", out var isReference) && isReference.GetBoolean()
+            );
+
+    /// <summary>
+    /// A package document carries either a single <c>projectSchema</c> or a <c>projectSchemas</c> map, so both
+    /// shapes are walked rather than assuming one.
+    /// </summary>
+    private static IEnumerable<JsonElement> EnumerateProjectSchemas(JsonElement root)
+    {
+        if (root.TryGetProperty("projectSchema", out var projectSchema))
+        {
+            yield return projectSchema;
+        }
+
+        if (!root.TryGetProperty("projectSchemas", out var projectSchemas))
+        {
+            yield break;
+        }
+
+        if (projectSchemas.TryGetProperty("resourceSchemas", out _))
+        {
+            yield return projectSchemas;
+            yield break;
+        }
+
+        foreach (var project in projectSchemas.EnumerateObject())
+        {
+            yield return project.Value;
+        }
+    }
+
+    private static List<(string PackageName, JsonDocument Document)> LoadShippedApiSchemaPackages()
+    {
+        var packagesRoot = Path.Combine(AppContext.BaseDirectory, "ApiSchema", "Packages");
+
+        if (!Directory.Exists(packagesRoot))
+        {
+            return [];
+        }
+
+        List<(string, JsonDocument)> packages = [];
+
+        foreach (var packageDirectory in Directory.EnumerateDirectories(packagesRoot))
+        {
+            var schemaPath = Path.Combine(packageDirectory, "ApiSchema.json");
+
+            if (File.Exists(schemaPath))
+            {
+                packages.Add(
+                    (Path.GetFileName(packageDirectory), JsonDocument.Parse(File.ReadAllText(schemaPath)))
+                );
+            }
+        }
+
+        return packages;
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
@@ -426,6 +426,75 @@ public class DeleteByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Custom_View_Not_Authorized : DeleteByIdHandlerTests
+    {
+        internal static readonly CustomViewAuthorizationFailure CustomViewFailure = new(
+            CustomViewAuthorizationFailureKind.StoredValueUninitialized,
+            CustomViewAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            StrategyName: "StudentWithCTECourseEnrollments",
+            ReadableSecurableElements: ["StudentUniqueId"],
+            Hint: "You may need a Student with CTE Course Enrollments."
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<DeleteResult> DeleteDocumentById(IDeleteRequest deleteRequest)
+            {
+                return Task.FromResult<DeleteResult>(
+                    new DeleteFailureCustomViewNotAuthorized(CustomViewFailure)
+                );
+            }
+        }
+
+        private static readonly string _customViewTraceId = "custom-view-delete-403";
+        private readonly RequestInfo _customViewRequestInfo = RequestInfoWithRelationalMappingSet(
+            _customViewTraceId
+        );
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var projectSchemaNode = new JsonObject
+            {
+                ["educationOrganizationTypes"] = new JsonArray { "Type1", "Type2" },
+            };
+            _customViewRequestInfo.ProjectSchema = new ProjectSchema(projectSchemaNode, NullLogger.Instance);
+            _customViewRequestInfo.ResourceSchema = GetResourceSchema();
+
+            var (deleteHandler, serviceProvider) = Handler(new Repository());
+            _customViewRequestInfo.ScopedServiceProvider = serviceProvider;
+
+            await deleteHandler.Execute(_customViewRequestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_custom_view_denial_to_the_canonical_problem_details_403()
+        {
+            _customViewRequestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _customViewRequestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = CustomViewAuthorizationFailureResponse.ForFailure(
+                CustomViewFailure,
+                new TraceId(_customViewTraceId)
+            );
+
+            _customViewRequestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_customViewRequestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_customViewRequestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : DeleteByIdHandlerTests
     {
         internal static readonly NamespaceAuthorizationFailure Failure = new(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
@@ -598,7 +598,10 @@ public class GetByIdHandlerTests
 
         internal class Repository : NotImplementedDocumentStoreRepository
         {
-            public override Task<GetResult> GetDocumentById(IGetRequest getRequest)
+            public override Task<GetResult> GetDocumentById(
+                IGetRequest getRequest,
+                CancellationToken cancellationToken = default
+            )
             {
                 return Task.FromResult<GetResult>(new GetFailureCustomViewNotAuthorized(CustomViewFailure));
             }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
@@ -585,6 +585,66 @@ public class GetByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Custom_View_Not_Authorized : GetByIdHandlerTests
+    {
+        internal static readonly CustomViewAuthorizationFailure CustomViewFailure = new(
+            CustomViewAuthorizationFailureKind.NoMatchingRow,
+            CustomViewAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            StrategyName: "StudentWithCTECourseEnrollments",
+            ReadableSecurableElements: ["StudentUniqueId"],
+            Hint: "You may need a Student with CTE Course Enrollments."
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<GetResult> GetDocumentById(IGetRequest getRequest)
+            {
+                return Task.FromResult<GetResult>(new GetFailureCustomViewNotAuthorized(CustomViewFailure));
+            }
+        }
+
+        private static readonly string _customViewTraceId = "custom-view-get-403";
+        private readonly RequestInfo _customViewRequestInfo = RequestInfoWithRelationalMappingSet(
+            _customViewTraceId
+        );
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (getByIdHandler, serviceProvider) = Handler(new Repository());
+            _customViewRequestInfo.ScopedServiceProvider = serviceProvider;
+
+            await getByIdHandler.Execute(_customViewRequestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_custom_view_denial_to_the_canonical_problem_details_403()
+        {
+            _customViewRequestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _customViewRequestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = CustomViewAuthorizationFailureResponse.ForFailure(
+                CustomViewFailure,
+                new TraceId(_customViewTraceId)
+            );
+
+            _customViewRequestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_customViewRequestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_customViewRequestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : GetByIdHandlerTests
     {
         internal static readonly NamespaceAuthorizationFailure Failure = new(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/RelationalWriteSeamTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/RelationalWriteSeamTests.cs
@@ -719,6 +719,7 @@ actual: {requestInfo.FrontendResponse.Body}
                 ),
                 A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
                 A.Fake<INamespaceAuthorizationExecutor>(),
+                A.Fake<ICustomViewAuthorizationExecutor>(),
                 A.Fake<IRelationalCommandExecutor>(),
                 A.Fake<IDocumentCacheReadAccelerationCoordinator>()
             );

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
@@ -907,6 +907,68 @@ public class UpdateByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Custom_View_Not_Authorized : UpdateByIdHandlerTests
+    {
+        internal static readonly CustomViewAuthorizationFailure CustomViewFailure = new(
+            CustomViewAuthorizationFailureKind.NoMatchingRow,
+            CustomViewAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            StrategyName: "StudentWithCTECourseEnrollments",
+            ReadableSecurableElements: ["StudentUniqueId"],
+            Hint: "You may need a Student with CTE Course Enrollments."
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpdateResult> UpdateDocumentById(IUpdateRequest updateRequest)
+            {
+                return Task.FromResult<UpdateResult>(
+                    new UpdateFailureCustomViewNotAuthorized(CustomViewFailure)
+                );
+            }
+        }
+
+        private static readonly string _customViewTraceId = "custom-view-put-403";
+        private readonly RequestInfo _customViewRequestInfo = RequestInfoWithRelationalMappingSet(
+            _customViewTraceId
+        );
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (updateHandler, serviceProvider) = Handler(new Repository());
+            _customViewRequestInfo.ScopedServiceProvider = serviceProvider;
+
+            await updateHandler.Execute(_customViewRequestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_custom_view_denial_to_the_canonical_problem_details_403()
+        {
+            _customViewRequestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _customViewRequestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = CustomViewAuthorizationFailureResponse.ForFailure(
+                CustomViewFailure,
+                new TraceId(_customViewTraceId)
+            );
+
+            _customViewRequestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_customViewRequestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_customViewRequestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : UpdateByIdHandlerTests
     {
         internal static readonly NamespaceAuthorizationFailure Failure = new(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
@@ -992,6 +992,68 @@ public class UpsertHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Custom_View_Not_Authorized : UpsertHandlerTests
+    {
+        internal static readonly CustomViewAuthorizationFailure CustomViewFailure = new(
+            CustomViewAuthorizationFailureKind.ProposedValueMissing,
+            CustomViewAuthorizationFailureValueSource.Proposed,
+            EmittedAuth1Index: 0,
+            StrategyName: "StudentWithCTECourseEnrollments",
+            ReadableSecurableElements: ["StudentUniqueId"],
+            Hint: "You may need a Student with CTE Course Enrollments."
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpsertResult> UpsertDocument(IUpsertRequest upsertRequest)
+            {
+                return Task.FromResult<UpsertResult>(
+                    new UpsertFailureCustomViewNotAuthorized(CustomViewFailure)
+                );
+            }
+        }
+
+        private static readonly string _customViewTraceId = "custom-view-post-403";
+        private readonly RequestInfo _customViewRequestInfo = RequestInfoWithRelationalMappingSet(
+            _customViewTraceId
+        );
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (upsertHandler, serviceProvider) = Handler(new Repository());
+            _customViewRequestInfo.ScopedServiceProvider = serviceProvider;
+
+            await upsertHandler.Execute(_customViewRequestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_custom_view_denial_to_the_canonical_problem_details_403()
+        {
+            _customViewRequestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _customViewRequestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = CustomViewAuthorizationFailureResponse.ForFailure(
+                CustomViewFailure,
+                new TraceId(_customViewTraceId)
+            );
+
+            _customViewRequestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_customViewRequestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_customViewRequestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : UpsertHandlerTests
     {
         internal static readonly NamespaceAuthorizationFailure Failure = new(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/CustomViewAuthorizationFailureResponseTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/CustomViewAuthorizationFailureResponseTests.cs
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Response;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Response;
+
+[TestFixture]
+[Parallelizable]
+public class Given_CustomViewAuthorizationFailureResponse
+{
+    private const string Hint = "You may need a Student with CTE Course Enrollments.";
+    private const string StrategyName = "StudentWithCTECourseEnrollments";
+
+    private static readonly TraceId TestTraceId = new("cv-trace-id");
+
+    private static CustomViewAuthorizationFailure Failure(
+        CustomViewAuthorizationFailureKind failureKind,
+        CustomViewAuthorizationFailureValueSource valueSource,
+        string[]? readableSecurableElements = null,
+        string? hint = Hint
+    ) =>
+        new(
+            failureKind,
+            valueSource,
+            EmittedAuth1Index: 0,
+            StrategyName,
+            readableSecurableElements ?? ["StudentUniqueId"],
+            hint
+        );
+
+    private static string Text(JsonNode body, string property) => body[property]!.GetValue<string>();
+
+    private static string[] Errors(JsonNode body) =>
+        [.. body["errors"]!.AsArray().Select(error => error!.GetValue<string>())];
+
+    [Test]
+    public void It_should_format_a_stored_no_matching_row_failure_as_the_bare_authorization_type()
+    {
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(
+                CustomViewAuthorizationFailureKind.NoMatchingRow,
+                CustomViewAuthorizationFailureValueSource.Stored
+            ),
+            TestTraceId
+        );
+
+        // auth.md §2.4 carries the bare authorization type, because a custom view need not involve education
+        // organization claims at all.
+        Text(body, "type").Should().Be("urn:ed-fi:api:security:authorization");
+        Text(body, "title").Should().Be("Authorization Denied");
+        body["status"]!.GetValue<int>().Should().Be(403);
+        Text(body, "correlationId").Should().Be("cv-trace-id");
+        Text(body, "detail")
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. "
+                    + "Hint: You may need a Student with CTE Course Enrollments."
+            );
+        Errors(body)
+            .Should()
+            .Equal(
+                "The caller is not authorized to perform the requested operation on the item based on the "
+                    + "existing value of the 'StudentUniqueId' property of the item."
+            );
+    }
+
+    [Test]
+    public void It_should_never_mention_education_organization_claims_for_a_no_matching_row_failure()
+    {
+        // §2.3's relationship wording names EdOrg claims; §2.4 exists precisely because custom views may have
+        // none, so that sentence must not leak into this response.
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(
+                CustomViewAuthorizationFailureKind.NoMatchingRow,
+                CustomViewAuthorizationFailureValueSource.Stored
+            ),
+            TestTraceId
+        );
+
+        body.ToJsonString().Should().NotContain("education organization");
+        body.ToJsonString().Should().NotContain("No relationships have been established");
+    }
+
+    [Test]
+    public void It_should_say_proposed_for_a_proposed_no_matching_row_failure()
+    {
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(
+                CustomViewAuthorizationFailureKind.NoMatchingRow,
+                CustomViewAuthorizationFailureValueSource.Proposed
+            ),
+            TestTraceId
+        );
+
+        Errors(body)
+            .Should()
+            .Equal(
+                "The caller is not authorized to perform the requested operation on the item based on the "
+                    + "proposed value of the 'StudentUniqueId' property of the item."
+            );
+    }
+
+    [Test]
+    public void It_should_use_the_multiple_element_phrasing_for_a_composite_identity_basis()
+    {
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(
+                CustomViewAuthorizationFailureKind.NoMatchingRow,
+                CustomViewAuthorizationFailureValueSource.Stored,
+                ["CourseCode", "EducationOrganizationId"]
+            ),
+            TestTraceId
+        );
+
+        Errors(body)
+            .Should()
+            .Equal(
+                "The caller is not authorized to perform the requested operation on the item based on the "
+                    + "existing values of one or more of the following properties of the item: "
+                    + "'CourseCode', 'EducationOrganizationId'."
+            );
+    }
+
+    [Test]
+    public void It_should_format_a_stored_value_uninitialized_failure_as_the_custom_view_invalid_data_type()
+    {
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(
+                CustomViewAuthorizationFailureKind.StoredValueUninitialized,
+                CustomViewAuthorizationFailureValueSource.Stored
+            ),
+            TestTraceId
+        );
+
+        Text(body, "type")
+            .Should()
+            .Be("urn:ed-fi:api:security:authorization:custom-view:invalid-data:element-uninitialized");
+        Text(body, "detail")
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. "
+                    + "The existing 'StudentUniqueId' value is required for authorization purposes. "
+                    + "Hint: You may need a Student with CTE Course Enrollments."
+            );
+        Errors(body)
+            .Should()
+            .Equal(
+                "The existing resource item is inaccessible to clients using the "
+                    + "'StudentWithCTECourseEnrollments' authorization strategy."
+            );
+    }
+
+    [Test]
+    public void It_should_format_a_proposed_value_missing_failure_as_the_custom_view_element_required_type()
+    {
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(
+                CustomViewAuthorizationFailureKind.ProposedValueMissing,
+                CustomViewAuthorizationFailureValueSource.Proposed
+            ),
+            TestTraceId
+        );
+
+        Text(body, "type")
+            .Should()
+            .Be("urn:ed-fi:api:security:authorization:custom-view:access-denied:element-required");
+        Text(body, "detail")
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. "
+                    + "The 'StudentUniqueId' value is required for authorization purposes. "
+                    + "Hint: You may need a Student with CTE Course Enrollments."
+            );
+        // auth.md §2.8 specifies an empty errors collection.
+        Errors(body).Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_should_use_the_multiple_element_phrasing_for_an_uninitialized_composite_identity()
+    {
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(
+                CustomViewAuthorizationFailureKind.StoredValueUninitialized,
+                CustomViewAuthorizationFailureValueSource.Stored,
+                ["CourseCode", "EducationOrganizationId"],
+                hint: null
+            ),
+            TestTraceId
+        );
+
+        Text(body, "detail")
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. "
+                    + "The existing values of one or more of the following properties are required for "
+                    + "authorization purposes: 'CourseCode', 'EducationOrganizationId'."
+            );
+    }
+
+    [Test]
+    public void It_should_use_the_multiple_element_phrasing_for_a_missing_composite_identity()
+    {
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(
+                CustomViewAuthorizationFailureKind.ProposedValueMissing,
+                CustomViewAuthorizationFailureValueSource.Proposed,
+                ["CourseCode", "EducationOrganizationId"],
+                hint: null
+            ),
+            TestTraceId
+        );
+
+        Text(body, "detail")
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. "
+                    + "The values of one or more of the following properties are required for "
+                    + "authorization purposes: 'CourseCode', 'EducationOrganizationId'."
+            );
+    }
+
+    [TestCase(CustomViewAuthorizationFailureKind.NoMatchingRow)]
+    [TestCase(CustomViewAuthorizationFailureKind.StoredValueUninitialized)]
+    public void It_should_omit_the_hint_sentence_when_no_hint_applies(
+        CustomViewAuthorizationFailureKind failureKind
+    )
+    {
+        var body = CustomViewAuthorizationFailureResponse.ForFailure(
+            Failure(failureKind, CustomViewAuthorizationFailureValueSource.Stored, hint: null),
+            TestTraceId
+        );
+
+        Text(body, "detail").Should().NotContain("Hint:");
+    }
+
+    [Test]
+    public void It_should_append_the_hint_to_every_failure_kind()
+    {
+        // The hint is what tells a caller how to gain access, and the relationship formatter already appends
+        // it to its uninitialized and missing-element cases. Diverging here would make two sibling formatters
+        // disagree about the same failure family.
+        foreach (
+            var (failureKind, valueSource) in new[]
+            {
+                (
+                    CustomViewAuthorizationFailureKind.NoMatchingRow,
+                    CustomViewAuthorizationFailureValueSource.Stored
+                ),
+                (
+                    CustomViewAuthorizationFailureKind.StoredValueUninitialized,
+                    CustomViewAuthorizationFailureValueSource.Stored
+                ),
+                (
+                    CustomViewAuthorizationFailureKind.ProposedValueMissing,
+                    CustomViewAuthorizationFailureValueSource.Proposed
+                ),
+            }
+        )
+        {
+            var body = CustomViewAuthorizationFailureResponse.ForFailure(
+                Failure(failureKind, valueSource),
+                TestTraceId
+            );
+
+            Text(body, "detail")
+                .Should()
+                .EndWith(
+                    "Hint: You may need a Student with CTE Course Enrollments.",
+                    because: $"{failureKind}"
+                );
+        }
+    }
+
+    [Test]
+    public void It_should_reject_a_failure_that_names_no_securable_element()
+    {
+        // The planner always supplies at least one name across its three fallback tiers, so an empty list is
+        // a violated upstream contract rather than a renderable response.
+        var act = () =>
+            CustomViewAuthorizationFailureResponse.ForFailure(
+                Failure(
+                    CustomViewAuthorizationFailureKind.NoMatchingRow,
+                    CustomViewAuthorizationFailureValueSource.Stored,
+                    []
+                ),
+                TestTraceId
+            );
+
+        act.Should().Throw<ArgumentException>().WithMessage("*at least one readable securable element*");
+    }
+
+    [Test]
+    public void It_should_reject_an_unsupported_failure_kind()
+    {
+        var act = () =>
+            CustomViewAuthorizationFailureResponse.ForFailure(
+                Failure(
+                    (CustomViewAuthorizationFailureKind)999,
+                    CustomViewAuthorizationFailureValueSource.Stored
+                ),
+                TestTraceId
+            );
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/FailureResponseTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/FailureResponseTests.cs
@@ -166,20 +166,4 @@ public class Given_FailureResponse_For_Security_Configuration
                 "Could not find authorization strategy implementations for the following strategy names: 'StudentScope', 'CalendarScope'."
             );
     }
-
-    [Test]
-    public void It_formats_the_canonical_custom_view_basis_property_message()
-    {
-        string message = SecurityConfigurationFailureMessages.CustomViewBasisPropertyUnavailable(
-            "edfi.CourseTranscript",
-            "StudentUniqueId",
-            "edfi.Student"
-        );
-
-        message
-            .Should()
-            .Be(
-                "Unable to find a property on the authorization subject entity type 'edfi.CourseTranscript' corresponding to the 'StudentUniqueId' property on the custom authorization view's basis entity type 'edfi.Student' in order to perform authorization. Should a different authorization strategy be used?"
-            );
-    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
@@ -92,6 +92,15 @@ internal class DeleteByIdHandler(ILogger _logger, ResiliencePipeline _resilience
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            DeleteFailureCustomViewNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: CustomViewAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.CustomViewFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             DeleteFailureNotImplemented failure => new FrontendResponse(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/GetByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/GetByIdHandler.cs
@@ -103,6 +103,15 @@ internal class GetByIdHandler(ILogger _logger, ResiliencePipeline _resiliencePip
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            GetFailureCustomViewNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: CustomViewAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.CustomViewFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             UnknownFailure failure => new FrontendResponse(
                 StatusCode: 500,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
@@ -172,6 +172,15 @@ internal class UpdateByIdHandler(ILogger _logger, ResiliencePipeline _resilience
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            UpdateFailureCustomViewNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: CustomViewAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.CustomViewFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             UpdateFailureNotImplemented failure => new FrontendResponse(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
@@ -169,6 +169,15 @@ internal class UpsertHandler(ILogger _logger, ResiliencePipeline _resiliencePipe
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            UpsertFailureCustomViewNotAuthorized notAuthorized => new(
+                StatusCode: 403,
+                Body: CustomViewAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.CustomViewFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             UpsertFailureNotImplemented failure => new(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/CustomViewAuthorizationFailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/CustomViewAuthorizationFailureResponse.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.Response;
+
+/// <summary>
+/// ProblemDetails factories for custom view-based authorization failures (auth.md §2.4, §2.7, §2.8).
+/// </summary>
+/// <remarks>
+/// <para>
+/// §2.4 deliberately carries the bare <c>urn:ed-fi:api:security:authorization</c> type and says nothing about
+/// education organization claims: a custom view need not involve them at all, which is exactly why auth.md
+/// separates it from the §2.3 relationship wording.
+/// </para>
+/// <para>
+/// The hint is appended to every case rather than only to §2.4. auth.md describes hints as applying when a
+/// view-based check fails, and <see cref="RelationshipAuthorizationProblemDetails"/> already appends them to
+/// its uninitialized and missing-element cases, so doing otherwise would make two sibling formatters disagree
+/// about the same failure family.
+/// </para>
+/// </remarks>
+public static class CustomViewAuthorizationFailureResponse
+{
+    private const string AuthorizationType = "urn:ed-fi:api:security:authorization";
+    private const string CustomViewTypePrefix = $"{AuthorizationType}:custom-view";
+    private const string ForbiddenTitle = "Authorization Denied";
+    private const string BaseDetail = "Access to the requested data could not be authorized.";
+
+    public static JsonNode ForFailure(CustomViewAuthorizationFailure failure, TraceId traceId)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+
+        // Every planned check names at least one securable element: the terminal reference's identity paths,
+        // else the basis resource's own identity, else the basis resource name. An empty list therefore means
+        // the planner's contract was violated upstream, and no wording could describe the denial.
+        if (failure.ReadableSecurableElements.Length == 0)
+        {
+            throw new ArgumentException(
+                "Custom view authorization failures must name at least one readable securable element.",
+                nameof(failure)
+            );
+        }
+
+        return failure.FailureKind switch
+        {
+            CustomViewAuthorizationFailureKind.NoMatchingRow => ForNoMatchingRow(failure, traceId),
+            CustomViewAuthorizationFailureKind.StoredValueUninitialized => ForStoredValueUninitialized(
+                failure,
+                traceId
+            ),
+            CustomViewAuthorizationFailureKind.ProposedValueMissing => ForProposedValueMissing(
+                failure,
+                traceId
+            ),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failure),
+                failure.FailureKind,
+                "Unsupported custom view authorization failure kind."
+            ),
+        };
+    }
+
+    private static JsonNode ForNoMatchingRow(CustomViewAuthorizationFailure failure, TraceId traceId)
+    {
+        var readableNames = failure.ReadableSecurableElements;
+        var valueWord = SelectValueWord(failure.ValueSource);
+        var error =
+            readableNames.Length == 1
+                ? $"The caller is not authorized to perform the requested operation on the item based on the {valueWord} value of the '{readableNames[0]}' property of the item."
+                : $"The caller is not authorized to perform the requested operation on the item based on the {valueWord} values of one or more of the following properties of the item: {FormatNameList(readableNames)}.";
+
+        return CreateResponse(AuthorizationType, AppendHint(BaseDetail, failure.Hint), [error], traceId);
+    }
+
+    private static JsonNode ForStoredValueUninitialized(
+        CustomViewAuthorizationFailure failure,
+        TraceId traceId
+    )
+    {
+        var readableNames = failure.ReadableSecurableElements;
+        var detail =
+            readableNames.Length == 1
+                ? $"{BaseDetail} The existing '{readableNames[0]}' value is required for authorization purposes."
+                : $"{BaseDetail} The existing values of one or more of the following properties are required for authorization purposes: {FormatNameList(readableNames)}.";
+
+        return CreateResponse(
+            $"{CustomViewTypePrefix}:invalid-data:element-uninitialized",
+            AppendHint(detail, failure.Hint),
+            [
+                $"The existing resource item is inaccessible to clients using the '{failure.StrategyName}' authorization strategy.",
+            ],
+            traceId
+        );
+    }
+
+    private static JsonNode ForProposedValueMissing(CustomViewAuthorizationFailure failure, TraceId traceId)
+    {
+        var readableNames = failure.ReadableSecurableElements;
+        var detail =
+            readableNames.Length == 1
+                ? $"{BaseDetail} The '{readableNames[0]}' value is required for authorization purposes."
+                : $"{BaseDetail} The values of one or more of the following properties are required for authorization purposes: {FormatNameList(readableNames)}.";
+
+        return CreateResponse(
+            $"{CustomViewTypePrefix}:access-denied:element-required",
+            AppendHint(detail, failure.Hint),
+            [],
+            traceId
+        );
+    }
+
+    private static JsonNode CreateResponse(string type, string detail, string[] errors, TraceId traceId) =>
+        FailureResponse.CreateBaseJsonObject(
+            detail: detail,
+            type: type,
+            title: ForbiddenTitle,
+            status: 403,
+            correlationId: traceId.Value,
+            validationErrors: [],
+            errors: errors
+        );
+
+    private static string SelectValueWord(CustomViewAuthorizationFailureValueSource valueSource) =>
+        valueSource switch
+        {
+            CustomViewAuthorizationFailureValueSource.Stored => "existing",
+            CustomViewAuthorizationFailureValueSource.Proposed => "proposed",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(valueSource),
+                valueSource,
+                "Unsupported custom view authorization failure value source."
+            ),
+        };
+
+    /// <summary>
+    /// Appends the hint sentence. The hint arrives without a <c>Hint:</c> prefix — the same convention
+    /// <see cref="RelationshipAuthorizationProblemDetails"/> normalizes to — and this is where that prefix is
+    /// supplied.
+    /// </summary>
+    private static string AppendHint(string detail, string? hint) =>
+        string.IsNullOrWhiteSpace(hint) ? detail : $"{detail} Hint: {hint.Trim()}";
+
+    private static string FormatNameList(string[] readableNames) =>
+        string.Join(", ", readableNames.Select(static readableName => $"'{readableName}'"));
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/CustomViewAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/CustomViewAuthorization.feature
@@ -81,3 +81,207 @@ Feature: CustomViewAuthorization
              When a GET request is made to "/ed-fi/students"
              Then it should respond with 500
               And the response body should contain "urn:ed-fi:api:system"
+
+    Rule: Single-record custom view authorization filters by basis-resource DocumentId
+
+        The basis resource is the Student itself, so each scenario's view either contains the target
+        Student's DocumentId or contains a different Student's. The view is left non-empty on the denial
+        scenarios so a denial cannot come from an empty view instead of from the filter.
+
+        @e2e-ci-shard-3
+        Scenario: Custom view authorizes GET by id for a Student it includes
+            Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with namespacePrefixes "uri://ed-fi.org"
+             When a POST request is made to "/ed-fi/students" with
+                  """
+                  {
+                      "studentUniqueId": "604831",
+                      "firstName": "Included",
+                      "lastSurname": "Student",
+                      "birthDate": "2010-01-05"
+                  }
+                  """
+             Then it should respond with 201 or 200
+            Given a claim set is uploaded to CMS that grants "Student" access to "E2E-StudentWithCTECourseEnrollmentsClaimSet" using authorization strategy "StudentWithCTECourseEnrollments"
+              And the claim set upload to CMS should be successful
+              And the claimSet "E2E-StudentWithCTECourseEnrollmentsClaimSet" is authorized with namespace "uri://ed-fi.org" and educationOrganizationIds ""
+              And the custom auth view "StudentWithCTECourseEnrollments" authorizes Student "604831"
+             When a GET request is made to "/ed-fi/students/{id}"
+             Then it should respond with 200
+              And the record can be retrieved with a GET request
+                  """
+                  {
+                      "id": "{id}",
+                      "studentUniqueId": "604831",
+                      "firstName": "Included",
+                      "lastSurname": "Student",
+                      "birthDate": "2010-01-05"
+                  }
+                  """
+
+        @e2e-ci-shard-3 @MssqlRepresentative
+        Scenario: Custom view denies GET by id for a Student it excludes
+            Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with namespacePrefixes "uri://ed-fi.org"
+              And the system has these "students"
+                  | studentUniqueId | firstName | lastSurname | birthDate  |
+                  | "604832"        | Other     | Student     | 2010-01-06 |
+             When a POST request is made to "/ed-fi/students" with
+                  """
+                  {
+                      "studentUniqueId": "604833",
+                      "firstName": "Excluded",
+                      "lastSurname": "Student",
+                      "birthDate": "2010-01-07"
+                  }
+                  """
+             Then it should respond with 201 or 200
+            Given a claim set is uploaded to CMS that grants "Student" access to "E2E-StudentWithCTECourseEnrollmentsClaimSet" using authorization strategy "StudentWithCTECourseEnrollments"
+              And the claim set upload to CMS should be successful
+              And the claimSet "E2E-StudentWithCTECourseEnrollmentsClaimSet" is authorized with namespace "uri://ed-fi.org" and educationOrganizationIds ""
+              And the custom auth view "StudentWithCTECourseEnrollments" authorizes Student "604832"
+             When a GET request is made to "/ed-fi/students/{id}"
+             Then it should respond with 403
+              And the response body is
+                  """
+                  {
+                      "detail": "Access to the requested data could not be authorized. Hint: You may need a Student with CTE Course Enrollments.",
+                      "type": "urn:ed-fi:api:security:authorization",
+                      "title": "Authorization Denied",
+                      "status": 403,
+                      "validationErrors": {},
+                      "errors": [
+                        "The caller is not authorized to perform the requested operation on the item based on the existing value of the 'StudentUniqueId' property of the item."
+                      ]
+                  }
+                  """
+              And the response body has a non-empty correlationId
+
+        @e2e-ci-shard-3
+        Scenario: Custom view denies PUT for a Student it excludes
+            Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with namespacePrefixes "uri://ed-fi.org"
+              And the system has these "students"
+                  | studentUniqueId | firstName | lastSurname | birthDate  |
+                  | "604834"        | Other     | Student     | 2010-01-08 |
+             When a POST request is made to "/ed-fi/students" with
+                  """
+                  {
+                      "studentUniqueId": "604835",
+                      "firstName": "Excluded",
+                      "lastSurname": "Student",
+                      "birthDate": "2010-01-09"
+                  }
+                  """
+             Then it should respond with 201 or 200
+            Given a claim set is uploaded to CMS that grants "Student" access to "E2E-StudentWithCTECourseEnrollmentsClaimSet" using authorization strategy "StudentWithCTECourseEnrollments"
+              And the claim set upload to CMS should be successful
+              And the claimSet "E2E-StudentWithCTECourseEnrollmentsClaimSet" is authorized with namespace "uri://ed-fi.org" and educationOrganizationIds ""
+              And the custom auth view "StudentWithCTECourseEnrollments" authorizes Student "604834"
+             When a PUT request is made to "/ed-fi/students/{id}" with
+                  """
+                  {
+                      "id": "{id}",
+                      "studentUniqueId": "604835",
+                      "firstName": "Renamed",
+                      "lastSurname": "Student",
+                      "birthDate": "2010-01-09"
+                  }
+                  """
+             Then it should respond with 403
+              And the response body is
+                  """
+                  {
+                      "detail": "Access to the requested data could not be authorized. Hint: You may need a Student with CTE Course Enrollments.",
+                      "type": "urn:ed-fi:api:security:authorization",
+                      "title": "Authorization Denied",
+                      "status": 403,
+                      "validationErrors": {},
+                      "errors": [
+                        "The caller is not authorized to perform the requested operation on the item based on the existing value of the 'StudentUniqueId' property of the item."
+                      ]
+                  }
+                  """
+
+        @e2e-ci-shard-3
+        Scenario: Custom view denies DELETE for a Student it excludes
+            Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with namespacePrefixes "uri://ed-fi.org"
+              And the system has these "students"
+                  | studentUniqueId | firstName | lastSurname | birthDate  |
+                  | "604836"        | Other     | Student     | 2010-01-10 |
+             When a POST request is made to "/ed-fi/students" with
+                  """
+                  {
+                      "studentUniqueId": "604837",
+                      "firstName": "Excluded",
+                      "lastSurname": "Student",
+                      "birthDate": "2010-01-11"
+                  }
+                  """
+             Then it should respond with 201 or 200
+            Given a claim set is uploaded to CMS that grants "Student" access to "E2E-StudentWithCTECourseEnrollmentsClaimSet" using authorization strategy "StudentWithCTECourseEnrollments"
+              And the claim set upload to CMS should be successful
+              And the claimSet "E2E-StudentWithCTECourseEnrollmentsClaimSet" is authorized with namespace "uri://ed-fi.org" and educationOrganizationIds ""
+              And the custom auth view "StudentWithCTECourseEnrollments" authorizes Student "604836"
+             When a DELETE request is made to "/ed-fi/students/{id}"
+             Then it should respond with 403
+              And the response body is
+                  """
+                  {
+                      "detail": "Access to the requested data could not be authorized. Hint: You may need a Student with CTE Course Enrollments.",
+                      "type": "urn:ed-fi:api:security:authorization",
+                      "title": "Authorization Denied",
+                      "status": 403,
+                      "validationErrors": {},
+                      "errors": [
+                        "The caller is not authorized to perform the requested operation on the item based on the existing value of the 'StudentUniqueId' property of the item."
+                      ]
+                  }
+                  """
+
+        @e2e-ci-shard-3
+        Scenario: Custom view authorizes DELETE for a Student it includes
+            Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with namespacePrefixes "uri://ed-fi.org"
+             When a POST request is made to "/ed-fi/students" with
+                  """
+                  {
+                      "studentUniqueId": "604838",
+                      "firstName": "Deletable",
+                      "lastSurname": "Student",
+                      "birthDate": "2010-01-12"
+                  }
+                  """
+             Then it should respond with 201 or 200
+            Given a claim set is uploaded to CMS that grants "Student" access to "E2E-StudentWithCTECourseEnrollmentsClaimSet" using authorization strategy "StudentWithCTECourseEnrollments"
+              And the claim set upload to CMS should be successful
+              And the claimSet "E2E-StudentWithCTECourseEnrollmentsClaimSet" is authorized with namespace "uri://ed-fi.org" and educationOrganizationIds ""
+              And the custom auth view "StudentWithCTECourseEnrollments" authorizes Student "604838"
+             When a DELETE request is made to "/ed-fi/students/{id}"
+             Then it should respond with 204
+
+        @e2e-ci-shard-3
+        Scenario: Custom view denies POST create even when the view authorizes the same identity
+            Given a claim set is uploaded to CMS that grants "Student" access to "E2E-StudentWithCTECourseEnrollmentsClaimSet" using authorization strategy "StudentWithCTECourseEnrollments"
+              And the claim set upload to CMS should be successful
+              And the claimSet "E2E-StudentWithCTECourseEnrollmentsClaimSet" is authorized with namespace "uri://ed-fi.org" and educationOrganizationIds ""
+              And the custom auth view "StudentWithCTECourseEnrollments" authorizes Student "604839"
+             When a POST request is made to "/ed-fi/students" with
+                  """
+                  {
+                      "studentUniqueId": "604839",
+                      "firstName": "Created",
+                      "lastSurname": "Student",
+                      "birthDate": "2010-01-13"
+                  }
+                  """
+             Then it should respond with 403
+              And the response body is
+                  """
+                  {
+                      "detail": "Access to the requested data could not be authorized. Hint: You may need a Student with CTE Course Enrollments.",
+                      "type": "urn:ed-fi:api:security:authorization",
+                      "title": "Authorization Denied",
+                      "status": 403,
+                      "validationErrors": {},
+                      "errors": [
+                        "The caller is not authorized to perform the requested operation on the item based on the proposed value of the 'StudentUniqueId' property of the item."
+                      ]
+                  }
+                  """


### PR DESCRIPTION
## What

Implements the view-based (custom) authorization strategy for the single-record operations — GET-by-id, POST, PUT, and DELETE — across both regular resources and descriptors.

## Why

DMS-1062 delivered custom view-based authorization for GET-many only; every other operation failed closed with a 501. This completes the strategy so a configured `auth.{StrategyName}` view is enforced on the remaining operations rather than blocking them.

## Changes

**Contracts and payloads**
- Adds the `cv1|index|kind` AUTH1 payload family with its own codec and index space, alongside the existing relationship (`1|`) and namespace (`ns1|`) families, and routes it through the shared dispatcher. Fixes two pre-existing cross-family misclassifications where one family's mapper could claim another's payload.
- Adds single-record check specs, the `CustomViewAuthorizationFailure` contract, and a `…FailureCustomViewNotAuthorized` case on the Get, Delete, Upsert, and Update results.
- Adds the ProblemDetails responses for the three documented outcomes: bare access-denied, element-uninitialized, and element-required, each with a readable securable-element list and a generated hint.

**Planning and SQL**
- Plans stored and proposed checks for one request in a single request-wide index space, so several emitted runs can share a command without their payload indexes colliding.
- Compiles the co-batched membership SQL per dialect, correlating transitive join paths to the addressed row.

**Execution**
- Regular resources: interleaves the checks with `NamespaceBased` by CMS-configured order inside the existing composite command seams, splitting into ordered segments where the parameter budget or a claim parameterization prevents co-batching.
- Descriptors: these paths have no AUTH1 statement to carry checks, so the checks run as their own membership query — for DELETE inside the locked-target boundary on the write session's connection — sequenced in C# against that path's namespace check.
- Proposed self-basis checks are settled without SQL: a create denies after the view is validated, and an existing target is satisfied only when the paired stored check authorized the row.

**Fail-closed behavior**
- Every preflight terminal on every single-record path validates the views configured ahead of it, so a missing or non-conforming view keeps its `urn:ed-fi:api:system` 500 instead of being masked by the terminal's own response.
- Descriptor writes fail closed on a proposed check whose basis is reached through a document reference, a shape no shipped ApiSchema produces but nothing in the model builder prevents; a test pins that schema fact.
- Metadata and security-configuration failures keep `urn:ed-fi:api:system:configuration:security`; missing or invalid runtime views keep `urn:ed-fi:api:system`.

**Coverage**
- Database integration tests on PostgreSQL and SQL Server for all four operations, placed in each operation's existing authorization fixture. Update denials separate the stored from the proposed check by putting the other value inside the view, so neither can mask the other. Descriptor DELETE denial is covered on PostgreSQL for both the plain and the `If-Match` locked boundary.
- E2E scenarios for the single-record paths against the real API, claim set, and view, asserting the exact problem details. They pin that a self-basis view denies POST-create even when it authorizes the identity being created, since a view can only contain rows that already exist.

**Documentation**
- `auth.md` gains a single-record subsection for the strategy, and the write-roundtrip tables gain custom-view rows. The measured DELETE table is left as-is, with the custom-view shape described beneath it as not yet recorded.
- Aligns the no-join-path security-configuration message with `auth.md`. ODS words this failure as a missing basis-entity property on the subject entity, which presumes joining on natural keys; DMS joins on DocumentId, so the message states that instead and keeps ODS's closing question. Removes an unused, ODS-worded Core helper that duplicated the old wording.

## Notes to consider

- `OwnershipBased` remains known-but-not-enabled per DMS-1060 and still reaches its 501; custom views configured ahead of that terminal are validated first.
- This branch was rebased onto `main` after DMS-1062 was squash-merged, which dropped the duplicated DMS-1062 commits. A `range-diff` against the pre-rebase range showed all but two commits byte-identical. Only the descriptor GET-by-id commit changed materially: it now rides main's centralized `TryResolveTerminalCustomViewChecks`, with the local delta being the removal of the remaining `ReadMany` gate inside that helper plus merging the constructor dependency alongside main's ordering policy. One further commit differs by comment wording only, adopting main's text.
