### PR TITLE
[DMS-1389] Cursor and partition authorization matrix

### DIFF
--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixScenario.cs
@@ -29,10 +29,12 @@ namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
 /// The strategies covered are those the production read path actually compiles into the candidate
 /// relation. <c>OwnershipBased</c> is not among them for any operation, GET-many included: it is
 /// recognized but not enabled, so the request fails closed before a candidate relation exists, and
-/// enabling it for read-many is work this matrix does not cover. Descriptor coverage is limited to the
-/// no-further and namespace strategies; descriptors expose no education-organization or person
-/// securable elements, so relationship strategies cannot apply to them, and descriptor custom views are
-/// excluded from this matrix.
+/// enabling it for read-many is work this matrix does not cover. Descriptor coverage spans the
+/// no-further, namespace, and custom-view strategies; relationship strategies are the descriptor
+/// exclusion, because descriptors expose no education-organization or person securable elements for one
+/// to range over. A descriptor custom view is not excluded: the descriptor read path plans custom-view
+/// checks into the same authorization spec for pages and for boundaries, which is exactly the agreement
+/// this matrix exists to prove.
 /// </para>
 /// </summary>
 internal static class CursorPartitionAuthorizationMatrixScenario
@@ -161,6 +163,24 @@ internal static class CursorPartitionAuthorizationMatrixScenario
         ArgumentNullException.ThrowIfNull(harness);
 
         var seeded = await SeedAcademicSubjectDescriptorsAsync(harness, MatrixAccessibility.Namespace);
+
+        await RunMatrixAsync(harness, AcademicSubjectDescriptorsEndpoint, seeded);
+    }
+
+    /// <summary>
+    /// The descriptor carrier read through a custom view. The descriptor read path plans custom-view checks
+    /// into the authorization spec that both the page relation and the boundary relation are compiled from,
+    /// so this is the descriptor row where the two surfaces could disagree for an authorization reason.
+    /// Every seeded descriptor is identical apart from the code value the view selects on.
+    /// </summary>
+    public static async Task It_agrees_on_the_descriptor_candidate_set_under_view_based_authorization(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedAcademicSubjectDescriptorsAsync(harness, MatrixAccessibility.Identity);
+        await CreateDescriptorMatrixCustomViewAsync(harness);
 
         await RunMatrixAsync(harness, AcademicSubjectDescriptorsEndpoint, seeded);
     }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixScenario.cs
@@ -109,8 +109,10 @@ internal static class CursorPartitionAuthorizationMatrixScenario
     {
         ArgumentNullException.ThrowIfNull(harness);
 
-        // Every seeded document is identical apart from the identity column the view selects on, so the
-        // view is the only thing that can be excluding the inaccessible ones.
+        // Every field another strategy could authorize on is seeded so that it would admit the whole
+        // collection: each namespace sits under the caller's authorized prefix, and every reference points
+        // at the authorized school. Only the identity column the view selects on, and the name no strategy
+        // reads, tell an accessible document from a denied one, so the view is what excludes them.
         var seeded = await SeedNamespaceResourcesAsync(harness, MatrixAccessibility.Identity);
         await CreateMatrixCustomViewAsync(harness);
 
@@ -171,7 +173,9 @@ internal static class CursorPartitionAuthorizationMatrixScenario
     /// The descriptor carrier read through a custom view. The descriptor read path plans custom-view checks
     /// into the authorization spec that both the page relation and the boundary relation are compiled from,
     /// so this is the descriptor row where the two surfaces could disagree for an authorization reason.
-    /// Every seeded descriptor is identical apart from the code value the view selects on.
+    /// The one field a descriptor strategy could authorize on, the namespace, is seeded identically across
+    /// the collection; only the code value the view selects on, and the short description mirroring it,
+    /// vary.
     /// </summary>
     public static async Task It_agrees_on_the_descriptor_candidate_set_under_view_based_authorization(
         ApiIntegrationHarness harness

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixScenario.cs
@@ -27,9 +27,13 @@ namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
 ///
 /// <para>
 /// The strategies covered are those the production read path actually compiles into the candidate
-/// relation. <c>OwnershipBased</c> is not among them for any operation, GET-many included: it is
-/// recognized but not enabled, so the request fails closed before a candidate relation exists, and
-/// enabling it for read-many is work this matrix does not cover. Descriptor coverage spans the
+/// relation. Relationship coverage spans both subject kinds the page and boundary relations can carry,
+/// the education-organization subject and the person subject, because those are the two the compiler
+/// emits different predicate shapes for; the named strategies within a kind differ upstream of the point
+/// the two surfaces share, and are covered where that difference lives. <c>OwnershipBased</c> is not
+/// among them for any operation, GET-many included: it is recognized but not enabled, so the request
+/// fails closed before a candidate relation exists, and enabling it for read-many is work this matrix
+/// does not cover. Descriptor coverage spans the
 /// no-further, namespace, and custom-view strategies; relationship strategies are the descriptor
 /// exclusion, because descriptors expose no education-organization or person securable elements for one
 /// to range over. A descriptor custom view is not excluded: the descriptor read path plans custom-view
@@ -145,6 +149,28 @@ internal static class CursorPartitionAuthorizationMatrixScenario
         );
 
         await RunMatrixAsync(harness, NamespaceResourcesEndpoint, seeded);
+    }
+
+    /// <summary>
+    /// A people strategy over a carrier whose person is reached through a reference to another resource.
+    /// The predicate compiled for it is anchored on the root row's reference column rather than on its
+    /// DocumentId, and nests a subquery over the referenced table inside the auth view membership test, so
+    /// the candidate relation the two surfaces share has a shape no other row in the matrix produces.
+    /// </summary>
+    public static async Task It_agrees_on_the_candidate_set_under_transitive_person_authorization(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedTransitivePersonResourcesAsync(harness, MatrixAccessibility.Person);
+        await PeopleRelationshipGetManyScenarioHelpers.InsertAuthEdgeAsync(
+            harness,
+            ClaimEducationOrganizationId,
+            AuthorizedSchoolId
+        );
+
+        await RunMatrixAsync(harness, StudentAcademicRecordResourcesEndpoint, seeded);
     }
 
     public static async Task It_agrees_on_the_descriptor_candidate_set_under_no_further_authorization(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixScenario.cs
@@ -1,0 +1,661 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Paging;
+using FluentAssertions;
+using static EdFi.DataManagementService.Tests.Integration.Scenarios.CursorPartitionAuthorizationMatrixSupport;
+
+namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+/// <summary>
+/// Proves that a cursor walk and the partition boundaries handed out for the same principal, filters, and
+/// seeded data resolve the same accessible candidate set, and that a client cannot widen that set by
+/// editing the range inside a token.
+///
+/// <para>
+/// The two surfaces compile the same authorized candidate relation but reach it differently: pages select
+/// a bounded range from it, while boundaries rank and count the whole of it. A defect that authorized one
+/// and not the other would leave every single-surface test green, so every row here compares the two
+/// against an expected set that comes from the seed rather than from either surface.
+/// </para>
+///
+/// <para>
+/// The strategies covered are those the production read path actually compiles into the candidate
+/// relation. <c>OwnershipBased</c> is not among them for any operation, GET-many included: it is
+/// recognized but not enabled, so the request fails closed before a candidate relation exists, and
+/// enabling it for read-many is work this matrix does not cover. Descriptor coverage is limited to the
+/// no-further and namespace strategies; descriptors expose no education-organization or person
+/// securable elements, so relationship strategies cannot apply to them, and descriptor custom views are
+/// excluded from this matrix.
+/// </para>
+/// </summary>
+internal static class CursorPartitionAuthorizationMatrixScenario
+{
+    /// <summary>
+    /// The maximum page size the fixtures binding this scenario must configure their host with.
+    /// </summary>
+    /// <remarks>
+    /// The mandatory minimum partition size is <c>MaximumPageSize * 5</c>, so at the deployed value of 500
+    /// no collection seeded over HTTP could ever be cut into more than one partition and every union and
+    /// disjointness assertion below would pass without crossing a single range boundary. Lowering it to
+    /// two puts the minimum at ten candidate rows, which the seeded accessible sets clear.
+    /// </remarks>
+    internal const int HostMaximumPageSize = 2;
+
+    /// <summary>
+    /// Requested so that the seeded accessible sets produce three partitions: the computed size is smaller
+    /// than the ten-row minimum, so the minimum decides, and 21 accessible candidates fall into three
+    /// ranges.
+    /// </summary>
+    private const int RequestedPartitionCount = 3;
+
+    /// <summary>
+    /// A walk that failed to advance exhausts this and fails with the pages it did retrieve rather than
+    /// running forever. Derived from the accessible count so a larger seed does not silently truncate a
+    /// walk into a false failure.
+    /// </summary>
+    private static int MaximumWalkedPages(int accessibleCount) =>
+        ((accessibleCount + HostMaximumPageSize - 1) / HostMaximumPageSize) + 2;
+
+    public static async Task It_agrees_on_the_candidate_set_under_no_further_authorization(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedNamespaceResourcesAsync(harness, MatrixAccessibility.All);
+
+        await RunMatrixAsync(harness, NamespaceResourcesEndpoint, seeded);
+    }
+
+    public static async Task It_agrees_on_the_candidate_set_under_relationship_authorization(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedNamespaceResourcesAsync(harness, MatrixAccessibility.EducationOrganization);
+        await PeopleRelationshipGetManyScenarioHelpers.InsertAuthEdgeAsync(
+            harness,
+            ClaimEducationOrganizationId,
+            AuthorizedSchoolId
+        );
+
+        await RunMatrixAsync(harness, NamespaceResourcesEndpoint, seeded);
+    }
+
+    public static async Task It_agrees_on_the_candidate_set_under_namespace_authorization(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedNamespaceResourcesAsync(harness, MatrixAccessibility.Namespace);
+
+        await RunMatrixAsync(harness, NamespaceResourcesEndpoint, seeded);
+    }
+
+    public static async Task It_agrees_on_the_candidate_set_under_view_based_authorization(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        // Every seeded document is identical apart from the identity column the view selects on, so the
+        // view is the only thing that can be excluding the inaccessible ones.
+        var seeded = await SeedNamespaceResourcesAsync(harness, MatrixAccessibility.Identity);
+        await CreateMatrixCustomViewAsync(harness);
+
+        await RunMatrixAsync(harness, NamespaceResourcesEndpoint, seeded);
+    }
+
+    /// <summary>
+    /// The same carrier and strategy as the relationship row, read by a principal holding two education
+    /// organization claims that both reach the authorized school. The hierarchy relation the authorization
+    /// predicate ranges over therefore holds two matching rows for every accessible candidate, so a plan
+    /// that joined to it instead of testing membership would return each document twice, inflate the total
+    /// count, and shift every partition boundary.
+    /// </summary>
+    public static async Task It_agrees_on_the_candidate_set_when_authorization_matches_several_rows(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedNamespaceResourcesAsync(harness, MatrixAccessibility.EducationOrganization);
+        await PeopleRelationshipGetManyScenarioHelpers.InsertAuthEdgeAsync(
+            harness,
+            ClaimEducationOrganizationId,
+            AuthorizedSchoolId
+        );
+        await PeopleRelationshipGetManyScenarioHelpers.InsertAuthEdgeAsync(
+            harness,
+            SecondClaimEducationOrganizationId,
+            AuthorizedSchoolId
+        );
+
+        await RunMatrixAsync(harness, NamespaceResourcesEndpoint, seeded);
+    }
+
+    public static async Task It_agrees_on_the_descriptor_candidate_set_under_no_further_authorization(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedAcademicSubjectDescriptorsAsync(harness, MatrixAccessibility.All);
+
+        await RunMatrixAsync(harness, AcademicSubjectDescriptorsEndpoint, seeded);
+    }
+
+    public static async Task It_agrees_on_the_descriptor_candidate_set_under_namespace_authorization(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedAcademicSubjectDescriptorsAsync(harness, MatrixAccessibility.Namespace);
+
+        await RunMatrixAsync(harness, AcademicSubjectDescriptorsEndpoint, seeded);
+    }
+
+    /// <summary>
+    /// Authorization, not an empty collection, is what leaves nothing to page: the documents are seeded
+    /// and then every one of them is filtered out because the caller reaches no education organization.
+    /// </summary>
+    public static async Task It_returns_no_candidates_when_authorization_admits_none(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedNamespaceResourcesAsync(harness, MatrixAccessibility.None);
+
+        await RunEmptyCandidateSetAsync(harness, NamespaceResourcesEndpoint, seeded);
+    }
+
+    public static async Task It_returns_no_descriptor_candidates_when_authorization_admits_none(
+        ApiIntegrationHarness harness
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        var seeded = await SeedAcademicSubjectDescriptorsAsync(harness, MatrixAccessibility.None);
+
+        await RunEmptyCandidateSetAsync(harness, AcademicSubjectDescriptorsEndpoint, seeded);
+    }
+
+    private static async Task RunMatrixAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint,
+        SeededMatrix seeded
+    )
+    {
+        // A row whose accessible set could not fill two partitions would satisfy every assertion below
+        // without ever crossing a boundary.
+        seeded
+            .AccessibleIds.Should()
+            .HaveCountGreaterThan(
+                HostMaximumPageSize * 5,
+                "the accessible set must exceed the minimum partition size for the boundaries to be crossed"
+            );
+
+        int accessibleCount = seeded.AccessibleIds.Count;
+        int maximumWalkedPages = MaximumWalkedPages(accessibleCount);
+
+        // Compiled from the same candidate relation in traditional mode, so this is a cross-check rather
+        // than an independent oracle - and it is the most sensitive one available for a candidate relation
+        // that started returning a document more than once.
+        int totalCount = await ReadTotalCountAsync(harness, collectionEndpoint);
+        totalCount
+            .Should()
+            .Be(accessibleCount, "a total count over the same candidate relation counts each document once");
+
+        var walked = await WalkAsync(
+            harness,
+            collectionEndpoint,
+            PageTokenCodec.Encode(CursorRange.From(1)),
+            maximumWalkedPages
+        );
+        AssertResolvesTheAccessibleSet(walked, seeded, "the cursor walk");
+
+        IReadOnlyList<long> accessibleDocumentIds = await ReadDocumentIdsAsync(harness, seeded.AccessibleIds);
+        IReadOnlyList<long> inaccessibleDocumentIds = await ReadDocumentIdsAsync(
+            harness,
+            seeded.InaccessibleIds
+        );
+
+        var pageTokens = await ReadPageTokensAsync(
+            harness,
+            $"{collectionEndpoint}/partitions?number={RequestedPartitionCount}"
+        );
+
+        pageTokens
+            .Should()
+            .HaveCountGreaterThan(
+                1,
+                "the accessible set is large enough for several partitions, so the assertions below run "
+                    + "across separate ranges rather than inside one"
+            );
+        pageTokens
+            .Should()
+            .HaveCountLessThanOrEqualTo(
+                RequestedPartitionCount,
+                "the requested count is an upper bound the response may not exceed"
+            );
+
+        var ranges = DecodeRanges(pageTokens);
+
+        for (var index = 0; index < ranges.Count - 1; index++)
+        {
+            ranges[index]
+                .InclusiveMinimum.Should()
+                .BeLessThan(ranges[index + 1].InclusiveMinimum, "partition starts ascend");
+            (ranges[index].InclusiveMaximum + 1)
+                .Should()
+                .Be(
+                    ranges[index + 1].InclusiveMinimum,
+                    "consecutive partitions abut, so no candidate falls between two of them"
+                );
+        }
+
+        ranges[^1].InclusiveMaximum.Should().Be(long.MaxValue, "the final partition is unbounded above");
+
+        foreach (CursorRange range in ranges)
+        {
+            accessibleDocumentIds
+                .Should()
+                .Contain(
+                    range.InclusiveMinimum,
+                    "a partition starts at a candidate the caller may actually read"
+                );
+            inaccessibleDocumentIds
+                .Should()
+                .NotContain(
+                    range.InclusiveMinimum,
+                    "a starting identifier taken from an inaccessible row would disclose it"
+                );
+        }
+
+        List<List<string>> partitionWalks = [];
+        foreach (string partitionToken in pageTokens)
+        {
+            partitionWalks.Add(
+                await WalkAsync(harness, collectionEndpoint, partitionToken, maximumWalkedPages)
+            );
+        }
+
+        for (var first = 0; first < partitionWalks.Count - 1; first++)
+        {
+            for (int second = first + 1; second < partitionWalks.Count; second++)
+            {
+                partitionWalks[first]
+                    .Should()
+                    .NotIntersectWith(
+                        partitionWalks[second],
+                        "partitions are disjoint, so no document belongs to two of them"
+                    );
+            }
+        }
+
+        List<string> partitionUnion = [.. partitionWalks.SelectMany(static walk => walk)];
+        AssertResolvesTheAccessibleSet(partitionUnion, seeded, "the union of the partition walks");
+        partitionUnion
+            .Should()
+            .BeEquivalentTo(walked, "both surfaces resolve the same accessible candidate set");
+
+        await AssertAWidenedRangeStaysInsideTheAccessibleSetAsync(
+            harness,
+            collectionEndpoint,
+            seeded,
+            ranges[0],
+            maximumWalkedPages
+        );
+
+        await AssertMatchNothingRangesAsync(
+            harness,
+            collectionEndpoint,
+            accessibleDocumentIds,
+            inaccessibleDocumentIds
+        );
+
+        await AssertFiltersApplyToBothSurfacesAsync(harness, collectionEndpoint, seeded);
+    }
+
+    /// <summary>
+    /// A widened range is not a match-nothing range: it names every identifier the store could hold, and
+    /// authorization alone is what keeps the inaccessible documents out of it. One page could therefore
+    /// look clean while an interleaved inaccessible document waited on a later page, so the forged token
+    /// is walked to its terminal empty response and compared against the whole accessible set.
+    /// </summary>
+    private static async Task AssertAWidenedRangeStaysInsideTheAccessibleSetAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint,
+        SeededMatrix seeded,
+        CursorRange firstPartitionRange,
+        int maximumWalkedPages
+    )
+    {
+        string widenedToken = PageTokenCodec.Encode(new CursorRange(long.MinValue, long.MaxValue));
+
+        // Widening an emitted partition token produces this exact token, so the walk below is the walk of a
+        // widened token the endpoint really handed out rather than of an unrelated one, and a second walk
+        // would be the same request twice.
+        PageTokenCodec
+            .Encode(
+                firstPartitionRange with
+                {
+                    InclusiveMinimum = long.MinValue,
+                    InclusiveMaximum = long.MaxValue,
+                }
+            )
+            .Should()
+            .Be(widenedToken);
+
+        var widenedWalk = await WalkAsync(harness, collectionEndpoint, widenedToken, maximumWalkedPages);
+
+        AssertResolvesTheAccessibleSet(widenedWalk, seeded, "a maximally widened forged token");
+    }
+
+    private static async Task AssertMatchNothingRangesAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint,
+        IReadOnlyList<long> accessibleDocumentIds,
+        IReadOnlyList<long> inaccessibleDocumentIds
+    )
+    {
+        // Under a strategy that authorizes everything there is no inaccessible row to aim at, so the probe
+        // aims past the seed instead. The range still selects nothing, and the disclosure it would expose
+        // under a filtering strategy is covered by the rows that have one.
+        long probeDocumentId =
+            inaccessibleDocumentIds.Count > 0
+                ? inaccessibleDocumentIds[0]
+                : accessibleDocumentIds.Max() + 1_000_000;
+
+        await AssertSelectsNothingAsync(
+            harness,
+            collectionEndpoint,
+            new CursorRange(probeDocumentId, probeDocumentId),
+            "a range narrowed onto a single row the caller may not read"
+        );
+
+        await AssertSelectsNothingAsync(
+            harness,
+            collectionEndpoint,
+            new CursorRange(accessibleDocumentIds.Max(), accessibleDocumentIds.Min()),
+            "an inverted range"
+        );
+
+        await AssertSelectsNothingAsync(
+            harness,
+            collectionEndpoint,
+            new CursorRange(long.MaxValue, long.MaxValue),
+            "the highest representable range"
+        );
+
+        await AssertSelectsNothingAsync(
+            harness,
+            collectionEndpoint,
+            new CursorRange(long.MinValue, long.MinValue),
+            "the lowest representable range"
+        );
+    }
+
+    /// <summary>
+    /// The same filter is applied to the boundary request and to every page request, so a boundary set
+    /// calculated over a differently filtered candidate relation than the pages it describes would be
+    /// caught. The token count is what detects it: an unfiltered boundary calculation still delivers only
+    /// the matching document once each range is filtered, but it does not produce a single boundary.
+    /// </summary>
+    private static async Task AssertFiltersApplyToBothSurfacesAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint,
+        SeededMatrix seeded
+    )
+    {
+        string filteredCollection = $"{collectionEndpoint}?{seeded.FilterQuery}";
+
+        var filteredTokens = await ReadPageTokensAsync(
+            harness,
+            $"{collectionEndpoint}/partitions?{seeded.FilterQuery}&number={RequestedPartitionCount}"
+        );
+
+        filteredTokens
+            .Should()
+            .HaveCount(
+                1,
+                "the filter leaves a single candidate, so the boundaries are calculated over one row"
+            );
+
+        var filteredPartitionWalk = await WalkAsync(
+            harness,
+            filteredCollection,
+            filteredTokens[0],
+            MaximumWalkedPages(1)
+        );
+        filteredPartitionWalk.Should().Equal(seeded.FilterMatchedId);
+
+        var filteredCursorWalk = await WalkAsync(
+            harness,
+            filteredCollection,
+            PageTokenCodec.Encode(CursorRange.From(1)),
+            MaximumWalkedPages(1)
+        );
+        filteredCursorWalk.Should().Equal(seeded.FilterMatchedId);
+    }
+
+    private static async Task RunEmptyCandidateSetAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint,
+        SeededMatrix seeded
+    )
+    {
+        seeded
+            .AccessibleIds.Should()
+            .BeEmpty("this row's principal is configured to reach none of what it seeded");
+        seeded
+            .InaccessibleIds.Should()
+            .HaveCount(
+                SeededDocumentCount,
+                "the collection really holds documents, so an empty result is authorization's doing rather "
+                    + "than an empty database"
+            );
+
+        int totalCount = await ReadTotalCountAsync(harness, collectionEndpoint);
+        totalCount.Should().Be(0);
+
+        var pageTokens = await ReadPageTokensAsync(
+            harness,
+            $"{collectionEndpoint}/partitions?number={RequestedPartitionCount}"
+        );
+        pageTokens.Should().BeEmpty("a candidate set with no rows has no boundaries");
+
+        var (pageIds, nextPageToken) = await ReadPageAsync(
+            harness,
+            collectionEndpoint,
+            PageTokenCodec.Encode(CursorRange.From(1))
+        );
+
+        pageIds.Should().BeEmpty();
+        nextPageToken.Should().BeNull("there is nothing for a continuation to resume after");
+    }
+
+    private static void AssertResolvesTheAccessibleSet(
+        List<string> returnedIds,
+        SeededMatrix seeded,
+        string because
+    )
+    {
+        // Asserted on the list, before any set conversion: a candidate relation that returned a document
+        // twice must fail here rather than being normalized away by the comparison that follows.
+        returnedIds.Should().OnlyHaveUniqueItems($"{because} must not return a document more than once");
+        returnedIds
+            .Should()
+            .BeEquivalentTo(
+                seeded.AccessibleIds,
+                $"{because} must resolve exactly the accessible candidate set"
+            );
+
+        if (seeded.InaccessibleIds.Count > 0)
+        {
+            returnedIds
+                .Should()
+                .NotIntersectWith(
+                    seeded.InaccessibleIds,
+                    $"{because} must not disclose a document the caller may not read"
+                );
+        }
+    }
+
+    /// <summary>
+    /// Walks from the supplied token to the terminal empty response, returning every identifier in the
+    /// order it arrived. The result is a list rather than a set so a repeated document survives to the
+    /// caller's assertions.
+    /// </summary>
+    private static async Task<List<string>> WalkAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint,
+        string entryToken,
+        int maximumWalkedPages
+    )
+    {
+        List<string> returnedIds = [];
+        string? pageToken = entryToken;
+
+        for (var page = 0; page < maximumWalkedPages; page++)
+        {
+            var (pageIds, nextPageToken) = await ReadPageAsync(harness, collectionEndpoint, pageToken!);
+
+            pageIds
+                .Should()
+                .HaveCountLessThanOrEqualTo(HostMaximumPageSize, "a page cannot exceed its page size");
+            returnedIds.AddRange(pageIds);
+
+            if (nextPageToken is null)
+            {
+                pageIds.Should().BeEmpty("the page that ends a walk selects nothing");
+                return returnedIds;
+            }
+
+            pageToken = nextPageToken;
+        }
+
+        throw new InvalidOperationException(
+            $"A cursor walk of '{collectionEndpoint}' did not terminate within {maximumWalkedPages} pages."
+        );
+    }
+
+    private static async Task AssertSelectsNothingAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint,
+        CursorRange range,
+        string because
+    )
+    {
+        var (pageIds, nextPageToken) = await ReadPageAsync(
+            harness,
+            collectionEndpoint,
+            PageTokenCodec.Encode(range)
+        );
+
+        pageIds.Should().BeEmpty($"{because} selects nothing");
+        nextPageToken.Should().BeNull($"{because} has nothing for a continuation to resume after");
+    }
+
+    private static async Task<(List<string> PageIds, string? NextPageToken)> ReadPageAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint,
+        string pageToken
+    )
+    {
+        char separator = QuerySeparator(collectionEndpoint);
+        string requestUri =
+            $"{collectionEndpoint}{separator}pageToken={Uri.EscapeDataString(pageToken)}"
+            + $"&pageSize={HostMaximumPageSize}";
+
+        using HttpResponseMessage response = await harness.HttpClient.GetAsync(requestUri);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+
+        List<string> pageIds =
+        [
+            .. JsonNode.Parse(body)!.AsArray().Select(static document => document!["id"]!.GetValue<string>()),
+        ];
+
+        if (!response.Headers.TryGetValues("Next-Page-Token", out IEnumerable<string>? headerValues))
+        {
+            return (pageIds, null);
+        }
+
+        return (pageIds, headerValues.Single());
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadPageTokensAsync(
+        ApiIntegrationHarness harness,
+        string requestUri
+    )
+    {
+        using HttpResponseMessage response = await harness.HttpClient.GetAsync(requestUri);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+
+        return
+        [
+            .. JsonNode.Parse(body)!["pageTokens"]!
+                .AsArray()
+                .Select(static pageToken => pageToken!.GetValue<string>()),
+        ];
+    }
+
+    private static async Task<int> ReadTotalCountAsync(
+        ApiIntegrationHarness harness,
+        string collectionEndpoint
+    )
+    {
+        char separator = QuerySeparator(collectionEndpoint);
+
+        using HttpResponseMessage response = await harness.HttpClient.GetAsync(
+            $"{collectionEndpoint}{separator}limit=1&totalCount=true"
+        );
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+        response
+            .Headers.TryGetValues("Total-Count", out IEnumerable<string>? totalCountValues)
+            .Should()
+            .BeTrue("totalCount=true must emit the Total-Count header");
+
+        return int.Parse(totalCountValues!.Single(), CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Decodes every returned token through the codec that produced it, so a token naming a different
+    /// range than it encodes fails here rather than surviving as an opaque string.
+    /// </summary>
+    private static List<CursorRange> DecodeRanges(IReadOnlyList<string> pageTokens)
+    {
+        List<CursorRange> ranges = [];
+
+        foreach (string pageToken in pageTokens)
+        {
+            PageTokenCodec
+                .TryDecode(pageToken, out CursorRange? range)
+                .Should()
+                .BeTrue("an emitted partition token must decode through the codec that produced it");
+            ranges.Add(range!);
+        }
+
+        return ranges;
+    }
+
+    private static char QuerySeparator(string endpoint) =>
+        endpoint.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixSupport.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixSupport.cs
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using System.Globalization;
+using System.Net;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.External.Security;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using FluentAssertions;
+using static EdFi.DataManagementService.Tests.Integration.Scenarios.PeopleRelationshipGetManyScenarioHelpers;
+
+namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+/// <summary>
+/// Seeding, principal configuration, and database-side support for the cursor/partition authorization
+/// matrix. Kept beside the assertions rather than inside them so the scenario file states what is proven
+/// and this file states what it is proven over.
+/// </summary>
+internal static class CursorPartitionAuthorizationMatrixSupport
+{
+    // The shared authorization fixture already publishes the principal, the two schools, and the prefix
+    // pair its DDL and provider suites are built around; restating them here would let this matrix drift
+    // from the fixture it seeds.
+    public const long ClaimEducationOrganizationId =
+        RelationshipAuthorizationCrudTestSupport.ClaimEducationOrganizationId;
+
+    /// <summary>
+    /// A second education organization claim held alongside the first. Both reach the authorized school
+    /// through the hierarchy table, so every accessible candidate matches more than one authorization row.
+    /// </summary>
+    public const long SecondClaimEducationOrganizationId = ClaimEducationOrganizationId + 1;
+
+    public const long AuthorizedSchoolId = RelationshipAuthorizationCrudTestSupport.AuthorizedSchoolId;
+    public const long UnauthorizedSchoolId = RelationshipAuthorizationCrudTestSupport.UnauthorizedSchoolId;
+
+    public const string AuthorizedNamespacePrefix =
+        RelationshipAuthorizationCrudTestSupport.AuthorizedNamespacePrefix;
+    public const string UnauthorizedNamespacePrefix =
+        RelationshipAuthorizationCrudTestSupport.UnauthorizedNamespacePrefix;
+
+    /// <summary>
+    /// A prefix the caller holds that no seeded value starts with. Distinct from holding no prefixes at
+    /// all, which is the no-prefixes-configured 403 preflight terminal rather than an authorized-but-empty
+    /// candidate set.
+    /// </summary>
+    public const string UnmatchedNamespacePrefix = "uri://nothing.example/";
+
+    /// <summary>
+    /// Obeys the "{BasisResource}With..." convention the strategy classifier requires, so the basis
+    /// resource resolves to the seeded carrier and the check filters its root DocumentId by membership in
+    /// the matching auth view.
+    /// </summary>
+    public const string CustomViewStrategyName =
+        RelationshipAuthorizationCrudTestSupport.NamespaceResourceName + "WithCursorPartitionMatrix";
+
+    public const string NamespaceResourcesEndpoint = "/data/authz/authorizationNamespaceResources";
+    public const string AcademicSubjectDescriptorsEndpoint = "/data/ed-fi/academicSubjectDescriptors";
+
+    private const string SchoolsEndpoint = "/data/ed-fi/schools";
+    private const string EducationOrganizationCategoryDescriptorsEndpoint =
+        "/data/ed-fi/educationOrganizationCategoryDescriptors";
+    private const string GradeLevelDescriptorsEndpoint = "/data/ed-fi/gradeLevelDescriptors";
+
+    private const string SchoolCategoryDescriptor =
+        "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School";
+    private const string GradeLevelDescriptor = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade";
+
+    private const string EdFiProjectName = "Ed-Fi";
+    private const string AuthzProjectName = "Authz";
+    private const string AcademicSubjectDescriptorResourceName = "AcademicSubjectDescriptor";
+
+    /// <summary>
+    /// Documents seeded per row. Every fourth document is the inaccessible control, leaving 21 accessible
+    /// candidates: at the lowered maximum page size the mandatory minimum partition size is ten candidate
+    /// rows, so a request for three partitions over 21 candidates really produces three.
+    /// </summary>
+    public const int SeededDocumentCount = 28;
+
+    /// <summary>
+    /// The inaccessible controls are spread through the seed rather than clustered at one end. Boundary
+    /// rows then fall in different places for the authorized and the unauthorized candidate sets, so
+    /// boundaries calculated before authorization cannot coincidentally agree with a correctly authorized
+    /// walk.
+    /// </summary>
+    private static bool IsAccessibleIndex(int index) => index % 4 != 3;
+
+    private static bool IsAccessible(MatrixAccessibility accessibility, int index) =>
+        accessibility switch
+        {
+            MatrixAccessibility.All => true,
+            MatrixAccessibility.None => false,
+            _ => IsAccessibleIndex(index),
+        };
+
+    /// <summary>
+    /// The schema-name prefix the tracked-change inventory gives every project schema's shadow tables.
+    /// </summary>
+    private const string TrackedChangeSchemaPrefix = "tracked_changes_";
+
+    /// <summary>
+    /// The identity assigned to accessible rows stays below this value and inaccessible rows start at it,
+    /// which lets the custom-view row express accessibility as a range predicate over a real resource
+    /// column instead of a hard-coded identifier list.
+    /// </summary>
+    private const int InaccessibleIdentityFloor = 2000;
+
+    private const int AccessibleIdentityFloor = 1000;
+
+    /// <summary>How a seeded document is made inaccessible to the row's principal.</summary>
+    public enum MatrixAccessibility
+    {
+        /// <summary>Every document is accessible; the row's strategy filters nothing.</summary>
+        All,
+
+        /// <summary>The inaccessible documents reference an education organization the caller cannot reach.</summary>
+        EducationOrganization,
+
+        /// <summary>The inaccessible documents carry a namespace outside the caller's prefixes.</summary>
+        Namespace,
+
+        /// <summary>
+        /// The inaccessible documents differ only by identity, which is the column the matrix auth view
+        /// selects on. Everything else about them is identical to an accessible document, so nothing but
+        /// the view can be what excludes them.
+        /// </summary>
+        Identity,
+
+        /// <summary>
+        /// No document is accessible. The row's principal is configured to reach none of the seed, so an
+        /// empty result is authorization's doing rather than an empty collection.
+        /// </summary>
+        None,
+    }
+
+    /// <summary>
+    /// What a seed produced: the identities the row's principal may read, the identities it may not, and a
+    /// filter that selects exactly one accessible document. The expected sets come from the seed rather
+    /// than from a query, so nothing in the assertions re-derives accessibility from the endpoint under
+    /// test.
+    /// </summary>
+    public sealed record SeededMatrix(
+        IReadOnlyList<string> AccessibleIds,
+        IReadOnlyList<string> InaccessibleIds,
+        string FilterQuery,
+        string FilterMatchedId
+    );
+
+    public static IClaimSetProvider CreateRelationshipReadClaimSetProvider(FixtureContext fixture) =>
+        CreateClaimSetProvider(
+            fixture,
+            [
+                new RelationshipReadResource(
+                    AuthzProjectName,
+                    RelationshipAuthorizationCrudTestSupport.NamespaceResourceName
+                ),
+            ],
+            AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+        );
+
+    public static IClaimSetProvider CreateNamespaceReadClaimSetProvider(FixtureContext fixture) =>
+        CreateClaimSetProvider(
+            fixture,
+            [
+                new RelationshipReadResource(
+                    AuthzProjectName,
+                    RelationshipAuthorizationCrudTestSupport.NamespaceResourceName
+                ),
+            ],
+            AuthorizationStrategyNameConstants.NamespaceBased
+        );
+
+    public static IClaimSetProvider CreateCustomViewReadClaimSetProvider(FixtureContext fixture) =>
+        CreateClaimSetProvider(
+            fixture,
+            [
+                new RelationshipReadResource(
+                    AuthzProjectName,
+                    RelationshipAuthorizationCrudTestSupport.NamespaceResourceName
+                ),
+            ],
+            CustomViewStrategyName
+        );
+
+    public static IClaimSetProvider CreateDescriptorNamespaceReadClaimSetProvider(FixtureContext fixture) =>
+        CreateClaimSetProvider(
+            fixture,
+            [new RelationshipReadResource(EdFiProjectName, AcademicSubjectDescriptorResourceName)],
+            AuthorizationStrategyNameConstants.NamespaceBased
+        );
+
+    /// <summary>
+    /// Creates the descriptors and both education organizations the regular-resource carriers reference.
+    /// The unauthorized school exists as a real, resolvable reference target: an inaccessible document has
+    /// to be creatable before its exclusion from a read can mean anything.
+    /// </summary>
+    public static async Task SeedRegularReferenceDataAsync(ApiIntegrationHarness harness)
+    {
+        await CreateDescriptorAsync(
+            harness,
+            EducationOrganizationCategoryDescriptorsEndpoint,
+            "uri://ed-fi.org/EducationOrganizationCategoryDescriptor",
+            "School"
+        );
+        await CreateDescriptorAsync(
+            harness,
+            GradeLevelDescriptorsEndpoint,
+            "uri://ed-fi.org/GradeLevelDescriptor",
+            "Tenth grade"
+        );
+
+        await CreateSchoolAsync(
+            harness,
+            SchoolsEndpoint,
+            AuthorizedSchoolId,
+            "Matrix Authorized School",
+            SchoolCategoryDescriptor,
+            GradeLevelDescriptor
+        );
+        await CreateSchoolAsync(
+            harness,
+            SchoolsEndpoint,
+            UnauthorizedSchoolId,
+            "Matrix Unauthorized School",
+            SchoolCategoryDescriptor,
+            GradeLevelDescriptor
+        );
+    }
+
+    /// <summary>
+    /// Seeds the namespace-and-education-organization carrier. Documents are created in index order, so
+    /// their generated DocumentId values follow the interleaving above.
+    /// </summary>
+    public static async Task<SeededMatrix> SeedNamespaceResourcesAsync(
+        ApiIntegrationHarness harness,
+        MatrixAccessibility accessibility
+    )
+    {
+        await SeedRegularReferenceDataAsync(harness);
+
+        List<string> accessibleIds = [];
+        List<string> inaccessibleIds = [];
+        string filterQuery = string.Empty;
+        string filterMatchedId = string.Empty;
+
+        for (var index = 0; index < SeededDocumentCount; index++)
+        {
+            bool accessible = IsAccessible(accessibility, index);
+            string name = DocumentName(accessible, index);
+
+            var payload = new JsonObject
+            {
+                ["authorizationNamespaceId"] = Identity(accessible, index),
+                ["name"] = name,
+                ["namespace"] = DocumentNamespace(accessibility, accessible, index),
+                ["schoolReference"] = new JsonObject
+                {
+                    ["schoolId"] =
+                        accessibility == MatrixAccessibility.EducationOrganization && !accessible
+                            ? UnauthorizedSchoolId
+                            : AuthorizedSchoolId,
+                },
+                ["classPeriods"] = new JsonArray(),
+            };
+
+            string documentId = await CreateDocumentAsync(harness, NamespaceResourcesEndpoint, payload);
+
+            if (accessible)
+            {
+                accessibleIds.Add(documentId);
+                if (filterQuery.Length == 0)
+                {
+                    filterQuery = $"name={Uri.EscapeDataString(name)}";
+                    filterMatchedId = documentId;
+                }
+            }
+            else
+            {
+                inaccessibleIds.Add(documentId);
+            }
+        }
+
+        return new SeededMatrix(accessibleIds, inaccessibleIds, filterQuery, filterMatchedId);
+    }
+
+    /// <summary>
+    /// Seeds the descriptor carrier. This descriptor resource is not referenced by any reference data the
+    /// regular carriers need, so the collection holds exactly what this seed created and the accessible
+    /// set can be asserted as an exact equality rather than as containment.
+    /// </summary>
+    public static async Task<SeededMatrix> SeedAcademicSubjectDescriptorsAsync(
+        ApiIntegrationHarness harness,
+        MatrixAccessibility accessibility
+    )
+    {
+        List<string> accessibleIds = [];
+        List<string> inaccessibleIds = [];
+        string filterQuery = string.Empty;
+        string filterMatchedId = string.Empty;
+
+        for (var index = 0; index < SeededDocumentCount; index++)
+        {
+            bool accessible = IsAccessible(accessibility, index);
+            string codeValue = DocumentName(accessible, index);
+            string descriptorNamespace =
+                (accessibility == MatrixAccessibility.Namespace && !accessible)
+                    ? UnauthorizedNamespacePrefix + "AcademicSubjectDescriptor"
+                    : AuthorizedNamespacePrefix + "AcademicSubjectDescriptor";
+
+            var payload = new JsonObject
+            {
+                ["namespace"] = descriptorNamespace,
+                ["codeValue"] = codeValue,
+                ["shortDescription"] = codeValue,
+            };
+
+            string documentId = await CreateDocumentAsync(
+                harness,
+                AcademicSubjectDescriptorsEndpoint,
+                payload
+            );
+
+            if (accessible)
+            {
+                accessibleIds.Add(documentId);
+                if (filterQuery.Length == 0)
+                {
+                    filterQuery = $"codeValue={Uri.EscapeDataString(codeValue)}";
+                    filterMatchedId = documentId;
+                }
+            }
+            else
+            {
+                inaccessibleIds.Add(documentId);
+            }
+        }
+
+        return new SeededMatrix(accessibleIds, inaccessibleIds, filterQuery, filterMatchedId);
+    }
+
+    /// <summary>
+    /// Creates the auth view the custom-view row is configured against. The view is a deployment artifact
+    /// DMS never creates, so the row provisions it on the leased database exactly as an administrator
+    /// would, and it selects over a real resource column rather than over a fixed identifier list.
+    /// </summary>
+    public static async Task CreateMatrixCustomViewAsync(ApiIntegrationHarness harness)
+    {
+        string rootTable = RelationshipAuthorizationCrudTestSupport.NamespaceResourceName;
+        string schema = await ResolveTableSchemaAsync(harness, rootTable);
+        bool isMssql = IsMssql(harness.DbConnection);
+
+        string sql = isMssql
+            ? $"""
+                CREATE VIEW [auth].[{EscapeSqlServerIdentifier(CustomViewStrategyName)}] AS
+                SELECT [DocumentId]
+                FROM [{EscapeSqlServerIdentifier(schema)}].[{EscapeSqlServerIdentifier(rootTable)}]
+                WHERE [AuthorizationNamespaceId] < {InaccessibleIdentityFloor};
+                """
+            : $"""
+                CREATE VIEW "auth"."{EscapePostgresqlIdentifier(CustomViewStrategyName)}" AS
+                SELECT "DocumentId"
+                FROM "{EscapePostgresqlIdentifier(schema)}"."{EscapePostgresqlIdentifier(rootTable)}"
+                WHERE "AuthorizationNamespaceId" < {InaccessibleIdentityFloor};
+                """;
+
+        await ExecuteNonQueryAsync(harness.DbConnection, sql);
+    }
+
+    /// <summary>
+    /// The database identities behind a set of public identifiers, read straight from the document table.
+    /// This is an identity lookup rather than an authorization decision, which is what makes it usable as
+    /// the yardstick for the partition starting identifiers.
+    /// </summary>
+    public static async Task<IReadOnlyList<long>> ReadDocumentIdsAsync(
+        ApiIntegrationHarness harness,
+        IEnumerable<string> documentUuids
+    )
+    {
+        string sql = IsMssql(harness.DbConnection)
+            ? """
+                SELECT [DocumentId] FROM [dms].[Document] WHERE [DocumentUuid] = @documentUuid;
+                """
+            : """
+                SELECT "DocumentId" FROM "dms"."Document" WHERE "DocumentUuid" = @documentUuid;
+                """;
+
+        List<long> documentIds = [];
+
+        foreach (string documentUuid in documentUuids)
+        {
+            documentIds.Add(
+                await ReadInt64Async(harness.DbConnection, sql, ("@documentUuid", Guid.Parse(documentUuid)))
+            );
+        }
+
+        return documentIds;
+    }
+
+    private static async Task<string> ResolveTableSchemaAsync(ApiIntegrationHarness harness, string tableName)
+    {
+        string sql = IsMssql(harness.DbConnection)
+            ? """
+                SELECT s.[name]
+                FROM [sys].[tables] t
+                INNER JOIN [sys].[schemas] s ON s.[schema_id] = t.[schema_id]
+                WHERE t.[name] = @tableName;
+                """
+            : """
+                SELECT "table_schema"
+                FROM "information_schema"."tables"
+                WHERE "table_name" = @tableName;
+                """;
+
+        await using DbCommand command = harness.DbConnection.CreateCommand();
+        command.CommandText = sql;
+        AddParameters(command, ("@tableName", tableName));
+
+        List<string> schemas = [];
+        await using (DbDataReader reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                string schema = reader.GetString(0);
+
+                // Every project schema has a tracked-change twin holding a same-named table of Old/New
+                // column pairs. It is not the resource root the auth view must select from, and it is named
+                // by the fixed convention the model builder applies to the project schema.
+                if (!schema.StartsWith(TrackedChangeSchemaPrefix, StringComparison.Ordinal))
+                {
+                    schemas.Add(schema);
+                }
+            }
+        }
+
+        // Resolved rather than assumed: a schema-naming change then fails here, where the message names the
+        // table, instead of silently creating an auth view over nothing.
+        schemas.Should().ContainSingle($"exactly one schema must own the '{tableName}' root table");
+
+        return schemas[0];
+    }
+
+    private static async Task<string> CreateDocumentAsync(
+        ApiIntegrationHarness harness,
+        string endpoint,
+        JsonObject payload
+    )
+    {
+        using HttpResponseMessage response = await PostJsonAsync(harness, endpoint, payload);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, $"POST {endpoint} body: {body}");
+        response.Headers.Location.Should().NotBeNull($"POST {endpoint} must return a Location header");
+
+        Uri location = response.Headers.Location!;
+        string locationPath = location.IsAbsoluteUri ? location.AbsolutePath : location.OriginalString;
+
+        return locationPath[(locationPath.LastIndexOf('/') + 1)..];
+    }
+
+    private static int Identity(bool accessible, int index) =>
+        (accessible ? AccessibleIdentityFloor : InaccessibleIdentityFloor) + index;
+
+    private static string DocumentName(bool accessible, int index) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"matrix-{(accessible ? "accessible" : "denied")}-{index:D2}"
+        );
+
+    private static string DocumentNamespace(MatrixAccessibility accessibility, bool accessible, int index) =>
+        (accessibility == MatrixAccessibility.Namespace && !accessible)
+            ? $"{UnauthorizedNamespacePrefix}matrix/{index}"
+            : $"{AuthorizedNamespacePrefix}matrix/{index}";
+
+    private static string EscapeSqlServerIdentifier(string identifierPart) =>
+        identifierPart.Replace("]", "]]", StringComparison.Ordinal);
+
+    private static string EscapePostgresqlIdentifier(string identifierPart) =>
+        identifierPart.Replace("\"", "\"\"", StringComparison.Ordinal);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixSupport.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixSupport.cs
@@ -58,6 +58,14 @@ internal static class CursorPartitionAuthorizationMatrixSupport
     public const string CustomViewStrategyName =
         RelationshipAuthorizationCrudTestSupport.NamespaceResourceName + "WithCursorPartitionMatrix";
 
+    /// <summary>
+    /// The descriptor counterpart of <see cref="CustomViewStrategyName"/>. The basis resource is the
+    /// seeded descriptor, and the name carries a single "With" so the strategy classifier resolves that
+    /// resource rather than rejecting the name as ambiguous.
+    /// </summary>
+    public const string DescriptorCustomViewStrategyName =
+        AcademicSubjectDescriptorResourceName + "WithCursorPartitionMatrix";
+
     public const string NamespaceResourcesEndpoint = "/data/authz/authorizationNamespaceResources";
     public const string AcademicSubjectDescriptorsEndpoint = "/data/ed-fi/academicSubjectDescriptors";
 
@@ -110,6 +118,15 @@ internal static class CursorPartitionAuthorizationMatrixSupport
     private const int InaccessibleIdentityFloor = 2000;
 
     private const int AccessibleIdentityFloor = 1000;
+
+    /// <summary>
+    /// The name and code-value prefix an accessible seeded document carries. The descriptor auth view
+    /// selects on it, so it is a constant both the seed and the view read rather than a literal repeated
+    /// in each.
+    /// </summary>
+    private const string AccessibleNamePrefix = "matrix-accessible-";
+
+    private const string InaccessibleNamePrefix = "matrix-denied-";
 
     /// <summary>How a seeded document is made inaccessible to the row's principal.</summary>
     public enum MatrixAccessibility
@@ -191,6 +208,13 @@ internal static class CursorPartitionAuthorizationMatrixSupport
             fixture,
             [new RelationshipReadResource(EdFiProjectName, AcademicSubjectDescriptorResourceName)],
             AuthorizationStrategyNameConstants.NamespaceBased
+        );
+
+    public static IClaimSetProvider CreateDescriptorCustomViewReadClaimSetProvider(FixtureContext fixture) =>
+        CreateClaimSetProvider(
+            fixture,
+            [new RelationshipReadResource(EdFiProjectName, AcademicSubjectDescriptorResourceName)],
+            DescriptorCustomViewStrategyName
         );
 
     /// <summary>
@@ -371,6 +395,35 @@ internal static class CursorPartitionAuthorizationMatrixSupport
     }
 
     /// <summary>
+    /// Creates the auth view the descriptor custom-view row is configured against. It selects from
+    /// <c>dms.Descriptor</c>, which is the relation the descriptor page and boundary subqueries both root
+    /// on, so the view intersects the candidate relation on the same alias production uses.
+    /// </summary>
+    public static async Task CreateDescriptorMatrixCustomViewAsync(ApiIntegrationHarness harness)
+    {
+        bool isMssql = IsMssql(harness.DbConnection);
+
+        // Compared as a fixed-length prefix rather than matched with LIKE: the seeded prefix holds no
+        // pattern metacharacters today, and an equality test cannot silently widen the view if a later
+        // rename introduces one.
+        string sql = isMssql
+            ? $"""
+                CREATE VIEW [auth].[{EscapeSqlServerIdentifier(DescriptorCustomViewStrategyName)}] AS
+                SELECT [DocumentId]
+                FROM [dms].[Descriptor]
+                WHERE LEFT([CodeValue], {AccessibleNamePrefix.Length}) = '{AccessibleNamePrefix}';
+                """
+            : $"""
+                CREATE VIEW "auth"."{EscapePostgresqlIdentifier(DescriptorCustomViewStrategyName)}" AS
+                SELECT "DocumentId"
+                FROM "dms"."Descriptor"
+                WHERE LEFT("CodeValue", {AccessibleNamePrefix.Length}) = '{AccessibleNamePrefix}';
+                """;
+
+        await ExecuteNonQueryAsync(harness.DbConnection, sql);
+    }
+
+    /// <summary>
     /// The database identities behind a set of public identifiers, read straight from the document table.
     /// This is an identity lookup rather than an authorization decision, which is what makes it usable as
     /// the yardstick for the partition starting identifiers.
@@ -467,7 +520,7 @@ internal static class CursorPartitionAuthorizationMatrixSupport
     private static string DocumentName(bool accessible, int index) =>
         string.Create(
             CultureInfo.InvariantCulture,
-            $"matrix-{(accessible ? "accessible" : "denied")}-{index:D2}"
+            $"{(accessible ? AccessibleNamePrefix : InaccessibleNamePrefix)}{index:D2}"
         );
 
     private static string DocumentNamespace(MatrixAccessibility accessibility, bool accessible, int index) =>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixSupport.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPartitionAuthorizationMatrixSupport.cs
@@ -68,15 +68,35 @@ internal static class CursorPartitionAuthorizationMatrixSupport
 
     public const string NamespaceResourcesEndpoint = "/data/authz/authorizationNamespaceResources";
     public const string AcademicSubjectDescriptorsEndpoint = "/data/ed-fi/academicSubjectDescriptors";
+    public const string StudentAcademicRecordResourcesEndpoint =
+        "/data/authz/authorizationStudentAcademicRecordResources";
 
     private const string SchoolsEndpoint = "/data/ed-fi/schools";
     private const string EducationOrganizationCategoryDescriptorsEndpoint =
         "/data/ed-fi/educationOrganizationCategoryDescriptors";
     private const string GradeLevelDescriptorsEndpoint = "/data/ed-fi/gradeLevelDescriptors";
+    private const string TermDescriptorsEndpoint = "/data/ed-fi/termDescriptors";
+    private const string StudentsEndpoint = "/data/ed-fi/students";
+    private const string StudentSchoolAssociationsEndpoint = "/data/ed-fi/studentSchoolAssociations";
+    private const string SchoolYearTypesEndpoint = "/data/ed-fi/schoolYearTypes";
+    private const string StudentAcademicRecordsEndpoint = "/data/ed-fi/studentAcademicRecords";
 
     private const string SchoolCategoryDescriptor =
         "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School";
     private const string GradeLevelDescriptor = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade";
+    private const string TermDescriptorNamespace = "uri://ed-fi.org/TermDescriptor";
+    private const string TermDescriptor = $"{TermDescriptorNamespace}#Fall Semester";
+
+    /// <summary>
+    /// The two people the transitive row's academic records belong to. Only the first is enrolled at a
+    /// school the caller reaches, so which record a carrier document references is the only thing that
+    /// decides whether the caller may read it.
+    /// </summary>
+    private const string AuthorizedStudentUniqueId = "matrix-student-auth";
+
+    private const string UnauthorizedStudentUniqueId = "matrix-student-denied";
+
+    private const int StudentAcademicRecordSchoolYear = 2026;
 
     private const string EdFiProjectName = "Ed-Fi";
     private const string AuthzProjectName = "Authz";
@@ -141,6 +161,13 @@ internal static class CursorPartitionAuthorizationMatrixSupport
         Namespace,
 
         /// <summary>
+        /// The inaccessible documents reference a person the caller has no relationship to. The reference
+        /// is the carrier's only securable element, so the person reached through it is the whole of the
+        /// authorization decision.
+        /// </summary>
+        Person,
+
+        /// <summary>
         /// The inaccessible documents differ only by identity, which is the column the matrix auth view
         /// selects on. Everything else about them is identical to an accessible document, so nothing but
         /// the view can be what excludes them.
@@ -201,6 +228,26 @@ internal static class CursorPartitionAuthorizationMatrixSupport
                 ),
             ],
             CustomViewStrategyName
+        );
+
+    /// <summary>
+    /// A people strategy over the carrier whose only securable element is reached through a reference to
+    /// another resource. The planner compiles that into a transitive person predicate: the root row's
+    /// reference column is tested against a subquery over the referenced table, which in turn tests the
+    /// person column against the people auth view. Every other row in the matrix authorizes on a column
+    /// the root row itself carries, so this is the one that puts a nested subquery into the candidate
+    /// relation both surfaces are compiled from.
+    /// </summary>
+    public static IClaimSetProvider CreateTransitivePersonReadClaimSetProvider(FixtureContext fixture) =>
+        CreateClaimSetProvider(
+            fixture,
+            [
+                new RelationshipReadResource(
+                    AuthzProjectName,
+                    RelationshipAuthorizationCrudTestSupport.StudentAcademicRecordResourceName
+                ),
+            ],
+            AuthorizationStrategyNameConstants.RelationshipsWithStudentsOnly
         );
 
     public static IClaimSetProvider CreateDescriptorNamespaceReadClaimSetProvider(FixtureContext fixture) =>
@@ -309,6 +356,117 @@ internal static class CursorPartitionAuthorizationMatrixSupport
         }
 
         return new SeededMatrix(accessibleIds, inaccessibleIds, filterQuery, filterMatchedId);
+    }
+
+    /// <summary>
+    /// Seeds the transitive person carrier: two academic records belonging to two students, and documents
+    /// that reference one or the other. Both records sit behind the same reference shape, so a document is
+    /// inaccessible only because the record it points at belongs to a student the caller cannot reach.
+    /// </summary>
+    /// <remarks>
+    /// Two students and two records serve all twenty-eight documents. Seeding a person per document would
+    /// spread the accessible set over many auth view rows and let a candidate relation that lost the
+    /// person predicate still return a plausible subset; sharing one record per accessibility means a lost
+    /// predicate returns the whole collection.
+    /// </remarks>
+    public static async Task<SeededMatrix> SeedTransitivePersonResourcesAsync(
+        ApiIntegrationHarness harness,
+        MatrixAccessibility accessibility
+    )
+    {
+        await SeedRegularReferenceDataAsync(harness);
+        await CreateDescriptorAsync(
+            harness,
+            TermDescriptorsEndpoint,
+            TermDescriptorNamespace,
+            "Fall Semester"
+        );
+        await CreateSchoolYearTypeAsync(harness, SchoolYearTypesEndpoint, StudentAcademicRecordSchoolYear);
+
+        await SeedStudentAcademicRecordAsync(harness, AuthorizedStudentUniqueId, AuthorizedSchoolId, "Auth");
+        await SeedStudentAcademicRecordAsync(
+            harness,
+            UnauthorizedStudentUniqueId,
+            UnauthorizedSchoolId,
+            "Denied"
+        );
+
+        List<string> accessibleIds = [];
+        List<string> inaccessibleIds = [];
+        string filterQuery = string.Empty;
+        string filterMatchedId = string.Empty;
+
+        for (var index = 0; index < SeededDocumentCount; index++)
+        {
+            bool accessible = IsAccessible(accessibility, index);
+            string name = DocumentName(accessible, index);
+
+            var payload = new JsonObject
+            {
+                ["authorizationStudentAcademicRecordId"] = Identity(accessible, index),
+                ["name"] = name,
+                ["studentAcademicRecordReference"] = new JsonObject
+                {
+                    ["studentUniqueId"] = accessible
+                        ? AuthorizedStudentUniqueId
+                        : UnauthorizedStudentUniqueId,
+                    ["educationOrganizationId"] = accessible ? AuthorizedSchoolId : UnauthorizedSchoolId,
+                    ["schoolYear"] = StudentAcademicRecordSchoolYear,
+                    ["termDescriptor"] = TermDescriptor,
+                },
+            };
+
+            string documentId = await CreateDocumentAsync(
+                harness,
+                StudentAcademicRecordResourcesEndpoint,
+                payload
+            );
+
+            if (accessible)
+            {
+                accessibleIds.Add(documentId);
+                if (filterQuery.Length == 0)
+                {
+                    filterQuery = $"name={Uri.EscapeDataString(name)}";
+                    filterMatchedId = documentId;
+                }
+            }
+            else
+            {
+                inaccessibleIds.Add(documentId);
+            }
+        }
+
+        return new SeededMatrix(accessibleIds, inaccessibleIds, filterQuery, filterMatchedId);
+    }
+
+    /// <summary>
+    /// Creates one student, the enrollment that decides which education organizations reach it, and the
+    /// academic record the carrier documents reference.
+    /// </summary>
+    private static async Task SeedStudentAcademicRecordAsync(
+        ApiIntegrationHarness harness,
+        string studentUniqueId,
+        long schoolId,
+        string nameSuffix
+    )
+    {
+        await CreateStudentAsync(harness, StudentsEndpoint, studentUniqueId, nameSuffix);
+        await CreateStudentSchoolAssociationAsync(
+            harness,
+            StudentSchoolAssociationsEndpoint,
+            studentUniqueId,
+            schoolId,
+            GradeLevelDescriptor
+        );
+        await CreateStudentAcademicRecordAsync(
+            harness,
+            StudentAcademicRecordsEndpoint,
+            studentUniqueId,
+            schoolId,
+            StudentAcademicRecordSchoolYear,
+            TermDescriptor
+        );
     }
 
     /// <summary>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPartitionAuthorizationMatrix.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPartitionAuthorizationMatrix.cs
@@ -114,6 +114,26 @@ public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_SeveralMatchi
         );
 }
 
+/// <summary>
+/// A people strategy whose securable element is reached through a reference, so the compiled predicate
+/// anchors on the root row's reference column and nests a subquery inside the auth view membership test.
+/// </summary>
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_TransitivePersonAuthorization
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<long> ClientEducationOrganizationIds =>
+        [CursorPartitionAuthorizationMatrixSupport.ClaimEducationOrganizationId];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateTransitivePersonReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_transitive_person_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_transitive_person_authorization(
+            Harness
+        );
+}
+
 public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_DescriptorNoFurtherAuthorization
     : MssqlCursorPartitionAuthorizationMatrixTestBase
 {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPartitionAuthorizationMatrix.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPartitionAuthorizationMatrix.cs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Mssql;
+
+/// <summary>
+/// Shared SQL Server binding for the cursor/partition authorization matrix: the authorization fixture,
+/// the real authorization middleware, and the lowered page size the partition sizing depends on. Each
+/// row's own class adds only the principal and the strategy under test.
+/// </summary>
+[Category("Authorization")]
+public abstract class MssqlCursorPartitionAuthorizationMatrixTestBase : MssqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.AuthorizationQuery;
+
+    /// <summary>
+    /// The matrix reads through the production authorization path rather than around it, so the middleware
+    /// that compiles the candidate relation's predicates has to run.
+    /// </summary>
+    protected override bool BypassAuthorization => false;
+
+    protected override int? MaximumPageSizeOverride =>
+        CursorPartitionAuthorizationMatrixScenario.HostMaximumPageSize;
+}
+
+/// <summary>
+/// Nothing filters the candidate set, so the two surfaces must still agree on all of it. This is the row
+/// that would catch a boundary calculation disagreeing with page selection for a reason that has nothing
+/// to do with authorization.
+/// </summary>
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_NoFurtherAuthorization
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_no_further_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_no_further_authorization(
+            Harness
+        );
+}
+
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_RelationshipAuthorization
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<long> ClientEducationOrganizationIds =>
+        [CursorPartitionAuthorizationMatrixSupport.ClaimEducationOrganizationId];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateRelationshipReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_relationship_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_relationship_authorization(
+            Harness
+        );
+}
+
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_NamespaceAuthorization
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        [CursorPartitionAuthorizationMatrixSupport.AuthorizedNamespacePrefix];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateNamespaceReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_namespace_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_namespace_authorization(
+            Harness
+        );
+}
+
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_ViewBasedAuthorization
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateCustomViewReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_view_based_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_view_based_authorization(
+            Harness
+        );
+}
+
+/// <summary>
+/// Two education organization claims that both reach the authorized school, so the authorization relation
+/// holds several matching rows per candidate and one row per document is a property of the plan rather
+/// than of the data.
+/// </summary>
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_SeveralMatchingAuthorizationRows
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<long> ClientEducationOrganizationIds =>
+        [
+            CursorPartitionAuthorizationMatrixSupport.ClaimEducationOrganizationId,
+            CursorPartitionAuthorizationMatrixSupport.SecondClaimEducationOrganizationId,
+        ];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateRelationshipReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_when_authorization_matches_several_rows() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_when_authorization_matches_several_rows(
+            Harness
+        );
+}
+
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_DescriptorNoFurtherAuthorization
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    [Test]
+    public Task It_agrees_on_the_descriptor_candidate_set_under_no_further_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_descriptor_candidate_set_under_no_further_authorization(
+            Harness
+        );
+}
+
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_DescriptorNamespaceAuthorization
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        [CursorPartitionAuthorizationMatrixSupport.AuthorizedNamespacePrefix];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateDescriptorNamespaceReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_descriptor_candidate_set_under_namespace_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_descriptor_candidate_set_under_namespace_authorization(
+            Harness
+        );
+}
+
+/// <summary>
+/// The caller holds an education organization claim that reaches nothing, because no hierarchy edge was
+/// inserted for it.
+/// </summary>
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_NoAccessibleCandidates
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<long> ClientEducationOrganizationIds =>
+        [CursorPartitionAuthorizationMatrixSupport.ClaimEducationOrganizationId];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateRelationshipReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_returns_no_candidates_when_authorization_admits_none() =>
+        CursorPartitionAuthorizationMatrixScenario.It_returns_no_candidates_when_authorization_admits_none(
+            Harness
+        );
+}
+
+/// <summary>
+/// The caller holds a namespace prefix, so the request is authorized to proceed, but no seeded descriptor
+/// starts with it. Holding no prefix at all would instead be refused before any candidate set exists.
+/// </summary>
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_NoAccessibleDescriptorCandidates
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        [CursorPartitionAuthorizationMatrixSupport.UnmatchedNamespacePrefix];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateDescriptorNamespaceReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_returns_no_descriptor_candidates_when_authorization_admits_none() =>
+        CursorPartitionAuthorizationMatrixScenario.It_returns_no_descriptor_candidates_when_authorization_admits_none(
+            Harness
+        );
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPartitionAuthorizationMatrix.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPartitionAuthorizationMatrix.cs
@@ -141,6 +141,23 @@ public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_DescriptorNam
 }
 
 /// <summary>
+/// The descriptor carrier behind a real auth view, which the descriptor read path compiles into the same
+/// authorization spec for pages and for boundaries.
+/// </summary>
+public sealed class Given_Mssql_CursorPartitionAuthorizationMatrix_DescriptorViewBasedAuthorization
+    : MssqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateDescriptorCustomViewReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_descriptor_candidate_set_under_view_based_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_descriptor_candidate_set_under_view_based_authorization(
+            Harness
+        );
+}
+
+/// <summary>
 /// The caller holds an education organization claim that reaches nothing, because no hierarchy edge was
 /// inserted for it.
 /// </summary>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPartitionAuthorizationMatrix.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPartitionAuthorizationMatrix.cs
@@ -141,6 +141,23 @@ public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_Descript
 }
 
 /// <summary>
+/// The descriptor carrier behind a real auth view, which the descriptor read path compiles into the same
+/// authorization spec for pages and for boundaries.
+/// </summary>
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_DescriptorViewBasedAuthorization
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateDescriptorCustomViewReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_descriptor_candidate_set_under_view_based_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_descriptor_candidate_set_under_view_based_authorization(
+            Harness
+        );
+}
+
+/// <summary>
 /// The caller holds an education organization claim that reaches nothing, because no hierarchy edge was
 /// inserted for it.
 /// </summary>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPartitionAuthorizationMatrix.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPartitionAuthorizationMatrix.cs
@@ -114,6 +114,26 @@ public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_SeveralM
         );
 }
 
+/// <summary>
+/// A people strategy whose securable element is reached through a reference, so the compiled predicate
+/// anchors on the root row's reference column and nests a subquery inside the auth view membership test.
+/// </summary>
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_TransitivePersonAuthorization
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<long> ClientEducationOrganizationIds =>
+        [CursorPartitionAuthorizationMatrixSupport.ClaimEducationOrganizationId];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateTransitivePersonReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_transitive_person_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_transitive_person_authorization(
+            Harness
+        );
+}
+
 public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_DescriptorNoFurtherAuthorization
     : PostgresqlCursorPartitionAuthorizationMatrixTestBase
 {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPartitionAuthorizationMatrix.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPartitionAuthorizationMatrix.cs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Postgresql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Postgresql;
+
+/// <summary>
+/// Shared PostgreSQL binding for the cursor/partition authorization matrix: the authorization fixture,
+/// the real authorization middleware, and the lowered page size the partition sizing depends on. Each
+/// row's own class adds only the principal and the strategy under test.
+/// </summary>
+[Category("Authorization")]
+public abstract class PostgresqlCursorPartitionAuthorizationMatrixTestBase : PostgresqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.AuthorizationQuery;
+
+    /// <summary>
+    /// The matrix reads through the production authorization path rather than around it, so the middleware
+    /// that compiles the candidate relation's predicates has to run.
+    /// </summary>
+    protected override bool BypassAuthorization => false;
+
+    protected override int? MaximumPageSizeOverride =>
+        CursorPartitionAuthorizationMatrixScenario.HostMaximumPageSize;
+}
+
+/// <summary>
+/// Nothing filters the candidate set, so the two surfaces must still agree on all of it. This is the row
+/// that would catch a boundary calculation disagreeing with page selection for a reason that has nothing
+/// to do with authorization.
+/// </summary>
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_NoFurtherAuthorization
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_no_further_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_no_further_authorization(
+            Harness
+        );
+}
+
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_RelationshipAuthorization
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<long> ClientEducationOrganizationIds =>
+        [CursorPartitionAuthorizationMatrixSupport.ClaimEducationOrganizationId];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateRelationshipReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_relationship_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_relationship_authorization(
+            Harness
+        );
+}
+
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_NamespaceAuthorization
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        [CursorPartitionAuthorizationMatrixSupport.AuthorizedNamespacePrefix];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateNamespaceReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_namespace_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_namespace_authorization(
+            Harness
+        );
+}
+
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_ViewBasedAuthorization
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateCustomViewReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_under_view_based_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_under_view_based_authorization(
+            Harness
+        );
+}
+
+/// <summary>
+/// Two education organization claims that both reach the authorized school, so the authorization relation
+/// holds several matching rows per candidate and one row per document is a property of the plan rather
+/// than of the data.
+/// </summary>
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_SeveralMatchingAuthorizationRows
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<long> ClientEducationOrganizationIds =>
+        [
+            CursorPartitionAuthorizationMatrixSupport.ClaimEducationOrganizationId,
+            CursorPartitionAuthorizationMatrixSupport.SecondClaimEducationOrganizationId,
+        ];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateRelationshipReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_candidate_set_when_authorization_matches_several_rows() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_candidate_set_when_authorization_matches_several_rows(
+            Harness
+        );
+}
+
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_DescriptorNoFurtherAuthorization
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    [Test]
+    public Task It_agrees_on_the_descriptor_candidate_set_under_no_further_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_descriptor_candidate_set_under_no_further_authorization(
+            Harness
+        );
+}
+
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_DescriptorNamespaceAuthorization
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        [CursorPartitionAuthorizationMatrixSupport.AuthorizedNamespacePrefix];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateDescriptorNamespaceReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_agrees_on_the_descriptor_candidate_set_under_namespace_authorization() =>
+        CursorPartitionAuthorizationMatrixScenario.It_agrees_on_the_descriptor_candidate_set_under_namespace_authorization(
+            Harness
+        );
+}
+
+/// <summary>
+/// The caller holds an education organization claim that reaches nothing, because no hierarchy edge was
+/// inserted for it.
+/// </summary>
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_NoAccessibleCandidates
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<long> ClientEducationOrganizationIds =>
+        [CursorPartitionAuthorizationMatrixSupport.ClaimEducationOrganizationId];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateRelationshipReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_returns_no_candidates_when_authorization_admits_none() =>
+        CursorPartitionAuthorizationMatrixScenario.It_returns_no_candidates_when_authorization_admits_none(
+            Harness
+        );
+}
+
+/// <summary>
+/// The caller holds a namespace prefix, so the request is authorized to proceed, but no seeded descriptor
+/// starts with it. Holding no prefix at all would instead be refused before any candidate set exists.
+/// </summary>
+public sealed class Given_Postgresql_CursorPartitionAuthorizationMatrix_NoAccessibleDescriptorCandidates
+    : PostgresqlCursorPartitionAuthorizationMatrixTestBase
+{
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        [CursorPartitionAuthorizationMatrixSupport.UnmatchedNamespacePrefix];
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        CursorPartitionAuthorizationMatrixSupport.CreateDescriptorNamespaceReadClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_returns_no_descriptor_candidates_when_authorization_admits_none() =>
+        CursorPartitionAuthorizationMatrixScenario.It_returns_no_descriptor_candidates_when_authorization_admits_none(
+            Harness
+        );
+}


### PR DESCRIPTION
## What

Adds the cursor/partition authorization matrix: integration coverage proving that for the same principal, filters, and seeded data, a full cursor walk and the union of the `/partitions` ranges resolve **exactly** the accessible candidate set, and that a client cannot widen that set by editing the range inside a `pageToken`.

Ten rows per provider, run against real PostgreSQL and real SQL Server 2025 — 20 tests, test-only, no production code touched.

| Row | Carrier | Strategy | What it pins |
|---|---|---|---|
| R-NF | regular | no-further | Both surfaces agree when nothing filters |
| R-REL | regular | `RelationshipsWithEdOrgsOnly` | EdOrg hierarchy reach |
| R-NS | regular | `NamespaceBased` | Prefix filtering |
| R-VIEW | regular | custom view | A real `auth` view over a resource column |
| R-MULTI | regular | relationship, two EdOrg claims | One row per document is a property of the *plan*, not the data |
| D-NF | descriptor | no-further | |
| D-NS | descriptor | `NamespaceBased` | |
| D-VIEW | descriptor | custom view | Descriptor custom views reach both surfaces |
| E-REG / E-DESC | both | authorization admits nothing | Empty partition array, no `Next-Page-Token` |

## Why

The two surfaces compile the *same* authorized candidate relation but reach it differently: pages select a bounded range from it, while boundaries rank and count the whole of it. A defect that authorized one and not the other would leave every single-surface test green. So every row compares the two against an expected set derived from the **seed**, never from either surface under test.

Three design choices carry most of the evidential weight:

**The host maximum page size is lowered to 2.** The mandatory minimum partition size is `MaximumPageSize * 5`, so at the deployed 500 no collection seeded over HTTP could ever be cut into more than one partition, and every union and disjointness assertion would pass without crossing a single boundary. At 2 the minimum is ten candidate rows, which the 21-document accessible sets clear, so three requested partitions really produce three.

**The inaccessible controls are interleaved, not clustered.** Every fourth document is the control, so boundary rows fall in different places for the authorized and unauthorized sets. Boundaries computed *before* authorization cannot coincidentally agree with a correctly authorized walk.

**`totalCount` is the duplicate detector.** It is compiled from the same candidate relation in traditional mode, so it is a cross-check rather than an independent oracle — and it is the most sensitive one available for a relation that started returning a document twice. Walk results are asserted as a *list* with `OnlyHaveUniqueItems` before any set conversion, so a repeat fails rather than being normalized away.

## Changes

Four new files under `src/dms/tests/EdFi.DataManagementService.Tests.Integration/`:

- **`Scenarios/CursorPartitionAuthorizationMatrixScenario.cs`** — the assertions. `RunMatrixAsync` is shared by every row: total-count cross-check, full cursor walk, partition ascent/abutment/unbounded-tail, start-id accessibility, pairwise disjointness, union equivalence, forged-range probes, and filter agreement across both surfaces.
- **`Scenarios/CursorPartitionAuthorizationMatrixSupport.cs`** — seeding, principals, and the database-side auth views. Kept beside the assertions so one file states what is proven and the other what it is proven over.
- **`Tests/Postgresql/…`** and **`Tests/Mssql/…`** — the provider bindings. Each row's class adds only its principal and strategy; the shared base supplies the fixture, the real authorization middleware (`BypassAuthorization => false`), and the lowered page size.

### Negative cases

- **Widened forged token.** A maximally widened range names every identifier the store could hold, so authorization alone keeps the inaccessible documents out. The test asserts the forged token is byte-identical to what widening a *real* emitted partition token produces, then walks it to its terminal empty response — one clean page would not be enough, since an interleaved inaccessible document could wait on a later page.
- **Match-nothing ranges.** A range narrowed onto a single row the caller may not read, an inverted range, and both extreme `Int64` ranges each return nothing with no continuation.
- **Partition starting ids** are asserted to be actual accessible candidate ids and never inaccessible ones — a start taken from an inaccessible row would itself disclose it.

### Authorization is exercised through the real path

The custom-view rows provision a genuine `auth` view on the leased database exactly as an administrator would, because the view is a deployment artifact DMS never creates. Both select over a real resource column rather than a hard-coded identifier list, and the root table's schema is *resolved* from the catalog rather than assumed, so a schema-naming change fails with a message naming the table instead of silently creating a view over nothing.

For the regular-resource view every field another strategy could authorize on is seeded so that it would admit the whole collection — each namespace sits under the caller's authorized prefix, every reference points at the authorized school — so the view is demonstrably the only thing excluding the denied documents.

### Coverage boundaries, recorded rather than implied

- `OwnershipBased` is excluded for every operation including GET-many: it is recognized but not enabled, so the request fails closed before a candidate relation exists.
- **Relationship strategies are the descriptor exclusion**, because descriptors expose no education-organization or person securable elements to range over.
- Descriptor **custom views are in scope**. `PrepareDescriptorQueryAsync` and `PrepareDescriptorPartitionAsync` both call the same `BuildDescriptorQueryAuthorizationSpec`, so descriptor custom-view checks are compiled into the candidate relation behind *both* the page walk and the partition boundaries — precisely the agreement this matrix exists to prove. Omitting it would have left that compiled path uncovered on both providers.

## Verification

- CSharpier clean. Integration project builds **0 warnings / 0 errors**.
- Focused matrix: **20 passed, 0 failed, 0 skipped** against live PostgreSQL and SQL Server 2025, with both admin connections passed explicitly and both credential sets read from the running containers rather than assumed. Zero skips is the evidence the PostgreSQL lane actually executed rather than silently skipping on an absent connection string.
- **Non-vacuity, not just green.** The `D-VIEW` row was mutation-checked: widening its auth view to `WHERE 1 = 1` fails with `Expected totalCount to be 21 … but found 28`. The mutation was reverted and the suite re-run green, so the assertions are provably bound to the auth view rather than passing incidentally.
- Rebased onto current `main` and **re-verified there at 20/0/0**. This mattered: `main` gained DMS-1331, which anchors relationship-authorization paging subqueries on root-row columns and rewrites the very subquery shape the `R-REL` and `R-MULTI` rows read through. The rebase was conflict-free, but that proves nothing about files a branch *adds*, so it was audited separately — `main` touched neither `ApiIntegrationTestBase` nor `Core/Paging`, and the passing run on the new base covers the behavioral half.

## Notes for review

- Test-only. No production code, public contract, or OpenAPI surface changes.
- The custom-view rows create their view without a defensive drop, relying on a per-row leased database, consistent with the surrounding fixtures. It would only matter if these were ever pointed at a shared database.
- Full-project integration runs are left to CI; local full-suite PostgreSQL runs are known to exhaust shared memory at stock container settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
