### PR TITLE
[DMS-1375] Add Retry-After and problem-details body to rate-limit 429 responses

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -322,6 +322,30 @@ The `RateLimit` object should have the following parameters.
 | Window      | The number of seconds before the `PermitLimit` is reset. Must be > 0.                                                                                                                                                                                                      |
 | QueueLimit  | The maximum number of requests that can be Queued once `PermitLimit`s are exhausted. These requests will wait until the `Window` expires and will be processed FIFO. When the queue is exhausted, clients will receive a `429` `Too Many Requests` response. Must be >= 0. |
 
+### Rejection response
+
+A rejected request receives a `429 Too Many Requests` response with a
+`Retry-After` header and an Ed-Fi problem-details body served as
+`application/problem+json`. `Retry-After` carries the whole number of
+seconds, rounded up, until the fixed window resets; it is omitted in the
+unusual case that the limiter supplies no retry-after metadata, and the body
+is served either way. The `correlationId` is taken from the request header
+named by `AppSettings:CorrelationIdHeader` when that setting and header are
+present, otherwise from the server-generated trace identifier — the same
+selection the API's other error responses use.
+
+```json
+{
+  "detail": "The number of allowed requests has been exceeded. Retry the request later.",
+  "type": "urn:ed-fi:api:too-many-requests",
+  "title": "Too Many Requests",
+  "status": 429,
+  "correlationId": "0HNCTN1IRQMDG:00000001",
+  "validationErrors": {},
+  "errors": []
+}
+```
+
 ## OtlpLogging
 
 CMS and DMS compile in `Serilog.Sinks.OpenTelemetry` as a single

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -326,11 +326,14 @@ The `RateLimit` object should have the following parameters.
 
 A rejected request receives a `429 Too Many Requests` response with a
 `Retry-After` header and an Ed-Fi problem-details body served as
-`application/problem+json`. `Retry-After` carries the whole number of
-seconds, rounded up, until the fixed window resets; it is omitted in the
-unusual case that the limiter supplies no retry-after metadata, and the body
-is served either way. The `correlationId` is taken from the request header
-named by `AppSettings:CorrelationIdHeader` when that setting and header are
+`application/problem+json`. `Retry-After` carries the limiter-supplied
+recommended retry delay, rounded up to whole seconds. It is a suggested
+wait, not an exact countdown to the current window's reset — queue depth
+can make the recommended delay longer than one configured `Window`. The
+header is omitted in the unusual case that the limiter supplies no
+retry-after metadata, and the body is served either way. The
+`correlationId` is taken from the request header named by
+`AppSettings:CorrelationIdHeader` when that setting and header are
 present, otherwise from the server-generated trace identifier — the same
 selection the API's other error responses use.
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/FailureResponseTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/FailureResponseTests.cs
@@ -84,6 +84,66 @@ public class Given_FailureResponse_For_Data_Conflict
 
 [TestFixture]
 [Parallelizable]
+public class Given_FailureResponse_For_Too_Many_Requests
+{
+    private static readonly TraceId _traceId = new("rate-limit-trace");
+
+    private System.Text.Json.Nodes.JsonNode _response = default!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _response = FailureResponse.ForTooManyRequests(_traceId);
+    }
+
+    [Test]
+    public void It_has_the_too_many_requests_type()
+    {
+        _response["type"]!.ToString().Should().Be("urn:ed-fi:api:too-many-requests");
+    }
+
+    [Test]
+    public void It_has_the_too_many_requests_title()
+    {
+        _response["title"]!.ToString().Should().Be("Too Many Requests");
+    }
+
+    [Test]
+    public void It_has_status_429()
+    {
+        _response["status"]!.GetValue<int>().Should().Be(429);
+    }
+
+    [Test]
+    public void It_renders_a_detail_that_does_not_depend_on_the_retry_after_header()
+    {
+        _response["detail"]!
+            .ToString()
+            .Should()
+            .Be("The number of allowed requests has been exceeded. Retry the request later.");
+    }
+
+    [Test]
+    public void It_carries_the_supplied_correlation_id()
+    {
+        _response["correlationId"]!.ToString().Should().Be(_traceId.Value);
+    }
+
+    [Test]
+    public void It_has_empty_validation_errors()
+    {
+        _response["validationErrors"]!.AsObject().Count.Should().Be(0);
+    }
+
+    [Test]
+    public void It_has_an_empty_errors_array()
+    {
+        _response["errors"]!.AsArray().Count.Should().Be(0);
+    }
+}
+
+[TestFixture]
+[Parallelizable]
 public class Given_FailureResponse_For_Security_Configuration
 {
     private static readonly TraceId _traceId = new("security-trace");

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
@@ -45,6 +45,7 @@ public static class FailureResponse
     private static readonly string _parameterValidationFailedType =
         $"{_badRequestTypePrefix}:parameter-validation-failed";
     private static readonly string _unsupportedMediaTypeType = $"{_typePrefix}:unsupported-media-type";
+    private static readonly string _tooManyRequestsType = $"{_typePrefix}:too-many-requests";
 
     internal static JsonObject CreateBaseJsonObject(
         string detail,
@@ -247,6 +248,22 @@ public static class FailureResponse
             correlationId: traceId.Value,
             validationErrors: [],
             errors: errors
+        );
+
+    /// <summary>
+    /// Produces the 429 rate-limit rejection problem details. Retry timing is carried by the
+    /// Retry-After response header when the limiter supplies it, so the body stays constant
+    /// whether or not that metadata is available.
+    /// </summary>
+    public static JsonNode ForTooManyRequests(TraceId traceId) =>
+        CreateBaseJsonObject(
+            detail: "The number of allowed requests has been exceeded. Retry the request later.",
+            type: _tooManyRequestsType,
+            title: "Too Many Requests",
+            status: 429,
+            correlationId: traceId.Value,
+            validationErrors: [],
+            errors: []
         );
 
     public static JsonNode ForUnauthorized(TraceId traceId, string error, string description) =>

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RateLimitTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RateLimitTests.cs
@@ -4,22 +4,43 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Net;
+using System.Text.Json.Nodes;
+using System.Threading.RateLimiting;
+using EdFi.DataManagementService.Frontend.AspNetCore.Configuration;
+using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit;
 
 [TestFixture]
 [NonParallelizable]
-public class RateLimitTests
+public class Given_Requests_That_Exceed_The_Configured_Rate_Limit
 {
-    [Test]
-    public async Task TestRateLimit()
+    // The TestRateLimit environment permits one request per sixty-second window. The wide
+    // window keeps every request in this fixture inside a single window, so no assertion
+    // depends on timing and nothing waits for a reset.
+    private const int ConfiguredWindowSeconds = 60;
+    private const string SuppliedCorrelationId = "supplied-correlation-id";
+
+    private WebApplicationFactory<Program> _factory = default!;
+    private HttpClient _client = default!;
+    private HttpResponseMessage _permittedResponse = default!;
+    private HttpResponseMessage _rejectedResponse = default!;
+    private HttpResponseMessage _rejectedResponseWithoutCorrelationHeader = default!;
+    private JsonNode _rejectedBody = default!;
+    private JsonNode _rejectedBodyWithoutCorrelationHeader = default!;
+
+    [OneTimeSetUp]
+    public async Task Setup()
     {
-        // Arrange
-        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
             // This environment has an extreme rate limit
             builder.UseEnvironment("TestRateLimit");
@@ -30,14 +51,241 @@ public class RateLimitTests
                 }
             );
         });
-        using var client = factory.CreateClient();
+        _client = _factory.CreateClient();
 
-        // Act
-        var response1 = await client.GetAsync("/health");
-        var response2 = await client.GetAsync("/health");
+        _permittedResponse = await _client.GetAsync("/health");
 
-        // Assert
-        response1.StatusCode.Should().Be(HttpStatusCode.OK);
-        response2.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        using var overLimitRequest = new HttpRequestMessage(HttpMethod.Get, "/health");
+        overLimitRequest.Headers.Add("correlationid", SuppliedCorrelationId);
+        _rejectedResponse = await _client.SendAsync(overLimitRequest);
+        _rejectedBody = JsonNode.Parse(await _rejectedResponse.Content.ReadAsStringAsync())!;
+
+        _rejectedResponseWithoutCorrelationHeader = await _client.GetAsync("/health");
+        _rejectedBodyWithoutCorrelationHeader = JsonNode.Parse(
+            await _rejectedResponseWithoutCorrelationHeader.Content.ReadAsStringAsync()
+        )!;
+    }
+
+    [OneTimeTearDown]
+    public async Task Teardown()
+    {
+        _permittedResponse.Dispose();
+        _rejectedResponse.Dispose();
+        _rejectedResponseWithoutCorrelationHeader.Dispose();
+        _client.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Test]
+    public void It_permits_the_first_request_in_the_window()
+    {
+        _permittedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public void It_rejects_requests_over_the_limit_with_429()
+    {
+        _rejectedResponse.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        _rejectedResponseWithoutCorrelationHeader.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    [Test]
+    public void It_serves_a_retry_after_header_in_whole_seconds_within_the_window()
+    {
+        // Delta parses only from the integer delta-seconds form, so a non-null value also
+        // pins the header format. The range assertion avoids depending on how much of the
+        // window has elapsed when the rejected request is issued.
+        TimeSpan? delta = _rejectedResponse.Headers.RetryAfter?.Delta;
+
+        delta.Should().NotBeNull();
+        delta!.Value.TotalSeconds.Should().BeGreaterThanOrEqualTo(1);
+        delta.Value.TotalSeconds.Should().BeLessThanOrEqualTo(ConfiguredWindowSeconds);
+    }
+
+    [Test]
+    public void It_serves_the_problem_json_content_type()
+    {
+        _rejectedResponse.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+        _rejectedResponse.Content.Headers.ContentType!.CharSet.Should().Be("utf-8");
+    }
+
+    [Test]
+    public void It_serves_the_too_many_requests_problem_details_envelope()
+    {
+        _rejectedBody["type"]!.ToString().Should().Be("urn:ed-fi:api:too-many-requests");
+        _rejectedBody["title"]!.ToString().Should().Be("Too Many Requests");
+        _rejectedBody["status"]!.GetValue<int>().Should().Be(429);
+        _rejectedBody["detail"]!
+            .ToString()
+            .Should()
+            .Be("The number of allowed requests has been exceeded. Retry the request later.");
+        _rejectedBody["validationErrors"]!.AsObject().Count.Should().Be(0);
+        _rejectedBody["errors"]!.AsArray().Count.Should().Be(0);
+    }
+
+    [Test]
+    public void It_echoes_the_configured_correlation_header_as_the_correlation_id()
+    {
+        _rejectedBody["correlationId"]!.ToString().Should().Be(SuppliedCorrelationId);
+    }
+
+    [Test]
+    public void It_falls_back_to_the_trace_identifier_when_no_correlation_header_is_supplied()
+    {
+        string correlationId = _rejectedBodyWithoutCorrelationHeader["correlationId"]!.ToString();
+
+        correlationId.Should().NotBeNullOrEmpty();
+        correlationId.Should().NotBe(SuppliedCorrelationId);
+    }
+
+    [Test]
+    public void It_preserves_the_security_headers_on_the_rejected_response()
+    {
+        _rejectedResponse
+            .Headers.GetValues("X-Content-Type-Options")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("nosniff");
+        _rejectedResponse
+            .Headers.GetValues("Referrer-Policy")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("no-referrer");
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_A_Rate_Limit_Rejection_Without_Retry_After_Metadata
+{
+    private const string SuppliedTraceIdentifier = "test-trace-identifier";
+
+    private DefaultHttpContext _httpContext = default!;
+    private JsonNode _body = default!;
+
+    [OneTimeSetUp]
+    public async Task Setup()
+    {
+        _httpContext = RateLimitRejectionTestContext.CreateHttpContext();
+        _httpContext.TraceIdentifier = SuppliedTraceIdentifier;
+
+        await WebApplicationBuilderExtensions.WriteRateLimitRejectionAsync(
+            new OnRejectedContext
+            {
+                HttpContext = _httpContext,
+                Lease = new RateLimitRejectionTestContext.StubLease(retryAfter: null),
+            },
+            CancellationToken.None
+        );
+
+        _body = await RateLimitRejectionTestContext.ReadBody(_httpContext);
+    }
+
+    [Test]
+    public void It_does_not_set_a_retry_after_header()
+    {
+        _httpContext.Response.Headers.ContainsKey("Retry-After").Should().BeFalse();
+    }
+
+    [Test]
+    public void It_sets_the_problem_json_content_type()
+    {
+        _httpContext.Response.ContentType.Should().Be("application/problem+json; charset=utf-8");
+    }
+
+    [Test]
+    public void It_still_writes_the_too_many_requests_problem_details_body()
+    {
+        _body["type"]!.ToString().Should().Be("urn:ed-fi:api:too-many-requests");
+        _body["status"]!.GetValue<int>().Should().Be(429);
+        _body["correlationId"]!.ToString().Should().Be(SuppliedTraceIdentifier);
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_A_Rate_Limit_Rejection_With_Sub_Second_Retry_After_Metadata
+{
+    private DefaultHttpContext _httpContext = default!;
+
+    [OneTimeSetUp]
+    public async Task Setup()
+    {
+        _httpContext = RateLimitRejectionTestContext.CreateHttpContext();
+
+        await WebApplicationBuilderExtensions.WriteRateLimitRejectionAsync(
+            new OnRejectedContext
+            {
+                HttpContext = _httpContext,
+                Lease = new RateLimitRejectionTestContext.StubLease(
+                    retryAfter: TimeSpan.FromMilliseconds(200)
+                ),
+            },
+            CancellationToken.None
+        );
+    }
+
+    [Test]
+    public void It_rounds_the_retry_after_header_up_to_one_second()
+    {
+        _httpContext.Response.Headers.RetryAfter.ToString().Should().Be("1");
+    }
+}
+
+/// <summary>
+/// Builds the minimal HttpContext the rejection handler needs (request services carrying the
+/// frontend AppSettings options and a readable response body), plus a lease stub whose
+/// retry-after metadata can be present or absent.
+/// </summary>
+internal static class RateLimitRejectionTestContext
+{
+    public static DefaultHttpContext CreateHttpContext()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(
+            Options.Create(
+                new AppSettings
+                {
+                    AuthenticationService = "http://test-auth-service",
+                    Datastore = "postgresql",
+                    CorrelationIdHeader = "",
+                }
+            )
+        );
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            Response = { Body = new MemoryStream() },
+        };
+    }
+
+    public static async Task<JsonNode> ReadBody(DefaultHttpContext httpContext)
+    {
+        httpContext.Response.Body.Position = 0;
+        using var reader = new StreamReader(httpContext.Response.Body);
+        return JsonNode.Parse(await reader.ReadToEndAsync())!;
+    }
+
+    public sealed class StubLease(TimeSpan? retryAfter) : RateLimitLease
+    {
+        public override bool IsAcquired => false;
+
+        public override IEnumerable<string> MetadataNames =>
+            retryAfter is null ? [] : [MetadataName.RetryAfter.Name];
+
+        public override bool TryGetMetadata(string metadataName, out object? metadata)
+        {
+            if (retryAfter is not null && metadataName == MetadataName.RetryAfter.Name)
+            {
+                metadata = retryAfter.Value;
+                return true;
+            }
+
+            metadata = null;
+            return false;
+        }
     }
 }

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RateLimitTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RateLimitTests.cs
@@ -234,6 +234,36 @@ public class Given_A_Rate_Limit_Rejection_With_Sub_Second_Retry_After_Metadata
     }
 }
 
+[TestFixture]
+[Parallelizable]
+public class Given_A_Rate_Limit_Rejection_With_Multi_Window_Retry_After_Metadata
+{
+    private DefaultHttpContext _httpContext = default!;
+
+    [OneTimeSetUp]
+    public async Task Setup()
+    {
+        // Queued demand can make the limiter recommend a delay spanning several configured
+        // windows; the handler must serve that recommendation rather than clamp it to one window.
+        _httpContext = RateLimitRejectionTestContext.CreateHttpContext();
+
+        await WebApplicationBuilderExtensions.WriteRateLimitRejectionAsync(
+            new OnRejectedContext
+            {
+                HttpContext = _httpContext,
+                Lease = new RateLimitRejectionTestContext.StubLease(retryAfter: TimeSpan.FromSeconds(90.4)),
+            },
+            CancellationToken.None
+        );
+    }
+
+    [Test]
+    public void It_serves_the_recommended_delay_rounded_up_as_the_retry_after_header()
+    {
+        _httpContext.Response.Headers.RetryAfter.ToString().Should().Be("91");
+    }
+}
+
 /// <summary>
 /// Builds the minimal HttpContext the rejection handler needs (request services carrying the
 /// frontend AppSettings options and a readable response body), plus a lease stub whose

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -3,7 +3,9 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Globalization;
 using System.Net;
+using System.Text.Json;
 using System.Threading.RateLimiting;
 using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
@@ -15,10 +17,12 @@ using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.DocumentCache;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.OAuth;
+using EdFi.DataManagementService.Core.Response;
 using EdFi.DataManagementService.Core.Security;
 using EdFi.DataManagementService.Core.Startup;
 using EdFi.DataManagementService.Frontend.AspNetCore.Configuration;
 using EdFi.DataManagementService.Frontend.AspNetCore.Content;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Serilog;
@@ -344,6 +348,7 @@ public static class WebApplicationBuilderExtensions
         webAppBuilder.Services.AddRateLimiter(limiterOptions =>
         {
             limiterOptions.RejectionStatusCode = (int)HttpStatusCode.TooManyRequests;
+            limiterOptions.OnRejected = WriteRateLimitRejectionAsync;
             limiterOptions.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
                 RateLimitPartition.GetFixedWindowLimiter(
                     partitionKey: httpContext.Request.Headers.Host.ToString(),
@@ -356,6 +361,43 @@ public static class WebApplicationBuilderExtensions
                 )
             );
         });
+    }
+
+    /// <summary>
+    /// Serves the rejection produced by the rate limiter middleware, which applies
+    /// RejectionStatusCode before invoking this callback. Rejected requests never reach the DMS
+    /// core pipeline, so the Retry-After header and the problem-details body are written at this
+    /// boundary. The Retry-After value rounds up to whole seconds so a client never retries
+    /// before the window resets, and the body stays constant whether or not the limiter
+    /// supplies retry-after metadata.
+    /// </summary>
+    internal static async ValueTask WriteRateLimitRejectionAsync(
+        OnRejectedContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        HttpContext httpContext = context.HttpContext;
+
+        if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan retryAfter))
+        {
+            httpContext.Response.Headers.RetryAfter = ((int)Math.Ceiling(retryAfter.TotalSeconds)).ToString(
+                CultureInfo.InvariantCulture
+            );
+        }
+
+        var appSettings = httpContext.RequestServices.GetRequiredService<
+            IOptions<Frontend.AspNetCore.Configuration.AppSettings>
+        >();
+        var traceId = AspNetCoreFrontend.ExtractTraceIdFrom(httpContext.Request, appSettings);
+
+        httpContext.Response.ContentType = "application/problem+json; charset=utf-8";
+        await httpContext.Response.WriteAsync(
+            JsonSerializer.Serialize(
+                FailureResponse.ForTooManyRequests(traceId),
+                AspNetCoreFrontend.SharedSerializerOptions
+            ),
+            cancellationToken
+        );
     }
 
     private static void AddMssqlRelationalRuntimeServices(

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -367,9 +367,9 @@ public static class WebApplicationBuilderExtensions
     /// Serves the rejection produced by the rate limiter middleware, which applies
     /// RejectionStatusCode before invoking this callback. Rejected requests never reach the DMS
     /// core pipeline, so the Retry-After header and the problem-details body are written at this
-    /// boundary. The Retry-After value rounds up to whole seconds so a client never retries
-    /// before the window resets, and the body stays constant whether or not the limiter
-    /// supplies retry-after metadata.
+    /// boundary. The Retry-After value is the limiter's recommended retry delay rounded up to
+    /// whole seconds so a client never retries sooner than recommended, and the body stays
+    /// constant whether or not the limiter supplies retry-after metadata.
     /// </summary>
     internal static async ValueTask WriteRateLimitRejectionAsync(
         OnRejectedContext context,

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/appsettings.TestRateLimit.json
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/appsettings.TestRateLimit.json
@@ -2,7 +2,8 @@
     "AppSettings": {
         "AuthenticationService": "http://dev-test-auth-service",
         "UseApiSchemaPath": false,
-        "BypassAuthorization": true
+        "BypassAuthorization": true,
+        "CorrelationIdHeader": "correlationid"
     },
     "JwtAuthentication": {
         "MetadataAddress": "http://test-idp/.well-known/openid-configuration",
@@ -10,7 +11,7 @@
     },
     "RateLimit": {
         "PermitLimit": 1,
-        "Window": 5,
+        "Window": 60,
         "QueueLimit": 0
     },
     "ConfigurationServiceSettings": {


### PR DESCRIPTION
## What
Adds `Retry-After` and an Ed-Fi problem-details body to DMS rate-limit 429 responses.

## Why
Rejected requests currently return an empty 429 without retry guidance, which leaves SDK and integrator clients without a standard pacing signal or error contract.

## Changes
- Added `FailureResponse.ForTooManyRequests` using the standard Ed-Fi problem-details envelope.
- Wired the ASP.NET Core rate limiter `OnRejected` handler to emit `Retry-After`, problem JSON, and canonical correlation IDs.
- Expanded rate-limit tests to assert headers, content type, body shape, correlation behavior, security headers, missing metadata, and sub-second rounding.
- Documented the settled rate-limit rejection response in `docs/CONFIGURATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)