### PR TITLE
[DMS-1386] Cursor execution

### DIFF
--- a/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
+++ b/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
@@ -101,7 +101,7 @@ rule it governs.
 
 | Input/output | Contract |
 | --- | --- |
-| `Next-Page-Token` response header | Included whenever regular-resource or descriptor GET-many page selection produces a non-null `HighestSelectedDocumentId`, including on a `limit`/`offset` response that can begin a cursor walk and when concurrent deletes leave the hydrated response body empty. Absent when page selection is skipped or selects no keys, and at `Int64.MaxValue` where advancing would overflow. |
+| `Next-Page-Token` response header | Included whenever regular-resource or descriptor GET-many page selection produces a non-null `HighestSelectedDocumentId` and orders the page by `DocumentId`, including on a `limit`/`offset` response that can begin a cursor walk and when concurrent deletes leave the hydrated response body empty. Cursor page selection always orders by `DocumentId`; traditional page selection over a max-bearing change-version window orders by `ContentVersion`, so such a page carries no token until DMS-1394 gives it a `ContentVersion` anchor — see "Consistency Under Writes" below. Absent when page selection is skipped or selects no keys, and at `Int64.MaxValue` where advancing would overflow. |
 | `pageToken` | Selects the next inclusive `DocumentId` range. It is opaque to clients and is normally copied from `Next-Page-Token` or from a `/partitions` response. |
 | `pageSize` | Optional, and permitted only when `pageToken` is present; integer `0..MaximumPageSize`. When omitted, the configured `MaximumPageSize` applies — initially `500`, matching the existing default GET-many size. |
 | `limit`, `offset` | Remain supported for traditional paging. When `limit` is omitted, the configured `MaximumPageSize` applies. Neither parameter may be combined with `pageToken` or `pageSize`, including when its value is zero. |
@@ -116,11 +116,13 @@ first accessible candidate.
 
 Emitting `Next-Page-Token` on an ordinary `limit`/`offset` response is a deliberate extension: it
 lets a client enter a cursor walk without a separate call, and it is inert for clients that ignore
-it. The published guidance does not describe the header for traditional responses, and the
+it. The extension reaches every traditional response whose page selection ordered by `DocumentId`;
+a max-bearing change-version window orders by `ContentVersion` and so cannot yet be entered this
+way. The published guidance does not describe the header for traditional responses, and the
 authoritative collection fixtures do not define it as a response header.
 
 **Ending a walk.** The implementation does not fetch one extra row to predict the terminal page. It
-emits a token whenever page selection returns a non-empty keyset, and completion is normally
+emits a token whenever cursor page selection returns a non-empty keyset, and completion is normally
 discovered by the next request returning an empty keyset and no token. Consequently the last useful
 page is followed by one empty request. Predicting termination would require either an extra fetched
 row on every page or a count query, and both cost more across a full walk than one trailing empty

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/HydrationContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/HydrationContracts.cs
@@ -112,7 +112,8 @@ public sealed record HydratedPage(
     /// hydration completes, so this can be non-null while the body is empty. A body-derived boundary
     /// would stall a cursor walk on the last surviving document, or stop it entirely on an empty body.
     /// Populated from the ids the query keyset materialization returned; always null for a
-    /// <see cref="PageKeysetSpec.Single"/> keyset, which selects nothing.
+    /// <see cref="PageKeysetSpec.Single"/> keyset, which performs no page selection because it
+    /// materializes a caller-supplied id.
     /// </remarks>
     public long? HighestSelectedDocumentId { get; init; }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/HydrationContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/HydrationContracts.cs
@@ -111,7 +111,8 @@ public sealed record HydratedPage(
     /// Deliberately independent of the hydrated body: every selected row may be deleted before
     /// hydration completes, so this can be non-null while the body is empty. A body-derived boundary
     /// would stall a cursor walk on the last surviving document, or stop it entirely on an empty body.
-    /// Populated by hydration execution in a later story.
+    /// Populated from the ids the query keyset materialization returned; always null for a
+    /// <see cref="PageKeysetSpec.Single"/> keyset, which selects nothing.
     /// </remarks>
     public long? HighestSelectedDocumentId { get; init; }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/HydrationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/HydrationExecutorTests.cs
@@ -785,3 +785,278 @@ public class Given_A_Reference_Bearing_Resource_Mssql
         await cmd.ExecuteNonQueryAsync();
     }
 }
+
+/// <summary>
+/// The keyset materialization's <c>OUTPUT INSERTED</c> clause carries the selected page keyset out of
+/// hydration on the same command that hydrates it. These cases run the real batch against SQL Server,
+/// because the clause is only valid if the server accepts it.
+/// </summary>
+[TestFixture]
+[Category(MssqlCiShards.Shard4)]
+public class Given_A_Mssql_Query_Keyset_That_Returns_Its_Selected_Ids
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+
+    private const string TestSchema = "hydselected";
+
+    /// <summary>
+    /// Sparse ids, so a maximum cannot be confused with a count or a row position.
+    /// </summary>
+    private const long FirstDocumentId = 501L;
+    private const long SecondDocumentId = 509L;
+    private const long ThirdDocumentId = 517L;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("MSSQL connection string not configured.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        await ExecuteSql(
+            connection,
+            """
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'dms') EXEC('CREATE SCHEMA [dms]');
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'hydselected') EXEC('CREATE SCHEMA [hydselected]');
+
+            CREATE TABLE dms.Document (
+                DocumentId bigint PRIMARY KEY,
+                DocumentUuid uniqueidentifier NOT NULL,
+                ResourceKeyId smallint NOT NULL DEFAULT 0,
+                ContentVersion bigint NOT NULL DEFAULT 1,
+                IdentityVersion bigint NOT NULL DEFAULT 1,
+                ContentLastModifiedAt datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                IdentityLastModifiedAt datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                CreatedAt datetimeoffset NOT NULL DEFAULT sysdatetimeoffset()
+            );
+
+            CREATE TABLE hydselected.School (
+                DocumentId bigint PRIMARY KEY,
+                SchoolId int NOT NULL
+            );
+
+            CREATE TABLE hydselected.SchoolAddress (
+                CollectionItemId bigint PRIMARY KEY,
+                School_DocumentId bigint NOT NULL REFERENCES hydselected.School(DocumentId),
+                Ordinal int NOT NULL,
+                City varchar(100) NOT NULL
+            );
+
+            CREATE TABLE hydselected.SchoolAddressPeriod (
+                CollectionItemId bigint PRIMARY KEY,
+                School_DocumentId bigint NOT NULL,
+                ParentCollectionItemId bigint NOT NULL REFERENCES hydselected.SchoolAddress(CollectionItemId),
+                Ordinal int NOT NULL,
+                BeginDate varchar(10) NOT NULL
+            );
+            """
+        );
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        await ExecuteSql(
+            connection,
+            """
+            DELETE FROM hydselected.SchoolAddressPeriod;
+            DELETE FROM hydselected.SchoolAddress;
+            DELETE FROM hydselected.School;
+            DELETE FROM dms.Document;
+
+            INSERT INTO dms.Document (DocumentId, DocumentUuid)
+            VALUES
+                (501, '22222222-8888-8888-8888-222222222222'),
+                (509, '33333333-9999-9999-9999-333333333333'),
+                (517, '44444444-aaaa-aaaa-aaaa-444444444444');
+
+            INSERT INTO hydselected.School (DocumentId, SchoolId)
+            VALUES (501, 910001), (509, 910002), (517, 910003);
+            """
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public async Task It_returns_the_maximum_selected_document_id_for_a_cursor_page()
+    {
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            connection,
+            HydrationTestHelper.BuildSchoolReadPlan(TestSchema, SqlDialect.Mssql),
+            CreateCursorKeyset(pageSize: 2L),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        result.HighestSelectedDocumentId.Should().Be(SecondDocumentId);
+        result
+            .DocumentMetadata.Select(static documentMetadata => documentMetadata.DocumentId)
+            .Should()
+            .Equal(FirstDocumentId, SecondDocumentId);
+    }
+
+    [Test]
+    public async Task It_returns_no_maximum_for_a_zero_size_cursor_page()
+    {
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            connection,
+            HydrationTestHelper.BuildSchoolReadPlan(TestSchema, SqlDialect.Mssql),
+            CreateCursorKeyset(pageSize: 0L),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        result.HighestSelectedDocumentId.Should().BeNull();
+        result.DocumentMetadata.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_returns_no_maximum_when_the_range_selects_nothing()
+    {
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            connection,
+            HydrationTestHelper.BuildSchoolReadPlan(TestSchema, SqlDialect.Mssql),
+            CreateCursorKeyset(pageSize: 25L, inclusiveMinimum: 600L, inclusiveMaximum: 700L),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        result.HighestSelectedDocumentId.Should().BeNull();
+        result.DocumentMetadata.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Deletes every selected row inside the hydration batch, between the materialization that
+    /// selected them and the hydration selects that follow it. This is a deterministic stand-in for a
+    /// delete that commits in that same window — not a separate concurrent transaction — and it is the
+    /// case a body-derived boundary would answer wrongly by stalling the walk.
+    /// </summary>
+    [Test]
+    public async Task It_returns_the_maximum_when_every_selected_row_was_deleted_before_hydration()
+    {
+        const string SpliceAfter = "SELECT [DocumentId] FROM page_ids;";
+        const string DeleteEverySelectedRow = """
+
+            DELETE FROM hydselected.SchoolAddressPeriod;
+            DELETE FROM hydselected.SchoolAddress;
+            DELETE FROM hydselected.School;
+            DELETE FROM dms.Document;
+            """;
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+        var splicedBatches = new List<string>();
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            batchSql =>
+            {
+                CountOccurrences(batchSql, SpliceAfter)
+                    .Should()
+                    .Be(
+                        1,
+                        "the materialization statement is the splice point, so it must appear exactly once"
+                    );
+
+                var splicedBatch = batchSql.Replace(
+                    SpliceAfter,
+                    SpliceAfter + DeleteEverySelectedRow,
+                    StringComparison.Ordinal
+                );
+                splicedBatches.Add(splicedBatch);
+
+                var command = connection.CreateCommand();
+                command.CommandText = splicedBatch;
+                return command;
+            },
+            HydrationTestHelper.BuildSchoolReadPlan(TestSchema, SqlDialect.Mssql),
+            CreateCursorKeyset(pageSize: 25L),
+            SqlDialect.Mssql,
+            new HydrationExecutionOptions(),
+            CancellationToken.None
+        );
+
+        splicedBatches.Should().ContainSingle();
+        result.HighestSelectedDocumentId.Should().Be(ThirdDocumentId);
+        result.DocumentMetadata.Should().BeEmpty();
+        result.TableRowsInDependencyOrder.Should().OnlyContain(tableRows => tableRows.Rows.Count == 0);
+    }
+
+    private static PageKeysetSpec.Query CreateCursorKeyset(
+        object pageSize,
+        long inclusiveMinimum = 1L,
+        long inclusiveMaximum = long.MaxValue
+    ) =>
+        new(
+            new PageDocumentIdSqlPlan(
+                PageDocumentIdSql: """
+                SELECT TOP (@pageSize) DocumentId FROM hydselected.School
+                WHERE DocumentId >= @cursorMin
+                  AND DocumentId <= @cursorMax
+                ORDER BY DocumentId
+                """,
+                TotalCountSql: null,
+                PageParametersInOrder:
+                [
+                    new QuerySqlParameter(QuerySqlParameterRole.CursorInclusiveMinimum, "cursorMin"),
+                    new QuerySqlParameter(QuerySqlParameterRole.CursorInclusiveMaximum, "cursorMax"),
+                    new QuerySqlParameter(QuerySqlParameterRole.PageSize, "pageSize"),
+                ],
+                TotalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?>
+            {
+                ["cursorMin"] = inclusiveMinimum,
+                ["cursorMax"] = inclusiveMaximum,
+                ["pageSize"] = pageSize,
+            }
+        );
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var occurrences = 0;
+        var searchIndex = text.IndexOf(value, StringComparison.Ordinal);
+
+        while (searchIndex >= 0)
+        {
+            occurrences++;
+            searchIndex = text.IndexOf(value, searchIndex + value.Length, StringComparison.Ordinal);
+        }
+
+        return occurrences;
+    }
+
+    private static async Task ExecuteSql(SqlConnection connection, string sql)
+    {
+        await using var cmd = new SqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
@@ -23,6 +23,39 @@ using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
 
+internal sealed class DescriptorCommandRecorder
+{
+    private readonly List<string> _commandTexts = [];
+
+    public IReadOnlyList<string> CommandTexts => _commandTexts;
+
+    public void Reset() => _commandTexts.Clear();
+
+    public void Record(RelationalCommand command) => _commandTexts.Add(command.CommandText);
+}
+
+/// <summary>
+/// Records the descriptor page commands the real provider executor ran, so a test can prove a cursor
+/// page cost exactly one command and asked for no count rather than inferring it from a null TotalCount.
+/// </summary>
+internal sealed class RecordingDescriptorCommandExecutor(
+    MssqlRelationalCommandExecutor inner,
+    DescriptorCommandRecorder recorder
+) : IRelationalCommandExecutor
+{
+    public SqlDialect Dialect => inner.Dialect;
+
+    public Task<TResult> ExecuteReaderAsync<TResult>(
+        RelationalCommand command,
+        Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+        CancellationToken cancellationToken = default
+    )
+    {
+        recorder.Record(command);
+        return inner.ExecuteReaderAsync(command, readAsync, cancellationToken);
+    }
+}
+
 [TestFixture]
 [NonParallelizable]
 [Category("DatabaseIntegration")]
@@ -540,6 +573,14 @@ public class Given_A_Mssql_DescriptorRead_Query_Request
         services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
         services.AddTestReadableProfileProjector();
         services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddSingleton<DescriptorCommandRecorder>();
+        services.AddScoped<MssqlRelationalCommandExecutor>();
+        services.AddScoped<IRelationalCommandExecutor>(
+            serviceProvider => new RecordingDescriptorCommandExecutor(
+                serviceProvider.GetRequiredService<MssqlRelationalCommandExecutor>(),
+                serviceProvider.GetRequiredService<DescriptorCommandRecorder>()
+            )
+        );
         services.AddMssqlBackendIntegrationTestServices();
 
         return services.BuildServiceProvider(
@@ -749,6 +790,161 @@ public class Given_A_Mssql_DescriptorRead_Query_Request
 
         success.HighestSelectedDocumentId.Should().BeNull();
         success.EdfiDocs.Should().BeEmpty();
+    }
+
+    // The story requires real-provider descriptor evidence for the predicates a cursor page composes
+    // with, not only for the unfiltered walk. A filter reaching the descriptor candidate relation
+    // alongside the range is what keeps a filtered walk from returning documents the filter excludes.
+    [Test]
+    public async Task It_composes_a_descriptor_query_filter_with_the_cursor_range()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [CreateQueryElement("codeValue", "$.codeValue", PagingSecondSeed.CodeValue)],
+                "mssql-descriptor-cursor-filter",
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+        success.EdfiDocs.Should().ContainSingle();
+        AssertDescriptorDocument(success.EdfiDocs[0]!.AsObject(), PagingSecondSeed);
+        success.HighestSelectedDocumentId.Should().NotBeNull();
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    // A min-only window keeps DocumentId ordering, so a cursor page inside it continues normally.
+    [Test]
+    public async Task It_composes_a_min_only_change_version_window_with_the_descriptor_cursor_range()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+        var contentVersions = await ReadDescriptorContentVersionsByDocumentUuidAsync();
+        var lowestContentVersion = contentVersions.Values.Min();
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "mssql-descriptor-cursor-min-window",
+                changeVersionRange: new ChangeVersionRange(lowestContentVersion, null),
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+        success.EdfiDocs.Should().HaveCount(PagingDescriptorSeeds.Length);
+        success.HighestSelectedDocumentId.Should().NotBeNull();
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    // A window that excludes every descriptor selects nothing, so the page carries no boundary: the
+    // change-version predicate really reaches the cursor candidate relation rather than being dropped.
+    [Test]
+    public async Task It_composes_an_excluding_change_version_window_with_the_descriptor_cursor_range()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+        var contentVersions = await ReadDescriptorContentVersionsByDocumentUuidAsync();
+        var highestContentVersion = contentVersions.Values.Max();
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "mssql-descriptor-cursor-excluding-window",
+                changeVersionRange: new ChangeVersionRange(highestContentVersion + 1, null),
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+        success.EdfiDocs.Should().BeEmpty();
+        success.HighestSelectedDocumentId.Should().BeNull();
+    }
+
+    // A max-bearing window still leaves a cursor page ordered by DocumentId, so its selected maximum can
+    // anchor a continuation. A traditional page over the same window cannot, and that contrast is the
+    // interim suppression rule observed on a real descriptor query.
+    [Test]
+    public async Task It_composes_a_max_bearing_change_version_window_with_the_descriptor_cursor_range()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+        var contentVersions = await ReadDescriptorContentVersionsByDocumentUuidAsync();
+        var highestContentVersion = contentVersions.Values.Max();
+
+        var cursorSuccess = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "mssql-descriptor-cursor-max-window",
+                changeVersionRange: new ChangeVersionRange(null, highestContentVersion),
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+        cursorSuccess.EdfiDocs.Should().HaveCount(PagingDescriptorSeeds.Length);
+        cursorSuccess.HighestSelectedDocumentId.Should().NotBeNull();
+        cursorSuccess.AllowsDocumentIdContinuation.Should().BeTrue();
+
+        var traditionalSuccess = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "mssql-descriptor-traditional-max-window",
+                changeVersionRange: new ChangeVersionRange(null, highestContentVersion)
+            );
+
+        traditionalSuccess.HighestSelectedDocumentId.Should().NotBeNull();
+        traditionalSuccess.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task It_selects_the_whole_descriptor_collection_at_the_configured_maximum_page_size()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "mssql-descriptor-cursor-size-max",
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(MaximumPageSize))
+            );
+
+        success.EdfiDocs.Should().HaveCount(PagingDescriptorSeeds.Length);
+        success.HighestSelectedDocumentId.Should().NotBeNull();
+    }
+
+    // Observed at the provider command seam rather than inferred from a null TotalCount: a descriptor
+    // cursor page runs exactly one command, and that command asks for no count. A second roundtrip or a
+    // count would break the single-command invariant without changing any response value.
+    [Test]
+    public async Task It_runs_one_descriptor_command_with_no_count_for_a_cursor_page()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var recorder = _serviceProvider.GetRequiredService<DescriptorCommandRecorder>();
+        recorder.Reset();
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "mssql-descriptor-cursor-command-shape",
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(2))
+            );
+
+        success.EdfiDocs.Should().HaveCount(2);
+        recorder.CommandTexts.Should().ContainSingle("a cursor page must not add a command or a roundtrip");
+        recorder.CommandTexts[0].Should().NotContain("COUNT");
+        recorder.CommandTexts[0].Should().Contain("@cursorMin");
+        recorder.CommandTexts[0].Should().Contain("@cursorMax");
+        recorder.CommandTexts[0].Should().Contain("@pageSize");
+        recorder.CommandTexts[0].Should().NotContain("@offset");
+    }
+
+    // The traditional counterpart does compile count SQL when asked, so the assertion above is a property
+    // of cursor mode rather than of this fixture never counting at all.
+    [Test]
+    public async Task It_still_counts_for_a_traditional_descriptor_page_when_requested()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var recorder = _serviceProvider.GetRequiredService<DescriptorCommandRecorder>();
+        recorder.Reset();
+
+        await ExecuteQueryAsync([], "mssql-descriptor-traditional-command-shape", totalCount: true);
+
+        recorder.CommandTexts.Should().ContainSingle();
+        recorder.CommandTexts[0].Should().Contain("COUNT");
     }
 
     private static void AssertDescriptorPage(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
@@ -604,7 +604,8 @@ public class Given_A_Mssql_DescriptorRead_Query_Request
         int limit = 25,
         int offset = 0,
         ChangeVersionRange? changeVersionRange = null,
-        AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null
+        AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null,
+        CollectionPaging? paging = null
     )
     {
         await using var scope = _serviceProvider.CreateAsyncScope();
@@ -616,14 +617,15 @@ public class Given_A_Mssql_DescriptorRead_Query_Request
             MappingSet: _mappingSet,
             QueryElements: queryElements,
             AuthorizationStrategyEvaluators: authorizationStrategyEvaluators ?? [],
-            Paging: new CollectionPaging.Traditional(
-                new PaginationParameters(
-                    Limit: limit,
-                    Offset: offset,
-                    TotalCount: totalCount,
-                    MaximumPageSize: MaximumPageSize
-                )
-            ),
+            Paging: paging
+                ?? new CollectionPaging.Traditional(
+                    new PaginationParameters(
+                        Limit: limit,
+                        Offset: offset,
+                        TotalCount: totalCount,
+                        MaximumPageSize: MaximumPageSize
+                    )
+                ),
             TraceId: new TraceId(traceId),
             ChangeVersionRange: changeVersionRange
         );
@@ -685,6 +687,68 @@ public class Given_A_Mssql_DescriptorRead_Query_Request
     private static void AssertSingleDescriptorMatch(QueryResult result, DescriptorReadSeed expectedSeed)
     {
         AssertDescriptorPage(result, [expectedSeed]);
+    }
+
+    // A descriptor cursor walk against a real database. Descriptor selection and row retrieval are one
+    // statement, so the boundary each page reports is the maximum of the keys that statement selected,
+    // and following it must deliver every seeded descriptor exactly once before the walk ends empty.
+    [Test]
+    public async Task It_walks_descriptor_pages_by_cursor()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        List<string> walkedDocumentUuids = [];
+        var range = CursorRange.From(1);
+        var pages = 0;
+
+        while (pages++ < PagingDescriptorSeeds.Length + 1)
+        {
+            var success = (QueryResult.QuerySuccess)
+                await ExecuteQueryAsync(
+                    [],
+                    "mssql-descriptor-cursor-walk",
+                    paging: new CollectionPaging.Cursor(range, new PageSize(2))
+                );
+
+            // Cursor mode asks for no count on any page of the walk.
+            success.TotalCount.Should().BeNull();
+
+            walkedDocumentUuids.AddRange(
+                success.EdfiDocs.Select(document => document!["id"]!.GetValue<string>())
+            );
+
+            if (success.HighestSelectedDocumentId is not { } highestSelectedDocumentId)
+            {
+                success.EdfiDocs.Should().BeEmpty("the page that ends a walk selects nothing");
+                break;
+            }
+
+            success.AllowsDocumentIdContinuation.Should().BeTrue();
+            range = new CursorRange(highestSelectedDocumentId + 1, range.InclusiveMaximum);
+        }
+
+        string[] expectedDocumentUuids =
+        [
+            .. PagingDescriptorSeeds.Select(seed => seed.DocumentUuid.Value.ToString()),
+        ];
+
+        walkedDocumentUuids.Should().Equal(expectedDocumentUuids.AsEnumerable());
+    }
+
+    [Test]
+    public async Task It_selects_no_descriptor_page_at_a_zero_cursor_page_size()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "mssql-descriptor-cursor-size-0",
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(0))
+            );
+
+        success.HighestSelectedDocumentId.Should().BeNull();
+        success.EdfiDocs.Should().BeEmpty();
     }
 
     private static void AssertDescriptorPage(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
@@ -703,6 +703,235 @@ public class Given_A_Mssql_Relational_Query_With_The_Authoritative_Sample_School
         walkedDocumentUuids.Should().Equal(expectedProgression);
     }
 
+    // A cursor walk over the seeded collection: each page selects from the range the previous page's
+    // boundary opened, and the walk ends on a page that selects nothing. Every document is returned
+    // exactly once, which is the property a client depends on and the one an off-by-one boundary breaks.
+    [Test]
+    public async Task It_walks_every_document_exactly_once_across_cursor_pages()
+    {
+        var expectedDocumentIds = _persistedSchoolsInDocumentOrder
+            .Select(static school => school.DocumentId)
+            .ToArray();
+
+        List<long> walkedDocumentIds = [];
+        var range = CursorRange.From(1);
+        var pageCount = 0;
+
+        while (pageCount++ < expectedDocumentIds.Length + 1)
+        {
+            _recorder.Reset();
+            var success = (QueryResult.QuerySuccess)
+                await ExecuteCursorQueryAsync(range, pageSize: 2, traceId: $"mssql-cursor-walk-{pageCount}");
+
+            // One command per page, and no count SQL on any of them.
+            var keyset = AssertSingleQueryHydration();
+            keyset.Plan.TotalCountSql.Should().BeNull();
+            success.TotalCount.Should().BeNull();
+
+            walkedDocumentIds.AddRange(_recorder.PageMaterializedDocumentIds);
+
+            if (success.HighestSelectedDocumentId is not { } highestSelectedDocumentId)
+            {
+                success.EdfiDocs.Should().BeEmpty();
+                break;
+            }
+
+            success.AllowsDocumentIdContinuation.Should().BeTrue();
+            range = new CursorRange(highestSelectedDocumentId + 1, range.InclusiveMaximum);
+        }
+
+        walkedDocumentIds.Should().Equal(expectedDocumentIds);
+    }
+
+    [Test]
+    public async Task It_selects_one_document_per_page_at_page_size_one()
+    {
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(CursorRange.From(1), pageSize: 1, traceId: "mssql-cursor-size-1");
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[0].DocumentId);
+        AssertPageMaterialization(_persistedSchoolsInDocumentOrder[0].DocumentId);
+    }
+
+    [Test]
+    public async Task It_selects_the_whole_collection_at_the_configured_maximum_page_size()
+    {
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(1),
+                pageSize: MaximumPageSize,
+                traceId: "mssql-cursor-size-max"
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[^1].DocumentId);
+        AssertPageMaterialization([
+            .. _persistedSchoolsInDocumentOrder.Select(static school => school.DocumentId),
+        ]);
+    }
+
+    // A zero page size selects nothing and cannot advance a walk, by contract rather than by arithmetic.
+    [Test]
+    public async Task It_selects_nothing_at_page_size_zero()
+    {
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(CursorRange.From(1), pageSize: 0, traceId: "mssql-cursor-size-0");
+
+        success.HighestSelectedDocumentId.Should().BeNull();
+        success.EdfiDocs.Should().BeEmpty();
+    }
+
+    // An inverted range is the terminal condition of a bounded walk, not an error.
+    [Test]
+    public async Task It_selects_nothing_from_an_inverted_range()
+    {
+        var lastDocumentId = _persistedSchoolsInDocumentOrder[^1].DocumentId;
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                new CursorRange(lastDocumentId + 1, lastDocumentId),
+                pageSize: 25,
+                traceId: "mssql-cursor-inverted"
+            );
+
+        success.HighestSelectedDocumentId.Should().BeNull();
+        success.EdfiDocs.Should().BeEmpty();
+    }
+
+    // Range bounds are seek positions, not identities. Neither bound here is a stored DocumentId, and
+    // the page still selects exactly the documents inside the range — which is what keeps a walk correct
+    // across the identity gaps deletes leave behind.
+    [Test]
+    public async Task It_seeks_within_bounds_that_are_not_stored_document_ids()
+    {
+        var firstDocumentId = _persistedSchoolsInDocumentOrder[0].DocumentId;
+        var lastDocumentId = _persistedSchoolsInDocumentOrder[^1].DocumentId;
+        var storedDocumentIds = _persistedSchoolsInDocumentOrder
+            .Select(static school => school.DocumentId)
+            .ToArray();
+
+        storedDocumentIds.Should().NotContain(firstDocumentId - 1).And.NotContain(lastDocumentId + 1);
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                new CursorRange(firstDocumentId - 1, lastDocumentId + 1),
+                pageSize: 25,
+                traceId: "mssql-cursor-unstored-bounds"
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(lastDocumentId);
+        AssertPageMaterialization(storedDocumentIds);
+    }
+
+    // A bound that excludes the first stored id starts the page at the next one, so a continuation that
+    // resumes at maximum+1 cannot re-return the document it already delivered.
+    [Test]
+    public async Task It_excludes_documents_below_the_inclusive_minimum()
+    {
+        var firstDocumentId = _persistedSchoolsInDocumentOrder[0].DocumentId;
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(firstDocumentId + 1),
+                pageSize: 25,
+                traceId: "mssql-cursor-excludes-below-minimum"
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[^1].DocumentId);
+        AssertPageMaterialization([
+            .. _persistedSchoolsInDocumentOrder.Skip(1).Select(static school => school.DocumentId),
+        ]);
+    }
+
+    [Test]
+    public async Task It_composes_a_query_filter_with_the_cursor_range()
+    {
+        var targetSchool = _persistedSchoolsInDocumentOrder[1];
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(1),
+                pageSize: 25,
+                traceId: "mssql-cursor-filter",
+                queryElements:
+                [
+                    new QueryElement(
+                        "nameOfInstitution",
+                        [new JsonPath("$.nameOfInstitution")],
+                        targetSchool.NameOfInstitution,
+                        "string"
+                    ),
+                ]
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(targetSchool.DocumentId);
+        AssertPageMaterialization(targetSchool.DocumentId);
+    }
+
+    // A min-only window still orders by DocumentId, so a cursor page inside it continues normally.
+    [Test]
+    public async Task It_composes_a_min_only_change_version_window_with_the_cursor_range()
+    {
+        var lowestContentVersion = _persistedSchoolsInDocumentOrder.Min(static school =>
+            school.ContentVersion
+        );
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(1),
+                pageSize: 25,
+                traceId: "mssql-cursor-min-window",
+                changeVersionRange: new ChangeVersionRange(lowestContentVersion, null)
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[^1].DocumentId);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    // A max-bearing window keeps the DocumentId ordering a cursor page always uses, so the page it
+    // selects can still anchor a continuation. What it must not do is silently order by something else.
+    [Test]
+    public async Task It_composes_a_max_bearing_change_version_window_with_the_cursor_range()
+    {
+        var highestContentVersion = _persistedSchoolsInDocumentOrder.Max(static school =>
+            school.ContentVersion
+        );
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(1),
+                pageSize: 25,
+                traceId: "mssql-cursor-max-window",
+                changeVersionRange: new ChangeVersionRange(null, highestContentVersion)
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[^1].DocumentId);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+        AssertSingleQueryHydration().Plan.PageDocumentIdSql.Should().Contain("@cursorMin");
+    }
+
+    // A traditional page over the same window is ordered by ContentVersion, so it reports the maximum it
+    // really selected while refusing to let a DocumentId continuation be anchored on it.
+    [Test]
+    public async Task It_reports_a_boundary_without_continuation_for_a_windowed_traditional_page()
+    {
+        var highestContentVersion = _persistedSchoolsInDocumentOrder.Max(static school =>
+            school.ContentVersion
+        );
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                limit: MaximumPageSize,
+                offset: 0,
+                totalCount: false,
+                traceId: "mssql-traditional-max-window",
+                changeVersionRange: new ChangeVersionRange(null, highestContentVersion)
+            );
+
+        success.HighestSelectedDocumentId.Should().NotBeNull();
+        success.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
     private static ServiceProvider CreateServiceProvider(ChangeQueryPageOrderingPolicy? orderingPolicy = null)
     {
         ServiceCollection services = [];
@@ -788,6 +1017,42 @@ public class Given_A_Mssql_Relational_Query_With_The_Authoritative_Sample_School
         string traceId,
         ChangeVersionRange? changeVersionRange = null,
         ServiceProvider? serviceProvider = null
+    ) =>
+        await ExecuteQueryAsync(
+            new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: limit,
+                    Offset: offset,
+                    TotalCount: totalCount,
+                    MaximumPageSize: MaximumPageSize
+                )
+            ),
+            queryElements,
+            traceId,
+            changeVersionRange,
+            serviceProvider
+        );
+
+    private async Task<QueryResult> ExecuteCursorQueryAsync(
+        CursorRange range,
+        int pageSize,
+        string traceId,
+        QueryElement[]? queryElements = null,
+        ChangeVersionRange? changeVersionRange = null
+    ) =>
+        await ExecuteQueryAsync(
+            new CollectionPaging.Cursor(range, new PageSize(pageSize)),
+            queryElements ?? [],
+            traceId,
+            changeVersionRange
+        );
+
+    private async Task<QueryResult> ExecuteQueryAsync(
+        CollectionPaging paging,
+        QueryElement[] queryElements,
+        string traceId,
+        ChangeVersionRange? changeVersionRange = null,
+        ServiceProvider? serviceProvider = null
     )
     {
         await using var scope = (serviceProvider ?? _serviceProvider).CreateAsyncScope();
@@ -799,14 +1064,7 @@ public class Given_A_Mssql_Relational_Query_With_The_Authoritative_Sample_School
             MappingSet: _mappingSet,
             QueryElements: queryElements,
             AuthorizationStrategyEvaluators: [],
-            Paging: new CollectionPaging.Traditional(
-                new PaginationParameters(
-                    Limit: limit,
-                    Offset: offset,
-                    TotalCount: totalCount,
-                    MaximumPageSize: MaximumPageSize
-                )
-            ),
+            Paging: paging,
             TraceId: new TraceId(traceId),
             ChangeVersionRange: changeVersionRange
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationBatchBuilderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationBatchBuilderTests.cs
@@ -937,7 +937,7 @@ public class Given_HydrationBatchBuilder_With_Query_Keyset
                 SELECT r."DocumentId" FROM "edfi"."School" r ORDER BY r."DocumentId" LIMIT @limit OFFSET @offset
                 )
                 INSERT INTO "page" ("DocumentId")
-                SELECT "DocumentId" FROM page_ids;
+                SELECT "DocumentId" FROM page_ids RETURNING "DocumentId";
 
                 SELECT COUNT(*) AS TotalCount FROM "edfi"."School" r;
 
@@ -1010,7 +1010,7 @@ public class Given_HydrationBatchBuilder_With_Compiled_Query_Keyset
     public void It_should_emit_valid_cte_structure()
     {
         _pgsqlBatch.Should().Contain("WITH page_ids AS (");
-        _pgsqlBatch.Should().Contain("FROM page_ids;");
+        _pgsqlBatch.Should().Contain("FROM page_ids RETURNING \"DocumentId\";");
         _mssqlBatch.Should().Contain("WITH page_ids AS (");
         _mssqlBatch.Should().Contain("FROM page_ids;");
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationSelectedKeysetResultTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationSelectedKeysetResultTests.cs
@@ -596,6 +596,7 @@ public class Given_HydrationExecutor_With_A_Selected_Keyset_Result_Set
         table.Columns.Add("IdentityVersion", typeof(long));
         table.Columns.Add("ContentLastModifiedAt", typeof(DateTimeOffset));
         table.Columns.Add("IdentityLastModifiedAt", typeof(DateTimeOffset));
+        table.Columns.Add("ResourceKeyId", typeof(short));
 
         foreach (var row in rows)
         {
@@ -605,7 +606,8 @@ public class Given_HydrationExecutor_With_A_Selected_Keyset_Result_Set
                 row.ContentVersion,
                 row.IdentityVersion,
                 new DateTimeOffset(2026, 4, 2, 12, 0, 0, TimeSpan.Zero),
-                new DateTimeOffset(2026, 4, 2, 12, 1, 0, TimeSpan.Zero)
+                new DateTimeOffset(2026, 4, 2, 12, 1, 0, TimeSpan.Zero),
+                (short)1
             );
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationSelectedKeysetResultTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationSelectedKeysetResultTests.cs
@@ -1,0 +1,646 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+using static EdFi.DataManagementService.Backend.Plans.Tests.Unit.HydrationBatchBuilderTestHelper;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+/// <summary>
+/// A query keyset materialization returns the ids it inserted, which is how a page's selected-keyset
+/// boundary leaves hydration without a second candidate query. GET-by-id keysets select nothing and
+/// keep their existing batch shape.
+/// </summary>
+[TestFixture]
+public class Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization
+{
+    private string _pgsqlBatch = null!;
+    private string _mssqlBatch = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _pgsqlBatch = BuildCursorQueryBatch(SqlDialect.Pgsql, pageSize: 25L);
+        _mssqlBatch = BuildCursorQueryBatch(SqlDialect.Mssql, pageSize: 25L);
+    }
+
+    [Test]
+    public void It_returns_the_inserted_ids_from_a_pgsql_returning_clause()
+    {
+        _pgsqlBatch
+            .Should()
+            .Contain(
+                """
+                INSERT INTO "page" ("DocumentId")
+                SELECT "DocumentId" FROM page_ids RETURNING "DocumentId";
+                """
+            );
+    }
+
+    [Test]
+    public void It_returns_the_inserted_ids_from_an_mssql_output_clause()
+    {
+        _mssqlBatch
+            .Should()
+            .Contain(
+                """
+                INSERT INTO [#page] ([DocumentId])
+                OUTPUT INSERTED.[DocumentId]
+                SELECT [DocumentId] FROM page_ids;
+                """
+            );
+    }
+
+    [Test]
+    public void It_uses_only_the_dialect_specific_form_on_each_provider()
+    {
+        _pgsqlBatch.Should().NotContain("OUTPUT INSERTED");
+        _mssqlBatch.Should().NotContain("RETURNING");
+    }
+
+    [Test]
+    public void It_returns_the_inserted_ids_before_document_metadata()
+    {
+        AssertSelectedIdsPrecedeDocumentMetadata(
+            _pgsqlBatch,
+            "RETURNING \"DocumentId\";",
+            "\"dms\".\"Document\""
+        );
+        AssertSelectedIdsPrecedeDocumentMetadata(
+            _mssqlBatch,
+            "OUTPUT INSERTED.[DocumentId]",
+            "[dms].[Document]"
+        );
+    }
+
+    [Test]
+    public void It_returns_the_inserted_ids_before_an_optional_total_count()
+    {
+        var pgsqlBatchWithTotalCount = BuildTraditionalQueryBatch(
+            SqlDialect.Pgsql,
+            limit: 25L,
+            includeTotalCountSql: true
+        );
+        var mssqlBatchWithTotalCount = BuildTraditionalQueryBatch(
+            SqlDialect.Mssql,
+            limit: 25L,
+            includeTotalCountSql: true
+        );
+
+        AssertSelectedIdsPrecedeDocumentMetadata(
+            pgsqlBatchWithTotalCount,
+            "RETURNING \"DocumentId\";",
+            "SELECT COUNT(1)"
+        );
+        AssertSelectedIdsPrecedeDocumentMetadata(
+            mssqlBatchWithTotalCount,
+            "OUTPUT INSERTED.[DocumentId]",
+            "SELECT COUNT(1)"
+        );
+    }
+
+    private static void AssertSelectedIdsPrecedeDocumentMetadata(
+        string batch,
+        string selectedIdsClause,
+        string followingStatement
+    )
+    {
+        var selectedIdsIndex = batch.IndexOf(selectedIdsClause, StringComparison.Ordinal);
+        var followingIndex = batch.IndexOf(followingStatement, StringComparison.Ordinal);
+
+        selectedIdsIndex.Should().BePositive();
+        followingIndex.Should().BeGreaterThan(selectedIdsIndex);
+    }
+
+    internal static string BuildCursorQueryBatch(SqlDialect dialect, object pageSize) =>
+        HydrationBatchBuilder.Build(
+            BuildTestReadPlan(dialect),
+            CreateCursorKeyset(dialect, pageSize),
+            dialect
+        );
+
+    internal static string BuildTraditionalQueryBatch(
+        SqlDialect dialect,
+        object limit,
+        bool includeTotalCountSql = false
+    ) =>
+        HydrationBatchBuilder.Build(
+            BuildTestReadPlan(dialect),
+            CreateTraditionalKeyset(dialect, limit, includeTotalCountSql),
+            dialect
+        );
+
+    internal static PageKeysetSpec.Query CreateCursorKeyset(SqlDialect dialect, object pageSize)
+    {
+        var mode = new PageCandidateMode.Cursor();
+
+        return new PageKeysetSpec.Query(
+            Compile(dialect, mode),
+            new Dictionary<string, object?>
+            {
+                [mode.InclusiveMinimumParameterName] = 1L,
+                [mode.InclusiveMaximumParameterName] = long.MaxValue,
+                [mode.PageSizeParameterName] = pageSize,
+            }
+        );
+    }
+
+    internal static PageKeysetSpec.Query CreateTraditionalKeyset(
+        SqlDialect dialect,
+        object limit,
+        bool includeTotalCountSql
+    )
+    {
+        var mode = new PageCandidateMode.Traditional(IncludeTotalCountSql: includeTotalCountSql);
+
+        return new PageKeysetSpec.Query(
+            Compile(dialect, mode),
+            new Dictionary<string, object?>
+            {
+                [mode.OffsetParameterName] = 0L,
+                [mode.LimitParameterName] = limit,
+            }
+        );
+    }
+
+    private static PageDocumentIdSqlPlan Compile(SqlDialect dialect, PageCandidateMode mode) =>
+        new PageDocumentIdSqlCompiler(dialect).Compile(
+            new PageDocumentIdQuerySpec(
+                RootTable: new DbTableName(new DbSchemaName("edfi"), "School"),
+                Predicates: [],
+                UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+                Mode: mode
+            )
+        );
+}
+
+/// <summary>
+/// A zero-size page selects nothing, so it materializes the empty keyset instead of running the
+/// candidate query for zero rows — the behavior traditional paging already had, now reached by a
+/// cursor page size as well. The selected-id result set is still emitted, with no rows, so the
+/// positions of every later result set are independent of selection size.
+/// </summary>
+[TestFixture]
+public class Given_HydrationBatchBuilder_With_A_Zero_Size_Query_Keyset
+{
+    [Test]
+    public void It_returns_an_empty_pgsql_selected_id_result_set_for_a_zero_cursor_page_size()
+    {
+        var batch = Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.BuildCursorQueryBatch(
+            SqlDialect.Pgsql,
+            pageSize: 0L
+        );
+
+        batch
+            .Should()
+            .Contain(
+                """
+                INSERT INTO "page" ("DocumentId")
+                SELECT CAST(NULL AS bigint) AS "DocumentId" WHERE 1 = 0 RETURNING "DocumentId";
+                """
+            );
+    }
+
+    [Test]
+    public void It_returns_an_empty_mssql_selected_id_result_set_for_a_zero_cursor_page_size()
+    {
+        var batch = Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.BuildCursorQueryBatch(
+            SqlDialect.Mssql,
+            pageSize: 0L
+        );
+
+        batch
+            .Should()
+            .Contain(
+                """
+                INSERT INTO [#page] ([DocumentId])
+                OUTPUT INSERTED.[DocumentId]
+                SELECT CAST(NULL AS bigint) AS [DocumentId] WHERE 1 = 0;
+                """
+            );
+    }
+
+    [Test]
+    public void It_returns_an_empty_selected_id_result_set_for_a_zero_traditional_limit()
+    {
+        var pgsqlBatch =
+            Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.BuildTraditionalQueryBatch(
+                SqlDialect.Pgsql,
+                limit: 0L
+            );
+        var mssqlBatch =
+            Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.BuildTraditionalQueryBatch(
+                SqlDialect.Mssql,
+                limit: 0L
+            );
+
+        pgsqlBatch.Should().Contain("WHERE 1 = 0 RETURNING \"DocumentId\";");
+        mssqlBatch.Should().Contain("OUTPUT INSERTED.[DocumentId]");
+        mssqlBatch.Should().Contain("WHERE 1 = 0;");
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_does_not_run_candidate_selection_for_a_zero_cursor_page_size(SqlDialect dialect)
+    {
+        var batch = Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.BuildCursorQueryBatch(
+            dialect,
+            pageSize: 0L
+        );
+
+        batch.Should().NotContain("WITH page_ids AS (");
+        batch.Should().NotContain("@cursorMin");
+        batch.Should().NotContain("@pageSize");
+    }
+
+    [TestCaseSource(nameof(ZeroPageSizeValues))]
+    public void It_materializes_an_empty_keyset_for_all_integral_zero_cursor_page_sizes(object zeroPageSize)
+    {
+        var batch = Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.BuildCursorQueryBatch(
+            SqlDialect.Mssql,
+            zeroPageSize
+        );
+
+        batch.Should().Contain("SELECT CAST(NULL AS bigint) AS [DocumentId] WHERE 1 = 0;");
+        batch.Should().NotContain("WITH page_ids AS (");
+    }
+
+    [TestCaseSource(nameof(NonZeroOrUnsupportedPageSizeValues))]
+    public void It_runs_candidate_selection_for_non_zero_or_unsupported_cursor_page_sizes(object pageSize)
+    {
+        var batch = Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.BuildCursorQueryBatch(
+            SqlDialect.Mssql,
+            pageSize
+        );
+
+        batch.Should().Contain("WITH page_ids AS (");
+        batch.Should().Contain("TOP (@pageSize)");
+        batch.Should().NotContain("SELECT CAST(NULL AS bigint) AS [DocumentId] WHERE 1 = 0;");
+    }
+
+    private static IEnumerable<object> ZeroPageSizeValues() =>
+        [(byte)0, (sbyte)0, (short)0, (ushort)0, 0, 0U, 0L, 0UL];
+
+    private static IEnumerable<object> NonZeroOrUnsupportedPageSizeValues() =>
+        [(byte)1, (sbyte)1, (short)1, (ushort)1, 1, 1U, 1L, 1UL, "0"];
+}
+
+/// <summary>
+/// GET-by-id and guarded write-path hydration materialize a keyset they were handed rather than
+/// selecting one, so neither returns selected ids and neither moves a result-set position.
+/// </summary>
+[TestFixture]
+public class Given_HydrationBatchBuilder_With_A_Single_Document_Keyset
+{
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_does_not_return_selected_ids_from_the_values_materialization(SqlDialect dialect)
+    {
+        var batch = HydrationBatchBuilder.Build(
+            BuildTestReadPlan(dialect),
+            new PageKeysetSpec.Single(42L),
+            dialect,
+            new HydrationExecutionOptions(UseSingleDocumentFastPath: false)
+        );
+
+        batch.Should().NotContain("RETURNING");
+        batch.Should().NotContain("OUTPUT INSERTED");
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_does_not_return_selected_ids_from_the_guarded_materialization(SqlDialect dialect)
+    {
+        var batch = HydrationBatchBuilder.BuildGuardedSingleDocumentBatch(
+            BuildTestReadPlan(dialect),
+            dialect,
+            new HydrationExecutionOptions(UseSingleDocumentFastPath: false),
+            "1 = 1"
+        );
+
+        batch.Should().NotContain("RETURNING");
+        batch.Should().NotContain("OUTPUT INSERTED");
+    }
+}
+
+/// <summary>
+/// The result-set count is what a co-batched reader uses to skip past a hydration batch, so it must
+/// grow with the selected-id result set exactly when the batch emits one.
+/// </summary>
+[TestFixture]
+public class Given_HydrationExecutor_Result_Set_Count_With_Selected_Ids
+{
+    [Test]
+    public void It_counts_the_selected_id_result_set_for_a_query_keyset()
+    {
+        var plan = BuildTestReadPlan(SqlDialect.Pgsql);
+
+        HydrationExecutor
+            .GetResultSetCount(
+                plan,
+                Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.CreateCursorKeyset(
+                    SqlDialect.Pgsql,
+                    25L
+                ),
+                new HydrationExecutionOptions()
+            )
+            .Should()
+            // Selected ids, document metadata, root table, child table.
+            .Be(2 + plan.TablePlansInDependencyOrder.Length);
+    }
+
+    [Test]
+    public void It_counts_the_selected_id_result_set_alongside_an_optional_total_count()
+    {
+        var plan = BuildTestReadPlan(SqlDialect.Pgsql);
+
+        HydrationExecutor
+            .GetResultSetCount(
+                plan,
+                Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.CreateTraditionalKeyset(
+                    SqlDialect.Pgsql,
+                    25L,
+                    includeTotalCountSql: true
+                ),
+                new HydrationExecutionOptions()
+            )
+            .Should()
+            .Be(3 + plan.TablePlansInDependencyOrder.Length);
+    }
+
+    [Test]
+    public void It_does_not_count_a_selected_id_result_set_for_a_single_document_keyset()
+    {
+        var plan = BuildTestReadPlan(SqlDialect.Pgsql);
+
+        HydrationExecutor
+            .GetResultSetCount(plan, new PageKeysetSpec.Single(42L), new HydrationExecutionOptions())
+            .Should()
+            .Be(1 + plan.TablePlansInDependencyOrder.Length);
+    }
+}
+
+/// <summary>
+/// Neither <c>RETURNING</c> nor <c>OUTPUT</c> promises an order, so the maximum is taken across every
+/// returned row.
+/// </summary>
+[TestFixture]
+public class Given_HydrationReader_With_A_Selected_Keyset_Result_Set
+{
+    [Test]
+    public async Task It_reads_the_maximum_from_descending_ids()
+    {
+        using var reader = HydrationDescriptorResultTestHelper.CreateReader(
+            CreateSelectedIdsTable(2509L, 2508L, 7L)
+        );
+
+        var maximum = await HydrationReader.ReadSelectedDocumentIdMaximumAsync(
+            reader,
+            CancellationToken.None
+        );
+
+        maximum.Should().Be(2509L);
+    }
+
+    [Test]
+    public async Task It_reads_the_maximum_from_shuffled_ids()
+    {
+        using var reader = HydrationDescriptorResultTestHelper.CreateReader(
+            CreateSelectedIdsTable(11L, 2509L, 5L, 400L)
+        );
+
+        var maximum = await HydrationReader.ReadSelectedDocumentIdMaximumAsync(
+            reader,
+            CancellationToken.None
+        );
+
+        maximum.Should().Be(2509L);
+    }
+
+    [Test]
+    public async Task It_reads_a_single_id_as_the_maximum()
+    {
+        using var reader = HydrationDescriptorResultTestHelper.CreateReader(CreateSelectedIdsTable(42L));
+
+        var maximum = await HydrationReader.ReadSelectedDocumentIdMaximumAsync(
+            reader,
+            CancellationToken.None
+        );
+
+        maximum.Should().Be(42L);
+    }
+
+    [Test]
+    public async Task It_reads_no_maximum_from_an_empty_selection()
+    {
+        using var reader = HydrationDescriptorResultTestHelper.CreateReader(CreateSelectedIdsTable());
+
+        var maximum = await HydrationReader.ReadSelectedDocumentIdMaximumAsync(
+            reader,
+            CancellationToken.None
+        );
+
+        maximum.Should().BeNull();
+    }
+
+    internal static DataTable CreateSelectedIdsTable(params long[] selectedDocumentIds)
+    {
+        var table = new DataTable();
+        table.Columns.Add("DocumentId", typeof(long));
+
+        foreach (var selectedDocumentId in selectedDocumentIds)
+        {
+            table.Rows.Add(selectedDocumentId);
+        }
+
+        return table;
+    }
+}
+
+/// <summary>
+/// The boundary describes the keys page selection chose, not the rows hydration found. Every selected
+/// row can be deleted between materialization and the hydration selects that follow it in the same
+/// batch, which is exactly the case a body-derived boundary would get wrong.
+/// </summary>
+[TestFixture]
+public class Given_HydrationExecutor_With_A_Selected_Keyset_Result_Set
+{
+    [Test]
+    public async Task It_carries_the_selected_maximum_alongside_hydrated_documents()
+    {
+        var result = await ExecuteQueryHydrationAsync(
+            Given_HydrationReader_With_A_Selected_Keyset_Result_Set.CreateSelectedIdsTable(84L, 42L),
+            CreateDocumentMetadataTable((42L, DocumentUuid, 44L, 45L), (84L, OtherDocumentUuid, 46L, 47L)),
+            CreateRootTableRows((42L, 255901), (84L, 255902)),
+            CreateChildTableRows((100L, 42L, 0, "Springfield"))
+        );
+
+        result.HighestSelectedDocumentId.Should().Be(84L);
+        result.DocumentMetadata.Should().HaveCount(2);
+    }
+
+    [Test]
+    public async Task It_carries_the_selected_maximum_when_every_selected_row_was_deleted()
+    {
+        var result = await ExecuteQueryHydrationAsync(
+            Given_HydrationReader_With_A_Selected_Keyset_Result_Set.CreateSelectedIdsTable(84L, 42L),
+            CreateDocumentMetadataTable(),
+            CreateRootTableRows(),
+            CreateChildTableRows()
+        );
+
+        result.HighestSelectedDocumentId.Should().Be(84L);
+        result.DocumentMetadata.Should().BeEmpty();
+        result.TableRowsInDependencyOrder.Should().OnlyContain(tableRows => tableRows.Rows.Count == 0);
+    }
+
+    [Test]
+    public async Task It_carries_no_selected_maximum_when_selection_was_empty()
+    {
+        var result = await ExecuteQueryHydrationAsync(
+            Given_HydrationReader_With_A_Selected_Keyset_Result_Set.CreateSelectedIdsTable(),
+            CreateDocumentMetadataTable(),
+            CreateRootTableRows(),
+            CreateChildTableRows()
+        );
+
+        result.HighestSelectedDocumentId.Should().BeNull();
+        result.DocumentMetadata.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_carries_no_selected_maximum_for_a_single_document_keyset()
+    {
+        var command = new RecordingDbCommand(
+            HydrationDescriptorResultTestHelper.CreateReader(
+                CreateDocumentMetadataTable((42L, DocumentUuid, 44L, 45L)),
+                CreateRootTableRows((42L, 255901)),
+                CreateChildTableRows((100L, 42L, 0, "Springfield"))
+            )
+        );
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            new RecordingDbConnection(command),
+            BuildTestReadPlan(SqlDialect.Pgsql),
+            new PageKeysetSpec.Single(42L),
+            SqlDialect.Pgsql,
+            new HydrationExecutionOptions(UseSingleDocumentFastPath: false),
+            CancellationToken.None
+        );
+
+        result.HighestSelectedDocumentId.Should().BeNull();
+    }
+
+    [Test]
+    public async Task It_reports_a_batch_that_stops_after_the_selected_ids()
+    {
+        var command = new RecordingDbCommand(
+            HydrationDescriptorResultTestHelper.CreateReader(
+                Given_HydrationReader_With_A_Selected_Keyset_Result_Set.CreateSelectedIdsTable(42L)
+            )
+        );
+
+        var act = () =>
+            HydrationExecutor.ExecuteAsync(
+                new RecordingDbConnection(command),
+                BuildTestReadPlan(SqlDialect.Pgsql),
+                Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.CreateCursorKeyset(
+                    SqlDialect.Pgsql,
+                    25L
+                ),
+                SqlDialect.Pgsql,
+                CancellationToken.None
+            );
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>();
+        exception
+            .Which.Message.Should()
+            .Be(
+                "Expected a result set after the selected page keyset ids but no more result sets available."
+            );
+    }
+
+    private static readonly Guid DocumentUuid = Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
+    private static readonly Guid OtherDocumentUuid = Guid.Parse("cccccccc-4444-5555-6666-dddddddddddd");
+
+    private static Task<HydratedPage> ExecuteQueryHydrationAsync(params DataTable[] resultSets)
+    {
+        var command = new RecordingDbCommand(HydrationDescriptorResultTestHelper.CreateReader(resultSets));
+
+        return HydrationExecutor.ExecuteAsync(
+            new RecordingDbConnection(command),
+            BuildTestReadPlan(SqlDialect.Pgsql),
+            Given_HydrationBatchBuilder_With_A_Query_Keyset_Materialization.CreateCursorKeyset(
+                SqlDialect.Pgsql,
+                25L
+            ),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+    }
+
+    private static DataTable CreateDocumentMetadataTable(
+        params (long DocumentId, Guid DocumentUuid, long ContentVersion, long IdentityVersion)[] rows
+    )
+    {
+        var table = new DataTable();
+        table.Columns.Add("DocumentId", typeof(long));
+        table.Columns.Add("DocumentUuid", typeof(Guid));
+        table.Columns.Add("ContentVersion", typeof(long));
+        table.Columns.Add("IdentityVersion", typeof(long));
+        table.Columns.Add("ContentLastModifiedAt", typeof(DateTimeOffset));
+        table.Columns.Add("IdentityLastModifiedAt", typeof(DateTimeOffset));
+
+        foreach (var row in rows)
+        {
+            table.Rows.Add(
+                row.DocumentId,
+                row.DocumentUuid,
+                row.ContentVersion,
+                row.IdentityVersion,
+                new DateTimeOffset(2026, 4, 2, 12, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 4, 2, 12, 1, 0, TimeSpan.Zero)
+            );
+        }
+
+        return table;
+    }
+
+    private static DataTable CreateRootTableRows(params (long DocumentId, int SchoolId)[] rows)
+    {
+        var table = new DataTable();
+        table.Columns.Add("DocumentId", typeof(long));
+        table.Columns.Add("SchoolId", typeof(int));
+
+        foreach (var row in rows)
+        {
+            table.Rows.Add(row.DocumentId, row.SchoolId);
+        }
+
+        return table;
+    }
+
+    private static DataTable CreateChildTableRows(
+        params (long CollectionItemId, long SchoolDocumentId, int Ordinal, string City)[] rows
+    )
+    {
+        var table = new DataTable();
+        table.Columns.Add("CollectionItemId", typeof(long));
+        table.Columns.Add("School_DocumentId", typeof(long));
+        table.Columns.Add("Ordinal", typeof(int));
+        table.Columns.Add("City", typeof(string));
+
+        foreach (var row in rows)
+        {
+            table.Rows.Add(row.CollectionItemId, row.SchoolDocumentId, row.Ordinal, row.City);
+        }
+
+        return table;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
@@ -126,7 +126,15 @@ public static class HydrationBatchBuilder
         planDialect.AppendCreateKeysetTempTable(writer, plan.KeysetTable);
         writer.AppendLine();
 
-        AppendKeysetMaterialization(writer, planDialect, plan.KeysetTable, keyset);
+        // This batch's reader derives its candidates from the metadata rows and has no position for a
+        // selected-id result set, so the materialization must not return one.
+        AppendKeysetMaterialization(
+            writer,
+            planDialect,
+            plan.KeysetTable,
+            keyset,
+            returnsSelectedIds: false
+        );
         writer.AppendLine();
 
         if (keyset.Plan.TotalCountSql is not null)
@@ -255,6 +263,7 @@ public static class HydrationBatchBuilder
             planDialect,
             plan.KeysetTable,
             keyset,
+            returnsSelectedIds: true,
             singleRowGuardPredicateSql
         );
         writer.AppendLine();
@@ -439,14 +448,21 @@ public static class HydrationBatchBuilder
         }
     }
 
+    /// <param name="returnsSelectedIds">
+    /// Whether a query keyset's materialization returns the ids it inserted as a result set. True for
+    /// the hydration batch, whose reader consumes that result set. False for the candidate-metadata
+    /// batch, whose reader has no position for it and derives its candidates from the metadata rows.
+    /// </param>
     private static void AppendKeysetMaterialization(
         SqlWriter writer,
         IPlanSqlDialect planDialect,
         KeysetTableContract keyset,
         PageKeysetSpec spec,
+        bool returnsSelectedIds,
         string? singleRowGuardPredicateSql = null
     )
     {
+        IPlanSqlDialect? selectedIdDialect = returnsSelectedIds ? planDialect : null;
         var quotedDocIdCol = writer.Dialect.QuoteIdentifier(keyset.DocumentIdColumnName.Value);
 
         switch (spec)
@@ -478,8 +494,15 @@ public static class HydrationBatchBuilder
                     .AppendLine(");");
                 break;
 
+            // A selected-page keyset supplies its own ids, so hydration reads no selected-id result set
+            // for it and GetResultSetCount counts none.
             case PageKeysetSpec.SelectedPage { DocumentIds.Count: 0 }:
-                AppendEmptySelectedPageKeysetMaterialization(writer, keyset, quotedDocIdCol);
+                AppendEmptyKeysetMaterialization(
+                    writer,
+                    keyset,
+                    quotedDocIdCol,
+                    selectedIdDialect: null
+                );
                 break;
 
             case PageKeysetSpec.SelectedPage selectedPage:
@@ -487,11 +510,17 @@ public static class HydrationBatchBuilder
                 break;
 
             case PageKeysetSpec.Query query when HasZeroPageSelectionSize(query):
-                AppendEmptyQueryKeysetMaterialization(writer, planDialect, keyset, quotedDocIdCol);
+                AppendEmptyKeysetMaterialization(writer, keyset, quotedDocIdCol, selectedIdDialect);
                 break;
 
             case PageKeysetSpec.Query query:
-                AppendQueryKeysetMaterialization(writer, planDialect, keyset, query, quotedDocIdCol);
+                AppendQueryKeysetMaterialization(
+                    writer,
+                    selectedIdDialect,
+                    keyset,
+                    query,
+                    quotedDocIdCol
+                );
                 break;
 
             default:
@@ -503,9 +532,13 @@ public static class HydrationBatchBuilder
         }
     }
 
+    /// <summary>
+    /// Materializes the planned page keyset. Returns the ids it inserted only when
+    /// <paramref name="selectedIdDialect"/> is supplied.
+    /// </summary>
     private static void AppendQueryKeysetMaterialization(
         SqlWriter writer,
-        IPlanSqlDialect planDialect,
+        IPlanSqlDialect? selectedIdDialect,
         KeysetTableContract keyset,
         PageKeysetSpec.Query query,
         string quotedDocIdCol
@@ -520,51 +553,23 @@ public static class HydrationBatchBuilder
             .Append(" (")
             .Append(quotedDocIdCol)
             .AppendLine(")");
-        planDialect.AppendKeysetSelectedIdOutputClause(writer, keyset);
+        selectedIdDialect?.AppendKeysetSelectedIdOutputClause(writer, keyset);
         writer.Append("SELECT ").Append(quotedDocIdCol).Append(" FROM page_ids");
-        planDialect.AppendKeysetSelectedIdReturningClause(writer, keyset);
+        selectedIdDialect?.AppendKeysetSelectedIdReturningClause(writer, keyset);
         writer.AppendLine(";");
     }
 
     /// <summary>
-    /// Materializes no keyset row while still returning the selected-id result set, so a zero-size
-    /// page occupies the same result-set positions as any other query keyset.
+    /// Materializes no keyset row. Returns the (empty) selected-id result set only when
+    /// <paramref name="selectedIdDialect"/> is supplied, so a zero-size query page occupies the same
+    /// result-set positions as any other query keyset in the hydration batch, while a keyset whose
+    /// reader has no position for that result set does not gain one it would never consume.
     /// </summary>
-    private static void AppendEmptyQueryKeysetMaterialization(
-        SqlWriter writer,
-        IPlanSqlDialect planDialect,
-        KeysetTableContract keyset,
-        string quotedDocIdCol
-    )
-    {
-        AppendEmptyKeysetInsert(writer, keyset, quotedDocIdCol, planDialect);
-    }
-
-    /// <summary>
-    /// Materializes no keyset row and returns nothing. A selected-page keyset supplies its own ids, so
-    /// hydration reads no selected-id result set for it and
-    /// <see cref="HydrationExecutor.GetResultSetCount"/> counts none; returning one here would leave a
-    /// result set no reader consumes, and every position after it would be read as the wrong result set.
-    /// </summary>
-    private static void AppendEmptySelectedPageKeysetMaterialization(
-        SqlWriter writer,
-        KeysetTableContract keyset,
-        string quotedDocIdCol
-    )
-    {
-        AppendEmptyKeysetInsert(writer, keyset, quotedDocIdCol, planDialect: null);
-    }
-
-    /// <summary>
-    /// The shared zero-row keyset insert. Returns the ids it inserted only when
-    /// <paramref name="planDialect"/> is supplied, which is what keeps the returned result set tied to
-    /// the keyset kinds hydration actually reads one for.
-    /// </summary>
-    private static void AppendEmptyKeysetInsert(
+    private static void AppendEmptyKeysetMaterialization(
         SqlWriter writer,
         KeysetTableContract keyset,
         string quotedDocIdCol,
-        IPlanSqlDialect? planDialect
+        IPlanSqlDialect? selectedIdDialect
     )
     {
         writer
@@ -573,9 +578,9 @@ public static class HydrationBatchBuilder
             .Append(" (")
             .Append(quotedDocIdCol)
             .AppendLine(")");
-        planDialect?.AppendKeysetSelectedIdOutputClause(writer, keyset);
+        selectedIdDialect?.AppendKeysetSelectedIdOutputClause(writer, keyset);
         writer.Append("SELECT CAST(NULL AS bigint) AS ").Append(quotedDocIdCol).Append(" WHERE 1 = 0");
-        planDialect?.AppendKeysetSelectedIdReturningClause(writer, keyset);
+        selectedIdDialect?.AppendKeysetSelectedIdReturningClause(writer, keyset);
         writer.AppendLine(";");
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
@@ -21,6 +21,11 @@ namespace EdFi.DataManagementService.Backend.Plans;
 /// <remarks>
 /// The keyset batch emits result sets in a deterministic sequence:
 /// <list type="number">
+/// <item>
+/// Selected page keyset ids, for a <see cref="PageKeysetSpec.Query"/> keyset only. Always present for
+/// that keyset, with no rows when the selection was empty, so the positions below do not move with
+/// selection size.
+/// </item>
 /// <item>Optional <c>TotalCount</c> (single row, single column)</item>
 /// <item><c>dms.Document</c> metadata joined to the page keyset</item>
 /// <item>Root table rows (from <c>TablePlansInDependencyOrder[0]</c>)</item>
@@ -121,7 +126,7 @@ public static class HydrationBatchBuilder
         planDialect.AppendCreateKeysetTempTable(writer, plan.KeysetTable);
         writer.AppendLine();
 
-        AppendKeysetMaterialization(writer, plan.KeysetTable, keyset);
+        AppendKeysetMaterialization(writer, planDialect, plan.KeysetTable, keyset);
         writer.AppendLine();
 
         if (keyset.Plan.TotalCountSql is not null)
@@ -243,8 +248,15 @@ public static class HydrationBatchBuilder
         planDialect.AppendCreateKeysetTempTable(writer, plan.KeysetTable);
         writer.AppendLine();
 
-        // 2. Materialize keyset
-        AppendKeysetMaterialization(writer, plan.KeysetTable, keyset, singleRowGuardPredicateSql);
+        // 2. Materialize keyset. A query keyset also returns the ids it inserted as the batch's first
+        //    result set, which is what carries the selected-keyset boundary out of hydration.
+        AppendKeysetMaterialization(
+            writer,
+            planDialect,
+            plan.KeysetTable,
+            keyset,
+            singleRowGuardPredicateSql
+        );
         writer.AppendLine();
 
         // 3. Optional total count
@@ -429,6 +441,7 @@ public static class HydrationBatchBuilder
 
     private static void AppendKeysetMaterialization(
         SqlWriter writer,
+        IPlanSqlDialect planDialect,
         KeysetTableContract keyset,
         PageKeysetSpec spec,
         string? singleRowGuardPredicateSql = null
@@ -466,19 +479,19 @@ public static class HydrationBatchBuilder
                 break;
 
             case PageKeysetSpec.SelectedPage { DocumentIds.Count: 0 }:
-                AppendEmptyKeysetMaterialization(writer, keyset, quotedDocIdCol);
+                AppendEmptySelectedPageKeysetMaterialization(writer, keyset, quotedDocIdCol);
                 break;
 
             case PageKeysetSpec.SelectedPage selectedPage:
                 AppendSelectedPageKeysetMaterialization(writer, keyset, selectedPage, quotedDocIdCol);
                 break;
 
-            case PageKeysetSpec.Query query when HasZeroLimit(query):
-                AppendEmptyKeysetMaterialization(writer, keyset, quotedDocIdCol);
+            case PageKeysetSpec.Query query when HasZeroPageSelectionSize(query):
+                AppendEmptyQueryKeysetMaterialization(writer, planDialect, keyset, quotedDocIdCol);
                 break;
 
             case PageKeysetSpec.Query query:
-                AppendQueryKeysetMaterialization(writer, keyset, query, quotedDocIdCol);
+                AppendQueryKeysetMaterialization(writer, planDialect, keyset, query, quotedDocIdCol);
                 break;
 
             default:
@@ -492,6 +505,7 @@ public static class HydrationBatchBuilder
 
     private static void AppendQueryKeysetMaterialization(
         SqlWriter writer,
+        IPlanSqlDialect planDialect,
         KeysetTableContract keyset,
         PageKeysetSpec.Query query,
         string quotedDocIdCol
@@ -505,16 +519,52 @@ public static class HydrationBatchBuilder
             .AppendRelation(keyset.Table)
             .Append(" (")
             .Append(quotedDocIdCol)
-            .AppendLine(")")
-            .Append("SELECT ")
-            .Append(quotedDocIdCol)
-            .AppendLine(" FROM page_ids;");
+            .AppendLine(")");
+        planDialect.AppendKeysetSelectedIdOutputClause(writer, keyset);
+        writer.Append("SELECT ").Append(quotedDocIdCol).Append(" FROM page_ids");
+        planDialect.AppendKeysetSelectedIdReturningClause(writer, keyset);
+        writer.AppendLine(";");
     }
 
-    private static void AppendEmptyKeysetMaterialization(
+    /// <summary>
+    /// Materializes no keyset row while still returning the selected-id result set, so a zero-size
+    /// page occupies the same result-set positions as any other query keyset.
+    /// </summary>
+    private static void AppendEmptyQueryKeysetMaterialization(
+        SqlWriter writer,
+        IPlanSqlDialect planDialect,
+        KeysetTableContract keyset,
+        string quotedDocIdCol
+    )
+    {
+        AppendEmptyKeysetInsert(writer, keyset, quotedDocIdCol, planDialect);
+    }
+
+    /// <summary>
+    /// Materializes no keyset row and returns nothing. A selected-page keyset supplies its own ids, so
+    /// hydration reads no selected-id result set for it and
+    /// <see cref="HydrationExecutor.GetResultSetCount"/> counts none; returning one here would leave a
+    /// result set no reader consumes, and every position after it would be read as the wrong result set.
+    /// </summary>
+    private static void AppendEmptySelectedPageKeysetMaterialization(
         SqlWriter writer,
         KeysetTableContract keyset,
         string quotedDocIdCol
+    )
+    {
+        AppendEmptyKeysetInsert(writer, keyset, quotedDocIdCol, planDialect: null);
+    }
+
+    /// <summary>
+    /// The shared zero-row keyset insert. Returns the ids it inserted only when
+    /// <paramref name="planDialect"/> is supplied, which is what keeps the returned result set tied to
+    /// the keyset kinds hydration actually reads one for.
+    /// </summary>
+    private static void AppendEmptyKeysetInsert(
+        SqlWriter writer,
+        KeysetTableContract keyset,
+        string quotedDocIdCol,
+        IPlanSqlDialect? planDialect
     )
     {
         writer
@@ -522,10 +572,11 @@ public static class HydrationBatchBuilder
             .AppendRelation(keyset.Table)
             .Append(" (")
             .Append(quotedDocIdCol)
-            .AppendLine(")")
-            .Append("SELECT CAST(NULL AS bigint) AS ")
-            .Append(quotedDocIdCol)
-            .AppendLine(" WHERE 1 = 0;");
+            .AppendLine(")");
+        planDialect?.AppendKeysetSelectedIdOutputClause(writer, keyset);
+        writer.Append("SELECT CAST(NULL AS bigint) AS ").Append(quotedDocIdCol).Append(" WHERE 1 = 0");
+        planDialect?.AppendKeysetSelectedIdReturningClause(writer, keyset);
+        writer.AppendLine(";");
     }
 
     private static void AppendSelectedPageKeysetMaterialization(
@@ -597,23 +648,28 @@ public static class HydrationBatchBuilder
             .AppendLine(") selected_document_ids;");
     }
 
-    private static bool HasZeroLimit(PageKeysetSpec.Query query)
+    /// <summary>
+    /// Whether the planned page selection can select nothing because its size is zero. Traditional
+    /// paging carries that size as a limit and cursor paging as a page size; both mean the same thing
+    /// here, so both skip candidate selection entirely rather than executing it for zero rows.
+    /// </summary>
+    private static bool HasZeroPageSelectionSize(PageKeysetSpec.Query query)
     {
         foreach (var parameter in query.Plan.PageParametersInOrder)
         {
-            if (parameter.Role is not QuerySqlParameterRole.Limit)
+            if (parameter.Role is not QuerySqlParameterRole.Limit and not QuerySqlParameterRole.PageSize)
             {
                 continue;
             }
 
-            return query.ParameterValues.TryGetValue(parameter.ParameterName, out var limitValue)
-                && IsZeroLimitValue(limitValue);
+            return query.ParameterValues.TryGetValue(parameter.ParameterName, out var pageSelectionSize)
+                && IsZeroPageSelectionSizeValue(pageSelectionSize);
         }
 
         return false;
     }
 
-    private static bool IsZeroLimitValue(object? value)
+    private static bool IsZeroPageSelectionSizeValue(object? value)
     {
         return value switch
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
@@ -129,7 +129,7 @@ public static class HydrationBatchBuilder
         // The selected ids are returned even though this batch's candidates come from the metadata
         // rows: the page's continuation boundary describes the keys selection chose, and a row deleted
         // between materialization and the metadata select below would otherwise lower or erase it.
-        AppendKeysetMaterialization(writer, planDialect, plan.KeysetTable, keyset, returnsSelectedIds: true);
+        AppendKeysetMaterialization(writer, planDialect, plan.KeysetTable, keyset);
         writer.AppendLine();
 
         if (keyset.Plan.TotalCountSql is not null)
@@ -258,7 +258,6 @@ public static class HydrationBatchBuilder
             planDialect,
             plan.KeysetTable,
             keyset,
-            returnsSelectedIds: true,
             singleRowGuardPredicateSql
         );
         writer.AppendLine();
@@ -443,21 +442,19 @@ public static class HydrationBatchBuilder
         }
     }
 
-    /// <param name="returnsSelectedIds">
-    /// Whether a query keyset's materialization returns the ids it inserted as a result set. True for
-    /// the batches whose reader consumes that result set to resolve the page's continuation boundary.
-    /// False for a keyset that performs no page selection, which has no boundary to report.
-    /// </param>
+    /// <summary>
+    /// Materializes the page keyset. A query keyset also returns the ids it inserted as a result set,
+    /// which is what carries the page's continuation boundary out of hydration; the other keysets are
+    /// handed the ids to materialize, so they perform no page selection and have no boundary to report.
+    /// </summary>
     private static void AppendKeysetMaterialization(
         SqlWriter writer,
         IPlanSqlDialect planDialect,
         KeysetTableContract keyset,
         PageKeysetSpec spec,
-        bool returnsSelectedIds,
         string? singleRowGuardPredicateSql = null
     )
     {
-        IPlanSqlDialect? selectedIdDialect = returnsSelectedIds ? planDialect : null;
         var quotedDocIdCol = writer.Dialect.QuoteIdentifier(keyset.DocumentIdColumnName.Value);
 
         switch (spec)
@@ -500,11 +497,11 @@ public static class HydrationBatchBuilder
                 break;
 
             case PageKeysetSpec.Query query when HasZeroPageSelectionSize(query):
-                AppendEmptyKeysetMaterialization(writer, keyset, quotedDocIdCol, selectedIdDialect);
+                AppendEmptyKeysetMaterialization(writer, keyset, quotedDocIdCol, planDialect);
                 break;
 
             case PageKeysetSpec.Query query:
-                AppendQueryKeysetMaterialization(writer, selectedIdDialect, keyset, query, quotedDocIdCol);
+                AppendQueryKeysetMaterialization(writer, planDialect, keyset, query, quotedDocIdCol);
                 break;
 
             default:
@@ -517,12 +514,12 @@ public static class HydrationBatchBuilder
     }
 
     /// <summary>
-    /// Materializes the planned page keyset. Returns the ids it inserted only when
-    /// <paramref name="selectedIdDialect"/> is supplied.
+    /// Materializes the planned page keyset, returning the ids it inserted so the page's continuation
+    /// boundary describes the keys selection chose.
     /// </summary>
     private static void AppendQueryKeysetMaterialization(
         SqlWriter writer,
-        IPlanSqlDialect? selectedIdDialect,
+        IPlanSqlDialect planDialect,
         KeysetTableContract keyset,
         PageKeysetSpec.Query query,
         string quotedDocIdCol
@@ -537,9 +534,9 @@ public static class HydrationBatchBuilder
             .Append(" (")
             .Append(quotedDocIdCol)
             .AppendLine(")");
-        selectedIdDialect?.AppendKeysetSelectedIdOutputClause(writer, keyset);
+        planDialect.AppendKeysetSelectedIdOutputClause(writer, keyset);
         writer.Append("SELECT ").Append(quotedDocIdCol).Append(" FROM page_ids");
-        selectedIdDialect?.AppendKeysetSelectedIdReturningClause(writer, keyset);
+        planDialect.AppendKeysetSelectedIdReturningClause(writer, keyset);
         writer.AppendLine(";");
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
@@ -126,15 +126,10 @@ public static class HydrationBatchBuilder
         planDialect.AppendCreateKeysetTempTable(writer, plan.KeysetTable);
         writer.AppendLine();
 
-        // This batch's reader derives its candidates from the metadata rows and has no position for a
-        // selected-id result set, so the materialization must not return one.
-        AppendKeysetMaterialization(
-            writer,
-            planDialect,
-            plan.KeysetTable,
-            keyset,
-            returnsSelectedIds: false
-        );
+        // The selected ids are returned even though this batch's candidates come from the metadata
+        // rows: the page's continuation boundary describes the keys selection chose, and a row deleted
+        // between materialization and the metadata select below would otherwise lower or erase it.
+        AppendKeysetMaterialization(writer, planDialect, plan.KeysetTable, keyset, returnsSelectedIds: true);
         writer.AppendLine();
 
         if (keyset.Plan.TotalCountSql is not null)
@@ -450,8 +445,8 @@ public static class HydrationBatchBuilder
 
     /// <param name="returnsSelectedIds">
     /// Whether a query keyset's materialization returns the ids it inserted as a result set. True for
-    /// the hydration batch, whose reader consumes that result set. False for the candidate-metadata
-    /// batch, whose reader has no position for it and derives its candidates from the metadata rows.
+    /// the batches whose reader consumes that result set to resolve the page's continuation boundary.
+    /// False for a keyset that performs no page selection, which has no boundary to report.
     /// </param>
     private static void AppendKeysetMaterialization(
         SqlWriter writer,
@@ -497,12 +492,7 @@ public static class HydrationBatchBuilder
             // A selected-page keyset supplies its own ids, so hydration reads no selected-id result set
             // for it and GetResultSetCount counts none.
             case PageKeysetSpec.SelectedPage { DocumentIds.Count: 0 }:
-                AppendEmptyKeysetMaterialization(
-                    writer,
-                    keyset,
-                    quotedDocIdCol,
-                    selectedIdDialect: null
-                );
+                AppendEmptyKeysetMaterialization(writer, keyset, quotedDocIdCol, selectedIdDialect: null);
                 break;
 
             case PageKeysetSpec.SelectedPage selectedPage:
@@ -514,13 +504,7 @@ public static class HydrationBatchBuilder
                 break;
 
             case PageKeysetSpec.Query query:
-                AppendQueryKeysetMaterialization(
-                    writer,
-                    selectedIdDialect,
-                    keyset,
-                    query,
-                    quotedDocIdCol
-                );
+                AppendQueryKeysetMaterialization(writer, selectedIdDialect, keyset, query, quotedDocIdCol);
                 break;
 
             default:

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationExecutor.cs
@@ -183,10 +183,13 @@ public static class HydrationExecutor
         await using var reader = await command.ExecuteReaderAsync(ct);
 
         // Keyset batches begin with temp-table reset/creation + INSERT materialization. Both Npgsql
-        // and SqlClient skip statements that return no rows when advancing result sets, so the reader
-        // is positioned at the batch's first row-returning statement automatically: the query keyset's
-        // materialization insert, which returns the ids it selected, or otherwise the first SELECT.
-        // The PostgreSQL single-document fast path starts at that same first SELECT.
+        // and SqlClient skip statements that produce no result set (DDL, and DML without an
+        // OUTPUT/RETURNING clause), so the reader is positioned at the batch's first row-returning
+        // statement automatically. An OUTPUT/RETURNING clause still produces a result set when the
+        // statement affects zero rows, so a query keyset's materialization insert always holds that
+        // first position, returning the ids it selected — an empty result set for a zero-size page.
+        // Without such a clause the first position is the first SELECT, where the PostgreSQL
+        // single-document fast path also starts.
         return await ReadPageAsync(reader, plan, keyset, executionOptions, ct);
     }
 
@@ -194,7 +197,7 @@ public static class HydrationExecutor
     /// How many result sets the hydration batch for <paramref name="keyset"/> emits, which is also the
     /// number of result-set positions the batch occupies when co-batched into a larger command. A query
     /// keyset's materialization insert returns its selected ids and therefore occupies a position; the
-    /// batch's remaining DDL/DML statements return nothing and occupy none.
+    /// batch's remaining DDL/DML statements produce no result set and occupy none.
     /// </summary>
     public static int GetResultSetCount(
         ResourceReadPlan plan,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationExecutor.cs
@@ -15,11 +15,12 @@ namespace EdFi.DataManagementService.Backend.Plans;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The executor builds a single SQL batch that returns multiple result sets (document metadata,
-/// root rows, child rows, descriptor URI rows, and optional document-reference lookup rows)
-/// consumed sequentially via <see cref="DbDataReader.NextResultAsync"/>. Query and default
-/// single-document batches materialize a keyset relation first; the PostgreSQL single-document
-/// fast path starts directly with document metadata.
+/// The executor builds a single SQL batch that returns multiple result sets (a query keyset's
+/// selected ids, document metadata, root rows, child rows, descriptor URI rows, and optional
+/// document-reference lookup rows) consumed sequentially via
+/// <see cref="DbDataReader.NextResultAsync"/>. Query and default single-document batches materialize
+/// a keyset relation first; the PostgreSQL single-document fast path starts directly with document
+/// metadata.
 /// </para>
 /// <para>
 /// Takes an already-opened <see cref="DbConnection"/> so callers can manage connection
@@ -181,17 +182,19 @@ public static class HydrationExecutor
 
         await using var reader = await command.ExecuteReaderAsync(ct);
 
-        // Keyset batches begin with temp-table reset/creation + INSERT materialization. Both
-        // Npgsql and SqlClient skip DDL/DML statements when advancing result sets, so the reader
-        // is positioned at the first SELECT result set automatically. The PostgreSQL fast path
-        // starts with that same first SELECT result set.
+        // Keyset batches begin with temp-table reset/creation + INSERT materialization. Both Npgsql
+        // and SqlClient skip statements that return no rows when advancing result sets, so the reader
+        // is positioned at the batch's first row-returning statement automatically: the query keyset's
+        // materialization insert, which returns the ids it selected, or otherwise the first SELECT.
+        // The PostgreSQL single-document fast path starts at that same first SELECT.
         return await ReadPageAsync(reader, plan, keyset, executionOptions, ct);
     }
 
     /// <summary>
-    /// How many result sets the hydration batch for <paramref name="keyset"/> emits. The batch's
-    /// DDL/DML statements produce none, so this is also the number of result-set positions the batch
-    /// occupies when co-batched into a larger command.
+    /// How many result sets the hydration batch for <paramref name="keyset"/> emits, which is also the
+    /// number of result-set positions the batch occupies when co-batched into a larger command. A query
+    /// keyset's materialization insert returns its selected ids and therefore occupies a position; the
+    /// batch's remaining DDL/DML statements return nothing and occupy none.
     /// </summary>
     public static int GetResultSetCount(
         ResourceReadPlan plan,
@@ -203,6 +206,11 @@ public static class HydrationExecutor
         ArgumentNullException.ThrowIfNull(keyset);
 
         var count = 1 + plan.TablePlansInDependencyOrder.Length;
+
+        if (keyset is PageKeysetSpec.Query)
+        {
+            count++;
+        }
 
         if (keyset is PageKeysetSpec.Query { Plan.TotalCountSql: not null })
         {
@@ -240,7 +248,26 @@ public static class HydrationExecutor
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(keyset);
 
-        // 1. Optional total count
+        // 1. Selected page keyset ids, for a query keyset only. Read before anything else because the
+        //    materialization insert that returns them is the batch's first row-returning statement.
+        //    The boundary describes the keys selection chose, so it is independent of what the
+        //    metadata and table result sets below still find: every selected row may have been deleted
+        //    between materialization and hydration, leaving a non-null boundary and an empty page.
+        long? highestSelectedDocumentId = null;
+
+        if (keyset is PageKeysetSpec.Query)
+        {
+            highestSelectedDocumentId = await HydrationReader.ReadSelectedDocumentIdMaximumAsync(reader, ct);
+
+            if (!await reader.NextResultAsync(ct))
+            {
+                throw new InvalidOperationException(
+                    "Expected a result set after the selected page keyset ids but no more result sets available."
+                );
+            }
+        }
+
+        // 2. Optional total count
         long? totalCount = null;
         bool hasTotalCount = keyset is PageKeysetSpec.Query { Plan.TotalCountSql: not null };
 
@@ -255,10 +282,10 @@ public static class HydrationExecutor
             }
         }
 
-        // 2. Document metadata
+        // 3. Document metadata
         var documentMetadata = await HydrationReader.ReadDocumentMetadataAsync(reader, ct);
 
-        // 3. Table rows in dependency order
+        // 4. Table rows in dependency order
         var tableRows = new HydratedTableRows[plan.TablePlansInDependencyOrder.Length];
 
         for (var i = 0; i < plan.TablePlansInDependencyOrder.Length; i++)
@@ -281,7 +308,7 @@ public static class HydrationExecutor
 
         if (executionOptions.IncludeDescriptorProjection)
         {
-            // 4. Descriptor URI rows in compiled-plan order
+            // 5. Descriptor URI rows in compiled-plan order
             for (var i = 0; i < plan.DescriptorProjectionPlansInOrder.Length; i++)
             {
                 if (!await reader.NextResultAsync(ct))
@@ -299,7 +326,7 @@ public static class HydrationExecutor
             }
         }
 
-        // 5. Document-reference auxiliary lookup (gated by plan property AND the caller-supplied
+        // 6. Document-reference auxiliary lookup (gated by plan property AND the caller-supplied
         //    execution option — write-path callers opt out because they discard the result).
         HydratedDocumentReferenceLookup? documentReferenceLookup = null;
 
@@ -325,6 +352,7 @@ public static class HydrationExecutor
         return new HydratedPage(totalCount, documentMetadata, tableRows, descriptorRows)
         {
             DocumentReferenceLookup = documentReferenceLookup,
+            HighestSelectedDocumentId = highestSelectedDocumentId,
         };
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationReader.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationReader.cs
@@ -39,6 +39,39 @@ public static class HydrationReader
     }
 
     /// <summary>
+    /// Reads the selected page keyset ids from the current result set and returns the maximum, or
+    /// <see langword="null"/> when the selection was empty.
+    /// </summary>
+    /// <remarks>
+    /// Neither <c>RETURNING</c> nor <c>OUTPUT</c> promises an order, so the maximum is taken across
+    /// every returned row rather than from the first or last one.
+    /// </remarks>
+    /// <param name="reader">The data reader positioned at the selected keyset result set.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The maximum selected <c>DocumentId</c>, or null when no id was selected.</returns>
+    public static async Task<long?> ReadSelectedDocumentIdMaximumAsync(
+        DbDataReader reader,
+        CancellationToken ct
+    )
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        long? selectedMaximum = null;
+
+        while (await reader.ReadAsync(ct))
+        {
+            var selectedDocumentId = reader.GetInt64(0);
+
+            if (selectedMaximum is null || selectedDocumentId > selectedMaximum)
+            {
+                selectedMaximum = selectedDocumentId;
+            }
+        }
+
+        return selectedMaximum;
+    }
+
+    /// <summary>
     /// Expected column count for the document metadata result set, defined by
     /// <see cref="DocumentMetadataColumns.ColumnsInOrdinalOrder"/>.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/IPlanSqlDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/IPlanSqlDialect.cs
@@ -70,6 +70,25 @@ internal interface IPlanSqlDialect
     void AppendCreateKeysetTempTable(SqlWriter writer, KeysetTableContract keyset);
 
     /// <summary>
+    /// Appends a dialect-specific clause that returns the <c>DocumentId</c> values a query keyset
+    /// materialization inserted, positioned between the insert column list and the row source. SQL
+    /// Server emits <c>OUTPUT INSERTED.[DocumentId]</c> here; PostgreSQL returns them from a trailing
+    /// clause and emits nothing.
+    /// </summary>
+    /// <param name="writer">The SQL writer to append to.</param>
+    /// <param name="keyset">The keyset table contract specifying table and column names.</param>
+    void AppendKeysetSelectedIdOutputClause(SqlWriter writer, KeysetTableContract keyset);
+
+    /// <summary>
+    /// Appends a dialect-specific trailing clause that returns the <c>DocumentId</c> values a query
+    /// keyset materialization inserted. PostgreSQL emits <c>RETURNING "DocumentId"</c>; SQL Server has
+    /// already returned them from the insert's <c>OUTPUT</c> clause and emits nothing.
+    /// </summary>
+    /// <param name="writer">The SQL writer to append to.</param>
+    /// <param name="keyset">The keyset table contract specifying table and column names.</param>
+    void AppendKeysetSelectedIdReturningClause(SqlWriter writer, KeysetTableContract keyset);
+
+    /// <summary>
     /// Appends a <c>SELECT</c> statement that joins <c>dms.Document</c> metadata to the
     /// materialized keyset table, returning document metadata columns for the page,
     /// ordered by selected-page ordinal when available, otherwise deterministically by

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/MssqlPlanDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/MssqlPlanDialect.cs
@@ -99,6 +99,31 @@ internal sealed class MssqlPlanDialect : IPlanSqlDialect
             .AppendLine(" int NULL);");
     }
 
+    /// <summary>
+    /// Appends a SQL Server <c>OUTPUT INSERTED</c> clause naming the keyset document-id column.
+    /// </summary>
+    /// <param name="writer">The SQL writer to append to.</param>
+    /// <param name="keyset">The keyset table contract specifying table and column names.</param>
+    public void AppendKeysetSelectedIdOutputClause(SqlWriter writer, KeysetTableContract keyset)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(keyset);
+
+        writer.Append("OUTPUT INSERTED.").AppendQuoted(keyset.DocumentIdColumnName.Value).AppendLine();
+    }
+
+    /// <summary>
+    /// Emits nothing: SQL Server has already returned the inserted keyset ids from the insert's
+    /// <c>OUTPUT</c> clause.
+    /// </summary>
+    /// <param name="writer">The SQL writer to append to.</param>
+    /// <param name="keyset">The keyset table contract specifying table and column names.</param>
+    public void AppendKeysetSelectedIdReturningClause(SqlWriter writer, KeysetTableContract keyset)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(keyset);
+    }
+
     /// <inheritdoc />
     public void AppendDocumentMetadataSelect(SqlWriter writer, KeysetTableContract keyset)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PgsqlPlanDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PgsqlPlanDialect.cs
@@ -87,6 +87,30 @@ internal sealed class PgsqlPlanDialect : IPlanSqlDialect
             .AppendLine(" int NULL) ON COMMIT DROP;");
     }
 
+    /// <summary>
+    /// Emits nothing: PostgreSQL returns inserted keyset ids from a trailing <c>RETURNING</c> clause.
+    /// </summary>
+    /// <param name="writer">The SQL writer to append to.</param>
+    /// <param name="keyset">The keyset table contract specifying table and column names.</param>
+    public void AppendKeysetSelectedIdOutputClause(SqlWriter writer, KeysetTableContract keyset)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(keyset);
+    }
+
+    /// <summary>
+    /// Appends a PostgreSQL <c>RETURNING</c> clause naming the keyset document-id column.
+    /// </summary>
+    /// <param name="writer">The SQL writer to append to.</param>
+    /// <param name="keyset">The keyset table contract specifying table and column names.</param>
+    public void AppendKeysetSelectedIdReturningClause(SqlWriter writer, KeysetTableContract keyset)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(keyset);
+
+        writer.Append(" RETURNING ").AppendQuoted(keyset.DocumentIdColumnName.Value);
+    }
+
     /// <inheritdoc />
     public void AppendDocumentMetadataSelect(SqlWriter writer, KeysetTableContract keyset)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/HydrationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/HydrationExecutorTests.cs
@@ -1565,3 +1565,274 @@ public class Given_Two_Postgresql_Hydration_Batches_On_The_Same_Transaction
         return result is true;
     }
 }
+
+/// <summary>
+/// The keyset materialization's <c>RETURNING</c> clause carries the selected page keyset out of
+/// hydration on the same command that hydrates it. These cases run the real batch against PostgreSQL,
+/// because the clause is only valid if the server accepts it.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class Given_A_Pgsql_Query_Keyset_That_Returns_Its_Selected_Ids
+{
+    private NpgsqlDataSource _dataSource = null!;
+
+    private const string TestSchema = "hydselected";
+
+    /// <summary>
+    /// Sparse ids, so a maximum cannot be confused with a count or a row position.
+    /// </summary>
+    private const long FirstDocumentId = 501L;
+    private const long SecondDocumentId = 509L;
+    private const long ThirdDocumentId = 517L;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var connection = await _dataSource.OpenConnectionAsync();
+
+        await ExecuteSql(
+            connection,
+            """
+            DROP SCHEMA IF EXISTS hydselected CASCADE;
+            CREATE SCHEMA hydselected;
+            CREATE SCHEMA IF NOT EXISTS dms;
+
+            CREATE TABLE IF NOT EXISTS dms."Document" (
+                "DocumentId" bigint PRIMARY KEY,
+                "DocumentUuid" uuid NOT NULL,
+                "ResourceKeyId" smallint NOT NULL DEFAULT 0,
+                "ContentVersion" bigint NOT NULL DEFAULT 1,
+                "IdentityVersion" bigint NOT NULL DEFAULT 1,
+                "ContentLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "IdentityLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "CreatedAt" timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE hydselected."School" (
+                "DocumentId" bigint PRIMARY KEY,
+                "SchoolId" integer NOT NULL
+            );
+
+            CREATE TABLE hydselected."SchoolAddress" (
+                "CollectionItemId" bigint PRIMARY KEY,
+                "School_DocumentId" bigint NOT NULL REFERENCES hydselected."School"("DocumentId"),
+                "Ordinal" integer NOT NULL,
+                "City" varchar(100) NOT NULL
+            );
+
+            CREATE TABLE hydselected."SchoolAddressPeriod" (
+                "CollectionItemId" bigint PRIMARY KEY,
+                "School_DocumentId" bigint NOT NULL,
+                "ParentCollectionItemId" bigint NOT NULL REFERENCES hydselected."SchoolAddress"("CollectionItemId"),
+                "Ordinal" integer NOT NULL,
+                "BeginDate" varchar(10) NOT NULL
+            );
+            """
+        );
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync();
+
+        await ExecuteSql(
+            connection,
+            """
+            DELETE FROM hydselected."SchoolAddressPeriod";
+            DELETE FROM hydselected."SchoolAddress";
+            DELETE FROM hydselected."School";
+            DELETE FROM dms."Document" WHERE "DocumentId" IN (501, 509, 517);
+
+            INSERT INTO dms."Document" ("DocumentId", "DocumentUuid")
+            VALUES
+                (501, '22222222-8888-8888-8888-222222222222'),
+                (509, '33333333-9999-9999-9999-333333333333'),
+                (517, '44444444-aaaa-aaaa-aaaa-444444444444');
+
+            INSERT INTO hydselected."School" ("DocumentId", "SchoolId")
+            VALUES (501, 910001), (509, 910002), (517, 910003);
+            """
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var connection = await _dataSource.OpenConnectionAsync();
+            await ExecuteSql(
+                connection,
+                """
+                DROP SCHEMA IF EXISTS hydselected CASCADE;
+                DELETE FROM dms."Document" WHERE "DocumentId" IN (501, 509, 517);
+                """
+            );
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task It_returns_the_maximum_selected_document_id_for_a_cursor_page()
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync();
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            connection,
+            HydrationTestHelper.BuildSchoolReadPlan(TestSchema, SqlDialect.Pgsql),
+            CreateCursorKeyset(pageSize: 2L),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        result.HighestSelectedDocumentId.Should().Be(SecondDocumentId);
+        result
+            .DocumentMetadata.Select(static documentMetadata => documentMetadata.DocumentId)
+            .Should()
+            .Equal(FirstDocumentId, SecondDocumentId);
+    }
+
+    [Test]
+    public async Task It_returns_no_maximum_for_a_zero_size_cursor_page()
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync();
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            connection,
+            HydrationTestHelper.BuildSchoolReadPlan(TestSchema, SqlDialect.Pgsql),
+            CreateCursorKeyset(pageSize: 0L),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        result.HighestSelectedDocumentId.Should().BeNull();
+        result.DocumentMetadata.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_returns_no_maximum_when_the_range_selects_nothing()
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync();
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            connection,
+            HydrationTestHelper.BuildSchoolReadPlan(TestSchema, SqlDialect.Pgsql),
+            CreateCursorKeyset(pageSize: 25L, inclusiveMinimum: 600L, inclusiveMaximum: 700L),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        result.HighestSelectedDocumentId.Should().BeNull();
+        result.DocumentMetadata.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Deletes every selected row inside the hydration batch, between the materialization that
+    /// selected them and the hydration selects that follow it. This is a deterministic stand-in for a
+    /// delete that commits in that same window — not a separate concurrent transaction — and it is the
+    /// case a body-derived boundary would answer wrongly by stalling the walk.
+    /// </summary>
+    [Test]
+    public async Task It_returns_the_maximum_when_every_selected_row_was_deleted_before_hydration()
+    {
+        const string SpliceAfter = "SELECT \"DocumentId\" FROM page_ids RETURNING \"DocumentId\";";
+        const string DeleteEverySelectedRow = """
+
+            DELETE FROM hydselected."SchoolAddressPeriod";
+            DELETE FROM hydselected."SchoolAddress";
+            DELETE FROM hydselected."School";
+            DELETE FROM dms."Document" WHERE "DocumentId" IN (501, 509, 517);
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync();
+        var splicedBatches = new List<string>();
+
+        var result = await HydrationExecutor.ExecuteAsync(
+            batchSql =>
+            {
+                CountOccurrences(batchSql, SpliceAfter)
+                    .Should()
+                    .Be(
+                        1,
+                        "the materialization statement is the splice point, so it must appear exactly once"
+                    );
+
+                var splicedBatch = batchSql.Replace(
+                    SpliceAfter,
+                    SpliceAfter + DeleteEverySelectedRow,
+                    StringComparison.Ordinal
+                );
+                splicedBatches.Add(splicedBatch);
+
+                var command = connection.CreateCommand();
+                command.CommandText = splicedBatch;
+                return command;
+            },
+            HydrationTestHelper.BuildSchoolReadPlan(TestSchema, SqlDialect.Pgsql),
+            CreateCursorKeyset(pageSize: 25L),
+            SqlDialect.Pgsql,
+            new HydrationExecutionOptions(),
+            CancellationToken.None
+        );
+
+        splicedBatches.Should().ContainSingle();
+        result.HighestSelectedDocumentId.Should().Be(ThirdDocumentId);
+        result.DocumentMetadata.Should().BeEmpty();
+        result.TableRowsInDependencyOrder.Should().OnlyContain(tableRows => tableRows.Rows.Count == 0);
+    }
+
+    private static PageKeysetSpec.Query CreateCursorKeyset(
+        object pageSize,
+        long inclusiveMinimum = 1L,
+        long inclusiveMaximum = long.MaxValue
+    ) =>
+        new(
+            new PageDocumentIdSqlPlan(
+                PageDocumentIdSql: """
+                SELECT "DocumentId" FROM hydselected."School"
+                WHERE "DocumentId" >= @cursorMin
+                  AND "DocumentId" <= @cursorMax
+                ORDER BY "DocumentId"
+                LIMIT @pageSize
+                """,
+                TotalCountSql: null,
+                PageParametersInOrder:
+                [
+                    new QuerySqlParameter(QuerySqlParameterRole.CursorInclusiveMinimum, "cursorMin"),
+                    new QuerySqlParameter(QuerySqlParameterRole.CursorInclusiveMaximum, "cursorMax"),
+                    new QuerySqlParameter(QuerySqlParameterRole.PageSize, "pageSize"),
+                ],
+                TotalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?>
+            {
+                ["cursorMin"] = inclusiveMinimum,
+                ["cursorMax"] = inclusiveMaximum,
+                ["pageSize"] = pageSize,
+            }
+        );
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var occurrences = 0;
+        var searchIndex = text.IndexOf(value, StringComparison.Ordinal);
+
+        while (searchIndex >= 0)
+        {
+            occurrences++;
+            searchIndex = text.IndexOf(value, searchIndex + value.Length, StringComparison.Ordinal);
+        }
+
+        return occurrences;
+    }
+
+    private static async Task ExecuteSql(NpgsqlConnection connection, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
@@ -23,6 +23,39 @@ using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
+internal sealed class DescriptorCommandRecorder
+{
+    private readonly List<string> _commandTexts = [];
+
+    public IReadOnlyList<string> CommandTexts => _commandTexts;
+
+    public void Reset() => _commandTexts.Clear();
+
+    public void Record(RelationalCommand command) => _commandTexts.Add(command.CommandText);
+}
+
+/// <summary>
+/// Records the descriptor page commands the real provider executor ran, so a test can prove a cursor
+/// page cost exactly one command and asked for no count rather than inferring it from a null TotalCount.
+/// </summary>
+internal sealed class RecordingDescriptorCommandExecutor(
+    PostgresqlRelationalCommandExecutor inner,
+    DescriptorCommandRecorder recorder
+) : IRelationalCommandExecutor
+{
+    public SqlDialect Dialect => inner.Dialect;
+
+    public Task<TResult> ExecuteReaderAsync<TResult>(
+        RelationalCommand command,
+        Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+        CancellationToken cancellationToken = default
+    )
+    {
+        recorder.Record(command);
+        return inner.ExecuteReaderAsync(command, readAsync, cancellationToken);
+    }
+}
+
 [TestFixture]
 [NonParallelizable]
 [Category("DatabaseIntegration")]
@@ -528,6 +561,14 @@ public class Given_A_Postgresql_DescriptorRead_Query_Request
         services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
         services.AddTestReadableProfileProjector();
         services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddSingleton<DescriptorCommandRecorder>();
+        services.AddScoped<PostgresqlRelationalCommandExecutor>();
+        services.AddScoped<IRelationalCommandExecutor>(
+            serviceProvider => new RecordingDescriptorCommandExecutor(
+                serviceProvider.GetRequiredService<PostgresqlRelationalCommandExecutor>(),
+                serviceProvider.GetRequiredService<DescriptorCommandRecorder>()
+            )
+        );
         services.AddPostgresqlBackendIntegrationTestServices();
 
         return services.BuildServiceProvider(
@@ -732,6 +773,161 @@ public class Given_A_Postgresql_DescriptorRead_Query_Request
 
         success.HighestSelectedDocumentId.Should().BeNull();
         success.EdfiDocs.Should().BeEmpty();
+    }
+
+    // The story requires real-provider descriptor evidence for the predicates a cursor page composes
+    // with, not only for the unfiltered walk. A filter reaching the descriptor candidate relation
+    // alongside the range is what keeps a filtered walk from returning documents the filter excludes.
+    [Test]
+    public async Task It_composes_a_descriptor_query_filter_with_the_cursor_range()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [CreateQueryElement("codeValue", "$.codeValue", PagingSecondSeed.CodeValue)],
+                "pg-descriptor-cursor-filter",
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+        success.EdfiDocs.Should().ContainSingle();
+        AssertDescriptorDocument(success.EdfiDocs[0]!.AsObject(), PagingSecondSeed);
+        success.HighestSelectedDocumentId.Should().NotBeNull();
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    // A min-only window keeps DocumentId ordering, so a cursor page inside it continues normally.
+    [Test]
+    public async Task It_composes_a_min_only_change_version_window_with_the_descriptor_cursor_range()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+        var contentVersions = await ReadDescriptorContentVersionsByDocumentUuidAsync();
+        var lowestContentVersion = contentVersions.Values.Min();
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "pg-descriptor-cursor-min-window",
+                changeVersionRange: new ChangeVersionRange(lowestContentVersion, null),
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+        success.EdfiDocs.Should().HaveCount(PagingDescriptorSeeds.Length);
+        success.HighestSelectedDocumentId.Should().NotBeNull();
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    // A window that excludes every descriptor selects nothing, so the page carries no boundary: the
+    // change-version predicate really reaches the cursor candidate relation rather than being dropped.
+    [Test]
+    public async Task It_composes_an_excluding_change_version_window_with_the_descriptor_cursor_range()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+        var contentVersions = await ReadDescriptorContentVersionsByDocumentUuidAsync();
+        var highestContentVersion = contentVersions.Values.Max();
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "pg-descriptor-cursor-excluding-window",
+                changeVersionRange: new ChangeVersionRange(highestContentVersion + 1, null),
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+        success.EdfiDocs.Should().BeEmpty();
+        success.HighestSelectedDocumentId.Should().BeNull();
+    }
+
+    // A max-bearing window still leaves a cursor page ordered by DocumentId, so its selected maximum can
+    // anchor a continuation. A traditional page over the same window cannot, and that contrast is the
+    // interim suppression rule observed on a real descriptor query.
+    [Test]
+    public async Task It_composes_a_max_bearing_change_version_window_with_the_descriptor_cursor_range()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+        var contentVersions = await ReadDescriptorContentVersionsByDocumentUuidAsync();
+        var highestContentVersion = contentVersions.Values.Max();
+
+        var cursorSuccess = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "pg-descriptor-cursor-max-window",
+                changeVersionRange: new ChangeVersionRange(null, highestContentVersion),
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+        cursorSuccess.EdfiDocs.Should().HaveCount(PagingDescriptorSeeds.Length);
+        cursorSuccess.HighestSelectedDocumentId.Should().NotBeNull();
+        cursorSuccess.AllowsDocumentIdContinuation.Should().BeTrue();
+
+        var traditionalSuccess = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "pg-descriptor-traditional-max-window",
+                changeVersionRange: new ChangeVersionRange(null, highestContentVersion)
+            );
+
+        traditionalSuccess.HighestSelectedDocumentId.Should().NotBeNull();
+        traditionalSuccess.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task It_selects_the_whole_descriptor_collection_at_the_configured_maximum_page_size()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "pg-descriptor-cursor-size-max",
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(MaximumPageSize))
+            );
+
+        success.EdfiDocs.Should().HaveCount(PagingDescriptorSeeds.Length);
+        success.HighestSelectedDocumentId.Should().NotBeNull();
+    }
+
+    // Observed at the provider command seam rather than inferred from a null TotalCount: a descriptor
+    // cursor page runs exactly one command, and that command asks for no count. A second roundtrip or a
+    // count would break the single-command invariant without changing any response value.
+    [Test]
+    public async Task It_runs_one_descriptor_command_with_no_count_for_a_cursor_page()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var recorder = _serviceProvider.GetRequiredService<DescriptorCommandRecorder>();
+        recorder.Reset();
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "pg-descriptor-cursor-command-shape",
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(2))
+            );
+
+        success.EdfiDocs.Should().HaveCount(2);
+        recorder.CommandTexts.Should().ContainSingle("a cursor page must not add a command or a roundtrip");
+        recorder.CommandTexts[0].Should().NotContain("COUNT");
+        recorder.CommandTexts[0].Should().Contain("@cursorMin");
+        recorder.CommandTexts[0].Should().Contain("@cursorMax");
+        recorder.CommandTexts[0].Should().Contain("@pageSize");
+        recorder.CommandTexts[0].Should().NotContain("@offset");
+    }
+
+    // The traditional counterpart does compile count SQL when asked, so the assertion above is a property
+    // of cursor mode rather than of this fixture never counting at all.
+    [Test]
+    public async Task It_still_counts_for_a_traditional_descriptor_page_when_requested()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var recorder = _serviceProvider.GetRequiredService<DescriptorCommandRecorder>();
+        recorder.Reset();
+
+        await ExecuteQueryAsync([], "pg-descriptor-traditional-command-shape", totalCount: true);
+
+        recorder.CommandTexts.Should().ContainSingle();
+        recorder.CommandTexts[0].Should().Contain("COUNT");
     }
 
     private static void AssertDescriptorPage(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
@@ -587,7 +587,8 @@ public class Given_A_Postgresql_DescriptorRead_Query_Request
         int limit = 25,
         int offset = 0,
         ChangeVersionRange? changeVersionRange = null,
-        AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null
+        AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null,
+        CollectionPaging? paging = null
     )
     {
         await using var scope = _serviceProvider.CreateAsyncScope();
@@ -599,14 +600,15 @@ public class Given_A_Postgresql_DescriptorRead_Query_Request
             MappingSet: _mappingSet,
             QueryElements: queryElements,
             AuthorizationStrategyEvaluators: authorizationStrategyEvaluators ?? [],
-            Paging: new CollectionPaging.Traditional(
-                new PaginationParameters(
-                    Limit: limit,
-                    Offset: offset,
-                    TotalCount: totalCount,
-                    MaximumPageSize: MaximumPageSize
-                )
-            ),
+            Paging: paging
+                ?? new CollectionPaging.Traditional(
+                    new PaginationParameters(
+                        Limit: limit,
+                        Offset: offset,
+                        TotalCount: totalCount,
+                        MaximumPageSize: MaximumPageSize
+                    )
+                ),
             TraceId: new TraceId(traceId),
             ChangeVersionRange: changeVersionRange
         );
@@ -668,6 +670,68 @@ public class Given_A_Postgresql_DescriptorRead_Query_Request
     private static void AssertSingleDescriptorMatch(QueryResult result, DescriptorReadSeed expectedSeed)
     {
         AssertDescriptorPage(result, [expectedSeed]);
+    }
+
+    // A descriptor cursor walk against a real database. Descriptor selection and row retrieval are one
+    // statement, so the boundary each page reports is the maximum of the keys that statement selected,
+    // and following it must deliver every seeded descriptor exactly once before the walk ends empty.
+    [Test]
+    public async Task It_walks_descriptor_pages_by_cursor()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        List<string> walkedDocumentUuids = [];
+        var range = CursorRange.From(1);
+        var pages = 0;
+
+        while (pages++ < PagingDescriptorSeeds.Length + 1)
+        {
+            var success = (QueryResult.QuerySuccess)
+                await ExecuteQueryAsync(
+                    [],
+                    "pg-descriptor-cursor-walk",
+                    paging: new CollectionPaging.Cursor(range, new PageSize(2))
+                );
+
+            // Cursor mode asks for no count on any page of the walk.
+            success.TotalCount.Should().BeNull();
+
+            walkedDocumentUuids.AddRange(
+                success.EdfiDocs.Select(document => document!["id"]!.GetValue<string>())
+            );
+
+            if (success.HighestSelectedDocumentId is not { } highestSelectedDocumentId)
+            {
+                success.EdfiDocs.Should().BeEmpty("the page that ends a walk selects nothing");
+                break;
+            }
+
+            success.AllowsDocumentIdContinuation.Should().BeTrue();
+            range = new CursorRange(highestSelectedDocumentId + 1, range.InclusiveMaximum);
+        }
+
+        string[] expectedDocumentUuids =
+        [
+            .. PagingDescriptorSeeds.Select(seed => seed.DocumentUuid.Value.ToString()),
+        ];
+
+        walkedDocumentUuids.Should().Equal(expectedDocumentUuids.AsEnumerable());
+    }
+
+    [Test]
+    public async Task It_selects_no_descriptor_page_at_a_zero_cursor_page_size()
+    {
+        await SeedDescriptorsAsync(PagingDescriptorSeeds);
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                "pg-descriptor-cursor-size-0",
+                paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(0))
+            );
+
+        success.HighestSelectedDocumentId.Should().BeNull();
+        success.EdfiDocs.Should().BeEmpty();
     }
 
     private static void AssertDescriptorPage(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryExecutionTests.cs
@@ -621,6 +621,235 @@ public class Given_A_Postgresql_Relational_Query_With_The_Authoritative_Ds52_Sch
         walkedDocumentUuids.Should().Equal(expectedProgression);
     }
 
+    // A cursor walk over the seeded collection: each page selects from the range the previous page's
+    // boundary opened, and the walk ends on a page that selects nothing. Every document is returned
+    // exactly once, which is the property a client depends on and the one an off-by-one boundary breaks.
+    [Test]
+    public async Task It_walks_every_document_exactly_once_across_cursor_pages()
+    {
+        var expectedDocumentIds = _persistedSchoolsInDocumentOrder
+            .Select(static school => school.DocumentId)
+            .ToArray();
+
+        List<long> walkedDocumentIds = [];
+        var range = CursorRange.From(1);
+        var pageCount = 0;
+
+        while (pageCount++ < expectedDocumentIds.Length + 1)
+        {
+            _recorder.Reset();
+            var success = (QueryResult.QuerySuccess)
+                await ExecuteCursorQueryAsync(range, pageSize: 2, traceId: $"pg-cursor-walk-{pageCount}");
+
+            // One command per page, and no count SQL on any of them.
+            var keyset = AssertSingleQueryHydration();
+            keyset.Plan.TotalCountSql.Should().BeNull();
+            success.TotalCount.Should().BeNull();
+
+            walkedDocumentIds.AddRange(_recorder.PageMaterializedDocumentIds);
+
+            if (success.HighestSelectedDocumentId is not { } highestSelectedDocumentId)
+            {
+                success.EdfiDocs.Should().BeEmpty();
+                break;
+            }
+
+            success.AllowsDocumentIdContinuation.Should().BeTrue();
+            range = new CursorRange(highestSelectedDocumentId + 1, range.InclusiveMaximum);
+        }
+
+        walkedDocumentIds.Should().Equal(expectedDocumentIds);
+    }
+
+    [Test]
+    public async Task It_selects_one_document_per_page_at_page_size_one()
+    {
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(CursorRange.From(1), pageSize: 1, traceId: "pg-cursor-size-1");
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[0].DocumentId);
+        AssertPageMaterialization(_persistedSchoolsInDocumentOrder[0].DocumentId);
+    }
+
+    [Test]
+    public async Task It_selects_the_whole_collection_at_the_configured_maximum_page_size()
+    {
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(1),
+                pageSize: MaximumPageSize,
+                traceId: "pg-cursor-size-max"
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[^1].DocumentId);
+        AssertPageMaterialization([
+            .. _persistedSchoolsInDocumentOrder.Select(static school => school.DocumentId),
+        ]);
+    }
+
+    // A zero page size selects nothing and cannot advance a walk, by contract rather than by arithmetic.
+    [Test]
+    public async Task It_selects_nothing_at_page_size_zero()
+    {
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(CursorRange.From(1), pageSize: 0, traceId: "pg-cursor-size-0");
+
+        success.HighestSelectedDocumentId.Should().BeNull();
+        success.EdfiDocs.Should().BeEmpty();
+    }
+
+    // An inverted range is the terminal condition of a bounded walk, not an error.
+    [Test]
+    public async Task It_selects_nothing_from_an_inverted_range()
+    {
+        var lastDocumentId = _persistedSchoolsInDocumentOrder[^1].DocumentId;
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                new CursorRange(lastDocumentId + 1, lastDocumentId),
+                pageSize: 25,
+                traceId: "pg-cursor-inverted"
+            );
+
+        success.HighestSelectedDocumentId.Should().BeNull();
+        success.EdfiDocs.Should().BeEmpty();
+    }
+
+    // Range bounds are seek positions, not identities. Neither bound here is a stored DocumentId, and
+    // the page still selects exactly the documents inside the range — which is what keeps a walk correct
+    // across the identity gaps deletes leave behind.
+    [Test]
+    public async Task It_seeks_within_bounds_that_are_not_stored_document_ids()
+    {
+        var firstDocumentId = _persistedSchoolsInDocumentOrder[0].DocumentId;
+        var lastDocumentId = _persistedSchoolsInDocumentOrder[^1].DocumentId;
+        var storedDocumentIds = _persistedSchoolsInDocumentOrder
+            .Select(static school => school.DocumentId)
+            .ToArray();
+
+        storedDocumentIds.Should().NotContain(firstDocumentId - 1).And.NotContain(lastDocumentId + 1);
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                new CursorRange(firstDocumentId - 1, lastDocumentId + 1),
+                pageSize: 25,
+                traceId: "pg-cursor-unstored-bounds"
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(lastDocumentId);
+        AssertPageMaterialization(storedDocumentIds);
+    }
+
+    // A bound that excludes the first stored id starts the page at the next one, so a continuation that
+    // resumes at maximum+1 cannot re-return the document it already delivered.
+    [Test]
+    public async Task It_excludes_documents_below_the_inclusive_minimum()
+    {
+        var firstDocumentId = _persistedSchoolsInDocumentOrder[0].DocumentId;
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(firstDocumentId + 1),
+                pageSize: 25,
+                traceId: "pg-cursor-excludes-below-minimum"
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[^1].DocumentId);
+        AssertPageMaterialization([
+            .. _persistedSchoolsInDocumentOrder.Skip(1).Select(static school => school.DocumentId),
+        ]);
+    }
+
+    [Test]
+    public async Task It_composes_a_query_filter_with_the_cursor_range()
+    {
+        var targetSchool = _persistedSchoolsInDocumentOrder[1];
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(1),
+                pageSize: 25,
+                traceId: "pg-cursor-filter",
+                queryElements:
+                [
+                    new QueryElement(
+                        "nameOfInstitution",
+                        [new JsonPath("$.nameOfInstitution")],
+                        targetSchool.NameOfInstitution,
+                        "string"
+                    ),
+                ]
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(targetSchool.DocumentId);
+        AssertPageMaterialization(targetSchool.DocumentId);
+    }
+
+    // A min-only window still orders by DocumentId, so a cursor page inside it continues normally.
+    [Test]
+    public async Task It_composes_a_min_only_change_version_window_with_the_cursor_range()
+    {
+        var lowestContentVersion = _persistedSchoolsInDocumentOrder.Min(static school =>
+            school.ContentVersion
+        );
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(1),
+                pageSize: 25,
+                traceId: "pg-cursor-min-window",
+                changeVersionRange: new ChangeVersionRange(lowestContentVersion, null)
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[^1].DocumentId);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    // A max-bearing window keeps the DocumentId ordering a cursor page always uses, so the page it
+    // selects can still anchor a continuation. What it must not do is silently order by something else.
+    [Test]
+    public async Task It_composes_a_max_bearing_change_version_window_with_the_cursor_range()
+    {
+        var highestContentVersion = _persistedSchoolsInDocumentOrder.Max(static school =>
+            school.ContentVersion
+        );
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteCursorQueryAsync(
+                CursorRange.From(1),
+                pageSize: 25,
+                traceId: "pg-cursor-max-window",
+                changeVersionRange: new ChangeVersionRange(null, highestContentVersion)
+            );
+
+        success.HighestSelectedDocumentId.Should().Be(_persistedSchoolsInDocumentOrder[^1].DocumentId);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+        AssertSingleQueryHydration().Plan.PageDocumentIdSql.Should().Contain("@cursorMin");
+    }
+
+    // A traditional page over the same window is ordered by ContentVersion, so it reports the maximum it
+    // really selected while refusing to let a DocumentId continuation be anchored on it.
+    [Test]
+    public async Task It_reports_a_boundary_without_continuation_for_a_windowed_traditional_page()
+    {
+        var highestContentVersion = _persistedSchoolsInDocumentOrder.Max(static school =>
+            school.ContentVersion
+        );
+
+        var success = (QueryResult.QuerySuccess)
+            await ExecuteQueryAsync(
+                [],
+                limit: MaximumPageSize,
+                offset: 0,
+                totalCount: false,
+                traceId: "pg-traditional-max-window",
+                changeVersionRange: new ChangeVersionRange(null, highestContentVersion)
+            );
+
+        success.HighestSelectedDocumentId.Should().NotBeNull();
+        success.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
     private static ServiceProvider CreateServiceProvider(ChangeQueryPageOrderingPolicy? orderingPolicy = null)
     {
         ServiceCollection services = [];
@@ -820,6 +1049,42 @@ public class Given_A_Postgresql_Relational_Query_With_The_Authoritative_Ds52_Sch
         string traceId,
         ChangeVersionRange? changeVersionRange = null,
         ServiceProvider? serviceProvider = null
+    ) =>
+        await ExecuteQueryAsync(
+            new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: limit,
+                    Offset: offset,
+                    TotalCount: totalCount,
+                    MaximumPageSize: MaximumPageSize
+                )
+            ),
+            queryElements,
+            traceId,
+            changeVersionRange,
+            serviceProvider
+        );
+
+    private async Task<QueryResult> ExecuteCursorQueryAsync(
+        CursorRange range,
+        int pageSize,
+        string traceId,
+        QueryElement[]? queryElements = null,
+        ChangeVersionRange? changeVersionRange = null
+    ) =>
+        await ExecuteQueryAsync(
+            new CollectionPaging.Cursor(range, new PageSize(pageSize)),
+            queryElements ?? [],
+            traceId,
+            changeVersionRange
+        );
+
+    private async Task<QueryResult> ExecuteQueryAsync(
+        CollectionPaging paging,
+        QueryElement[] queryElements,
+        string traceId,
+        ChangeVersionRange? changeVersionRange = null,
+        ServiceProvider? serviceProvider = null
     )
     {
         await using var scope = (serviceProvider ?? _serviceProvider).CreateAsyncScope();
@@ -831,14 +1096,7 @@ public class Given_A_Postgresql_Relational_Query_With_The_Authoritative_Ds52_Sch
             MappingSet: _mappingSet,
             QueryElements: queryElements,
             AuthorizationStrategyEvaluators: [],
-            Paging: new CollectionPaging.Traditional(
-                new PaginationParameters(
-                    Limit: limit,
-                    Offset: offset,
-                    TotalCount: totalCount,
-                    MaximumPageSize: MaximumPageSize
-                )
-            ),
+            Paging: paging,
             TraceId: new TraceId(traceId),
             ChangeVersionRange: changeVersionRange
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadContractsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadContractsTests.cs
@@ -71,11 +71,8 @@ public class Given_Descriptor_Read_Contracts
                 "string"
             ),
         ];
-        var paginationParameters = new PaginationParameters(
-            Limit: 25,
-            Offset: 10,
-            TotalCount: true,
-            MaximumPageSize: 500
+        var paging = new CollectionPaging.Traditional(
+            new PaginationParameters(Limit: 25, Offset: 10, TotalCount: true, MaximumPageSize: 500)
         );
         AuthorizationStrategyEvaluator[] authorizationStrategyEvaluators =
         [
@@ -92,7 +89,7 @@ public class Given_Descriptor_Read_Contracts
             mappingSet,
             _descriptorResource,
             queryElements,
-            paginationParameters,
+            paging,
             authorizationStrategyEvaluators,
             readableProfileProjectionContext,
             traceId
@@ -102,7 +99,7 @@ public class Given_Descriptor_Read_Contracts
         request.MappingSet.Should().BeSameAs(mappingSet);
         request.Resource.Should().Be(_descriptorResource);
         request.QueryElements.Should().BeSameAs(queryElements);
-        request.PaginationParameters.Should().BeSameAs(paginationParameters);
+        request.Paging.Should().BeSameAs(paging);
         request.AuthorizationStrategyEvaluators.Should().BeSameAs(authorizationStrategyEvaluators);
         request.ReadableProfileProjectionContext.Should().BeSameAs(readableProfileProjectionContext);
         request.TraceId.Should().Be(traceId);
@@ -121,7 +118,9 @@ public class Given_Descriptor_Read_Contracts
             mappingSet,
             _descriptorResource,
             [],
-            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            new CollectionPaging.Traditional(
+                new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+            ),
             [],
             null,
             new TraceId("trace-id"),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
@@ -78,7 +78,9 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
             CreateMappingSet(SqlDialect.Pgsql),
             _descriptorResource,
             [],
-            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            new CollectionPaging.Traditional(
+                new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+            ),
             evaluators,
             readableProfileProjectionContext: null,
             new TraceId("descriptor-query-contract"),
@@ -97,7 +99,9 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
             CreateMappingSet(SqlDialect.Pgsql),
             _descriptorResource,
             [],
-            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            new CollectionPaging.Traditional(
+                new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+            ),
             [],
             readableProfileProjectionContext: null,
             new TraceId("descriptor-query-contract-default")
@@ -1075,7 +1079,9 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
             CreateMappingSet(dialect),
             _descriptorResource,
             [],
-            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: totalCount, MaximumPageSize: 500),
+            new CollectionPaging.Traditional(
+                new PaginationParameters(Limit: 25, Offset: 0, TotalCount: totalCount, MaximumPageSize: 500)
+            ),
             additionalAuthorizationStrategy is null
                 ? [authorizationStrategy]
                 : [authorizationStrategy, additionalAuthorizationStrategy],

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -1984,7 +1984,10 @@ public class Given_DescriptorReadHandler
                         ),
                     ],
                     TotalCount: 7,
-                    HighestSelectedDocumentId: null,
+                    ContinuationBoundary: new PageContinuationBoundary(
+                        205L,
+                        AllowsDocumentIdContinuation: true
+                    ),
                     IncludesTotalCount: true
                 )
             );
@@ -1997,6 +2000,54 @@ public class Given_DescriptorReadHandler
                 )
             )
             .MustHaveHappenedOnceExactly();
+    }
+
+    // A windowed traditional descriptor page is ordered by ContentVersion, so the candidate page a
+    // cache-served response is shaped from reports the selected maximum without the continuation
+    // eligibility that maximum cannot carry.
+    [Test]
+    public async Task It_exposes_a_windowed_descriptor_candidate_page_that_cannot_anchor_a_continuation()
+    {
+        var documentUuid = Guid.Parse("aaaaaaaa-1111-2222-3333-999999999994");
+        var readAccelerationCoordinator = A.Fake<IDocumentCacheReadAccelerationCoordinator>();
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(documentUuid, documentId: 205L, codeValue: "Charter")
+                ),
+            ]),
+        ]);
+        DocumentCacheReadAccelerationQuerySelectionResult.CandidatePage capturedSelection = null!;
+
+        A.CallTo(() =>
+                readAccelerationCoordinator.QueryAsync(
+                    A<DocumentCacheReadAccelerationQueryRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .ReturnsLazily(async call =>
+            {
+                var request = call.GetArgument<DocumentCacheReadAccelerationQueryRequest>(0)!;
+                var selectionResult = await request
+                    .SelectAuthorizedCandidatePage(call.GetArgument<CancellationToken>(1))
+                    .ConfigureAwait(false);
+                capturedSelection = selectionResult
+                    .Should()
+                    .BeOfType<DocumentCacheReadAccelerationQuerySelectionResult.CandidatePage>()
+                    .Subject;
+
+                return new QueryResult.QuerySuccess([], TotalCount: null);
+            });
+
+        var sut = CreateHandler(commandExecutor, readAccelerationCoordinator: readAccelerationCoordinator);
+
+        await sut.HandleQueryAsync(
+            CreateQueryRequest(SqlDialect.Pgsql, changeVersionRange: new ChangeVersionRange(null, 900L))
+        );
+
+        capturedSelection
+            .AuthorizedCandidatePage.ContinuationBoundary.Should()
+            .Be(new PageContinuationBoundary(205L, AllowsDocumentIdContinuation: false));
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -492,6 +492,108 @@ public class Given_DescriptorReadHandler
             .MustNotHaveHappened();
     }
 
+    // Descriptor selection and row retrieval are one statement, so the returned rows are the selected
+    // keyset and their maximum is the page's boundary.
+    [Test]
+    public async Task It_reports_the_maximum_selected_document_id_from_descriptor_query_rows()
+    {
+        var sut = CreateHandler(
+            CreateQueryRowsExecutor(
+                CreateDescriptorRow(Guid.NewGuid(), documentId: 101L, codeValue: "Alternative"),
+                CreateDescriptorRow(Guid.NewGuid(), documentId: 205L, codeValue: "Charter")
+            )
+        );
+
+        var result = await sut.HandleQueryAsync(CreateQueryRequest(SqlDialect.Pgsql));
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(205L);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    // The page query orders ascending today, but a boundary taken from the last row rather than the
+    // maximum would silently under-report if that ever changed.
+    [Test]
+    public async Task It_reports_the_maximum_selected_document_id_whatever_order_the_rows_arrive_in()
+    {
+        var sut = CreateHandler(
+            CreateQueryRowsExecutor(
+                CreateDescriptorRow(Guid.NewGuid(), documentId: 205L, codeValue: "Charter"),
+                CreateDescriptorRow(Guid.NewGuid(), documentId: 101L, codeValue: "Alternative")
+            )
+        );
+
+        var result = await sut.HandleQueryAsync(CreateQueryRequest(SqlDialect.Pgsql));
+
+        result
+            .Should()
+            .BeOfType<QueryResult.QuerySuccess>()
+            .Which.HighestSelectedDocumentId.Should()
+            .Be(205L);
+    }
+
+    [Test]
+    public async Task It_reports_no_boundary_when_descriptor_page_selection_returned_no_rows()
+    {
+        var sut = CreateHandler(CreateQueryRowsExecutor());
+
+        var result = await sut.HandleQueryAsync(CreateQueryRequest(SqlDialect.Pgsql));
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().BeNull();
+        success.EdfiDocs.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_selects_a_descriptor_cursor_page_from_the_shared_candidate_plan()
+    {
+        var commandExecutor = CreateQueryRowsExecutor(
+            CreateDescriptorRow(Guid.NewGuid(), documentId: 101L, codeValue: "Alternative")
+        );
+        var sut = CreateHandler(commandExecutor);
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(
+                SqlDialect.Pgsql,
+                paging: new CollectionPaging.Cursor(new CursorRange(10, 2509), new PageSize(100))
+            )
+        );
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(101L);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+        success.TotalCount.Should().BeNull();
+        commandExecutor.Commands.Should().ContainSingle();
+        commandExecutor.Commands[0].CommandText.Should().Contain("@cursorMin");
+        commandExecutor.Commands[0].CommandText.Should().Contain("@cursorMax");
+        commandExecutor.Commands[0].CommandText.Should().Contain("@pageSize");
+        commandExecutor.Commands[0].CommandText.Should().NotContain("COUNT(1)");
+    }
+
+    // A windowed traditional descriptor page is ordered by ContentVersion, so its real selected maximum
+    // is reported while the continuation it cannot anchor is withheld.
+    [Test]
+    public async Task It_keeps_the_descriptor_boundary_but_disallows_continuation_for_a_windowed_traditional_page()
+    {
+        var sut = CreateHandler(
+            CreateQueryRowsExecutor(
+                CreateDescriptorRow(Guid.NewGuid(), documentId: 205L, codeValue: "Charter")
+            )
+        );
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(SqlDialect.Pgsql, changeVersionRange: new ChangeVersionRange(null, 900L))
+        );
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(205L);
+        success.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
+    private static InMemoryRelationalCommandExecutor CreateQueryRowsExecutor(
+        params IReadOnlyDictionary<string, object?>[] descriptorRows
+    ) => new([new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create(descriptorRows)])]);
+
     [Test]
     public async Task It_fails_closed_for_descriptor_query_authorization_without_executing_sql()
     {
@@ -2417,7 +2519,9 @@ public class Given_DescriptorReadHandler
         ReadableProfileProjectionContext? readableProfileProjectionContext = null,
         int? limit = 25,
         int? offset = 0,
-        bool includeDescriptorMetadata = true
+        bool includeDescriptorMetadata = true,
+        CollectionPaging? paging = null,
+        ChangeVersionRange? changeVersionRange = null
     )
     {
         var mappingSet = CreateQueryMappingSet(
@@ -2430,16 +2534,20 @@ public class Given_DescriptorReadHandler
             mappingSet,
             _descriptorResource,
             queryElements ?? [],
-            new PaginationParameters(
-                Limit: limit,
-                Offset: offset,
-                TotalCount: totalCount,
-                MaximumPageSize: 500
-            ),
+            paging
+                ?? new CollectionPaging.Traditional(
+                    new PaginationParameters(
+                        Limit: limit,
+                        Offset: offset,
+                        TotalCount: totalCount,
+                        MaximumPageSize: 500
+                    )
+                ),
             authorizationStrategyEvaluators ?? [],
             readableProfileProjectionContext,
             new TraceId("descriptor-query-trace"),
-            new RelationalAuthorizationContext([], namespacePrefixes ?? [])
+            new RelationalAuthorizationContext([], namespacePrefixes ?? []),
+            changeVersionRange
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -2920,11 +2920,9 @@ public class Given_DescriptorReadHandler
             StringComparison.Ordinal
         );
         selectIndex.Should().BeGreaterThanOrEqualTo(0);
-        int fromIndex = commandText.IndexOf(
-            $"{Environment.NewLine}FROM ",
-            documentIdProjectionIndex,
-            StringComparison.Ordinal
-        );
+        // Emitted SQL is canonicalized to Unix line endings, so the line break is matched literally
+        // rather than through the platform's newline.
+        int fromIndex = commandText.IndexOf("\nFROM ", documentIdProjectionIndex, StringComparison.Ordinal);
         fromIndex.Should().BeGreaterThan(documentIdProjectionIndex);
 
         return commandText[..(selectIndex + "SELECT".Length)] + commandText[fromIndex..];

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DocumentCacheReadAccelerationCoordinatorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DocumentCacheReadAccelerationCoordinatorTests.cs
@@ -2912,7 +2912,7 @@ public class Given_DocumentCacheReadAccelerationCoordinator
         new(
             candidates ?? [Candidate()],
             totalCount,
-            highestSelectedDocumentId,
+            new PageContinuationBoundary(highestSelectedDocumentId, AllowsDocumentIdContinuation: true),
             includesTotalCount ?? (totalCount is not null)
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DocumentCacheReadLookupTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DocumentCacheReadLookupTests.cs
@@ -505,8 +505,22 @@ public class Given_DocumentCacheReadLookup
         );
 
         DocumentCacheReadLookupResult<QueryResult> result = await adapter.TryQueryAsync(
-            QueryRequest(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
-            QuerySelection(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
+            QueryRequest(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
+            QuerySelection(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
             ExecutionContext()
         );
 
@@ -542,8 +556,22 @@ public class Given_DocumentCacheReadLookup
         );
 
         DocumentCacheReadLookupResult<QueryResult> result = await adapter.TryQueryAsync(
-            QueryRequest(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
-            QuerySelection(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
+            QueryRequest(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
+            QuerySelection(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
             ExecutionContext()
         );
 
@@ -581,8 +609,22 @@ public class Given_DocumentCacheReadLookup
         );
 
         DocumentCacheReadLookupResult<QueryResult> result = await adapter.TryQueryAsync(
-            QueryRequest(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
-            QuerySelection(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
+            QueryRequest(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
+            QuerySelection(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
             ExecutionContext()
         );
 
@@ -650,8 +692,22 @@ public class Given_DocumentCacheReadLookup
         );
 
         DocumentCacheReadLookupResult<QueryResult> result = await adapter.TryQueryAsync(
-            QueryRequest(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
-            QuerySelection(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
+            QueryRequest(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
+            QuerySelection(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
             ExecutionContext()
         );
 
@@ -690,8 +746,22 @@ public class Given_DocumentCacheReadLookup
         );
 
         DocumentCacheReadLookupResult<QueryResult> result = await adapter.TryQueryAsync(
-            QueryRequest(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
-            QuerySelection(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
+            QueryRequest(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
+            QuerySelection(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
             ExecutionContext()
         );
 
@@ -743,8 +813,22 @@ public class Given_DocumentCacheReadLookup
         );
 
         DocumentCacheReadLookupResult<QueryResult> result = await adapter.TryQueryAsync(
-            QueryRequest(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
-            QuerySelection(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
+            QueryRequest(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
+            QuerySelection(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
             ExecutionContext()
         );
 
@@ -779,8 +863,22 @@ public class Given_DocumentCacheReadLookup
         );
 
         DocumentCacheReadLookupResult<QueryResult> result = await adapter.TryQueryAsync(
-            QueryRequest(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
-            QuerySelection(new DocumentCacheReadAccelerationCandidatePage([first, second], 2, 346, true)),
+            QueryRequest(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
+            QuerySelection(
+                new DocumentCacheReadAccelerationCandidatePage(
+                    [first, second],
+                    2,
+                    new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
+                    true
+                )
+            ),
             ExecutionContext()
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DocumentCacheReadResponseShaperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DocumentCacheReadResponseShaperTests.cs
@@ -191,7 +191,7 @@ public class Given_DocumentCacheReadResponseShaper
     }
 
     [Test]
-    public void It_shapes_a_fresh_query_page_in_candidate_order_without_a_traditional_paging_boundary()
+    public void It_shapes_a_fresh_query_page_in_candidate_order_carrying_the_selection_boundary()
     {
         var sut = CreateShaper();
         var first = Candidate(documentId: 345, documentUuid: DocumentUuid);
@@ -203,7 +203,7 @@ public class Given_DocumentCacheReadResponseShaper
         var candidatePage = new DocumentCacheReadAccelerationCandidatePage(
             [first, second],
             TotalCount: 7,
-            HighestSelectedDocumentId: null,
+            ContinuationBoundary: new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
             IncludesTotalCount: true
         );
 
@@ -215,11 +215,63 @@ public class Given_DocumentCacheReadResponseShaper
 
         var success = result.CachedResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
         success.TotalCount.Should().Be(7);
-        success.HighestSelectedDocumentId.Should().BeNull();
+        success.HighestSelectedDocumentId.Should().Be(346);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
         success
             .EdfiDocs.Select(document => document!["name"]!.GetValue<string>())
             .Should()
             .Equal("Lincoln High", "Washington High");
+    }
+
+    [Test]
+    public void It_shapes_a_fresh_query_page_that_cannot_anchor_a_document_id_continuation()
+    {
+        var sut = CreateShaper();
+        var candidate = Candidate(documentId: 345, documentUuid: DocumentUuid);
+        var hitPage = DocumentCacheReadBatchLookupResult.FromDocuments([
+            FreshHit(candidate, CachedDocumentJson(candidate, "Lincoln High")),
+        ]);
+        var candidatePage = new DocumentCacheReadAccelerationCandidatePage(
+            [candidate],
+            TotalCount: 1,
+            ContinuationBoundary: new PageContinuationBoundary(345, AllowsDocumentIdContinuation: false),
+            IncludesTotalCount: true
+        );
+
+        DocumentCacheReadLookupResult<QueryResult> result = sut.ShapeQuery(
+            CreateQueryRequest(candidatePage),
+            candidatePage,
+            hitPage
+        );
+
+        var success = result.CachedResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(345);
+        success.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
+    [Test]
+    public void It_shapes_a_fresh_query_page_selected_without_a_continuation_boundary()
+    {
+        var sut = CreateShaper();
+        var candidate = Candidate(documentId: 345, documentUuid: DocumentUuid);
+        var hitPage = DocumentCacheReadBatchLookupResult.FromDocuments([
+            FreshHit(candidate, CachedDocumentJson(candidate, "Lincoln High")),
+        ]);
+        var candidatePage = new DocumentCacheReadAccelerationCandidatePage(
+            [candidate],
+            TotalCount: 1,
+            ContinuationBoundary: new PageContinuationBoundary(null, AllowsDocumentIdContinuation: true),
+            IncludesTotalCount: true
+        );
+
+        DocumentCacheReadLookupResult<QueryResult> result = sut.ShapeQuery(
+            CreateQueryRequest(candidatePage),
+            candidatePage,
+            hitPage
+        );
+
+        var success = result.CachedResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().BeNull();
     }
 
     [Test]
@@ -233,7 +285,7 @@ public class Given_DocumentCacheReadResponseShaper
         var candidatePage = new DocumentCacheReadAccelerationCandidatePage(
             [candidate],
             TotalCount: 7,
-            HighestSelectedDocumentId: null,
+            ContinuationBoundary: default,
             IncludesTotalCount: false
         );
 
@@ -260,7 +312,7 @@ public class Given_DocumentCacheReadResponseShaper
         var candidatePage = new DocumentCacheReadAccelerationCandidatePage(
             [authorized],
             TotalCount: 1,
-            HighestSelectedDocumentId: 345,
+            ContinuationBoundary: new PageContinuationBoundary(345, AllowsDocumentIdContinuation: true),
             IncludesTotalCount: true
         );
 
@@ -298,7 +350,7 @@ public class Given_DocumentCacheReadResponseShaper
         var candidatePage = new DocumentCacheReadAccelerationCandidatePage(
             [first, second],
             TotalCount: 2,
-            HighestSelectedDocumentId: 346,
+            ContinuationBoundary: new PageContinuationBoundary(346, AllowsDocumentIdContinuation: true),
             IncludesTotalCount: true
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/PageContinuationBoundaryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/PageContinuationBoundaryTests.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// The selected maximum and whether it may anchor a continuation are two independent facts, resolved
+/// together so the regular-resource and descriptor paths cannot answer the same page differently.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_A_Page_Continuation_Boundary
+{
+    private static readonly CollectionPaging _traditionalPaging = new CollectionPaging.Traditional(
+        new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+    );
+
+    private static readonly CollectionPaging _cursorPaging = new CollectionPaging.Cursor(
+        CursorRange.From(1),
+        new PageSize(25)
+    );
+
+    [Test]
+    public void It_allows_continuation_for_a_document_id_ordered_traditional_page()
+    {
+        PageContinuationBoundary
+            .For(_traditionalPaging, PageOrderingMode.DocumentId, 2509L)
+            .Should()
+            .Be(new PageContinuationBoundary(2509L, AllowsDocumentIdContinuation: true));
+    }
+
+    [Test]
+    public void It_disallows_continuation_for_a_content_version_ordered_traditional_page()
+    {
+        PageContinuationBoundary
+            .For(_traditionalPaging, PageOrderingMode.ContentVersion, 2509L)
+            .Should()
+            .Be(new PageContinuationBoundary(2509L, AllowsDocumentIdContinuation: false));
+    }
+
+    // Cursor selection carries no ordering choice at all: it is always ordered by DocumentId, so its
+    // token anchor is always the key its own page was ordered by.
+    [TestCase(PageOrderingMode.DocumentId)]
+    [TestCase(PageOrderingMode.ContentVersion)]
+    public void It_allows_continuation_for_a_cursor_page_whatever_the_resolved_ordering(
+        PageOrderingMode orderingMode
+    )
+    {
+        PageContinuationBoundary
+            .For(_cursorPaging, orderingMode, 2509L)
+            .Should()
+            .Be(new PageContinuationBoundary(2509L, AllowsDocumentIdContinuation: true));
+    }
+
+    [Test]
+    public void It_keeps_a_null_selected_maximum_null()
+    {
+        PageContinuationBoundary
+            .For(_traditionalPaging, PageOrderingMode.ContentVersion, null)
+            .SelectedMaximum.Should()
+            .BeNull();
+        PageContinuationBoundary
+            .For(_cursorPaging, PageOrderingMode.DocumentId, null)
+            .SelectedMaximum.Should()
+            .BeNull();
+    }
+
+    // Eligibility is a property of the page's ordering, not of whether the page selected anything, so a
+    // page that selected nothing still reports the eligibility its ordering implies.
+    [Test]
+    public void It_decides_eligibility_independently_of_the_selected_maximum()
+    {
+        PageContinuationBoundary
+            .For(_traditionalPaging, PageOrderingMode.ContentVersion, null)
+            .AllowsDocumentIdContinuation.Should()
+            .BeFalse();
+        PageContinuationBoundary
+            .For(_traditionalPaging, PageOrderingMode.DocumentId, null)
+            .AllowsDocumentIdContinuation.Should()
+            .BeTrue();
+    }
+
+    [TestCase(long.MinValue)]
+    [TestCase(0L)]
+    [TestCase(long.MaxValue)]
+    public void It_returns_the_selected_maximum_unmodified(long selectedMaximum)
+    {
+        PageContinuationBoundary
+            .For(_traditionalPaging, PageOrderingMode.DocumentId, selectedMaximum)
+            .SelectedMaximum.Should()
+            .Be(selectedMaximum);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -3757,6 +3757,61 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .MustNotHaveHappened();
     }
 
+    // The boundary describes the keys candidate selection chose, so a page whose selected rows were all
+    // deleted before the metadata select still advances a walk past them instead of stalling it.
+    [Test]
+    public async Task It_reports_the_selected_boundary_when_candidate_selection_found_no_surviving_rows()
+    {
+        var readAccelerationCoordinator = new RecordingReadAccelerationCoordinator();
+        var mappingSet = CreateQuerySupportedMappingSet(_schoolResourceInfo);
+        var queryRequest = CreateQueryRequest(mappingSet, [], totalCount: false);
+
+        UseReadAccelerationCoordinator(readAccelerationCoordinator);
+
+        A.CallTo(() =>
+                _commandExecutor.ExecuteReaderAsync(
+                    A<RelationalCommand>._,
+                    A<
+                        Func<
+                            IRelationalCommandReader,
+                            CancellationToken,
+                            Task<DocumentCacheReadAccelerationCandidatePage>
+                        >
+                    >._,
+                    A<CancellationToken>._
+                )
+            )
+            .ReturnsLazily(
+                (
+                    RelationalCommand _,
+                    Func<
+                        IRelationalCommandReader,
+                        CancellationToken,
+                        Task<DocumentCacheReadAccelerationCandidatePage>
+                    > readAsync,
+                    CancellationToken cancellationToken
+                ) =>
+                    readAsync(
+                        new InMemoryRelationalCommandReader([
+                            InMemoryRelationalResultSet.Create(
+                                RelationalAccessTestData.CreateRow(("DocumentId", 345L)),
+                                RelationalAccessTestData.CreateRow(("DocumentId", 678L))
+                            ),
+                            InMemoryRelationalResultSet.Create(),
+                        ]),
+                        cancellationToken
+                    )
+            );
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.EdfiDocs.Should().BeEmpty();
+        success.HighestSelectedDocumentId.Should().Be(678L);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+        readAccelerationCoordinator.SelectedQueryCandidatePage.Should().BeNull();
+    }
+
     [Test]
     public async Task It_exposes_an_authorized_query_candidate_page_to_read_acceleration_before_hydration()
     {
@@ -3841,6 +3896,10 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     readAsync(
                         new InMemoryRelationalCommandReader([
                             InMemoryRelationalResultSet.Create(
+                                RelationalAccessTestData.CreateRow(("DocumentId", 345L)),
+                                RelationalAccessTestData.CreateRow(("DocumentId", 678L))
+                            ),
+                            InMemoryRelationalResultSet.Create(
                                 RelationalAccessTestData.CreateRow(
                                     ("DocumentId", 345L),
                                     ("DocumentUuid", firstDocumentUuid.Value),
@@ -3892,7 +3951,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
         var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
         success.EdfiDocs.Should().HaveCount(2);
         success.TotalCount.Should().BeNull();
-        success.HighestSelectedDocumentId.Should().BeNull();
+        success.HighestSelectedDocumentId.Should().Be(678L);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
         capturedSelectedPage.DocumentIds.Should().Equal(345L, 678L);
         readAccelerationCoordinator.QueryAttempts.Should().Be(1);
         readAccelerationCoordinator.SelectedQueryRequest.Should().NotBeNull();
@@ -3920,7 +3980,10 @@ public class Given_RelationalDocumentStoreRepositoryTests
                         ),
                     ],
                     TotalCount: null,
-                    HighestSelectedDocumentId: null,
+                    ContinuationBoundary: new PageContinuationBoundary(
+                        678L,
+                        AllowsDocumentIdContinuation: true
+                    ),
                     IncludesTotalCount: false
                 )
             );
@@ -3981,6 +4044,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 ) =>
                     readAsync(
                         new InMemoryRelationalCommandReader([
+                            InMemoryRelationalResultSet.Create(
+                                RelationalAccessTestData.CreateRow(("DocumentId", 345L))
+                            ),
                             InMemoryRelationalResultSet.Create(
                                 RelationalAccessTestData.CreateRow(
                                     ("DocumentId", 345L),
@@ -4268,6 +4334,11 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     return readAsync(
                         new InMemoryRelationalCommandReader([
                             InMemoryRelationalResultSet.Create(
+                                RelationalAccessTestData.CreateRow(
+                                    ("DocumentId", selectedMetadata.DocumentId)
+                                )
+                            ),
+                            InMemoryRelationalResultSet.Create(
                                 RelationalAccessTestData.CreateRow(("TotalCount", 3L))
                             ),
                             InMemoryRelationalResultSet.Create(
@@ -4304,9 +4375,15 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Equal(contentVersionSelectedMetadata.DocumentId);
         authorizedCandidatePage.IncludesTotalCount.Should().BeTrue();
         authorizedCandidatePage.TotalCount.Should().Be(3);
+        authorizedCandidatePage
+            .ContinuationBoundary.SelectedMaximum.Should()
+            .Be(contentVersionSelectedMetadata.DocumentId);
+        authorizedCandidatePage.ContinuationBoundary.AllowsDocumentIdContinuation.Should().BeFalse();
 
         var success = acceleratedResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
         success.TotalCount.Should().Be(3);
+        success.HighestSelectedDocumentId.Should().Be(contentVersionSelectedMetadata.DocumentId);
+        success.AllowsDocumentIdContinuation.Should().BeFalse();
         success.EdfiDocs.Single()!["id"]!
             .GetValue<string>()
             .Should()
@@ -4401,6 +4478,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 ) =>
                     readAsync(
                         new InMemoryRelationalCommandReader([
+                            InMemoryRelationalResultSet.Create(
+                                RelationalAccessTestData.CreateRow(("DocumentId", 345L))
+                            ),
                             InMemoryRelationalResultSet.Create(
                                 RelationalAccessTestData.CreateRow(("TotalCount", 7L))
                             ),
@@ -8591,12 +8671,13 @@ public class Given_RelationalDocumentStoreRepositoryTests
                             totalCount
                                 ?
                                 [
+                                    InMemoryRelationalResultSet.Create(),
                                     InMemoryRelationalResultSet.Create(
                                         RelationalAccessTestData.CreateRow(("TotalCount", 7L))
                                     ),
                                     InMemoryRelationalResultSet.Create(),
                                 ]
-                                : [InMemoryRelationalResultSet.Create()]
+                                : [InMemoryRelationalResultSet.Create(), InMemoryRelationalResultSet.Create()]
                         ),
                         cancellationToken
                     )

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -5123,9 +5123,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     /// <summary>
-    /// Read-acceleration candidate selection reports no selected-keyset boundary, so a cursor page
-    /// served through it would carry documents and no continuation, stalling the walk one page in.
-    /// Cursor pages therefore take the relational path, which does report the boundary.
+    /// A cursor walk depends on every page reporting the selected-keyset boundary its successor resumes
+    /// from, and only traditional paging is exercised against the read-acceleration path, so cursor
+    /// selection must route to the relational path.
     /// </summary>
     [Test]
     public async Task It_selects_a_cursor_page_without_read_acceleration()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -5042,6 +5042,70 @@ public class Given_RelationalDocumentStoreRepositoryTests
         success.AllowsDocumentIdContinuation.Should().BeTrue();
     }
 
+    /// <summary>
+    /// Read-acceleration candidate selection reports no selected-keyset boundary, so a cursor page
+    /// served through it would carry documents and no continuation, stalling the walk one page in.
+    /// Cursor pages therefore take the relational path, which does report the boundary.
+    /// </summary>
+    [Test]
+    public async Task It_selects_a_cursor_page_without_read_acceleration()
+    {
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+        );
+        var readAccelerationCoordinator = new RecordingReadAccelerationCoordinator();
+
+        UseReadAccelerationCoordinator(readAccelerationCoordinator);
+        StubHydrationWithBoundary(readPlan, 2509L);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        readAccelerationCoordinator.QueryAttempts.Should().Be(0);
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(2509L);
+    }
+
+    /// <summary>
+    /// The traditional counterpart, so the test above proves cursor-specific routing rather than a
+    /// coordinator that is never consulted for queries at all.
+    /// </summary>
+    [Test]
+    public async Task It_selects_a_traditional_page_through_read_acceleration()
+    {
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(mappingSet, [], totalCount: false);
+        var readAccelerationCoordinator = new RecordingReadAccelerationCoordinator();
+
+        UseReadAccelerationCoordinator(readAccelerationCoordinator);
+        StubHydrationWithBoundary(readPlan, 2509L);
+
+        await _sut.QueryDocuments(queryRequest);
+
+        readAccelerationCoordinator.QueryAttempts.Should().Be(1);
+    }
+
     private RelationalDocumentStoreRepository CreateRepositoryWithOrderingPolicy(
         ChangeQueryPageOrderingPolicy orderingPolicy
     ) =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -4528,9 +4528,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         capturedRequest.MappingSet.Should().BeSameAs(mappingSet);
         capturedRequest.Resource.Should().Be(new QualifiedResourceName("Ed-Fi", "SchoolTypeDescriptor"));
         capturedRequest.QueryElements.Should().BeSameAs(queryElements);
-        capturedRequest
-            .PaginationParameters.Should()
-            .Be(((CollectionPaging.Traditional)queryRequest.Paging).Parameters);
+        capturedRequest.Paging.Should().BeSameAs(queryRequest.Paging);
         capturedRequest.AuthorizationStrategyEvaluators.Should().BeSameAs(authorizationStrategyEvaluators);
         capturedRequest.ReadableProfileProjectionContext.Should().BeSameAs(projectionContext);
         capturedRequest.TraceId.Value.Should().Be("query-trace");
@@ -4556,43 +4554,97 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_declines_a_cursor_paged_query_until_cursor_page_selection_is_implemented()
+    public async Task It_selects_a_cursor_page_from_the_shared_candidate_plan()
     {
-        var queryRequest = A.Fake<IQueryRequest>();
-        A.CallTo(() => queryRequest.Paging)
-            .Returns(new CollectionPaging.Cursor(new CursorRange(10, 2509), new PageSize(100)));
-
-        var result = await _sut.QueryDocuments(queryRequest);
-
-        result
-            .Should()
-            .BeOfType<QueryResult.QueryFailureNotImplemented>()
-            .Which.FailureMessage.Should()
-            .Be("Cursor paging is not yet supported for relational queries.");
-    }
-
-    [Test]
-    public async Task It_declines_a_cursor_paged_query_before_resolving_any_read_dependency()
-    {
-        var queryRequest = A.Fake<IQueryRequest>();
-        A.CallTo(() => queryRequest.Paging)
-            .Returns(new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25)));
-
-        await _sut.QueryDocuments(queryRequest);
-
-        A.CallTo(() =>
-                _descriptorReadHandler.HandleQueryAsync(A<DescriptorQueryRequest>._, A<CancellationToken>._)
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
             )
-            .MustNotHaveHappened();
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            paging: new CollectionPaging.Cursor(new CursorRange(10, 2509), new PageSize(100))
+        );
+
+        PageKeysetSpec? capturedKeyset = null;
         A.CallTo(() =>
                 _documentHydrator.HydrateAsync(
-                    A<ResourceReadPlan>._,
+                    readPlan,
                     A<PageKeysetSpec>._,
                     A<HydrationExecutionOptions>._,
                     A<CancellationToken>._
                 )
             )
-            .MustNotHaveHappened();
+            .Invokes(call => capturedKeyset = call.GetArgument<PageKeysetSpec>(1))
+            .Returns(new HydratedPage(null, [], [new HydratedTableRows(readPlan.Model.Root, [])], []));
+        A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
+            .Returns([]);
+
+        await _sut.QueryDocuments(queryRequest);
+
+        var query = capturedKeyset.Should().BeOfType<PageKeysetSpec.Query>().Subject;
+        query
+            .ParameterValues.Should()
+            .Contain(
+                new KeyValuePair<string, object?>(PageCandidateParameterNames.CursorInclusiveMinimum, 10L)
+            )
+            .And.Contain(
+                new KeyValuePair<string, object?>(PageCandidateParameterNames.CursorInclusiveMaximum, 2509L)
+            )
+            .And.Contain(new KeyValuePair<string, object?>(PageCandidateParameterNames.PageSize, 100L));
+        query
+            .Plan.PageParametersInOrder.Select(static parameter => parameter.Role)
+            .Should()
+            .Contain(QuerySqlParameterRole.CursorInclusiveMinimum);
+    }
+
+    // Cursor mode never asks for a count, so the compiled page plan must carry none: a count would be a
+    // second scan of the candidate relation on every page of a walk.
+    [Test]
+    public async Task It_compiles_no_total_count_sql_for_a_cursor_page()
+    {
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+        );
+
+        PageKeysetSpec? capturedKeyset = null;
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call => capturedKeyset = call.GetArgument<PageKeysetSpec>(1))
+            .Returns(new HydratedPage(null, [], [new HydratedTableRows(readPlan.Model.Root, [])], []));
+        A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
+            .Returns([]);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        capturedKeyset.Should().BeOfType<PageKeysetSpec.Query>().Which.Plan.TotalCountSql.Should().BeNull();
+        result.Should().BeOfType<QueryResult.QuerySuccess>().Which.TotalCount.Should().BeNull();
     }
 
     [Test]
@@ -4892,6 +4944,148 @@ public class Given_RelationalDocumentStoreRepositoryTests
         var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
         success.HighestSelectedDocumentId.Should().Be(2509L);
         success.EdfiDocs.Should().BeEmpty();
+    }
+
+    // A traditional page over a max-bearing change-version window is ordered by ContentVersion, so its
+    // highest selected DocumentId is a real selected maximum that nevertheless does not describe where
+    // the page ended. The maximum is reported as selected; only continuation eligibility is withheld.
+    [Test]
+    public async Task It_keeps_the_real_boundary_but_disallows_continuation_for_a_windowed_traditional_page()
+    {
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            changeVersionRange: new ChangeVersionRange(null, 900L)
+        );
+
+        StubHydrationWithBoundary(readPlan, 2509L);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(2509L);
+        success.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
+    // The legacy ordering switch keeps a windowed traditional page ordered by DocumentId, so the same
+    // request really can anchor a continuation. Eligibility follows the effective ordering, not the filter.
+    [Test]
+    public async Task It_allows_continuation_for_a_windowed_traditional_page_under_legacy_document_id_ordering()
+    {
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            changeVersionRange: new ChangeVersionRange(null, 900L)
+        );
+
+        _sut = CreateRepositoryWithOrderingPolicy(
+            new ChangeQueryPageOrderingPolicy(useLegacyDocumentIdOrdering: true)
+        );
+        StubHydrationWithBoundary(readPlan, 2509L);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(2509L);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task It_allows_continuation_for_a_cursor_page_over_a_max_bearing_window()
+    {
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            paging: new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25)),
+            changeVersionRange: new ChangeVersionRange(null, 900L)
+        );
+
+        StubHydrationWithBoundary(readPlan, 2509L);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(2509L);
+        success.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    private RelationalDocumentStoreRepository CreateRepositoryWithOrderingPolicy(
+        ChangeQueryPageOrderingPolicy orderingPolicy
+    ) =>
+        new(
+            _logger,
+            _writeExecutor,
+            _currentEtagPreconditionChecker,
+            new ThrowingDescriptorWriteHandler(),
+            _descriptorReadHandler,
+            _referenceResolver,
+            _documentHydrator,
+            _readTargetLookupService,
+            _readMaterializer,
+            _readableProfileProjector,
+            _writeExceptionClassifier,
+            _deleteConstraintResolver,
+            _writeSessionFactory,
+            CreateAuthorizationSubjectSelector(),
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor,
+            _customViewAuthorizationExecutor,
+            _commandExecutor,
+            readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance,
+            orderingPolicy: orderingPolicy
+        );
+
+    private void StubHydrationWithBoundary(ResourceReadPlan readPlan, long highestSelectedDocumentId)
+    {
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                new HydratedPage(null, [], [new HydratedTableRows(readPlan.Model.Root, [])], [])
+                {
+                    HighestSelectedDocumentId = highestSelectedDocumentId,
+                }
+            );
+        A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
+            .Returns([]);
     }
 
     [Test]
@@ -14725,7 +14919,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
         ResourceInfo? resourceInfo = null,
         IReadOnlyList<string>? namespacePrefixes = null,
         ChangeVersionRange? changeVersionRange = null,
-        PaginationParameters? paginationParameters = null
+        PaginationParameters? paginationParameters = null,
+        CollectionPaging? paging = null
     )
     {
         authorizationStrategyEvaluators ??= [];
@@ -14740,6 +14935,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
         );
 
         var queryRequest = A.Fake<IQueryRequest>();
+        A.CallTo(() => queryRequest.ChangeVersionRange)
+            .Returns(changeVersionRange ?? ChangeVersionRange.None);
         A.CallTo(() => queryRequest.ResourceInfo).Returns(resourceInfo);
         A.CallTo(() => queryRequest.MappingSet).Returns(mappingSet);
         A.CallTo(() => queryRequest.QueryElements).Returns(queryElements);
@@ -14748,11 +14945,11 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 new RelationalAuthorizationContext(claimEducationOrganizationIds, namespacePrefixes ?? [])
             );
         A.CallTo(() => queryRequest.AuthorizationStrategyEvaluators).Returns(authorizationStrategyEvaluators);
-        A.CallTo(() => queryRequest.Paging).Returns(new CollectionPaging.Traditional(paginationParameters));
+        A.CallTo(() => queryRequest.Paging)
+            .Returns(paging ?? new CollectionPaging.Traditional(paginationParameters));
         A.CallTo(() => queryRequest.TraceId).Returns(new TraceId("query-trace"));
         A.CallTo(() => queryRequest.ReadableProfileProjectionContext)
             .Returns(readableProfileProjectionContext);
-        A.CallTo(() => queryRequest.ChangeVersionRange).Returns(changeVersionRange);
         return queryRequest;
     }
 
@@ -14909,6 +15106,17 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     new RelationalScalarType(ScalarKind.String, MaxLength: 75),
                     false,
                     new JsonPathExpression("$.name", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                // The mirrored stamp that change-version filtering binds to. Appended last so the
+                // scalar column ordinals hydrated rows are asserted by stay where they are.
+                new DbColumnModel(
+                    new DbColumnName("ContentVersion"),
+                    ColumnKind.MirroredContentVersion,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
                     null,
                     new ColumnStorage.Stored()
                 ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ChangeQueryPageOrderingPolicy.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ChangeQueryPageOrderingPolicy.cs
@@ -17,9 +17,10 @@ namespace EdFi.DataManagementService.Backend;
 /// let offset paging return it twice while its departure shifts offsets and skips another row.
 /// </summary>
 /// <remarks>
-/// Consulted only by traditional limit/offset page selection. Cursor and partition planning
-/// (DMS-1348) always anchor on <c>DocumentId</c> and must not call this policy. Snapshot data
-/// sources get their own explicit entry point when snapshot support lands; do not widen
+/// Only traditional limit/offset page selection consumes the resolved ordering. Cursor and partition
+/// selection always anchor on <c>DocumentId</c>: their candidate modes carry no ordering choice at
+/// all, so a resolved mode reaching them is discarded rather than applied. Snapshot data sources get
+/// their own explicit entry point when snapshot support lands; do not widen
 /// <see cref="ResolveForLiveQuery"/> to cover them.
 /// </remarks>
 public sealed class ChangeQueryPageOrderingPolicy(bool useLegacyDocumentIdOrdering)

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadContracts.cs
@@ -103,7 +103,7 @@ public sealed record DescriptorQueryRequest
         MappingSet mappingSet,
         QualifiedResourceName resource,
         QueryElement[] queryElements,
-        PaginationParameters paginationParameters,
+        CollectionPaging paging,
         AuthorizationStrategyEvaluator[] authorizationStrategyEvaluators,
         ReadableProfileProjectionContext? readableProfileProjectionContext,
         TraceId traceId,
@@ -116,8 +116,7 @@ public sealed record DescriptorQueryRequest
         MappingSet = mappingSet ?? throw new ArgumentNullException(nameof(mappingSet));
         Resource = resource;
         QueryElements = queryElements ?? throw new ArgumentNullException(nameof(queryElements));
-        PaginationParameters =
-            paginationParameters ?? throw new ArgumentNullException(nameof(paginationParameters));
+        Paging = paging ?? throw new ArgumentNullException(nameof(paging));
         AuthorizationStrategyEvaluators =
             authorizationStrategyEvaluators
             ?? throw new ArgumentNullException(nameof(authorizationStrategyEvaluators));
@@ -146,9 +145,10 @@ public sealed record DescriptorQueryRequest
     public QueryElement[] QueryElements { get; init; }
 
     /// <summary>
-    /// The paging inputs for descriptor GET-many execution.
+    /// The paging choice for descriptor GET-many execution: traditional limit/offset, or cursor
+    /// selection over an inclusive DocumentId range.
     /// </summary>
-    public PaginationParameters PaginationParameters { get; init; }
+    public CollectionPaging Paging { get; init; }
 
     /// <summary>
     /// The effective GET-many authorization strategies already resolved by Core.

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -552,7 +552,7 @@ internal sealed class DescriptorReadHandler(
         {
             QueryResult.QuerySuccess relationalSuccess = new(
                 [],
-                request.PaginationParameters.TotalCount
+                request.Paging.IncludesTotalCount
                     ? RelationalReadGuardrails.ConvertTotalCountOrThrow(
                         request.Resource,
                         rowsPage.Page.TotalCount,
@@ -566,7 +566,7 @@ internal sealed class DescriptorReadHandler(
 
         var candidatePage = CreateDescriptorReadAccelerationCandidatePage(
             rowsPage.Page,
-            request.PaginationParameters.TotalCount
+            request.Paging.IncludesTotalCount
         );
 
         return new DocumentCacheReadAccelerationQuerySelectionResult.CandidatePage(
@@ -943,7 +943,7 @@ internal sealed class DescriptorReadHandler(
                 .ConfigureAwait(false);
 
             return new DescriptorQueryPreparationResult.Complete(
-                new QueryResult.QuerySuccess([], request.PaginationParameters.TotalCount ? 0 : null)
+                new QueryResult.QuerySuccess([], request.Paging.IncludesTotalCount ? 0 : null)
             );
         }
 
@@ -995,6 +995,17 @@ internal sealed class DescriptorReadHandler(
             new DescriptorQueryPreparation(authorizationSpec, plannedQuery)
         );
     }
+
+    /// <summary>
+    /// The maximum <c>DocumentId</c> among the selected descriptor rows, or <see langword="null"/> when
+    /// the page selected none. Taken across every row rather than from the last one: the page query
+    /// orders ascending today, but a boundary that depended on that could not survive an ordering
+    /// change, and the maximum costs the same either way.
+    /// </summary>
+    private static long? SelectedMaximumOf(IReadOnlyList<DescriptorReadRow> descriptorRows) =>
+        descriptorRows.Count == 0
+            ? null
+            : descriptorRows.Max(static descriptorRow => descriptorRow.DocumentId);
 
     /// <summary>
     /// Plans the single-record custom-view checks descriptor GET-by-id executes, or reports the
@@ -1175,24 +1186,15 @@ internal sealed class DescriptorReadHandler(
         + (changeVersionRange.MaxChangeVersion is null ? 0 : 1);
 
     /// <summary>
-    /// Builds the paging choice for a descriptor query request. Descriptor query requests carry only
-    /// traditional pagination parameters; cursor page selection reaches the descriptor handler with
-    /// cursor execution. This is the single construction site, so the parameter budget below and the
-    /// planner always describe the same candidate mode.
-    /// </summary>
-    private static CollectionPaging BuildPaging(DescriptorQueryRequest request) =>
-        new CollectionPaging.Traditional(request.PaginationParameters);
-
-    /// <summary>
     /// Counts the paging parameters the descriptor page query will bind, taken from the candidate mode
     /// the planner will receive rather than assumed. The count is mode-dependent — traditional paging
     /// binds an offset and a limit, cursor selection binds two bounds and a page size — so a fixed count
-    /// would undercount as soon as a non-traditional mode reaches this handler, and the budget would
-    /// fail at execution instead of failing closed.
+    /// would undercount the request's real command and the budget would fail at execution instead of
+    /// failing closed.
     /// </summary>
     private int CountPagingParameters(DescriptorQueryRequest request) =>
         PageCandidateModePlanning
-            .ForPaging(BuildPaging(request), _orderingPolicy.ResolveForLiveQuery(request.ChangeVersionRange))
+            .ForPaging(request.Paging, _orderingPolicy.ResolveForLiveQuery(request.ChangeVersionRange))
             .ParameterValues.Count;
 
     /// <summary>
@@ -1272,7 +1274,7 @@ internal sealed class DescriptorReadHandler(
             request.MappingSet,
             request.Resource,
             preprocessingResult,
-            BuildPaging(request),
+            request.Paging,
             authorizationSpec,
             request.ChangeVersionRange,
             orderingMode: _orderingPolicy.ResolveForLiveQuery(request.ChangeVersionRange)
@@ -1363,20 +1365,46 @@ internal sealed class DescriptorReadHandler(
             null
         );
 
+    /// <summary>
+    /// Builds the descriptor query response, including the selected-keyset boundary a cursor walk
+    /// continues from.
+    /// </summary>
+    /// <remarks>
+    /// The rows reaching here are the selected keyset, so their maximum is the boundary. That holds on
+    /// both read paths. Uncached selection retrieves rows in the same statement that selects them. The
+    /// cache-accelerated path selects candidates and retrieves rows separately, but it admits a page
+    /// only when every selected candidate is still present and unchanged, and otherwise re-reads through
+    /// the uncached path — so a page that lost rows between selection and retrieval never arrives here
+    /// with a short row set that would understate the boundary and stall the walk. Whether the maximum
+    /// may anchor a continuation is a separate fact, decided from the ordering the page was selected
+    /// with through the same helper the regular-resource path uses.
+    /// </remarks>
     private QueryResult.QuerySuccess MaterializeDescriptorQuerySuccess(
         DescriptorQueryRequest request,
         DescriptorQueryRowsPage queryRowsPage
-    ) =>
-        new(
+    )
+    {
+        var continuationBoundary = PageContinuationBoundary.For(
+            request.Paging,
+            _orderingPolicy.ResolveForLiveQuery(request.ChangeVersionRange),
+            SelectedMaximumOf(queryRowsPage.Rows)
+        );
+
+        return new QueryResult.QuerySuccess(
             MaterializeDescriptorQueryDocuments(request, queryRowsPage.Rows),
-            request.PaginationParameters.TotalCount
+            request.Paging.IncludesTotalCount
                 ? RelationalReadGuardrails.ConvertTotalCountOrThrow(
                     request.Resource,
                     queryRowsPage.TotalCount,
                     "descriptor query"
                 )
-                : null
-        );
+                : null,
+            continuationBoundary.SelectedMaximum
+        )
+        {
+            AllowsDocumentIdContinuation = continuationBoundary.AllowsDocumentIdContinuation,
+        };
+    }
 
     private JsonArray MaterializeDescriptorQueryDocuments(
         DescriptorQueryRequest request,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -485,6 +485,15 @@ internal sealed class DescriptorReadHandler(
             request.TraceId.Value
         );
 
+        // Cursor pages take the uncached path, which is the only one that reports the selected-keyset
+        // boundary a continuation is anchored on. Read-acceleration candidate selection reports no
+        // boundary, so a cursor page served from cache would return documents with no continuation and
+        // stall the walk one page in.
+        if (request.Paging is CollectionPaging.Cursor)
+        {
+            return await HandleQueryNoCacheResultAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
         return await _readAccelerationCoordinator
             .QueryAsync(
                 new DocumentCacheReadAccelerationQueryRequest(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -575,6 +575,11 @@ internal sealed class DescriptorReadHandler(
 
         var candidatePage = CreateDescriptorReadAccelerationCandidatePage(
             rowsPage.Page,
+            PageContinuationBoundary.For(
+                request.Paging,
+                _orderingPolicy.ResolveForLiveQuery(request.ChangeVersionRange),
+                SelectedMaximumOf(rowsPage.Page.Rows)
+            ),
             request.Paging.IncludesTotalCount
         );
 
@@ -1011,7 +1016,7 @@ internal sealed class DescriptorReadHandler(
     /// orders ascending today, but a boundary that depended on that could not survive an ordering
     /// change, and the maximum costs the same either way.
     /// </summary>
-    private static long? SelectedMaximumOf(IReadOnlyList<DescriptorReadRow> descriptorRows) =>
+    private static long? SelectedMaximumOf(IReadOnlyList<IDescriptorReadCandidateMetadata> descriptorRows) =>
         descriptorRows.Count == 0
             ? null
             : descriptorRows.Max(static descriptorRow => descriptorRow.DocumentId);
@@ -1454,12 +1459,13 @@ internal sealed class DescriptorReadHandler(
 
     private static DocumentCacheReadAccelerationCandidatePage CreateDescriptorReadAccelerationCandidatePage(
         DescriptorQueryCandidatePage queryRowsPage,
+        PageContinuationBoundary continuationBoundary,
         bool includesTotalCount
     ) =>
         new(
             [.. queryRowsPage.Rows.Select(CreateDescriptorReadAccelerationCandidate)],
             queryRowsPage.TotalCount,
-            HighestSelectedDocumentId: null,
+            continuationBoundary,
             IncludesTotalCount: includesTotalCount
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -485,10 +485,10 @@ internal sealed class DescriptorReadHandler(
             request.TraceId.Value
         );
 
-        // Cursor pages take the uncached path, which is the only one that reports the selected-keyset
-        // boundary a continuation is anchored on. Read-acceleration candidate selection reports no
-        // boundary, so a cursor page served from cache would return documents with no continuation and
-        // stall the walk one page in.
+        // Cursor pages take the uncached path rather than read acceleration. A cursor walk depends on
+        // every page reporting the selected-keyset boundary its successor resumes from, and only
+        // traditional paging is exercised against the read-acceleration path, so cursor selection keeps
+        // to the path whose boundary reporting is covered end to end.
         if (request.Paging is CollectionPaging.Cursor)
         {
             return await HandleQueryNoCacheResultAsync(request, cancellationToken).ConfigureAwait(false);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DocumentCacheReadAccelerationCoordinator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DocumentCacheReadAccelerationCoordinator.cs
@@ -44,10 +44,15 @@ public sealed record DocumentCacheReadAccelerationCandidate(
     DateTimeOffset ContentLastModifiedAt
 );
 
+/// <param name="ContinuationBoundary">
+/// What the page selection that produced these candidates can tell Core about continuing after it.
+/// Carried on the candidate page because a page served from cache is shaped from the candidates alone,
+/// and a boundary left behind there would make the continuation header depend on cache state.
+/// </param>
 public sealed record DocumentCacheReadAccelerationCandidatePage(
     IReadOnlyList<DocumentCacheReadAccelerationCandidate> Candidates,
     long? TotalCount,
-    long? HighestSelectedDocumentId,
+    PageContinuationBoundary ContinuationBoundary,
     bool IncludesTotalCount
 )
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DocumentCacheReadResponseShaper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DocumentCacheReadResponseShaper.cs
@@ -126,6 +126,8 @@ internal sealed class DocumentCacheReadResponseShaper(
                 );
             }
 
+            // The boundary is reported exactly as page selection resolved it, so a page answered from
+            // cache hands Core the same continuation facts the relational path would have.
             return DocumentCacheReadLookupResult<QueryResult>.Hit(
                 new QueryResult.QuerySuccess(
                     edfiDocs,
@@ -136,8 +138,13 @@ internal sealed class DocumentCacheReadResponseShaper(
                             "cache query response shaping"
                         )
                         : null,
-                    authorizedCandidatePage.HighestSelectedDocumentId
+                    authorizedCandidatePage.ContinuationBoundary.SelectedMaximum
                 )
+                {
+                    AllowsDocumentIdContinuation = authorizedCandidatePage
+                        .ContinuationBoundary
+                        .AllowsDocumentIdContinuation,
+                }
             );
         });
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/PageContinuationBoundary.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/PageContinuationBoundary.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// What a completed page selection can tell Core about continuing after it: the maximum DocumentId it
+/// selected, and whether that maximum may anchor a continuation.
+/// </summary>
+/// <param name="SelectedMaximum">
+/// The maximum DocumentId in the selected page keyset, or <see langword="null"/> when page selection
+/// was skipped or selected no keys.
+/// </param>
+/// <param name="AllowsDocumentIdContinuation">
+/// Whether <paramref name="SelectedMaximum"/> describes where this page ended, which it does only when
+/// the page was ordered by DocumentId.
+/// </param>
+internal readonly record struct PageContinuationBoundary(
+    long? SelectedMaximum,
+    bool AllowsDocumentIdContinuation
+)
+{
+    /// <summary>
+    /// Pairs a page's selected maximum with its continuation eligibility. Regular-resource and
+    /// descriptor query execution both resolve it here, so the two resource families cannot answer the
+    /// same page differently.
+    /// </summary>
+    /// <remarks>
+    /// A continuation anchored on DocumentId is only valid when DocumentId is the key the page was
+    /// ordered by. Cursor selection always orders by DocumentId — its mode carries no ordering choice
+    /// at all — so a cursor page is always eligible. Traditional selection orders by ContentVersion for
+    /// a max-bearing change-version window, and a DocumentId anchor taken from such a page would skip
+    /// qualifying rows with a smaller DocumentId and a later ContentVersion, so it is not eligible.
+    /// The caller supplies the effective ordering rather than the request's filters, which is what
+    /// keeps the legacy DocumentId-ordering switch honored: under it a windowed traditional page really
+    /// is ordered by DocumentId, and really can anchor a continuation.
+    /// </remarks>
+    /// <param name="paging">The paging choice the page was selected with.</param>
+    /// <param name="orderingMode">The effective page-selection ordering key.</param>
+    /// <param name="selectedMaximum">The maximum selected DocumentId, unchanged by this decision.</param>
+    public static PageContinuationBoundary For(
+        CollectionPaging paging,
+        PageOrderingMode orderingMode,
+        long? selectedMaximum
+    )
+    {
+        ArgumentNullException.ThrowIfNull(paging);
+
+        var allowsDocumentIdContinuation = paging switch
+        {
+            CollectionPaging.Cursor => true,
+            CollectionPaging.Traditional => orderingMode is PageOrderingMode.DocumentId,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(paging),
+                paging.GetType().Name,
+                "Unsupported collection paging mode."
+            ),
+        };
+
+        return new PageContinuationBoundary(selectedMaximum, allowsDocumentIdContinuation);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/PageContinuationBoundary.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/PageContinuationBoundary.cs
@@ -20,7 +20,7 @@ namespace EdFi.DataManagementService.Backend;
 /// Whether <paramref name="SelectedMaximum"/> describes where this page ended, which it does only when
 /// the page was ordered by DocumentId.
 /// </param>
-internal readonly record struct PageContinuationBoundary(
+public readonly record struct PageContinuationBoundary(
     long? SelectedMaximum,
     bool AllowsDocumentIdContinuation
 )

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -1138,10 +1138,10 @@ public sealed class RelationalDocumentStoreRepository(
             return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken).ConfigureAwait(false);
         }
 
-        // Cursor pages select their keyset through the relational path, which is the only path that
-        // returns the selected-keyset boundary a continuation is anchored on. The read-acceleration
-        // candidate selection reports no boundary, so a cursor page routed through it would return
-        // documents with no continuation and stall the walk one page in.
+        // Cursor pages select their keyset through the relational path rather than read acceleration. A
+        // cursor walk depends on every page reporting the selected-keyset boundary its successor resumes
+        // from, and only traditional paging is exercised against the read-acceleration path, so cursor
+        // selection keeps to the path whose boundary reporting is covered end to end.
         if (queryRequest.Paging is CollectionPaging.Cursor)
         {
             return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken).ConfigureAwait(false);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -1484,7 +1484,8 @@ public sealed class RelationalDocumentStoreRepository(
                     preparation.Resource,
                     preparation.ReadPlan,
                     preparation.PlannedQuery,
-                    queryRequest.Paging.IncludesTotalCount,
+                    queryRequest.Paging,
+                    preparation.OrderingMode,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -1506,8 +1507,13 @@ public sealed class RelationalDocumentStoreRepository(
                             "query candidate selection"
                         )
                         : null,
-                    candidatePage.HighestSelectedDocumentId
+                    candidatePage.ContinuationBoundary.SelectedMaximum
                 )
+                {
+                    AllowsDocumentIdContinuation = candidatePage
+                        .ContinuationBoundary
+                        .AllowsDocumentIdContinuation,
+                }
             );
         }
 
@@ -1563,7 +1569,7 @@ public sealed class RelationalDocumentStoreRepository(
         hydratedPage = hydratedPage with
         {
             TotalCount = candidatePage.TotalCount,
-            HighestSelectedDocumentId = candidatePage.HighestSelectedDocumentId,
+            HighestSelectedDocumentId = candidatePage.ContinuationBoundary.SelectedMaximum,
         };
 
         if (!SelectedQueryCandidatePageStillMatches(candidatePage, hydratedPage.DocumentMetadata))
@@ -1620,7 +1626,8 @@ public sealed class RelationalDocumentStoreRepository(
         QualifiedResourceName resource,
         ResourceReadPlan readPlan,
         PageKeysetSpec.Query plannedQuery,
-        bool includesTotalCount,
+        CollectionPaging paging,
+        PageOrderingMode orderingMode,
         CancellationToken cancellationToken
     )
     {
@@ -1634,7 +1641,8 @@ public sealed class RelationalDocumentStoreRepository(
                     ReadDocumentCandidatePageAsync(
                         reader,
                         plannedQuery.Plan.TotalCountSql is not null,
-                        includesTotalCount,
+                        paging,
+                        orderingMode,
                         resourceKeyId,
                         ct
                     ),
@@ -1683,12 +1691,26 @@ public sealed class RelationalDocumentStoreRepository(
     private static async Task<DocumentCacheReadAccelerationCandidatePage> ReadDocumentCandidatePageAsync(
         IRelationalCommandReader reader,
         bool hasTotalCount,
-        bool includesTotalCount,
+        CollectionPaging paging,
+        PageOrderingMode orderingMode,
         short resourceKeyId,
         CancellationToken cancellationToken
     )
     {
         ArgumentNullException.ThrowIfNull(reader);
+
+        // The keyset materialization returns the ids it selected, ahead of every other result set. The
+        // boundary is taken from them rather than from the candidates below, so it stays the keys
+        // selection chose even when a row is deleted before the metadata select reaches it.
+        long? selectedMaximum = await ReadSelectedDocumentIdMaximumAsync(reader, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!await reader.NextResultAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException(
+                "Expected a query candidate result set after the selected page keyset ids but no more result sets were available."
+            );
+        }
 
         long? totalCount = null;
 
@@ -1720,14 +1742,37 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        // This candidate reader is used only by traditional paging. A cursor boundary must come from
-        // cursor page selection itself rather than being inferred from the selected document ids.
         return new DocumentCacheReadAccelerationCandidatePage(
             candidates,
             totalCount,
-            HighestSelectedDocumentId: null,
-            IncludesTotalCount: includesTotalCount
+            PageContinuationBoundary.For(paging, orderingMode, selectedMaximum),
+            IncludesTotalCount: paging.IncludesTotalCount
         );
+    }
+
+    /// <summary>
+    /// Reads the selected page keyset ids from the current result set and returns the maximum, or
+    /// <see langword="null"/> when the selection was empty. Taken across every returned row because
+    /// neither <c>RETURNING</c> nor <c>OUTPUT</c> promises an order.
+    /// </summary>
+    private static async Task<long?> ReadSelectedDocumentIdMaximumAsync(
+        IRelationalCommandReader reader,
+        CancellationToken cancellationToken
+    )
+    {
+        long? selectedMaximum = null;
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var selectedDocumentId = reader.GetFieldValue<long>(0);
+
+            if (selectedMaximum is null || selectedDocumentId > selectedMaximum)
+            {
+                selectedMaximum = selectedDocumentId;
+            }
+        }
+
+        return selectedMaximum;
     }
 
     private static async Task<long> ReadCandidatePageTotalCountAsync(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -1135,8 +1135,7 @@ public sealed class RelationalDocumentStoreRepository(
 
         if (queryRequest.MappingSet.TryGetDescriptorResourceModel(resource, out _))
         {
-            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken)
-                .ConfigureAwait(false);
+            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken).ConfigureAwait(false);
         }
 
         // Cursor pages select their keyset through the relational path, which is the only path that
@@ -1145,8 +1144,7 @@ public sealed class RelationalDocumentStoreRepository(
         // documents with no continuation and stall the walk one page in.
         if (queryRequest.Paging is CollectionPaging.Cursor)
         {
-            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken)
-                .ConfigureAwait(false);
+            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken).ConfigureAwait(false);
         }
 
         return await _readAccelerationCoordinator
@@ -1570,8 +1568,7 @@ public sealed class RelationalDocumentStoreRepository(
 
         if (!SelectedQueryCandidatePageStillMatches(candidatePage, hydratedPage.DocumentMetadata))
         {
-            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken)
-                .ConfigureAwait(false);
+            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken).ConfigureAwait(false);
         }
 
         return BuildQuerySuccess(queryRequest, resource, readPlan, hydratedPage, orderingMode);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -105,11 +105,16 @@ public sealed class RelationalDocumentStoreRepository(
         edOrgAuthorizationSubjectSelector
     );
 
+    /// <param name="OrderingMode">
+    /// The ordering the page was planned with. Carried rather than re-resolved so the continuation
+    /// decision is made from the ordering page selection actually used.
+    /// </param>
     private sealed record RelationalQueryPreparation(
         QualifiedResourceName Resource,
         ResourceReadPlan ReadPlan,
         PageKeysetSpec.Query PlannedQuery,
-        PageDocumentIdAuthorizationSpec? Authorization
+        PageDocumentIdAuthorizationSpec? Authorization,
+        PageOrderingMode OrderingMode
     );
 
     private abstract record RelationalQueryPreparationResult
@@ -1126,19 +1131,21 @@ public sealed class RelationalDocumentStoreRepository(
     {
         ArgumentNullException.ThrowIfNull(queryRequest);
 
-        if (queryRequest.Paging is not CollectionPaging.Traditional traditionalPaging)
-        {
-            // Cursor page selection arrives with the shared candidate planner and cursor execution.
-            return new QueryResult.QueryFailureNotImplemented(
-                "Cursor paging is not yet supported for relational queries."
-            );
-        }
-
         var resource = RelationalWriteSupport.ToQualifiedResourceName(queryRequest.ResourceInfo);
 
         if (queryRequest.MappingSet.TryGetDescriptorResourceModel(resource, out _))
         {
-            return await QueryDocumentsRelationalAsync(queryRequest, traditionalPaging, cancellationToken)
+            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        // Cursor pages select their keyset through the relational path, which is the only path that
+        // returns the selected-keyset boundary a continuation is anchored on. The read-acceleration
+        // candidate selection reports no boundary, so a cursor page routed through it would return
+        // documents with no continuation and stall the walk one page in.
+        if (queryRequest.Paging is CollectionPaging.Cursor)
+        {
+            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -1150,15 +1157,10 @@ public sealed class RelationalDocumentStoreRepository(
                     resource,
                     DocumentCacheReadAccelerationResourceKind.Resource,
                     fallbackCancellationToken =>
-                        QueryDocumentsRelationalAsync(
-                            queryRequest,
-                            traditionalPaging,
-                            fallbackCancellationToken
-                        ),
+                        QueryDocumentsRelationalAsync(queryRequest, fallbackCancellationToken),
                     selectionCancellationToken =>
                         SelectQueryReadAccelerationCandidatePageAsync(
                             queryRequest,
-                            traditionalPaging,
                             selectionCancellationToken
                         )
                 )
@@ -1173,7 +1175,6 @@ public sealed class RelationalDocumentStoreRepository(
 
     private async Task<QueryResult> QueryDocumentsRelationalAsync(
         IQueryRequest queryRequest,
-        CollectionPaging.Traditional traditionalPaging,
         CancellationToken cancellationToken = default
     )
     {
@@ -1193,7 +1194,7 @@ public sealed class RelationalDocumentStoreRepository(
                         mappingSet,
                         resource,
                         queryRequest.QueryElements,
-                        traditionalPaging.Parameters,
+                        queryRequest.Paging,
                         queryRequest.AuthorizationStrategyEvaluators,
                         queryRequest.ReadableProfileProjectionContext,
                         queryRequest.TraceId,
@@ -1209,7 +1210,6 @@ public sealed class RelationalDocumentStoreRepository(
 
         RelationalQueryPreparationResult preparationResult = await PrepareQueryReadAsync(
                 queryRequest,
-                traditionalPaging,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -1244,12 +1244,17 @@ public sealed class RelationalDocumentStoreRepository(
             throw new CustomViewAuthorizationValidationException(ex);
         }
 
-        return BuildQuerySuccess(queryRequest, preparation.Resource, preparation.ReadPlan, hydratedPage);
+        return BuildQuerySuccess(
+            queryRequest,
+            preparation.Resource,
+            preparation.ReadPlan,
+            hydratedPage,
+            preparation.OrderingMode
+        );
     }
 
     private async Task<RelationalQueryPreparationResult> PrepareQueryReadAsync(
         IQueryRequest queryRequest,
-        CollectionPaging.Traditional traditionalPaging,
         CancellationToken cancellationToken
     )
     {
@@ -1365,6 +1370,10 @@ public sealed class RelationalDocumentStoreRepository(
 
         PageKeysetSpec.Query? plannedQuery;
 
+        // Resolved once and reused for the selected-keyset boundary below, so the ordering the page was
+        // actually selected with is the ordering the continuation decision is made from.
+        var orderingMode = _orderingPolicy.ResolveForLiveQuery(queryRequest.ChangeVersionRange);
+
         try
         {
             var planner = new RelationalQueryPageKeysetPlanner(mappingSet.Key.Dialect);
@@ -1373,12 +1382,12 @@ public sealed class RelationalDocumentStoreRepository(
                 !planner.TryPlan(
                     readPlan.Model.Root,
                     preprocessingResult,
-                    traditionalPaging,
+                    queryRequest.Paging,
                     out plannedQuery,
                     out _,
                     authorization: pageQueryAuthorization,
                     changeVersionRange: queryRequest.ChangeVersionRange,
-                    orderingMode: _orderingPolicy.ResolveForLiveQuery(queryRequest.ChangeVersionRange)
+                    orderingMode: orderingMode
                 ) || plannedQuery is null
             )
             {
@@ -1439,20 +1448,24 @@ public sealed class RelationalDocumentStoreRepository(
         }
 
         return new RelationalQueryPreparationResult.Prepared(
-            new RelationalQueryPreparation(resource, readPlan, plannedQuery, pageQueryAuthorization)
+            new RelationalQueryPreparation(
+                resource,
+                readPlan,
+                plannedQuery,
+                pageQueryAuthorization,
+                orderingMode
+            )
         );
     }
 
     private async Task<DocumentCacheReadAccelerationQuerySelectionResult> SelectQueryReadAccelerationCandidatePageAsync(
         IQueryRequest queryRequest,
-        CollectionPaging.Traditional traditionalPaging,
         CancellationToken cancellationToken = default
     )
     {
         var mappingSet = queryRequest.MappingSet;
         RelationalQueryPreparationResult preparationResult = await PrepareQueryReadAsync(
                 queryRequest,
-                traditionalPaging,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -1505,7 +1518,7 @@ public sealed class RelationalDocumentStoreRepository(
             fallbackCancellationToken =>
                 HydrateSelectedQueryCandidatePageAsync(
                     queryRequest,
-                    traditionalPaging,
+                    preparation.OrderingMode,
                     preparation.Resource,
                     preparation.ReadPlan,
                     preparation.Authorization?.CustomViewChecks,
@@ -1517,7 +1530,7 @@ public sealed class RelationalDocumentStoreRepository(
 
     private async Task<QueryResult> HydrateSelectedQueryCandidatePageAsync(
         IQueryRequest queryRequest,
-        CollectionPaging.Traditional traditionalPaging,
+        PageOrderingMode orderingMode,
         QualifiedResourceName resource,
         ResourceReadPlan readPlan,
         IReadOnlyList<PageDocumentIdAuthorizationCustomViewCheck>? customViewChecks,
@@ -1547,6 +1560,8 @@ public sealed class RelationalDocumentStoreRepository(
             throw new CustomViewAuthorizationValidationException(ex);
         }
 
+        // The boundary comes from the candidate selection, not from what hydration found, which is what
+        // keeps a cache-accelerated page's continuation describing the keys selection chose.
         hydratedPage = hydratedPage with
         {
             TotalCount = candidatePage.TotalCount,
@@ -1555,11 +1570,11 @@ public sealed class RelationalDocumentStoreRepository(
 
         if (!SelectedQueryCandidatePageStillMatches(candidatePage, hydratedPage.DocumentMetadata))
         {
-            return await QueryDocumentsRelationalAsync(queryRequest, traditionalPaging, cancellationToken)
+            return await QueryDocumentsRelationalAsync(queryRequest, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        return BuildQuerySuccess(queryRequest, resource, readPlan, hydratedPage);
+        return BuildQuerySuccess(queryRequest, resource, readPlan, hydratedPage, orderingMode);
     }
 
     private static bool SelectedQueryCandidatePageStillMatches(
@@ -5486,7 +5501,8 @@ public sealed class RelationalDocumentStoreRepository(
         IQueryRequest relationalQueryRequest,
         QualifiedResourceName resource,
         ResourceReadPlan readPlan,
-        HydratedPage hydratedPage
+        HydratedPage hydratedPage,
+        PageOrderingMode orderingMode
     )
     {
         ArgumentNullException.ThrowIfNull(relationalQueryRequest);
@@ -5534,7 +5550,14 @@ public sealed class RelationalDocumentStoreRepository(
         }
 
         // The selected-keyset boundary passes through unchanged, including when the body above came back
-        // empty: it describes what page selection chose, not what survived to hydration.
+        // empty: it describes what page selection chose, not what survived to hydration. Whether it may
+        // anchor a continuation is a separate fact, decided from the ordering the page was selected with.
+        var continuationBoundary = PageContinuationBoundary.For(
+            relationalQueryRequest.Paging,
+            orderingMode,
+            hydratedPage.HighestSelectedDocumentId
+        );
+
         return new QueryResult.QuerySuccess(
             edfiDocs,
             relationalQueryRequest.Paging.IncludesTotalCount
@@ -5544,8 +5567,11 @@ public sealed class RelationalDocumentStoreRepository(
                     "query hydration"
                 )
                 : null,
-            hydratedPage.HighestSelectedDocumentId
-        );
+            continuationBoundary.SelectedMaximum
+        )
+        {
+            AllowsDocumentIdContinuation = continuationBoundary.AllowsDocumentIdContinuation,
+        };
     }
 
     private static WritePrecondition NormalizeWritePrecondition(WritePrecondition? writePrecondition) =>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/QueryResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/QueryResult.cs
@@ -20,10 +20,29 @@ public record QueryResult
     /// The maximum DocumentId in the selected page keyset, or null when page selection was skipped or
     /// selected no keys, including early-empty paths and zero-size pages. Independent of
     /// <paramref name="EdfiDocs"/>: it can be non-null while the body is empty, because every selected
-    /// row may be deleted before hydration completes. Populated by cursor execution in a later story.
+    /// row may be deleted before hydration completes.
     /// </param>
     public record QuerySuccess(JsonArray EdfiDocs, int? TotalCount, long? HighestSelectedDocumentId = null)
-        : QueryResult();
+        : QueryResult()
+    {
+        /// <summary>
+        /// Whether a DocumentId-anchored continuation may be created from
+        /// <see cref="HighestSelectedDocumentId"/>. False when this page was ordered by something else,
+        /// so its highest selected DocumentId does not describe where the page ended.
+        /// </summary>
+        /// <remarks>
+        /// Independent of <see cref="HighestSelectedDocumentId"/>, and deliberately not folded into it:
+        /// a page that selected keys but cannot anchor a DocumentId continuation is a different state
+        /// from a page that selected none, and collapsing the two would make the maximum report a
+        /// selection that happened as one that did not. Defaults to true because only page selection
+        /// ordered by something other than DocumentId can invalidate the anchor, and only the two
+        /// backend sites that produce a real maximum can observe that ordering; every other result
+        /// carries no maximum for this to qualify. Temporary: the only ordering that sets it false is
+        /// traditional paging over a max-bearing change-version window, which acquires its own
+        /// ContentVersion anchor in later work.
+        /// </remarks>
+        public bool AllowsDocumentIdContinuation { get; init; } = true;
+    }
 
     /// <summary>
     /// A known failure from the query handler, likely invalid query terms that

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/QueryResultBoundaryTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/QueryResultBoundaryTests.cs
@@ -51,4 +51,42 @@ public class Given_A_Query_Success_Result
             .PropertyType.Should()
             .Be<long?>();
     }
+
+    [Test]
+    public void It_allows_a_document_id_continuation_by_default()
+    {
+        new QueryResult.QuerySuccess([], 0).AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    // The two are independent: a page can select keys it cannot anchor a DocumentId continuation on,
+    // which is a different state from a page that selected none.
+    [Test]
+    public void It_allows_a_selected_boundary_that_cannot_anchor_a_document_id_continuation()
+    {
+        QueryResult.QuerySuccess success = new([], null, 2509) { AllowsDocumentIdContinuation = false };
+
+        success.HighestSelectedDocumentId.Should().Be(2509);
+        success.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The masked-logging result formatter replaces only the documents, by copy. Rebuilding the record
+    /// there would drop any member the rebuild forgot, so this asserts the copy the formatter performs
+    /// keeps every other member intact.
+    /// </summary>
+    [Test]
+    public void It_preserves_every_other_member_when_a_copy_replaces_only_the_documents()
+    {
+        QueryResult.QuerySuccess success = new([JsonValue.Create(1)], 7, 2509)
+        {
+            AllowsDocumentIdContinuation = false,
+        };
+
+        var redacted = success with { EdfiDocs = new JsonArray("REDACTED") };
+
+        redacted.EdfiDocs.Should().ContainSingle().Which!.GetValue<string>().Should().Be("REDACTED");
+        redacted.TotalCount.Should().Be(7);
+        redacted.HighestSelectedDocumentId.Should().Be(2509);
+        redacted.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -13,6 +13,7 @@ using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.External.Security;
 using EdFi.DataManagementService.Core.Handler;
 using EdFi.DataManagementService.Core.Model;
+using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.Response;
@@ -46,9 +47,23 @@ public class QueryRequestHandlerTests
     }
 
     /// <summary>
-    /// Collection paging reaches the backend as the typed choice request validation produced. Cursor
-    /// page selection itself is not implemented yet, so a cursor request is answered from the
-    /// backend's not-implemented seam; the story that adds cursor execution replaces that answer.
+    /// The emitted continuation range, decoded by the codec that encodes it, so the assertion cannot
+    /// drift from the transport encoding by transcribing it.
+    /// </summary>
+    internal static CursorRange? DecodeNextPageToken(RequestInfo requestInfo)
+    {
+        if (!requestInfo.FrontendResponse.Headers.TryGetValue("Next-Page-Token", out var nextPageToken))
+        {
+            return null;
+        }
+
+        PageTokenCodec.TryDecode(nextPageToken, out var range).Should().BeTrue();
+        return range;
+    }
+
+    /// <summary>
+    /// Collection paging reaches the backend as the typed choice request validation produced, and the
+    /// page it selects comes back with a continuation the client can walk from.
     /// </summary>
     [TestFixture]
     [Parallelizable]
@@ -65,15 +80,7 @@ public class QueryRequestHandlerTests
             {
                 CapturedRequest = queryRequest;
 
-                // Mirrors the relational repository's guard: any paging other than traditional is
-                // not yet selectable.
-                return Task.FromResult<QueryResult>(
-                    queryRequest.Paging is CollectionPaging.Traditional
-                        ? new QueryResult.QuerySuccess([], 0)
-                        : new QueryResult.QueryFailureNotImplemented(
-                            "Cursor paging is not yet supported for relational queries."
-                        )
-                );
+                return Task.FromResult<QueryResult>(new QueryResult.QuerySuccess([], null, 21L));
             }
         }
 
@@ -102,9 +109,188 @@ public class QueryRequestHandlerTests
         }
 
         [Test]
-        public void It_returns_not_implemented_until_cursor_execution_lands()
+        public void It_serves_the_selected_page()
         {
-            _requestInfo.FrontendResponse.StatusCode.Should().Be(501);
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(200);
+        }
+
+        // The next range starts after the keys this page selected and keeps the request's own upper
+        // bound, which is how a walk that entered through a partition stays inside it.
+        [Test]
+        public void It_continues_after_the_selected_keys_within_the_requested_bound()
+        {
+            DecodeNextPageToken(_requestInfo).Should().Be(new CursorRange(22, 42));
+        }
+    }
+
+    /// <summary>
+    /// One gate decides the continuation header for every GET-many response: the page selected keys,
+    /// and the maximum it selected can anchor a DocumentId continuation. Nothing about the response
+    /// body participates, and neither resource family has a rule of its own.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Query_Success_Reaching_The_Continuation_Gate : QueryRequestHandlerTests
+    {
+        private sealed class Repository(QueryResult.QuerySuccess success)
+            : NotImplementedDocumentStoreRepository
+        {
+            public override Task<QueryResult> QueryDocuments(
+                IQueryRequest queryRequest,
+                CancellationToken cancellationToken = default
+            ) => Task.FromResult<QueryResult>(success);
+        }
+
+        private static readonly CollectionPaging _traditionalPaging = new CollectionPaging.Traditional(
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+        );
+
+        private static async Task<RequestInfo> ExecuteAsync(
+            QueryResult.QuerySuccess success,
+            CollectionPaging? paging = null,
+            RequestInfo? requestInfo = null
+        )
+        {
+            requestInfo ??= RequestInfoWithRelationalMappingSet();
+            requestInfo.CollectionPaging = paging ?? _traditionalPaging;
+
+            var (queryHandler, serviceProvider) = Handler(new Repository(success));
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            await queryHandler.Execute(requestInfo, NullNext);
+
+            return requestInfo;
+        }
+
+        // A traditional response can begin a cursor walk. It carried no upper bound, so the walk it
+        // starts is unbounded above.
+        [Test]
+        public async Task It_starts_an_unbounded_walk_from_a_traditional_page()
+        {
+            var requestInfo = await ExecuteAsync(new QueryResult.QuerySuccess([], null, 2509L));
+
+            DecodeNextPageToken(requestInfo).Should().Be(new CursorRange(2510, long.MaxValue));
+        }
+
+        [Test]
+        public async Task It_emits_no_continuation_when_page_selection_chose_nothing()
+        {
+            var requestInfo = await ExecuteAsync(new QueryResult.QuerySuccess([], null));
+
+            requestInfo.FrontendResponse.Headers.Should().NotContainKey("Next-Page-Token");
+        }
+
+        // The boundary describes selected keys, not surviving rows: a page whose every selected row was
+        // deleted before hydration still advances the walk past them. A client that stopped on an empty
+        // body would stop early, which is why the gate never asks about the body.
+        [Test]
+        public async Task It_continues_past_selected_keys_whose_rows_were_all_deleted()
+        {
+            var requestInfo = await ExecuteAsync(new QueryResult.QuerySuccess([], null, 2509L));
+
+            requestInfo.FrontendResponse.Body!.AsArray().Should().BeEmpty();
+            DecodeNextPageToken(requestInfo).Should().Be(new CursorRange(2510, long.MaxValue));
+        }
+
+        // A zero-size page selects no keys, so it cannot advance a walk — by contract, not by accident.
+        [Test]
+        public async Task It_emits_no_continuation_for_a_zero_size_page()
+        {
+            var requestInfo = await ExecuteAsync(
+                new QueryResult.QuerySuccess([], null),
+                new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(0))
+            );
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(200);
+            requestInfo.FrontendResponse.Body!.AsArray().Should().BeEmpty();
+            requestInfo.FrontendResponse.Headers.Should().NotContainKey("Next-Page-Token");
+        }
+
+        // The terminal page of a walk: the range selected nothing, so the client learns the walk is
+        // over by receiving no continuation rather than by an extra fetched row or a count.
+        [Test]
+        public async Task It_emits_no_continuation_for_an_empty_terminal_page()
+        {
+            var requestInfo = await ExecuteAsync(
+                new QueryResult.QuerySuccess([], null),
+                new CollectionPaging.Cursor(new CursorRange(2510, 42), new PageSize(25))
+            );
+
+            requestInfo.FrontendResponse.Headers.Should().NotContainKey("Next-Page-Token");
+        }
+
+        // Advancing past Int64.MaxValue would overflow, so there is no next range to name.
+        [Test]
+        public async Task It_emits_no_continuation_at_the_maximum_document_id()
+        {
+            var requestInfo = await ExecuteAsync(new QueryResult.QuerySuccess([], null, long.MaxValue));
+
+            requestInfo.FrontendResponse.Headers.Should().NotContainKey("Next-Page-Token");
+        }
+
+        // A page ordered by something other than DocumentId really did select keys, and reports their
+        // maximum, but that maximum does not say where the page ended, so it cannot anchor a walk.
+        [Test]
+        public async Task It_emits_no_continuation_when_the_page_cannot_anchor_one()
+        {
+            var requestInfo = await ExecuteAsync(
+                new QueryResult.QuerySuccess([], null, 2509L) { AllowsDocumentIdContinuation = false }
+            );
+
+            requestInfo.FrontendResponse.Headers.Should().NotContainKey("Next-Page-Token");
+        }
+
+        [Test]
+        public async Task It_keeps_total_count_alongside_a_continuation()
+        {
+            var requestInfo = await ExecuteAsync(
+                new QueryResult.QuerySuccess([], 7, 2509L),
+                new CollectionPaging.Traditional(
+                    new PaginationParameters(Limit: 25, Offset: 0, TotalCount: true, MaximumPageSize: 500)
+                )
+            );
+
+            requestInfo
+                .FrontendResponse.Headers.Should()
+                .ContainKey("Total-Count")
+                .WhoseValue.Should()
+                .Be("7");
+            DecodeNextPageToken(requestInfo).Should().Be(new CursorRange(2510, long.MaxValue));
+        }
+
+        [Test]
+        public async Task It_emits_no_total_count_for_a_cursor_page()
+        {
+            var requestInfo = await ExecuteAsync(
+                new QueryResult.QuerySuccess([], null, 2509L),
+                new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25))
+            );
+
+            requestInfo.FrontendResponse.Headers.Should().NotContainKey("Total-Count");
+            requestInfo.FrontendResponse.ContentType.Should().Be("application/json");
+        }
+
+        // Regular-resource and descriptor results reach the handler as the same QuerySuccess, so the
+        // header they receive is decided once rather than by two rules that could drift apart.
+        [Test]
+        public async Task It_decides_the_continuation_the_same_way_for_both_resource_families()
+        {
+            QueryResult.QuerySuccess success = new([], null, 2509L);
+
+            var regularResourceRequestInfo = await ExecuteAsync(success);
+
+            var descriptorRequestInfo = RequestInfoWithRelationalMappingSet();
+            descriptorRequestInfo.ResourceInfo = descriptorRequestInfo.ResourceInfo with
+            {
+                ResourceName = new ResourceName("SchoolTypeDescriptor"),
+                IsDescriptor = true,
+            };
+
+            await ExecuteAsync(success, requestInfo: descriptorRequestInfo);
+
+            descriptorRequestInfo
+                .FrontendResponse.Headers.Should()
+                .Equal(regularResourceRequestInfo.FrontendResponse.Headers);
+            DecodeNextPageToken(descriptorRequestInfo).Should().Be(new CursorRange(2510, long.MaxValue));
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
@@ -146,11 +146,12 @@ public static class DmsCoreServiceExtensions
                             getSuccess.LastModifiedDate,
                             getSuccess.LastModifiedTraceId
                         ),
-                        QueryResult.QuerySuccess querySuccess => new QueryResult.QuerySuccess(
-                            new JsonArray("REDACTED"),
-                            querySuccess.TotalCount,
-                            querySuccess.HighestSelectedDocumentId
-                        ),
+                        // Copied rather than rebuilt, so a member added to the result later cannot be
+                        // dropped from the logged copy by omission here.
+                        QueryResult.QuerySuccess querySuccess => querySuccess with
+                        {
+                            EdfiDocs = new JsonArray("REDACTED"),
+                        },
                         _ => result,
                     };
                 };

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
@@ -3,11 +3,13 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Model;
+using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.Response;
@@ -21,6 +23,12 @@ namespace EdFi.DataManagementService.Core.Handler;
 
 internal class QueryRequestHandler(ILogger _logger, ResiliencePipeline _resiliencePipeline) : IPipelineStep
 {
+    /// <summary>
+    /// The response header carrying the token for the page after this one, as published by the Ed-Fi
+    /// cursor-paging client contract.
+    /// </summary>
+    private const string NextPageTokenHeaderName = "Next-Page-Token";
+
     public async Task Execute(RequestInfo requestInfo, Func<Task> next)
     {
         _logger.LogDebug(
@@ -101,14 +109,66 @@ internal class QueryRequestHandler(ILogger _logger, ResiliencePipeline _resilien
             )
             : "application/json";
 
+        Dictionary<string, string> headers = requestInfo.CollectionPaging.IncludesTotalCount
+            ? new() { { "Total-Count", (success.TotalCount ?? 0).ToString() } }
+            : [];
+
+        if (TryCreateNextPageToken(requestInfo, success, out var nextPageToken))
+        {
+            headers.Add(NextPageTokenHeaderName, nextPageToken);
+        }
+
         return new FrontendResponse(
             StatusCode: 200,
             Body: success.EdfiDocs,
-            Headers: requestInfo.CollectionPaging.IncludesTotalCount
-                ? new() { { "Total-Count", (success.TotalCount ?? 0).ToString() } }
-                : [],
+            Headers: headers,
             ContentType: contentType
         );
+    }
+
+    /// <summary>
+    /// Whether this page can hand the client a token for the page after it, and what that token is.
+    /// </summary>
+    /// <remarks>
+    /// The one gate both resource families pass through: regular-resource and descriptor results reach
+    /// it as the same <see cref="QuerySuccess"/>, so neither can acquire a header rule of its own. It
+    /// asks what page selection chose, never what the response body contains — a page whose selected
+    /// rows were all deleted before hydration still advances the walk past them, and a client that
+    /// stopped on an empty body would stop early. A page that selected nothing, or one whose ordering
+    /// key was not DocumentId, has nothing to anchor a continuation on. At
+    /// <see cref="long.MaxValue"/> there is no next range to name, so the codec reports no token and
+    /// the header is omitted.
+    /// </remarks>
+    private static bool TryCreateNextPageToken(
+        RequestInfo requestInfo,
+        QuerySuccess success,
+        [NotNullWhen(true)] out string? nextPageToken
+    )
+    {
+        nextPageToken = null;
+
+        if (success.HighestSelectedDocumentId is not { } highestSelectedDocumentId)
+        {
+            return false;
+        }
+
+        if (!success.AllowsDocumentIdContinuation)
+        {
+            return false;
+        }
+
+        // A cursor request keeps its own upper bound, which is how a walk that entered through a
+        // partition stays inside that partition. A traditional request carried no bound, so a walk
+        // entered from one is unbounded above.
+        long inclusiveMaximum = requestInfo.CollectionPaging is CollectionPaging.Cursor cursor
+            ? cursor.Range.InclusiveMaximum
+            : long.MaxValue;
+
+        return PageTokenCodec.TryCreateNextPageToken(
+                highestSelectedDocumentId,
+                inclusiveMaximum,
+                out nextPageToken
+            ) && nextPageToken is not null;
     }
 
     private static IQueryRequest CreateQueryRequest(RequestInfo requestInfo)

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Paging;
+using FluentAssertions;
+
+namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+/// <summary>
+/// What a client actually receives from a cursor walk against the assembled host: pages served over
+/// documents it created through the same HTTP pipeline, and a <c>Next-Page-Token</c> it can replay
+/// without knowing anything about the identities behind it.
+///
+/// <para>
+/// Handler tests can show the header a <c>QuerySuccess</c> produces, and provider tests can show the
+/// keyset a page selects, but neither shows that a token this host emitted is a token this host
+/// accepts. These walks only ever follow the header they were handed, so a token the frontend, Core
+/// validation, the codec, and page selection did not agree on would fail to advance.
+/// </para>
+///
+/// <para>
+/// Each walk tolerates documents other scenarios sharing this fixture may have left behind: it asserts
+/// that its own seeded documents each arrive exactly once and that no document arrives twice, which
+/// holds regardless of what else the collection contains.
+/// </para>
+/// </summary>
+internal static class CursorPagingExecutionScenario
+{
+    private const string MergeItemsEndpoint = "/data/ed-fi/profileRootOnlyMergeItems";
+    private const string DescriptorEndpoint = "/data/ed-fi/schoolTypeDescriptors";
+    private const string StandardJsonContentType = "application/json";
+    private const string NextPageTokenHeaderName = "Next-Page-Token";
+
+    /// <summary>
+    /// Above any change version this fixture can reach, so the window includes every seeded document
+    /// and the only thing under test is what a max-bearing window does to the continuation.
+    /// </summary>
+    private const long UnreachableMaxChangeVersion = 999_999_999L;
+
+    /// <summary>
+    /// Enough documents that a page size of two cannot return them all, so the walk must genuinely
+    /// continue rather than terminate on its first page.
+    /// </summary>
+    private const int SeededDocumentCount = 5;
+
+    /// <summary>
+    /// The walk cannot loop forever on a broken continuation: a token that failed to advance would
+    /// exhaust this and fail with the pages it did retrieve rather than hanging.
+    /// </summary>
+    private const int MaximumWalkedPages = 25;
+
+    public static async Task It_walks_a_regular_resource_collection_by_cursor(ApiIntegrationHarness harness)
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seededIds = await SeedMergeItemsAsync(harness, "cursor-walk");
+
+        var walk = await WalkFromFirstPageAsync(harness, MergeItemsEndpoint, pageSize: 2);
+
+        walk.Pages.Should().BeGreaterThan(1, "a page size of two cannot deliver five documents at once");
+        walk.ReturnedIds.Should().OnlyHaveUniqueItems("a cursor walk must not return a document twice");
+        walk.ReturnedIds.Should().Contain(seededIds);
+    }
+
+    public static async Task It_walks_a_descriptor_collection_by_cursor(ApiIntegrationHarness harness)
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seededIds = await SeedDescriptorsAsync(harness, "cursor-walk");
+
+        var walk = await WalkFromFirstPageAsync(harness, DescriptorEndpoint, pageSize: 2);
+
+        walk.Pages.Should().BeGreaterThan(1);
+        walk.ReturnedIds.Should().OnlyHaveUniqueItems();
+        walk.ReturnedIds.Should().Contain(seededIds);
+    }
+
+    /// <summary>
+    /// A traditional <c>limit</c> response carries a continuation too, which is what lets a client enter
+    /// a cursor walk without a separate call. The token is replayed here, so the assertion is that the
+    /// walk it starts really continues rather than merely that a header was present.
+    /// </summary>
+    public static async Task It_enters_a_cursor_walk_from_a_traditional_page(ApiIntegrationHarness harness)
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seededIds = await SeedMergeItemsAsync(harness, "traditional-entry");
+
+        var (firstPageIds, firstPageToken) = await ReadPageAsync(harness, $"{MergeItemsEndpoint}?limit=2");
+
+        firstPageIds.Should().HaveCount(2);
+        firstPageToken.Should().NotBeNull("a traditional page that selected keys can begin a cursor walk");
+
+        HashSet<string> returnedIds = [.. firstPageIds];
+        var continued = await ContinueWalkAsync(harness, MergeItemsEndpoint, firstPageToken!, returnedIds);
+
+        continued.Should().BeGreaterThan(0, "the token from a traditional page must advance the walk");
+        returnedIds.Should().Contain(seededIds);
+    }
+
+    /// <summary>
+    /// A traditional page over a max-bearing change-version window is ordered by <c>ContentVersion</c>,
+    /// so the highest <c>DocumentId</c> it selected does not describe where the page ended and cannot
+    /// anchor a continuation. The page is still served; only the header is withheld.
+    /// </summary>
+    public static async Task It_withholds_a_continuation_from_a_windowed_traditional_page(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        await SeedMergeItemsAsync(harness, "windowed-suppression");
+
+        var (windowedIds, windowedToken) = await ReadPageAsync(
+            harness,
+            $"{MergeItemsEndpoint}?limit=2&maxChangeVersion={UnreachableMaxChangeVersion}"
+        );
+
+        windowedIds.Should().NotBeEmpty("the window includes every seeded document");
+        windowedToken.Should().BeNull();
+
+        // The same request without the window does continue, so the suppression above is the window's
+        // effect rather than an empty selection or a missing feature.
+        var (_, unwindowedToken) = await ReadPageAsync(harness, $"{MergeItemsEndpoint}?limit=2");
+        unwindowedToken.Should().NotBeNull();
+    }
+
+    private static async Task<CursorWalk> WalkFromFirstPageAsync(
+        ApiIntegrationHarness harness,
+        string endpoint,
+        int pageSize
+    )
+    {
+        // Encoded by the codec that decodes it, so the entry token is decodable by construction rather
+        // than by a transcription of the transport encoding happening to stay in step with it.
+        string entryToken = PageTokenCodec.Encode(CursorRange.From(1));
+
+        HashSet<string> returnedIds = [];
+        var pages = 0;
+        string? pageToken = entryToken;
+
+        while (pageToken is not null && pages < MaximumWalkedPages)
+        {
+            var (pageIds, nextPageToken) = await ReadPageAsync(
+                harness,
+                $"{endpoint}?pageToken={Uri.EscapeDataString(pageToken)}&pageSize={pageSize}"
+            );
+
+            pages++;
+            pageIds.Should().HaveCountLessThanOrEqualTo(pageSize, "a page cannot exceed its page size");
+
+            foreach (string id in pageIds)
+            {
+                returnedIds.Add(id).Should().BeTrue($"document '{id}' was returned more than once");
+            }
+
+            if (nextPageToken is null)
+            {
+                // The walk ends by being told nothing follows, and the terminal request is the one that
+                // selected nothing at all.
+                pageIds.Should().BeEmpty("the page that ends a walk selects nothing");
+                return new CursorWalk(pages, returnedIds);
+            }
+
+            pageToken = nextPageToken;
+        }
+
+        throw new InvalidOperationException(
+            $"A cursor walk of '{endpoint}' did not terminate within {MaximumWalkedPages} pages."
+        );
+    }
+
+    private static async Task<int> ContinueWalkAsync(
+        ApiIntegrationHarness harness,
+        string endpoint,
+        string pageToken,
+        HashSet<string> returnedIds
+    )
+    {
+        var continued = 0;
+        string? nextPageToken = pageToken;
+
+        while (nextPageToken is not null && continued < MaximumWalkedPages)
+        {
+            var (pageIds, followingToken) = await ReadPageAsync(
+                harness,
+                $"{endpoint}?pageToken={Uri.EscapeDataString(nextPageToken)}&pageSize=2"
+            );
+
+            foreach (string id in pageIds)
+            {
+                returnedIds.Add(id).Should().BeTrue($"document '{id}' was returned more than once");
+            }
+
+            continued += pageIds.Count;
+            nextPageToken = followingToken;
+        }
+
+        return continued;
+    }
+
+    /// <summary>
+    /// Reads one page, returning the document ids it contains and the continuation it offers. The
+    /// continuation is round-tripped through the codec so a token that decoded to a different range
+    /// than it names would be caught here rather than surviving as an opaque string.
+    /// </summary>
+    private static async Task<(List<string> PageIds, string? NextPageToken)> ReadPageAsync(
+        ApiIntegrationHarness harness,
+        string requestUri
+    )
+    {
+        using HttpResponseMessage response = await harness.HttpClient.GetAsync(requestUri);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+
+        List<string> pageIds =
+        [
+            .. JsonNode.Parse(body)!.AsArray().Select(static document => document!["id"]!.GetValue<string>()),
+        ];
+
+        if (!response.Headers.TryGetValues(NextPageTokenHeaderName, out var headerValues))
+        {
+            return (pageIds, null);
+        }
+
+        string nextPageToken = headerValues.Single();
+        PageTokenCodec
+            .TryDecode(nextPageToken, out var range)
+            .Should()
+            .BeTrue("an emitted continuation must decode through the codec that produced it");
+        range!.InclusiveMinimum.Should().BePositive("a continuation resumes after the keys just selected");
+
+        return (pageIds, nextPageToken);
+    }
+
+    private static async Task<string[]> SeedMergeItemsAsync(ApiIntegrationHarness harness, string scenario)
+    {
+        string suffix = Guid.NewGuid().ToString("N")[..8];
+
+        // The merge item requires a resolvable descriptor reference, so the reference target is created
+        // through the same pipeline before the documents that point at it.
+        string descriptorNamespace = $"uri://ed-fi.org/SchoolTypeDescriptor/DMS-1386/{scenario}/{suffix}";
+        string descriptorCodeValue = $"DMS-1386-{scenario}-{suffix}-ref";
+        await CreateAsync(
+            harness,
+            DescriptorEndpoint,
+            new JsonObject
+            {
+                ["namespace"] = descriptorNamespace,
+                ["codeValue"] = descriptorCodeValue,
+                ["shortDescription"] = $"DMS-1386 {scenario} {suffix} reference",
+            }
+        );
+
+        List<string> seededIds = [];
+
+        for (var index = 0; index < SeededDocumentCount; index++)
+        {
+            var payload = new JsonObject
+            {
+                ["profileRootOnlyMergeItemId"] = UniqueIdentity(suffix, index),
+                ["displayName"] = $"DMS-1386 {scenario} {suffix} {index}",
+                ["primarySchoolTypeDescriptor"] = $"{descriptorNamespace}#{descriptorCodeValue}",
+            };
+
+            seededIds.Add(await CreateAsync(harness, MergeItemsEndpoint, payload));
+        }
+
+        return [.. seededIds];
+    }
+
+    private static async Task<string[]> SeedDescriptorsAsync(ApiIntegrationHarness harness, string scenario)
+    {
+        string suffix = Guid.NewGuid().ToString("N")[..8];
+        List<string> seededIds = [];
+
+        for (var index = 0; index < SeededDocumentCount; index++)
+        {
+            var payload = new JsonObject
+            {
+                ["namespace"] = $"uri://ed-fi.org/SchoolTypeDescriptor/DMS-1386/{scenario}/{suffix}",
+                ["codeValue"] = $"DMS-1386-{scenario}-{suffix}-{index}",
+                ["shortDescription"] = $"DMS-1386 {scenario} {suffix} {index}",
+            };
+
+            seededIds.Add(await CreateAsync(harness, DescriptorEndpoint, payload));
+        }
+
+        return [.. seededIds];
+    }
+
+    /// <summary>
+    /// A per-run identity that stays inside Int32, because the merge item's identity is an integer and a
+    /// collision with a sibling scenario's seed would answer 200 on an update instead of 201.
+    /// </summary>
+    private static int UniqueIdentity(string suffix, int index) =>
+        1_386_000 + Math.Abs(suffix.GetHashCode(StringComparison.Ordinal) % 100_000) * 10 + index;
+
+    private static async Task<string> CreateAsync(
+        ApiIntegrationHarness harness,
+        string endpoint,
+        JsonObject payload
+    )
+    {
+        using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, StandardJsonContentType);
+        using HttpResponseMessage response = await harness.HttpClient.PostAsync(endpoint, content);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, $"POST {endpoint} body: {body}");
+        response.Headers.Location.Should().NotBeNull($"POST {endpoint} must return a Location header");
+
+        Uri location = response.Headers.Location!;
+        string locationPath = location.IsAbsoluteUri ? location.AbsolutePath : location.OriginalString;
+
+        return locationPath[(locationPath.LastIndexOf('/') + 1)..];
+    }
+
+    private sealed record CursorWalk(int Pages, HashSet<string> ReturnedIds);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
@@ -246,8 +246,8 @@ internal static class CursorPagingExecutionScenario
 
         // The merge item requires a resolvable descriptor reference, so the reference target is created
         // through the same pipeline before the documents that point at it.
-        string descriptorNamespace = $"uri://ed-fi.org/SchoolTypeDescriptor/DMS-1386/{scenario}/{suffix}";
-        string descriptorCodeValue = $"DMS-1386-{scenario}-{suffix}-ref";
+        string descriptorNamespace = $"uri://ed-fi.org/SchoolTypeDescriptor/CursorPaging/{scenario}/{suffix}";
+        string descriptorCodeValue = $"CursorPaging-{scenario}-{suffix}-ref";
         await CreateAsync(
             harness,
             DescriptorEndpoint,
@@ -255,7 +255,7 @@ internal static class CursorPagingExecutionScenario
             {
                 ["namespace"] = descriptorNamespace,
                 ["codeValue"] = descriptorCodeValue,
-                ["shortDescription"] = $"DMS-1386 {scenario} {suffix} reference",
+                ["shortDescription"] = $"CursorPaging {scenario} {suffix} reference",
             }
         );
 
@@ -266,7 +266,7 @@ internal static class CursorPagingExecutionScenario
             var payload = new JsonObject
             {
                 ["profileRootOnlyMergeItemId"] = UniqueIdentity(suffix, index),
-                ["displayName"] = $"DMS-1386 {scenario} {suffix} {index}",
+                ["displayName"] = $"CursorPaging {scenario} {suffix} {index}",
                 ["primarySchoolTypeDescriptor"] = $"{descriptorNamespace}#{descriptorCodeValue}",
             };
 
@@ -285,9 +285,9 @@ internal static class CursorPagingExecutionScenario
         {
             var payload = new JsonObject
             {
-                ["namespace"] = $"uri://ed-fi.org/SchoolTypeDescriptor/DMS-1386/{scenario}/{suffix}",
-                ["codeValue"] = $"DMS-1386-{scenario}-{suffix}-{index}",
-                ["shortDescription"] = $"DMS-1386 {scenario} {suffix} {index}",
+                ["namespace"] = $"uri://ed-fi.org/SchoolTypeDescriptor/CursorPaging/{scenario}/{suffix}",
+                ["codeValue"] = $"CursorPaging-{scenario}-{suffix}-{index}",
+                ["shortDescription"] = $"CursorPaging {scenario} {suffix} {index}",
             };
 
             seededIds.Add(await CreateAsync(harness, DescriptorEndpoint, payload));

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingOperationScopeScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingOperationScopeScenario.cs
@@ -142,7 +142,7 @@ internal static class CursorPagingOperationScopeScenario
     private static async Task SeedSchoolAsync(ApiIntegrationHarness harness)
     {
         string suffix = Guid.NewGuid().ToString("N")[..8];
-        string namespaceUri = $"uri://ed-fi.org/dms-1386/{suffix}";
+        string namespaceUri = $"uri://ed-fi.org/CursorPaging/{suffix}";
         long schoolId = 1_386_000L + Math.Abs(suffix.GetHashCode(StringComparison.Ordinal) % 100_000);
 
         await SeedDescriptorAsync(
@@ -161,7 +161,7 @@ internal static class CursorPagingOperationScopeScenario
         var schoolPayload = new JsonObject
         {
             ["schoolId"] = schoolId,
-            ["nameOfInstitution"] = $"DMS-1386 School {suffix}",
+            ["nameOfInstitution"] = $"CursorPaging School {suffix}",
             ["educationOrganizationCategories"] = new JsonArray(
                 new JsonObject
                 {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingOperationScopeScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingOperationScopeScenario.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Net;
+using System.Text;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Paging;
@@ -25,11 +26,12 @@ namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
 /// </para>
 ///
 /// <para>
-/// No documents are seeded. The Change Query requests pass through query validation, which excludes
-/// the cursor parameter names, and are answered by the Change Query validation step that follows it;
-/// the accepted cursor request is answered by the read path's cursor guard. All of that is before any
-/// candidate selection. The leased database is still required because these pipelines resolve the
-/// database fingerprint, resource key seed, and mapping set before query validation runs.
+/// The Change Query requests seed nothing: they pass through query validation, which excludes the
+/// cursor parameter names, and are answered by the Change Query validation step that follows it,
+/// before any candidate selection. The accepted cursor request seeds one school through the same
+/// pipeline, because what it pins is the page the read path actually serves. The leased database is
+/// required either way, since these pipelines resolve the database fingerprint, resource key seed, and
+/// mapping set before query validation runs.
 /// </para>
 /// </summary>
 internal static class CursorPagingOperationScopeScenario
@@ -91,10 +93,9 @@ internal static class CursorPagingOperationScopeScenario
 
     /// <summary>
     /// A collection read carrying a decodable token and a page size is not rejected during query
-    /// validation. It passes through to the read path, which does not yet select cursor pages and says
-    /// so. HTTP 501 with that message is the current boundary of cursor paging support, and the
-    /// request having reached it is the fact this pins: the request was accepted as a cursor request,
-    /// carried typed cursor paging to the repository contract, and was answered there.
+    /// validation: it reaches the read path, which selects the page and hands back a continuation. This
+    /// is where the accepted cursor request lands, observed on the assembled host rather than inferred
+    /// from a handler double.
     /// </summary>
     public static async Task It_carries_an_accepted_cursor_request_to_the_read_path(
         ApiIntegrationHarness harness
@@ -102,25 +103,111 @@ internal static class CursorPagingOperationScopeScenario
     {
         ArgumentNullException.ThrowIfNull(harness);
 
+        await SeedSchoolAsync(harness);
+
         // Encoded by the codec that decodes it, so the token is decodable by construction rather than
-        // by a transcription of the transport encoding happening to stay in step with it.
-        string pageToken = PageTokenCodec.Encode(new CursorRange(1, 100));
+        // by a transcription of the transport encoding happening to stay in step with it. The upper
+        // bound is open, so the seeded school is inside the range whatever identity it received.
+        string pageToken = PageTokenCodec.Encode(CursorRange.From(1));
 
         var response = await harness.HttpClient.GetAsync(
-            $"{SchoolsEndpoint}?pageToken={pageToken}&pageSize={WellFormedPageSize}"
+            $"{SchoolsEndpoint}?pageToken={Uri.EscapeDataString(pageToken)}&pageSize={WellFormedPageSize}"
         );
 
         string content = await response.Content.ReadAsStringAsync();
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented, content);
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        JsonNode.Parse(content)!.AsArray().Should().NotBeEmpty("the seeded school is inside the range");
 
-        JsonNode body = JsonNode.Parse(content)!;
-
-        body["error"]!
-            .GetValue<string>()
+        response
+            .Headers.TryGetValues("Next-Page-Token", out var nextPageTokenValues)
             .Should()
-            .Be("Cursor paging is not yet supported for relational queries.");
-        body["correlationId"]!.GetValue<string>().Should().NotBeNullOrWhiteSpace();
+            .BeTrue("a page that selected keys must carry a continuation");
+
+        PageTokenCodec
+            .TryDecode(nextPageTokenValues!.Single(), out var nextRange)
+            .Should()
+            .BeTrue("the emitted continuation must decode through the codec that produced it");
+
+        // The request carried no upper bound, so the walk it starts is unbounded above, and it resumes
+        // after the keys this page already delivered.
+        nextRange!.InclusiveMaximum.Should().Be(long.MaxValue);
+        nextRange.InclusiveMinimum.Should().BePositive();
+    }
+
+    /// <summary>
+    /// Seeds one school through the same HTTP pipeline the read under test uses, with per-run unique
+    /// values so the scenario stays isolated from anything else bound to this fixture.
+    /// </summary>
+    private static async Task SeedSchoolAsync(ApiIntegrationHarness harness)
+    {
+        string suffix = Guid.NewGuid().ToString("N")[..8];
+        string namespaceUri = $"uri://ed-fi.org/dms-1386/{suffix}";
+        long schoolId = 1_386_000L + Math.Abs(suffix.GetHashCode(StringComparison.Ordinal) % 100_000);
+
+        await SeedDescriptorAsync(
+            harness,
+            "/data/ed-fi/educationOrganizationCategoryDescriptors",
+            $"{namespaceUri}/EducationOrganizationCategoryDescriptor",
+            "School"
+        );
+        await SeedDescriptorAsync(
+            harness,
+            "/data/ed-fi/gradeLevelDescriptors",
+            $"{namespaceUri}/GradeLevelDescriptor",
+            "Tenth grade"
+        );
+
+        var schoolPayload = new JsonObject
+        {
+            ["schoolId"] = schoolId,
+            ["nameOfInstitution"] = $"DMS-1386 School {suffix}",
+            ["educationOrganizationCategories"] = new JsonArray(
+                new JsonObject
+                {
+                    ["educationOrganizationCategoryDescriptor"] =
+                        $"{namespaceUri}/EducationOrganizationCategoryDescriptor#School",
+                }
+            ),
+            ["gradeLevels"] = new JsonArray(
+                new JsonObject
+                {
+                    ["gradeLevelDescriptor"] = $"{namespaceUri}/GradeLevelDescriptor#Tenth grade",
+                }
+            ),
+        };
+
+        await PostJsonAsync(harness, SchoolsEndpoint, schoolPayload);
+    }
+
+    private static async Task SeedDescriptorAsync(
+        ApiIntegrationHarness harness,
+        string endpoint,
+        string namespaceUri,
+        string codeValue
+    ) =>
+        await PostJsonAsync(
+            harness,
+            endpoint,
+            new JsonObject
+            {
+                ["namespace"] = namespaceUri,
+                ["codeValue"] = codeValue,
+                ["shortDescription"] = codeValue,
+            }
+        );
+
+    private static async Task PostJsonAsync(
+        ApiIntegrationHarness harness,
+        string endpoint,
+        JsonObject payload
+    )
+    {
+        using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+        using HttpResponseMessage response = await harness.HttpClient.PostAsync(endpoint, content);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, $"POST {endpoint} body: {body}");
     }
 
     /// <summary>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/DocumentCacheReadAccelerationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/DocumentCacheReadAccelerationScenario.cs
@@ -13,6 +13,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.Etag;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.External.Security;
+using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Security;
 using EdFi.DataManagementService.Core.Security.Model;
 using EdFi.DataManagementService.Tests.Integration.Doubles;
@@ -30,6 +31,7 @@ internal static class DocumentCacheReadAccelerationScenario
     private const string VisibleReadableContentType =
         "application/vnd.ed-fi.profilerootonlymergeitem.profilerootonlymergeitem-visible.readable+json";
     private const string LastModifiedDateFormat = "yyyy-MM-ddTHH:mm:ss'Z'";
+    private const string NextPageTokenHeaderName = "Next-Page-Token";
 
     public static IClaimSetProvider CreateStudentCreateOnlyClaimSetProvider() =>
         new StaticClaimSetProvider([
@@ -109,6 +111,20 @@ internal static class DocumentCacheReadAccelerationScenario
             .Select(node => node!["_etag"]!.GetValue<string>())
             .Should()
             .OnlyContain(etag => !string.IsNullOrWhiteSpace(etag));
+
+        // Every document on this page came from cache, and the continuation a cursor walk enters on
+        // still names the page after it: what a client is handed cannot depend on cache state.
+        string nextPageToken = queryResponse.Headers.GetValues(NextPageTokenHeaderName).Single();
+        PageTokenCodec
+            .TryDecode(nextPageToken, out var continuation)
+            .Should()
+            .BeTrue("an emitted continuation must decode through the codec that produced it");
+        continuation!
+            .InclusiveMinimum.Should()
+            .Be(
+                secondQueryMetadata.DocumentId + 1,
+                "the continuation resumes after the highest key this page selected"
+            );
     }
 
     public static async Task It_falls_back_relationally_when_cache_row_is_missing_or_stale(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingExecution.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingExecution.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Mssql;
+
+/// <summary>
+/// SQL Server twin of the cursor walk proof. A walk only ever follows the continuation it was handed, and
+/// both the page selection and the keyset that anchors that continuation come from real SQL Server query
+/// execution, so the answer is provider-specific and is observed on both engines.
+/// </summary>
+/// <remarks>
+/// Leases the descriptor runtime fixture because its ApiSchema declares both the regular resource and the
+/// descriptor these walks page over; the walks seed the documents they assert on themselves.
+/// </remarks>
+public sealed class Given_Mssql_CursorPagingExecution : MssqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.DescriptorRuntime;
+
+    [Test]
+    public Task It_walks_a_regular_resource_collection_by_cursor() =>
+        CursorPagingExecutionScenario.It_walks_a_regular_resource_collection_by_cursor(Harness);
+
+    [Test]
+    public Task It_walks_a_descriptor_collection_by_cursor() =>
+        CursorPagingExecutionScenario.It_walks_a_descriptor_collection_by_cursor(Harness);
+
+    [Test]
+    public Task It_enters_a_cursor_walk_from_a_traditional_page() =>
+        CursorPagingExecutionScenario.It_enters_a_cursor_walk_from_a_traditional_page(Harness);
+
+    [Test]
+    public Task It_withholds_a_continuation_from_a_windowed_traditional_page() =>
+        CursorPagingExecutionScenario.It_withholds_a_continuation_from_a_windowed_traditional_page(Harness);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingOperationScope.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingOperationScope.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Mssql;
+
+/// <summary>
+/// SQL Server twin of the cursor operation-scope proof. Parameter recognition is provider-neutral, but
+/// the accepted cursor request now selects a page and emits a continuation from real SQL Server page
+/// selection, so the answer is provider-specific and is observed on both engines.
+/// </summary>
+public sealed class Given_Mssql_CursorPagingOperationScope : MssqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.AuthoritativeDs52;
+
+    [Test]
+    public Task It_rejects_a_page_token_on_a_deletes_request() =>
+        CursorPagingOperationScopeScenario.It_rejects_a_page_token_on_a_deletes_request(Harness);
+
+    [Test]
+    public Task It_rejects_a_page_size_on_a_key_changes_request() =>
+        CursorPagingOperationScopeScenario.It_rejects_a_page_size_on_a_key_changes_request(Harness);
+
+    [Test]
+    public Task It_carries_an_accepted_cursor_request_to_the_read_path() =>
+        CursorPagingOperationScopeScenario.It_carries_an_accepted_cursor_request_to_the_read_path(Harness);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_DescriptorRuntime.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_DescriptorRuntime.cs
@@ -47,4 +47,20 @@ public sealed class Given_Mssql_DescriptorRuntime : MssqlApiIntegrationTestBase
     [Test]
     public Task It_requires_descriptor_reference_resolution_before_resource_write() =>
         DescriptorRuntimeScenario.It_requires_descriptor_reference_resolution_before_resource_write(Harness);
+
+    [Test]
+    public Task It_walks_a_regular_resource_collection_by_cursor() =>
+        CursorPagingExecutionScenario.It_walks_a_regular_resource_collection_by_cursor(Harness);
+
+    [Test]
+    public Task It_walks_a_descriptor_collection_by_cursor() =>
+        CursorPagingExecutionScenario.It_walks_a_descriptor_collection_by_cursor(Harness);
+
+    [Test]
+    public Task It_enters_a_cursor_walk_from_a_traditional_page() =>
+        CursorPagingExecutionScenario.It_enters_a_cursor_walk_from_a_traditional_page(Harness);
+
+    [Test]
+    public Task It_withholds_a_continuation_from_a_windowed_traditional_page() =>
+        CursorPagingExecutionScenario.It_withholds_a_continuation_from_a_windowed_traditional_page(Harness);
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_DescriptorRuntime.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_DescriptorRuntime.cs
@@ -47,20 +47,4 @@ public sealed class Given_Mssql_DescriptorRuntime : MssqlApiIntegrationTestBase
     [Test]
     public Task It_requires_descriptor_reference_resolution_before_resource_write() =>
         DescriptorRuntimeScenario.It_requires_descriptor_reference_resolution_before_resource_write(Harness);
-
-    [Test]
-    public Task It_walks_a_regular_resource_collection_by_cursor() =>
-        CursorPagingExecutionScenario.It_walks_a_regular_resource_collection_by_cursor(Harness);
-
-    [Test]
-    public Task It_walks_a_descriptor_collection_by_cursor() =>
-        CursorPagingExecutionScenario.It_walks_a_descriptor_collection_by_cursor(Harness);
-
-    [Test]
-    public Task It_enters_a_cursor_walk_from_a_traditional_page() =>
-        CursorPagingExecutionScenario.It_enters_a_cursor_walk_from_a_traditional_page(Harness);
-
-    [Test]
-    public Task It_withholds_a_continuation_from_a_windowed_traditional_page() =>
-        CursorPagingExecutionScenario.It_withholds_a_continuation_from_a_windowed_traditional_page(Harness);
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPagingExecution.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPagingExecution.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Postgresql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Postgresql;
+
+/// <summary>
+/// PostgreSQL end-to-end proof that a cursor walk over the assembled host advances: a continuation this
+/// host emitted is one it accepts, and following it returns each document exactly once. Page selection
+/// and the keyset that anchors the continuation are provider-specific, so the walk is observed on both
+/// engines.
+/// </summary>
+/// <remarks>
+/// Leases the descriptor runtime fixture because its ApiSchema declares both the regular resource and the
+/// descriptor these walks page over; the walks seed the documents they assert on themselves.
+/// </remarks>
+public sealed class Given_Postgresql_CursorPagingExecution : PostgresqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.DescriptorRuntime;
+
+    [Test]
+    public Task It_walks_a_regular_resource_collection_by_cursor() =>
+        CursorPagingExecutionScenario.It_walks_a_regular_resource_collection_by_cursor(Harness);
+
+    [Test]
+    public Task It_walks_a_descriptor_collection_by_cursor() =>
+        CursorPagingExecutionScenario.It_walks_a_descriptor_collection_by_cursor(Harness);
+
+    [Test]
+    public Task It_enters_a_cursor_walk_from_a_traditional_page() =>
+        CursorPagingExecutionScenario.It_enters_a_cursor_walk_from_a_traditional_page(Harness);
+
+    [Test]
+    public Task It_withholds_a_continuation_from_a_windowed_traditional_page() =>
+        CursorPagingExecutionScenario.It_withholds_a_continuation_from_a_windowed_traditional_page(Harness);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_DescriptorRuntime.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_DescriptorRuntime.cs
@@ -47,20 +47,4 @@ public sealed class Given_Postgresql_DescriptorRuntime : PostgresqlApiIntegratio
     [Test]
     public Task It_requires_descriptor_reference_resolution_before_resource_write() =>
         DescriptorRuntimeScenario.It_requires_descriptor_reference_resolution_before_resource_write(Harness);
-
-    [Test]
-    public Task It_walks_a_regular_resource_collection_by_cursor() =>
-        CursorPagingExecutionScenario.It_walks_a_regular_resource_collection_by_cursor(Harness);
-
-    [Test]
-    public Task It_walks_a_descriptor_collection_by_cursor() =>
-        CursorPagingExecutionScenario.It_walks_a_descriptor_collection_by_cursor(Harness);
-
-    [Test]
-    public Task It_enters_a_cursor_walk_from_a_traditional_page() =>
-        CursorPagingExecutionScenario.It_enters_a_cursor_walk_from_a_traditional_page(Harness);
-
-    [Test]
-    public Task It_withholds_a_continuation_from_a_windowed_traditional_page() =>
-        CursorPagingExecutionScenario.It_withholds_a_continuation_from_a_windowed_traditional_page(Harness);
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_DescriptorRuntime.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_DescriptorRuntime.cs
@@ -47,4 +47,20 @@ public sealed class Given_Postgresql_DescriptorRuntime : PostgresqlApiIntegratio
     [Test]
     public Task It_requires_descriptor_reference_resolution_before_resource_write() =>
         DescriptorRuntimeScenario.It_requires_descriptor_reference_resolution_before_resource_write(Harness);
+
+    [Test]
+    public Task It_walks_a_regular_resource_collection_by_cursor() =>
+        CursorPagingExecutionScenario.It_walks_a_regular_resource_collection_by_cursor(Harness);
+
+    [Test]
+    public Task It_walks_a_descriptor_collection_by_cursor() =>
+        CursorPagingExecutionScenario.It_walks_a_descriptor_collection_by_cursor(Harness);
+
+    [Test]
+    public Task It_enters_a_cursor_walk_from_a_traditional_page() =>
+        CursorPagingExecutionScenario.It_enters_a_cursor_walk_from_a_traditional_page(Harness);
+
+    [Test]
+    public Task It_withholds_a_continuation_from_a_windowed_traditional_page() =>
+        CursorPagingExecutionScenario.It_withholds_a_continuation_from_a_windowed_traditional_page(Harness);
 }


### PR DESCRIPTION
## Summary

Activates cursor page selection for regular resources and descriptors through their existing
single-command query paths, and emits `Next-Page-Token` from one shared Core response gate. A cursor
request now selects, hydrates, and returns a page with a continuation a client can replay — with no
second candidate query, no extra database command, no count SQL, and no lookahead row.

`RelationalDocumentStoreRepository.QueryDocuments` no longer answers `QueryFailureNotImplemented` for
non-traditional paging; the compiled cursor plans DMS-1385 delivered are now executed.

Out of scope and untouched: `/partitions` (DMS-1387), OpenAPI publication (DMS-1388), the
authorization matrix (DMS-1389), broad parity/E2E (DMS-1390), the performance harness and gates
(DMS-1391/1392), telemetry (DMS-1393), and `ContentVersion` anchoring (DMS-1394).

## The selected keyset leaves hydration on the command that materializes it

A `PageKeysetSpec.Query` materialization now returns the ids it inserted as the batch's **first**
result set:

```sql
-- PostgreSQL                          -- SQL Server
INSERT INTO "page" ("DocumentId")      INSERT INTO [#page] ([DocumentId])
SELECT "DocumentId" FROM page_ids      OUTPUT INSERTED.[DocumentId]
  RETURNING "DocumentId";              SELECT [DocumentId] FROM page_ids;
```

Two dialect hooks carry this, each a deliberate no-op on the provider that does not use that form —
the same pattern `AppendCursorPagingClause` already established. The result set is **always** present
for a query keyset, including the zero-row empty materialization, so no later result-set position
moves with selection size. `HydrationExecutor.GetResultSetCount` grows by one for a query keyset and
the decoder reads the ids first, taking their maximum without assuming `RETURNING`/`OUTPUT` row order.

`PageKeysetSpec.Single` keeps its existing shape in both its `VALUES` and guarded
`INSERT … SELECT` forms, so GET-by-id and the co-batched write-path hydration are unchanged.

Zero-size page selection now also recognizes the cursor page-size role, not only the traditional limit
role, so `pageSize=0` materializes the empty keyset instead of running the authorized candidate query
for zero rows.

## Two independent facts, one decision

`HighestSelectedDocumentId` keeps exactly the meaning DMS-1383/1385 gave it: the real maximum of the
selected keyset, null only when selection was skipped or selected nothing. It is deliberately
independent of the response body — every selected row may be deleted before hydration completes, and a
body-derived boundary would stall a walk on the last surviving document.

A new init-only `QuerySuccess.AllowsDocumentIdContinuation` says whether that maximum may anchor a
`DocumentId` continuation. It cannot when the page was ordered by `ContentVersion`, which
`ChangeQueryPageOrderingPolicy` selects for a max-bearing change-version window: a token taken from
such a page could skip a qualifying row with a smaller `DocumentId` and a later `ContentVersion`.

Collapsing the two into one nullable value was rejected during design review — a page that selected
keys it cannot continue from is a different state from a page that selected none, and merging them
would report a selection that happened as one that did not.

Both facts come from one Backend `PageContinuationBoundary` helper shared by regular resources and
descriptors, so the two families cannot answer the same page differently. It decides from the
**effective** ordering rather than the request's filters, which keeps the legacy DocumentId-ordering
kill switch honored, and it never modifies the maximum.

This withholding is the interim suppression the epic records DMS-1394 as removing.

## One Core header gate

`QueryRequestHandler` emits `Next-Page-Token` from a single site when a real maximum is present,
continuation is eligible, and `PageTokenCodec.TryCreateNextPageToken` succeeds. A cursor request keeps
its own `Range.InclusiveMaximum`, so a walk entered through a partition stays inside that slice; a
traditional request passes `Int64.MaxValue`, so a walk entered from an ordinary response is unbounded
above. At `Int64.MaxValue` the codec reports no token and the header is omitted rather than
overflowing.

`Total-Count` keeps its existing traditional-only rule, profile content-type behavior is unchanged,
and no token text exists anywhere in Backend.

**Note for reviewers:** traditional `limit`/`offset` responses now carry `Next-Page-Token` as well.
That is the design's deliberate cursor-walk entry point and is inert for clients that ignore it, but it
is new observable output on every regular-resource and descriptor collection read.

## Descriptors

`DescriptorQueryRequest` carries `CollectionPaging` instead of `PaginationParameters`, so the handler's
paging, total-count, and parameter-budget decisions all read one value rather than reconstructing a
traditional choice the caller may not have made. Descriptor selection and row retrieval are one
statement, so the boundary is the maximum across returned rows, taken order-independently even though
the query orders ascending today.

Descriptor filters, namespace and custom-view authorization, materialization, profile projection,
etags, and change-version behavior are preserved.

## Verification

| Suite | Result |
| --- | --- |
| `Backend.Plans.Tests.Unit` | 1888 passed |
| `Backend.Tests.Unit` | 2770 passed |
| `Core.Tests.Unit` | 3388 passed, 1 pre-existing skip |
| PostgreSQL regular-resource query fixture | 22 passed |
| PostgreSQL descriptor fixture | 31 passed |
| PostgreSQL hydration fixtures | 27 passed |
| PostgreSQL write/query regression sweep | 39 passed |
| SQL Server 2025 regular-resource query fixture | 22 passed |
| SQL Server 2025 descriptor fixture | 31 passed |
| SQL Server 2025 hydration fixtures | 17 passed |
| API-level PostgreSQL (cursor scope + descriptor runtime) | 16 passed |
| API-level SQL Server 2025 (cursor scope + descriptor runtime) | 16 passed |

Real-provider evidence covers, on both engines: multi-page walks returning every document exactly once
and terminating on a page that selects nothing; one command and no count SQL on **every** page of the
walk; page sizes 0, 1, and the configured maximum; inverted and terminal ranges; bounds that are not
stored `DocumentId`s; filter and change-version composition for both resource families; and — for
descriptors — the command shape observed at the provider command seam rather than inferred from a null
`TotalCount`.

The assembled-host scenarios walk regular-resource and descriptor collections by following only the
emitted header, enter a walk from a traditional page, and observe the continuation withheld from a
max-bearing request while the same request without the window still continues.

Concurrency: a page whose every selected row is deleted between keyset materialization and hydration
still reports its boundary, proved deterministically on both providers by splicing one `DELETE` into
the assembled batch at that exact point. That is evidence for the selection/hydration deletion window,
not a separately committed transaction.

Every unit was RED-verified by mutation rather than assumed — including breaking the SQL Server
`OUTPUT` column, which fails with a real `Invalid column name` from the server, and removing the
eligibility check, which fails the suppression assertion through the assembled HTTP host.

## Known follow-ups (non-blocking)

- Two comments describe a `PageKeysetSpec.Single` keyset as selecting nothing; it materializes a
  caller-known id and skips only collection page selection.
- The masked-logging redaction contract test repeats the production `with`-copy expression rather than
  invoking the formatter, which is a lambda with no test seam.
- The new integration scenarios derive numeric seed identities by hashing a GUID suffix; a rare
  collision would fail seeding rather than assert wrongly.
