### PR TITLE
[DMS-1322] Pin CDC connector key and tombstone contracts

### DIFF
--- a/reference/design/backend-redesign/design-docs/cdc/0002-kafka-topic-and-message-contract.md
+++ b/reference/design/backend-redesign/design-docs/cdc/0002-kafka-topic-and-message-contract.md
@@ -255,8 +255,12 @@ as a malformed native heartbeat. A relational table topic whose configured Debez
 source metadata rather than by topic prefix alone.
 
 Progress output preserves the input value schema, value, headers, source partition,
-source offset, and Connect record timestamp, including a null native-heartbeat value or
-value schema. It replaces only the output topic, key schema, and key.
+source offset, and Connect record timestamp for retained `dms.CdcHeartbeat` records and
+for native Debezium heartbeat records with non-null values. A native Debezium heartbeat
+whose value schema and value are both null is normalized to the non-null
+`Schema.STRING_SCHEMA` value `native-heartbeat` before routing, so the compacted progress
+topic does not receive a tombstone. Apart from that null native-heartbeat substitution,
+progress routing replaces only the output topic, key schema, and key.
 
 The progress topic is binding-scoped and has one partition, so its key does not repeat
 instance, generation, provider, or source-partition identity. The fixed non-null key makes

--- a/reference/design/backend-redesign/design-docs/cdc/0002-kafka-topic-and-message-contract.md
+++ b/reference/design/backend-redesign/design-docs/cdc/0002-kafka-topic-and-message-contract.md
@@ -257,10 +257,10 @@ source metadata rather than by topic prefix alone.
 Progress output preserves the input value schema, value, headers, source partition,
 source offset, and Connect record timestamp for retained `dms.CdcHeartbeat` records and
 for native Debezium heartbeat records with non-null values. A native Debezium heartbeat
-whose value schema and value are both null is normalized to the non-null
-`Schema.STRING_SCHEMA` value `native-heartbeat` before routing, so the compacted progress
-topic does not receive a tombstone. Apart from that null native-heartbeat substitution,
-progress routing replaces only the output topic, key schema, and key.
+whose value is null is normalized to the non-null `Schema.STRING_SCHEMA` value
+`native-heartbeat` before routing, so the compacted progress topic does not receive a
+tombstone. Apart from that null native-heartbeat substitution, progress routing replaces
+only the output topic, key schema, and key.
 
 The progress topic is binding-scoped and has one partition, so its key does not repeat
 instance, generation, provider, or source-partition identity. The fixed non-null key makes

--- a/reference/design/backend-redesign/design-docs/cdc/0002-kafka-topic-and-message-contract.md
+++ b/reference/design/backend-redesign/design-docs/cdc/0002-kafka-topic-and-message-contract.md
@@ -379,16 +379,18 @@ next second, or plain field rename is non-conforming. The transform also verifie
 emitted value exactly matches `document._lastModifiedDate`; a mismatch fails the record
 rather than publishing inconsistent metadata.
 
-For SQL Server `nvarchar(max)` source data, including `DocumentJson`, the connector pins
-Debezium 3.6's unavailable-value marker. A required retained value carrying that marker is
-a transformation failure; it is never interpreted as JSON `null` or emitted in the public
-record.
+For provider source data that Debezium can report as unavailable, including PostgreSQL
+TOAST-backed `jsonb` and SQL Server `nvarchar(max)` `DocumentJson`, the connector pins
+Debezium 3.6's unavailable-value marker. A required retained `DocumentJson` value carrying
+that marker is a transformation failure; it is never interpreted as JSON `null` or emitted
+in the public record.
 
 The transform validates every required retained `dms.DocumentCache` field against the
 pinned provider fixture schema as well as its semantic content. `DocumentJson` is a
 schema-backed Kafka Connect `STRING`: PostgreSQL `jsonb` uses Debezium's
-`io.debezium.data.Json` logical string shape, and SQL Server `nvarchar(max)` uses the
-pinned string shape plus the unavailable-marker check above. `ContentVersion` is the
+`io.debezium.data.Json` logical string shape, SQL Server `nvarchar(max)` uses the pinned
+string shape, and both provider shapes apply the required-field unavailable-marker check
+above. `ContentVersion` is the
 pinned `INT64`/Java `Long` shape. `ProjectName`, `ResourceName`, `ResourceVersion`, and
 `StreamEtag` are pinned schema-backed string fields. `LastModifiedAt` is PostgreSQL's
 pinned `io.debezium.time.ZonedTimestamp` string shape for `TIMESTAMPTZ` or SQL Server's

--- a/reference/design/backend-redesign/design-docs/cdc/cdc-streaming.md
+++ b/reference/design/backend-redesign/design-docs/cdc/cdc-streaming.md
@@ -1015,6 +1015,11 @@ the provider source-position barrier.
   validation trigger and canonical UUID uniqueness.
 - Set `dms.Document` to `REPLICA IDENTITY FULL` so its non-primary-key
   `DocumentUuid` is available in delete records.
+- Set `unavailable.value.placeholder=__debezium_unavailable_value` explicitly. Debezium
+  3.6 can use this marker when an unchanged TOAST-backed value is unavailable in an update
+  event. A retained cache upsert whose required `DocumentJson` column value equals the
+  marker fails transformation; it is never treated as JSON `null` or published as document
+  state.
 - Verify exact quoted table identifiers, `message.key.columns`, replica-identity SQL,
   and connector properties against the pinned Connect/Debezium image.
 

--- a/reference/design/backend-redesign/design-docs/cdc/cdc-streaming.md
+++ b/reference/design/backend-redesign/design-docs/cdc/cdc-streaming.md
@@ -1094,18 +1094,25 @@ Connector templates invoke the required Ed-Fi `DocumentState` SMT defined by the
 That ADR owns source and operation classification, transform configuration, public
 key/value/tombstone shaping, progress routing, malformed-record behavior, and compatibility.
 Templates and live registration use those fixed values with the pinned connector runtime.
-They also set and validate the exact public value converter path required by the ADR:
+They also set and validate the exact key converter, public value converter, and duplicate
+delete-tombstone suppression required by the ADR:
 
 ```properties
+key.converter=org.apache.kafka.connect.storage.StringConverter
 value.converter=org.edfi.kafka.connect.converters.DocumentStateJsonConverter
 value.converter.schemas.enable=false
 value.converter.decimal.format=NUMERIC
+tombstones.on.delete=false
 ```
 
-Rendering rejects missing, duplicate, or conflicting converter properties before connector
-startup, and live validation rejects drift from those exact values. Verification asserts
-final published bytes, routing, and failure behavior rather than treating generated
-connector JSON alone as evidence.
+Rendering rejects missing, duplicate, or conflicting key converter, value converter, and
+delete-tombstone properties before connector startup, and live validation rejects drift
+from those exact values. `StringConverter` preserves public document keys and internal
+progress keys as unwrapped UTF-8 strings. `tombstones.on.delete=false` keeps Debezium's
+automatic delete tombstone from adding a second source tombstone after the single
+authoritative `dms.Document` delete that `DocumentState` converts to a public tombstone.
+Verification asserts final published bytes, routing, and failure behavior rather than
+treating generated connector JSON alone as evidence.
 
 ## Contract Change and Repair Operations
 

--- a/reference/design/backend-redesign/epics/19-cdc-kafka/02-connector-template-generation.md
+++ b/reference/design/backend-redesign/epics/19-cdc-kafka/02-connector-template-generation.md
@@ -38,6 +38,10 @@ the published `DocumentState` transform.
   reject any connector configuration that includes `DocumentProjectionWork`.
 - Integrate binding-derived identity, provider setup, Kafka policy, transform, heartbeat,
   metrics, and source-offset settings owned by the design.
+- Generate and validate the exact key converter and Debezium delete-tombstone settings
+  required by the public document and progress key contracts:
+  `key.converter=org.apache.kafka.connect.storage.StringConverter` and
+  `tombstones.on.delete=false`.
 - Generate and validate the exact value-converter settings required for public document
   state publication:
   `value.converter=org.edfi.kafka.connect.converters.DocumentStateJsonConverter`,
@@ -55,6 +59,9 @@ the published `DocumentState` transform.
 
 - Rendering tests cover every generated and rejected configuration category in the design
   references.
+- Rendering and live-validation tests require the exact `StringConverter` key-converter
+  path and `tombstones.on.delete=false` for PostgreSQL and SQL Server connector templates,
+  and reject missing, duplicate, or conflicting values.
 - Rendering and live-validation tests require the exact `DocumentStateJsonConverter`
   value-converter path and the `schemas.enable=false` and `decimal.format=NUMERIC`
   delegate settings, and reject missing, duplicate, or conflicting converter properties.


### PR DESCRIPTION
## Summary
- Require generated CDC connector templates to use `StringConverter` for keys and `tombstones.on.delete=false` for Debezium delete tombstones.
- Clarify native heartbeat progress normalization so null native heartbeat values do not become compacted-topic tombstones.
- Generalize the Debezium unavailable-value marker contract for required `DocumentJson` across provider shapes.

## Testing
- Not run; documentation/template story updates only.