### PR TITLE
[DMS-1393] Bounded Cursor and Partition Telemetry

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -36,6 +36,11 @@ how it might be useful in the DMS platform. The article references the Project
 Meadowlark application stack, but is equally applicable here: [What Is Open
 Telemetry?](https://github.com/Ed-Fi-Exchange-OSS/Meadowlark/blob/main/docs/design/open-telemetry/README.md)
 
+For the metrics the Ed-Fi API publishes for collection reads — traditional
+paging, cursor paging, and partition planning — including the instrument names,
+units, dimensions, and what collecting them requires of the host, see
+[Collection Paging Telemetry](./PAGING-TELEMETRY.md).
+
 ## Security
 
 ### Transport Encryption

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -114,7 +114,7 @@ Investigate it as a deployment problem; it is not a routine bucket to chart.
 |---|---|
 | `success` | A page or a boundary set was produced. Also covers a page served with documents that *cannot* anchor a cursor continuation, and therefore carries no continuation token — see the first note below — and a `partitions` request whose boundary command ran and found no ranges. |
 | `terminal_page` | A collection `GET` **after which nothing follows**: a continuation was possible for this page and none could be produced. On `paging_mode=cursor` that is the request ending a walk. On `paging_mode=traditional` it is the ordinary end of a `limit`/`offset` walk — most often a selection that chose no rows, which is how such a client learns it has reached the end — so it is expected traffic there rather than a cursor-specific signal. Never reported for `partitions`, which has no successor to offer. |
-| `early_empty` | An empty result the API answered without issuing any selection command. Selection is the work this skips; a request that also validates a custom view still issues that command first. |
+| `early_empty` | An empty result the API answered without issuing any selection command. Selection is the work this skips, and only that: a request that first had to resolve a descriptor filter value, or validate a custom view, still issued that command. |
 | `validation_rejected` | Parameter validation answered the request: a paging, partition-count, change-version, or resource-filter parameter was refused. |
 | `not_authorized` | Namespace authorization denied the request. A client whose claim set does not authorize reading the resource at all is refused before backend execution begins and is not counted at all; see the `requests` note under [Aggregation Intent](#aggregation-intent). |
 | `not_implemented` | The operation is intentionally unavailable for that resource. |
@@ -162,8 +162,10 @@ measuring how long the client waited before giving up.
   plain pages hides both. Exclude `command_category=none` from read-latency
   objectives, and watch it as a series of its own rather than as a fast
   remainder. That bucket holds two unlike populations: a skipped selection,
-  which issued no command and is therefore fast by construction, and every
-  failure, whose command may or may not have run. `retry_exhausted` is the
+  which issued no selection command — it may still have issued a reference
+  lookup to establish that it had nothing to select, so it is cheaper than a
+  served page rather than free — and every failure, whose command may or may
+  not have run. `retry_exhausted` is the
   extreme — a retryable condition that survived the whole retry pipeline — and
   it carries the slowest samples this instrument records. Mixed into the `page`,
   `page_with_count`, and `boundary` shapes, the two pull the percentiles in

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -113,7 +113,7 @@ Investigate it as a deployment problem; it is not a routine bucket to chart.
 | Value | Meaning |
 |---|---|
 | `success` | A page or a boundary set was produced. Also covers a page served with documents that *cannot* anchor a cursor continuation, and therefore carries no continuation token — see the first note below — and a `partitions` request whose boundary command ran and found no ranges. |
-| `terminal_page` | A collection `GET` that **ends a cursor walk**: a continuation was possible for this page and none could be produced, so nothing follows it. Never reported for `partitions`, which has no successor to offer. |
+| `terminal_page` | A collection `GET` **after which nothing follows**: a continuation was possible for this page and none could be produced. On `paging_mode=cursor` that is the request ending a walk. On `paging_mode=traditional` it is the ordinary end of a `limit`/`offset` walk — most often a selection that chose no rows, which is how such a client learns it has reached the end — so it is expected traffic there rather than a cursor-specific signal. Never reported for `partitions`, which has no successor to offer. |
 | `early_empty` | An empty result the API answered without issuing any selection command. Selection is the work this skips; a request that also validates a custom view still issues that command first. |
 | `validation_rejected` | Parameter validation answered the request: a paging, partition-count, change-version, or resource-filter parameter was refused. |
 | `not_authorized` | Namespace authorization denied the request. A client whose claim set does not authorize reading the resource at all is refused before backend execution begins and is not counted at all; see the `requests` note under [Aggregation Intent](#aggregation-intent). |
@@ -160,9 +160,15 @@ measuring how long the client waited before giving up.
   `command_category`. Keep `page_with_count` in its own bucket: requesting a
   total count is expected to be the slow shape, and averaging it together with
   plain pages hides both. Exclude `command_category=none` from read-latency
-  objectives: those samples time a backend attempt that issued no selection
-  command, so they are fast by construction and pull the percentiles of the
-  `page`, `page_with_count`, and `boundary` shapes down if mixed in.
+  objectives, and watch it as a series of its own rather than as a fast
+  remainder. That bucket holds two unlike populations: a skipped selection,
+  which issued no command and is therefore fast by construction, and every
+  failure, whose command may or may not have run. `retry_exhausted` is the
+  extreme — a retryable condition that survived the whole retry pipeline — and
+  it carries the slowest samples this instrument records. Mixed into the `page`,
+  `page_with_count`, and `boundary` shapes, the two pull the percentiles in
+  opposite directions, and neither movement describes the cost of serving a
+  page.
 - **`page_size.requested` vs `page_size.returned`** — compare the two
   distributions, excluding `command_category=none` from both sides as the
   latency objectives do. A persistent gap in what remains means pages are being

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -187,22 +187,40 @@ confirm it.
   in opposing directions, and no movement among them describes the cost of
   serving a page.
 - **`page_size.requested` vs `page_size.returned`** — compare the two
-  distributions, excluding `command_category=none` from both sides as the
-  latency objectives do. A persistent gap in what remains means pages are being
-  trimmed after selection, either by authorization or by documents deleted
-  between selection and retrieval. Left in, the `none` samples manufacture a gap
-  that is not trimming at all: an `early_empty` request reports the page size it
-  asked for against a returned zero, because it answered without selecting
-  anything. It is the only outcome in that category that reaches a returned
-  instrument — failures record no returned size — so the one filter removes
-  exactly the skipped selections.
+  distributions, excluding both `command_category=none` and
+  `outcome=terminal_page` from either side. A persistent gap in what remains
+  means pages are being trimmed after selection, either by authorization or by
+  documents deleted between selection and retrieval. Each exclusion removes a
+  population that reports the page size it asked for against a returned zero
+  for a reason that is not trimming. An `early_empty` answered without selecting
+  anything; it is the only outcome in `command_category=none` that reaches a
+  returned instrument, because failures record no returned size. A
+  `terminal_page` selected and found nothing, which on
+  `paging_mode=traditional` is the empty page a client walks into at the end of
+  a `limit`/`offset` traversal — roughly one per walk, so ordinary traffic
+  rather than an edge case.
+
+  One residual survives both exclusions and cannot be filtered out. An empty
+  page inside a bounded change-version window is reported `success`, not
+  `terminal_page`, because it could never have anchored a continuation at all —
+  see the first note under [`outcome`](#outcome) — so it still contributes an
+  asked-against-zero sample. Its volume is bounded by how many windowed walks
+  run rather than by the size of the data. Separating it would take knowing
+  whether selection chose any rows, and the fact that answers that is a
+  document identifier, which is deliberately never a dimension. Read a small
+  residual gap on a deployment whose clients walk change-version windows as
+  expected, and look for trimming in a gap that grows beyond it.
 - **`partition_count.requested` vs `partition_count.returned`** — compare the
-  two distributions, excluding `command_category=none` for the same reason. A
-  persistent gap in what remains means the collection is too small to be cut
-  into as many partitions as clients ask for: the requested count is an upper
-  bound, and a minimum partition size reduces it. This is normal for small
-  collections and is only worth investigating if it appears on collections large
-  enough to partition.
+  two distributions, excluding `command_category=none` to remove the
+  short-circuits, for the same reason as above. That is the only exclusion
+  needed here: `partitions` never reports `terminal_page`, and an executed
+  boundary command that found no starts is a genuine `success` with a returned
+  zero, which the reading that follows already accounts for. A persistent gap
+  in what remains means the collection is too small to be cut into as many
+  partitions as clients ask for: the requested count is an upper bound, and a
+  minimum partition size reduces it. This is normal for small collections and is
+  only worth investigating if it appears on collections large enough to
+  partition.
 
 ## What Is Never Recorded
 

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -72,8 +72,10 @@ values listed here.
 | `provider` | `postgresql`, `sqlserver`, `unknown` |
 | `outcome` | `success`, `terminal_page`, `early_empty`, `validation_rejected`, `not_authorized`, `not_implemented`, `security_configuration`, `retry_exhausted`, `unknown_failure`, `execution_exception` |
 
-That is at most 360 dimension combinations. The set actually reachable is far
-smaller, because most combinations describe states that cannot occur together.
+That is at most 240 reachable dimension combinations — 360 as spelled out above,
+less the `unknown` provider third that a correctly assembled server never emits.
+The set actually reached is smaller still, because most of the rest describe
+states that cannot occur together.
 
 ### `command_category`
 
@@ -97,14 +99,20 @@ an operator needs is lost.
 
 ### `provider`
 
-The database engine that answered the request: `postgresql` or `sqlserver`. It
-is `unknown` only when the request was answered before the engine was resolved.
+The database engine that answered the request: `postgresql` or `sqlserver`. One
+of those two is always present. The engine is resolved before paging validation
+runs, so a request answered ahead of that resolution is not counted on any of
+these instruments at all, rather than counted as `unknown`.
+
+`unknown` therefore reports a server assembly fault rather than a client
+outcome: a collection read that reached its handler with no engine resolved.
+Investigate it as a deployment problem; it is not a routine bucket to chart.
 
 ### `outcome`
 
 | Value | Meaning |
 |---|---|
-| `success` | A page or a boundary set was produced. Also covers a page served with documents that carries no continuation token, and a `partitions` request whose boundary command ran and found no ranges. |
+| `success` | A page or a boundary set was produced. Also covers a page served with documents that *cannot* anchor a cursor continuation, and therefore carries no continuation token — see the first note below — and a `partitions` request whose boundary command ran and found no ranges. |
 | `terminal_page` | A collection `GET` that **ends a cursor walk**: a continuation was possible for this page and none could be produced, so nothing follows it. Never reported for `partitions`, which has no successor to offer. |
 | `early_empty` | An empty result the API answered without issuing any selection command. Selection is the work this skips; a request that also validates a custom view still issues that command first. |
 | `validation_rejected` | Parameter validation answered the request: a paging, partition-count, change-version, or resource-filter parameter was refused. |
@@ -112,7 +120,7 @@ is `unknown` only when the request was answered before the engine was resolved.
 | `not_implemented` | The operation is intentionally unavailable for that resource. |
 | `security_configuration` | The security configuration metadata for the request is invalid. |
 | `retry_exhausted` | A retryable condition survived the retry pipeline. |
-| `unknown_failure` | The database returned a failure the API could not classify. |
+| `unknown_failure` | A backend failure with no outcome value of its own. Includes a backend-reported query-term error, which is answered with a 400, so a rising rate here can mean client misuse rather than an unhealthy backend. |
 | `execution_exception` | An exception escaped execution. The exception itself still propagates and is reported unchanged. |
 
 Two distinctions are worth knowing when reading these values.

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -43,7 +43,7 @@ receives nothing from these instruments no matter how it is configured.
 
 | Instrument | Type | Unit | Recorded for |
 |---|---|---|---|
-| `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every collection read paging validation refused, plus every one that reached backend execution. Clearing paging validation is not on its own enough — see [Aggregation Intent](#aggregation-intent) |
+| `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every collection read paging validation refused, plus every one that reached its handler. Clearing paging validation is not on its own enough — see [Aggregation Intent](#aggregation-intent) |
 | `edfi.dms.collection_paging.duration` | Histogram | `ms` | Every request where backend execution was attempted, so a request refused by parameter validation never contributes a microsecond-scale sample |
 | `edfi.dms.collection_paging.page_size.requested` | Histogram | `{item}` | Collection `GET` requests that reached execution |
 | `edfi.dms.collection_paging.page_size.returned` | Histogram | `{item}` | Collection `GET` requests that produced a page, an empty one included |
@@ -121,9 +121,9 @@ Investigate it as a deployment problem; it is not a routine bucket to chart.
 | `security_configuration` | The security configuration metadata for the request is invalid. |
 | `retry_exhausted` | A retryable condition survived the retry pipeline. |
 | `unknown_failure` | A backend failure with no outcome value of its own. Includes a backend-reported query-term error, which is answered with a 400, so a rising rate here can mean client misuse rather than an unhealthy backend. |
-| `execution_exception` | An exception escaped execution. The exception itself still propagates and is reported unchanged. |
+| `execution_exception` | An exception escaped execution. The exception itself still propagates and is reported unchanged. Also covers a request the circuit breaker refused, which never reached the database and is answered `503` — while the breaker is open that is expected to be the whole of this outcome, so see the third note below before reading a rise here as a code fault. |
 
-Two distinctions are worth knowing when reading these values.
+Three distinctions are worth knowing when reading these values.
 
 **`success` is not the same as "a continuation was offered."** A traditional
 page inside a bounded change-version window is ordered so that it cannot anchor
@@ -137,6 +137,17 @@ is the absence of a completed collection read rather than a kind of one, and
 counting it would report client behavior as backend failure with a duration
 measuring how long the client waited before giving up.
 
+**An open circuit breaker moves the failure rate into `execution_exception`.**
+The breaker opens on the same backend results that produce `unknown_failure`.
+While it is open, every collection read is refused before it reaches the
+database and is recorded as `execution_exception` with a near-zero duration. So
+`unknown_failure` rising and then dropping to zero is not recovery — it is the
+point at which the refusal became total, and the two outcomes have to be read
+together. The breaker is shared with the write pipelines, so write traffic alone
+can open it and place reads that never failed into this outcome. A `503` carrying
+`Retry-After`, and the single breaker-opened entry in the API's logs, are what
+confirm it.
+
 ## Aggregation Intent
 
 - **`requests`** — rate, sliced by `outcome`. This is the primary health view:
@@ -145,7 +156,9 @@ measuring how long the client waited before giving up.
   client is sending parameters the API refuses, not that the API is unhealthy.
   Read that denominator as counted traffic rather than as every request the
   route received. Exactly two classes are counted: a request paging validation
-  refused, and a request that reached backend execution. A request the API
+  refused, and a request that reached its handler. The second is stated as the
+  handler rather than the database on purpose: a request the circuit breaker
+  refused is counted, and it never reached the database. A request the API
   answers anywhere else is not counted on any of these instruments, and that
   class straddles paging validation rather than sitting in front of it. Part of
   it is settled first — an unknown resource, a rejected profile or media type.
@@ -160,17 +173,19 @@ measuring how long the client waited before giving up.
   `command_category`. Keep `page_with_count` in its own bucket: requesting a
   total count is expected to be the slow shape, and averaging it together with
   plain pages hides both. Exclude `command_category=none` from read-latency
-  objectives, and watch it as a series of its own rather than as a fast
-  remainder. That bucket holds two unlike populations: a skipped selection,
-  which issued no selection command — it may still have issued a reference
-  lookup to establish that it had nothing to select, so it is cheaper than a
-  served page rather than free — and every failure, whose command may or may
-  not have run. `retry_exhausted` is the
-  extreme — a retryable condition that survived the whole retry pipeline — and
-  it carries the slowest samples this instrument records. Mixed into the `page`,
-  `page_with_count`, and `boundary` shapes, the two pull the percentiles in
-  opposite directions, and neither movement describes the cost of serving a
-  page.
+  objectives, and watch it as a series of its own — sliced by `outcome`, because
+  it holds unlike populations. A skipped selection issued no selection command;
+  it may still have issued a reference lookup to establish that it had nothing
+  to select, so it is cheaper than a served page rather than free. Every failure
+  is here too, and its command may or may not have run. The two extremes both
+  arrive in bulk and sit at opposite ends: `retry_exhausted` is a retryable
+  condition that survived the whole retry pipeline and carries the slowest
+  samples this instrument records, while `execution_exception` under an open
+  circuit breaker is refused before reaching the database and carries the
+  fastest, for every request over the whole break duration. Mixed into the
+  `page`, `page_with_count`, and `boundary` shapes, these pull the percentiles
+  in opposing directions, and no movement among them describes the cost of
+  serving a page.
 - **`page_size.requested` vs `page_size.returned`** — compare the two
   distributions, excluding `command_category=none` from both sides as the
   latency objectives do. A persistent gap in what remains means pages are being

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -44,7 +44,7 @@ receives nothing from these instruments no matter how it is configured.
 | Instrument | Type | Unit | Recorded for |
 |---|---|---|---|
 | `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every classified request, including those refused by parameter validation |
-| `edfi.dms.collection_paging.duration` | Histogram | `ms` | Requests that reached the database, so a refused request never contributes a microsecond-scale sample |
+| `edfi.dms.collection_paging.duration` | Histogram | `ms` | Every request where backend execution was attempted, so a request refused by parameter validation never contributes a microsecond-scale sample |
 | `edfi.dms.collection_paging.page_size.requested` | Histogram | `{item}` | Collection `GET` requests |
 | `edfi.dms.collection_paging.page_size.returned` | Histogram | `{item}` | Collection `GET` requests that produced a page |
 | `edfi.dms.collection_paging.partition_count.requested` | Histogram | `{partition}` | `partitions` requests |
@@ -100,7 +100,7 @@ is `unknown` only when the request was answered before the engine was resolved.
 |---|---|
 | `success` | A page or a boundary set was produced. Also covers a page served with documents that carries no continuation token, and a `partitions` request whose boundary command ran and found no ranges. |
 | `terminal_page` | A collection `GET` that **ends a cursor walk**: a continuation was possible for this page and none could be produced, so nothing follows it. Never reported for `partitions`, which has no successor to offer. |
-| `early_empty` | An empty result the API answered without issuing any selection command, so no database work was done. |
+| `early_empty` | An empty result the API answered without issuing any selection command. Selection is the work this skips; a request that also validates a custom view still issues that command first. |
 | `validation_rejected` | Parameter validation answered the request: a paging, partition-count, change-version, or resource-filter parameter was refused. |
 | `not_authorized` | Namespace authorization denied the request. |
 | `not_implemented` | The operation is intentionally unavailable for that resource. |
@@ -132,7 +132,10 @@ measuring how long the client waited before giving up.
 - **`duration`** — p50, p95, and p99, sliced by `paging_mode` and
   `command_category`. Keep `page_with_count` in its own bucket: requesting a
   total count is expected to be the slow shape, and averaging it together with
-  plain pages hides both.
+  plain pages hides both. Exclude `command_category=none` from read-latency
+  objectives: those samples time a backend attempt that issued no selection
+  command, so they are fast by construction and pull the percentiles of the
+  `page`, `page_with_count`, and `boundary` shapes down if mixed in.
 - **`page_size.requested` vs `page_size.returned`** — compare the two
   distributions. A persistent gap means pages are being trimmed after
   selection, either by authorization or by documents deleted between selection

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -43,7 +43,7 @@ receives nothing from these instruments no matter how it is configured.
 
 | Instrument | Type | Unit | Recorded for |
 |---|---|---|---|
-| `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every classified request, including those refused by parameter validation |
+| `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every collection read that reached paging validation, including those refused by it |
 | `edfi.dms.collection_paging.duration` | Histogram | `ms` | Every request where backend execution was attempted, so a request refused by parameter validation never contributes a microsecond-scale sample |
 | `edfi.dms.collection_paging.page_size.requested` | Histogram | `{item}` | Collection `GET` requests |
 | `edfi.dms.collection_paging.page_size.returned` | Histogram | `{item}` | Collection `GET` requests that produced a page |
@@ -102,7 +102,7 @@ is `unknown` only when the request was answered before the engine was resolved.
 | `terminal_page` | A collection `GET` that **ends a cursor walk**: a continuation was possible for this page and none could be produced, so nothing follows it. Never reported for `partitions`, which has no successor to offer. |
 | `early_empty` | An empty result the API answered without issuing any selection command. Selection is the work this skips; a request that also validates a custom view still issues that command first. |
 | `validation_rejected` | Parameter validation answered the request: a paging, partition-count, change-version, or resource-filter parameter was refused. |
-| `not_authorized` | Namespace authorization denied the request. |
+| `not_authorized` | Namespace authorization denied the request. A client whose claim set does not authorize reading the resource at all is refused earlier and is not counted; see the `requests` note under [Aggregation Intent](#aggregation-intent). |
 | `not_implemented` | The operation is intentionally unavailable for that resource. |
 | `security_configuration` | The security configuration metadata for the request is invalid. |
 | `retry_exhausted` | A retryable condition survived the retry pipeline. |
@@ -126,9 +126,17 @@ measuring how long the client waited before giving up.
 ## Aggregation Intent
 
 - **`requests`** — rate, sliced by `outcome`. This is the primary health view:
-  watch `validation_rejected` and the failure outcomes as a share of total
+  watch `validation_rejected` and the failure outcomes as a share of counted
   collection-read traffic. A rising `validation_rejected` share usually means a
   client is sending parameters the API refuses, not that the API is unhealthy.
+  Read that denominator as counted traffic rather than as every request the
+  route received. A request the API answers before it validates paging
+  parameters is not counted on any of these instruments — an unknown resource,
+  a rejected profile or media type, a failed authentication, or a client whose
+  claim set does not authorize reading the resource at all. A collection-read
+  rate that falls with no matching rise in any failure outcome is the signature
+  of that class of refusal, and the API's request logs rather than these
+  metrics are where it is diagnosed.
 - **`duration`** — p50, p95, and p99, sliced by `paging_mode` and
   `command_category`. Keep `page_with_count` in its own bucket: requesting a
   total count is expected to be the slow shape, and averaging it together with

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -45,14 +45,20 @@ receives nothing from these instruments no matter how it is configured.
 |---|---|---|---|
 | `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every collection read that reached paging validation, including those refused by it |
 | `edfi.dms.collection_paging.duration` | Histogram | `ms` | Every request where backend execution was attempted, so a request refused by parameter validation never contributes a microsecond-scale sample |
-| `edfi.dms.collection_paging.page_size.requested` | Histogram | `{item}` | Collection `GET` requests |
-| `edfi.dms.collection_paging.page_size.returned` | Histogram | `{item}` | Collection `GET` requests that produced a page |
-| `edfi.dms.collection_paging.partition_count.requested` | Histogram | `{partition}` | `partitions` requests |
-| `edfi.dms.collection_paging.partition_count.returned` | Histogram | `{partition}` | `partitions` requests that produced a boundary set |
+| `edfi.dms.collection_paging.page_size.requested` | Histogram | `{item}` | Collection `GET` requests that reached execution |
+| `edfi.dms.collection_paging.page_size.returned` | Histogram | `{item}` | Collection `GET` requests that produced a page, an empty one included |
+| `edfi.dms.collection_paging.partition_count.requested` | Histogram | `{partition}` | `partitions` requests that reached execution |
+| `edfi.dms.collection_paging.partition_count.returned` | Histogram | `{partition}` | `partitions` requests that produced a boundary set, an empty one included |
 
 The page-size instruments are never recorded for a `partitions` request, and the
 partition-count instruments are never recorded for a collection `GET`, so
 neither histogram mixes two units of measure.
+
+A request refused by parameter validation records no size or count on any of the
+four, because the size it asked for may be the value that was refused. It is
+still counted on `requests`. A request that failed records the size it asked for
+but nothing on the returned instruments, so a failure never contributes a zero
+to a distribution of page sizes actually served.
 
 ## Dimensions
 
@@ -145,15 +151,22 @@ measuring how long the client waited before giving up.
   command, so they are fast by construction and pull the percentiles of the
   `page`, `page_with_count`, and `boundary` shapes down if mixed in.
 - **`page_size.requested` vs `page_size.returned`** — compare the two
-  distributions. A persistent gap means pages are being trimmed after
-  selection, either by authorization or by documents deleted between selection
-  and retrieval.
+  distributions, excluding `command_category=none` from both sides as the
+  latency objectives do. A persistent gap in what remains means pages are being
+  trimmed after selection, either by authorization or by documents deleted
+  between selection and retrieval. Left in, the `none` samples manufacture a gap
+  that is not trimming at all: an `early_empty` request reports the page size it
+  asked for against a returned zero, because it answered without selecting
+  anything. It is the only outcome in that category that reaches a returned
+  instrument — failures record no returned size — so the one filter removes
+  exactly the skipped selections.
 - **`partition_count.requested` vs `partition_count.returned`** — compare the
-  two distributions. A persistent gap means the collection is too small to be
-  cut into as many partitions as clients ask for: the requested count is an
-  upper bound, and a minimum partition size reduces it. This is normal for
-  small collections and is only worth investigating if it appears on
-  collections large enough to partition.
+  two distributions, excluding `command_category=none` for the same reason. A
+  persistent gap in what remains means the collection is too small to be cut
+  into as many partitions as clients ask for: the requested count is an upper
+  bound, and a minimum partition size reduces it. This is normal for small
+  collections and is only worth investigating if it appears on collections large
+  enough to partition.
 
 ## What Is Never Recorded
 

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -43,7 +43,7 @@ receives nothing from these instruments no matter how it is configured.
 
 | Instrument | Type | Unit | Recorded for |
 |---|---|---|---|
-| `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every collection read that reached paging validation, including those refused by it |
+| `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every collection read paging validation refused, plus every one that reached backend execution. Clearing paging validation is not on its own enough — see [Aggregation Intent](#aggregation-intent) |
 | `edfi.dms.collection_paging.duration` | Histogram | `ms` | Every request where backend execution was attempted, so a request refused by parameter validation never contributes a microsecond-scale sample |
 | `edfi.dms.collection_paging.page_size.requested` | Histogram | `{item}` | Collection `GET` requests that reached execution |
 | `edfi.dms.collection_paging.page_size.returned` | Histogram | `{item}` | Collection `GET` requests that produced a page, an empty one included |
@@ -108,7 +108,7 @@ is `unknown` only when the request was answered before the engine was resolved.
 | `terminal_page` | A collection `GET` that **ends a cursor walk**: a continuation was possible for this page and none could be produced, so nothing follows it. Never reported for `partitions`, which has no successor to offer. |
 | `early_empty` | An empty result the API answered without issuing any selection command. Selection is the work this skips; a request that also validates a custom view still issues that command first. |
 | `validation_rejected` | Parameter validation answered the request: a paging, partition-count, change-version, or resource-filter parameter was refused. |
-| `not_authorized` | Namespace authorization denied the request. A client whose claim set does not authorize reading the resource at all is refused earlier and is not counted; see the `requests` note under [Aggregation Intent](#aggregation-intent). |
+| `not_authorized` | Namespace authorization denied the request. A client whose claim set does not authorize reading the resource at all is refused before backend execution begins and is not counted at all; see the `requests` note under [Aggregation Intent](#aggregation-intent). |
 | `not_implemented` | The operation is intentionally unavailable for that resource. |
 | `security_configuration` | The security configuration metadata for the request is invalid. |
 | `retry_exhausted` | A retryable condition survived the retry pipeline. |
@@ -136,13 +136,18 @@ measuring how long the client waited before giving up.
   collection-read traffic. A rising `validation_rejected` share usually means a
   client is sending parameters the API refuses, not that the API is unhealthy.
   Read that denominator as counted traffic rather than as every request the
-  route received. A request the API answers before it validates paging
-  parameters is not counted on any of these instruments — an unknown resource,
-  a rejected profile or media type, a failed authentication, or a client whose
-  claim set does not authorize reading the resource at all. A collection-read
-  rate that falls with no matching rise in any failure outcome is the signature
-  of that class of refusal, and the API's request logs rather than these
-  metrics are where it is diagnosed.
+  route received. Exactly two classes are counted: a request paging validation
+  refused, and a request that reached backend execution. A request the API
+  answers anywhere else is not counted on any of these instruments, and that
+  class straddles paging validation rather than sitting in front of it. Part of
+  it is settled first — an unknown resource, a rejected profile or media type.
+  The rest is settled *after* paging validation has already passed the request:
+  a failed authentication, a client whose claim set does not authorize reading
+  the resource at all, or an error raised while authorizing. So neither
+  reaching paging validation nor clearing it is on its own enough to be
+  counted. A collection-read rate that falls with no matching rise in any
+  failure outcome is the signature of that whole class of refusal, and the
+  API's request logs rather than these metrics are where it is diagnosed.
 - **`duration`** — p50, p95, and p99, sliced by `paging_mode` and
   `command_category`. Keep `page_with_count` in its own bucket: requesting a
   total count is expected to be the slow shape, and averaging it together with

--- a/docs/PAGING-TELEMETRY.md
+++ b/docs/PAGING-TELEMETRY.md
@@ -1,0 +1,162 @@
+# Collection Paging Telemetry
+
+The Ed-Fi API publishes metrics for the three shapes a collection read can take:
+
+- **Traditional paging** — a collection `GET` using `limit` and `offset`.
+- **Cursor paging** — a collection `GET` using `pageToken` and `pageSize`.
+- **Partition planning** — a `GET` on a collection's `partitions` path, which
+  returns one page token per partition instead of documents.
+
+The metrics describe those reads only. They add no database work, and they
+change no status code, header, or response body.
+
+Regular resources and descriptors report through one shared contract. Their
+execution semantics are equivalent, so no metric name and no dimension value
+distinguishes the two.
+
+## Collecting These Metrics
+
+The meter name is:
+
+```text
+EdFi.DataManagementService.CollectionPaging
+```
+
+**Collecting these metrics requires an in-process metrics pipeline in the API
+host.** The API publishes .NET `Meter` instruments. It exports *logs* over OTLP
+through the `OtlpLogging` configuration section (see
+[Logging Policy](./LOGGING.md#otlp-export)), but it registers no meter provider,
+so out of the box nothing observes these instruments and nothing is collected.
+
+To collect them, the host process must run a meter provider that subscribes to
+the meter above by name — with the OpenTelemetry .NET SDK, that is an `AddMeter`
+call naming `EdFi.DataManagementService.CollectionPaging` — and then export from
+that pipeline to the metrics backend of choice.
+
+**Deploying an OpenTelemetry Collector alone does not work.** .NET `Meter`
+instruments are observable only inside the process that publishes them. A
+Collector is an export *destination* for an in-process pipeline, not a way to
+observe the instruments; with no meter provider in the host, a Collector
+receives nothing from these instruments no matter how it is configured.
+
+## Instruments
+
+| Instrument | Type | Unit | Recorded for |
+|---|---|---|---|
+| `edfi.dms.collection_paging.requests` | Counter | `{request}` | Every classified request, including those refused by parameter validation |
+| `edfi.dms.collection_paging.duration` | Histogram | `ms` | Requests that reached the database, so a refused request never contributes a microsecond-scale sample |
+| `edfi.dms.collection_paging.page_size.requested` | Histogram | `{item}` | Collection `GET` requests |
+| `edfi.dms.collection_paging.page_size.returned` | Histogram | `{item}` | Collection `GET` requests that produced a page |
+| `edfi.dms.collection_paging.partition_count.requested` | Histogram | `{partition}` | `partitions` requests |
+| `edfi.dms.collection_paging.partition_count.returned` | Histogram | `{partition}` | `partitions` requests that produced a boundary set |
+
+The page-size instruments are never recorded for a `partitions` request, and the
+partition-count instruments are never recorded for a collection `GET`, so
+neither histogram mixes two units of measure.
+
+## Dimensions
+
+All four dimensions are present on every measurement, and each carries only the
+values listed here.
+
+| Dimension | Allowed values |
+|---|---|
+| `paging_mode` | `traditional`, `cursor`, `partition` |
+| `command_category` | `page`, `page_with_count`, `boundary`, `none` |
+| `provider` | `postgresql`, `sqlserver`, `unknown` |
+| `outcome` | `success`, `terminal_page`, `early_empty`, `validation_rejected`, `not_authorized`, `not_implemented`, `security_configuration`, `retry_exhausted`, `unknown_failure`, `execution_exception` |
+
+That is at most 360 dimension combinations. The set actually reachable is far
+smaller, because most combinations describe states that cannot occur together.
+
+### `command_category`
+
+The shape of the database command a served result was built around:
+
+- `page` — a collection `GET` that selected a page.
+- `page_with_count` — a collection `GET` that also compiled a total count into
+  the same command, which is the more expensive shape.
+- `boundary` — a `partitions` request that selected partition boundaries.
+- `none` — **every other outcome**: every failure, every request refused by
+  parameter validation, and every request answered without issuing a selection
+  command at all.
+
+The uniform `none` rule is deliberate. For most failures the API cannot
+establish whether a selection command ran — some are resolved before a command
+is ever planned, and others can arise either before or after one — so
+attributing a command shape, and therefore a duration, to a request that may
+never have issued that command would be misleading. `paging_mode` still
+separates traditional, cursor, and partition traffic for failures, so no slice
+an operator needs is lost.
+
+### `provider`
+
+The database engine that answered the request: `postgresql` or `sqlserver`. It
+is `unknown` only when the request was answered before the engine was resolved.
+
+### `outcome`
+
+| Value | Meaning |
+|---|---|
+| `success` | A page or a boundary set was produced. Also covers a page served with documents that carries no continuation token, and a `partitions` request whose boundary command ran and found no ranges. |
+| `terminal_page` | A collection `GET` that **ends a cursor walk**: a continuation was possible for this page and none could be produced, so nothing follows it. Never reported for `partitions`, which has no successor to offer. |
+| `early_empty` | An empty result the API answered without issuing any selection command, so no database work was done. |
+| `validation_rejected` | Parameter validation answered the request: a paging, partition-count, change-version, or resource-filter parameter was refused. |
+| `not_authorized` | Namespace authorization denied the request. |
+| `not_implemented` | The operation is intentionally unavailable for that resource. |
+| `security_configuration` | The security configuration metadata for the request is invalid. |
+| `retry_exhausted` | A retryable condition survived the retry pipeline. |
+| `unknown_failure` | The database returned a failure the API could not classify. |
+| `execution_exception` | An exception escaped execution. The exception itself still propagates and is reported unchanged. |
+
+Two distinctions are worth knowing when reading these values.
+
+**`success` is not the same as "a continuation was offered."** A traditional
+page inside a bounded change-version window is ordered so that it cannot anchor
+a cursor continuation. It is served with documents, and a client keeps paging it
+with `limit` and `offset`. Such a page is `success`, never `terminal_page`:
+reporting it as terminal would say a healthy paging walk had ended.
+
+**Client disconnects are not an outcome and are not recorded.** When a client
+cancels a request in flight, nothing is emitted on any instrument. A disconnect
+is the absence of a completed collection read rather than a kind of one, and
+counting it would report client behavior as backend failure with a duration
+measuring how long the client waited before giving up.
+
+## Aggregation Intent
+
+- **`requests`** — rate, sliced by `outcome`. This is the primary health view:
+  watch `validation_rejected` and the failure outcomes as a share of total
+  collection-read traffic. A rising `validation_rejected` share usually means a
+  client is sending parameters the API refuses, not that the API is unhealthy.
+- **`duration`** — p50, p95, and p99, sliced by `paging_mode` and
+  `command_category`. Keep `page_with_count` in its own bucket: requesting a
+  total count is expected to be the slow shape, and averaging it together with
+  plain pages hides both.
+- **`page_size.requested` vs `page_size.returned`** — compare the two
+  distributions. A persistent gap means pages are being trimmed after
+  selection, either by authorization or by documents deleted between selection
+  and retrieval.
+- **`partition_count.requested` vs `partition_count.returned`** — compare the
+  two distributions. A persistent gap means the collection is too small to be
+  cut into as many partitions as clients ask for: the requested count is an
+  upper bound, and a minimum partition size reduces it. This is normal for
+  small collections and is only worth investigating if it appears on
+  collections large enough to partition.
+
+## What Is Never Recorded
+
+Every dimension value is drawn from the fixed lists above. Nothing derived from
+a request becomes a metric dimension. In particular, these never appear:
+
+- Resource or descriptor names, and no dimension distinguishing the two.
+- Tenant keys, instance identifiers, or namespaces.
+- Client identity, claims, or authorization details.
+- Query filter names and filter values.
+- Page token text, and the range bounds a page token decodes to.
+- Document or candidate identifiers.
+- Exception messages, types, or stack traces.
+
+This keeps the metric bounded by construction: the number of distinct dimension
+combinations cannot grow with traffic, with the size of the data, or with the
+number of clients.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
@@ -3515,7 +3515,7 @@ public class Given_A_Mssql_Relational_Query_Authorization_With_The_Authoritative
             totalCount: true
         );
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         _context.AssertNoHydration();
     }
 
@@ -4806,7 +4806,7 @@ public class Given_A_Mssql_Relational_Query_Authorization_With_Anchored_Person_P
             RelationshipAuthorizationCrudTestSupport.StudentsOnlyStrategyNames
         );
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         _context.AssertNoHydration();
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryAuthorizationTests.cs
@@ -2930,7 +2930,7 @@ public class Given_A_Postgresql_Relational_Query_Authorization_With_The_Authorit
             totalCount: true
         );
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         _context.AssertNoHydration();
     }
 
@@ -4041,7 +4041,7 @@ public class Given_A_Postgresql_Relational_Query_Authorization_With_Anchored_Per
             RelationshipAuthorizationCrudTestSupport.StudentsOnlyStrategyNames
         );
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         _context.AssertNoHydration();
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.Partitions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.Partitions.cs
@@ -90,7 +90,36 @@ public partial class Given_DescriptorReadHandler
 
         var result = await sut.HandlePartitionsAsync(CreatePartitionRequest(SqlDialect.Pgsql));
 
-        result.Should().BeOfType<PartitionResult.PartitionSuccess>().Which.Ranges.Should().BeEmpty();
+        var success = result.Should().BeOfType<PartitionResult.PartitionSuccess>().Subject;
+
+        success.Ranges.Should().BeEmpty();
+
+        // The boundary command ran and found no starts, so this empty result is executed rather than
+        // short-circuited.
+        success.SelectionSkipped.Should().BeFalse();
+        commandExecutor.Commands.Should().ContainSingle();
+    }
+
+    // Preprocessing proves an id filter cannot name a descriptor before a boundary statement is built,
+    // so the request costs no command and reports as a skipped selection.
+    [Test]
+    public async Task It_returns_no_ranges_without_a_command_when_preprocessing_proves_the_id_filter_matches_nothing()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateHandler(commandExecutor);
+
+        var result = await sut.HandlePartitionsAsync(
+            CreatePartitionRequest(
+                SqlDialect.Pgsql,
+                queryElements: [new QueryElement("id", [new JsonPath("$.id")], "not-a-guid", "string")]
+            )
+        );
+
+        var success = result.Should().BeOfType<PartitionResult.PartitionSuccess>().Subject;
+
+        success.Ranges.Should().BeEmpty();
+        success.SelectionSkipped.Should().BeTrue();
+        commandExecutor.Commands.Should().BeEmpty();
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -1451,6 +1451,7 @@ public partial class Given_DescriptorReadHandler
         var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
         success.EdfiDocs.Should().BeEmpty();
         success.TotalCount.Should().Be(totalCount ? 0 : null);
+        success.SelectionSkipped.Should().BeTrue();
         selectionResult.Should().BeOfType<DocumentCacheReadAccelerationQuerySelectionResult.Complete>();
         commandExecutor.Commands.Should().BeEmpty();
         A.CallTo(() =>
@@ -1510,6 +1511,10 @@ public partial class Given_DescriptorReadHandler
         var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
         success.EdfiDocs.Should().BeEmpty();
         success.TotalCount.Should().Be(totalCount ? 7 : null);
+
+        // The candidate command executed and selected nothing. An empty body alone must never be read as
+        // a skipped selection, or a normal empty page would be reported as costing no database work.
+        success.SelectionSkipped.Should().BeFalse();
         selectionResult.Should().BeOfType<DocumentCacheReadAccelerationQuerySelectionResult.Complete>();
         RelationalCommand command = commandExecutor.Commands.Should().ContainSingle().Subject;
         AssertDescriptorCandidateCommandOmitsBodyColumns(command);
@@ -1629,6 +1634,7 @@ public partial class Given_DescriptorReadHandler
 
         var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
         success.EdfiDocs.Should().BeEmpty();
+        success.SelectionSkipped.Should().BeTrue();
         commandExecutor
             .Commands.Select(command => command.CommandText)
             .Should()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -2056,6 +2056,78 @@ public partial class Given_DescriptorReadHandler
             .Be(new PageContinuationBoundary(205L, AllowsDocumentIdContinuation: false));
     }
 
+    // An accelerated selection that returned no rows still ran under an ordering, so it answers the
+    // continuation question the same way a non-empty one does. Left on the permissive default, an empty
+    // windowed page would tell Core a walk had ended that could never have been continued at all.
+    [Test]
+    public async Task It_withholds_continuation_from_an_empty_windowed_descriptor_candidate_selection()
+    {
+        var capturedSuccess = await SelectEmptyDescriptorCandidatePageAsync(
+            new ChangeVersionRange(null, 900L)
+        );
+
+        capturedSuccess.EdfiDocs.Should().BeEmpty();
+        capturedSuccess.HighestSelectedDocumentId.Should().BeNull();
+        capturedSuccess.AllowsDocumentIdContinuation.Should().BeFalse();
+    }
+
+    // The unwindowed page really is ordered by DocumentId, so an empty selection there ends the walk.
+    // Withholding continuation from every empty page would erase that distinction.
+    [Test]
+    public async Task It_keeps_continuation_for_an_empty_unwindowed_descriptor_candidate_selection()
+    {
+        var capturedSuccess = await SelectEmptyDescriptorCandidatePageAsync(changeVersionRange: null);
+
+        capturedSuccess.EdfiDocs.Should().BeEmpty();
+        capturedSuccess.HighestSelectedDocumentId.Should().BeNull();
+        capturedSuccess.AllowsDocumentIdContinuation.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Drives the read-acceleration path to a candidate selection that returns no rows and hands back
+    /// the short-circuit success the selection completed with.
+    /// </summary>
+    private static async Task<QueryResult.QuerySuccess> SelectEmptyDescriptorCandidatePageAsync(
+        ChangeVersionRange? changeVersionRange
+    )
+    {
+        var readAccelerationCoordinator = A.Fake<IDocumentCacheReadAccelerationCoordinator>();
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        QueryResult.QuerySuccess capturedSuccess = null!;
+
+        A.CallTo(() =>
+                readAccelerationCoordinator.QueryAsync(
+                    A<DocumentCacheReadAccelerationQueryRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .ReturnsLazily(async call =>
+            {
+                var request = call.GetArgument<DocumentCacheReadAccelerationQueryRequest>(0)!;
+                var selectionResult = await request
+                    .SelectAuthorizedCandidatePage(call.GetArgument<CancellationToken>(1))
+                    .ConfigureAwait(false);
+                capturedSuccess = selectionResult
+                    .Should()
+                    .BeOfType<DocumentCacheReadAccelerationQuerySelectionResult.Complete>()
+                    .Which.Result.Should()
+                    .BeOfType<QueryResult.QuerySuccess>()
+                    .Subject;
+
+                return capturedSuccess;
+            });
+
+        var sut = CreateHandler(commandExecutor, readAccelerationCoordinator: readAccelerationCoordinator);
+
+        await sut.HandleQueryAsync(
+            CreateQueryRequest(SqlDialect.Pgsql, changeVersionRange: changeVersionRange)
+        );
+
+        return capturedSuccess;
+    }
+
     [Test]
     public async Task It_wraps_a_provider_error_raised_by_descriptor_custom_view_selected_page_fallback()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DocumentCacheReadResponseShaperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DocumentCacheReadResponseShaperTests.cs
@@ -217,6 +217,10 @@ public class Given_DocumentCacheReadResponseShaper
         success.TotalCount.Should().Be(7);
         success.HighestSelectedDocumentId.Should().Be(346);
         success.AllowsDocumentIdContinuation.Should().BeTrue();
+
+        // A page answered from cache still selected its candidates with a command, so it reports the same
+        // selection fact the relational path would.
+        success.SelectionSkipped.Should().BeFalse();
         success
             .EdfiDocs.Select(document => document!["name"]!.GetValue<string>())
             .Should()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.Partitions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.Partitions.cs
@@ -62,7 +62,14 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryPartitions(partitionRequest);
 
-        result.Should().BeOfType<PartitionResult.PartitionSuccess>().Which.Ranges.Should().BeEmpty();
+        var success = result.Should().BeOfType<PartitionResult.PartitionSuccess>().Subject;
+
+        success.Ranges.Should().BeEmpty();
+
+        // The boundary command ran and found no starts, so this empty result is executed rather than
+        // short-circuited. Classifying it by shape alone would report a real boundary calculation as
+        // having done no database work.
+        success.SelectionSkipped.Should().BeFalse();
         _capturedPartitionCommands.Should().ContainSingle();
     }
 
@@ -229,7 +236,39 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryPartitions(partitionRequest);
 
-        result.Should().BeOfType<PartitionResult.PartitionSuccess>().Which.Ranges.Should().BeEmpty();
+        var success = result.Should().BeOfType<PartitionResult.PartitionSuccess>().Subject;
+
+        success.Ranges.Should().BeEmpty();
+        success.SelectionSkipped.Should().BeTrue();
+        _capturedPartitionCommands.Should().BeEmpty();
+    }
+
+    // Preprocessing proves an id filter cannot name a document before planning is even reached, which is
+    // the earliest of the partition short-circuits. It must cost no command and report as skipped.
+    [Test]
+    public async Task It_returns_no_ranges_without_a_command_when_preprocessing_proves_the_id_filter_matches_nothing()
+    {
+        var partitionRequest = CreatePartitionRequest(
+            CreateQuerySupportedMappingSet(
+                _schoolResourceInfo,
+                CreateSupportedQueryField(
+                    "id",
+                    "$.id",
+                    "string",
+                    new RelationalQueryFieldTarget.DocumentUuid()
+                )
+            ),
+            queryElements: [CreateQueryElement("id", "$.id", "not-a-guid", "string")]
+        );
+
+        StubPartitionBoundaryStarts();
+
+        var result = await _sut.QueryPartitions(partitionRequest);
+
+        var success = result.Should().BeOfType<PartitionResult.PartitionSuccess>().Subject;
+
+        success.Ranges.Should().BeEmpty();
+        success.SelectionSkipped.Should().BeTrue();
         _capturedPartitionCommands.Should().BeEmpty();
     }
 
@@ -254,7 +293,13 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryPartitions(partitionRequest);
 
-        result.Should().BeOfType<PartitionResult.PartitionSuccess>().Which.Ranges.Should().BeEmpty();
+        var success = result.Should().BeOfType<PartitionResult.PartitionSuccess>().Subject;
+
+        success.Ranges.Should().BeEmpty();
+
+        // The skip happens inside the shared authorization resolution, which answers in QueryResult, so
+        // this also proves the flag survives the query-to-partition restatement.
+        success.SelectionSkipped.Should().BeTrue();
         _capturedPartitionCommands.Should().BeEmpty();
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -5024,6 +5024,10 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
         success.HighestSelectedDocumentId.Should().Be(2509L);
         success.EdfiDocs.Should().BeEmpty();
+
+        // Selection ran and chose a keyset; only hydration came back empty. Reporting this as a skipped
+        // selection would claim no database work was done for a page that issued its command.
+        success.SelectionSkipped.Should().BeFalse();
     }
 
     // A traditional page over a max-bearing change-version window is ordered by ContentVersion, so its
@@ -5306,6 +5310,9 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         success.EdfiDocs.Should().BeEmpty();
         success.TotalCount.Should().Be(0);
+
+        // Planning proved the value cannot match, so no selection command was built.
+        success.SelectionSkipped.Should().BeTrue();
         A.CallTo(() =>
                 _documentHydrator.HydrateAsync(
                     A<ResourceReadPlan>._,
@@ -5496,7 +5503,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         A.CallTo(() =>
                 _documentHydrator.HydrateAsync(
                     A<ResourceReadPlan>._,
@@ -5537,7 +5544,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         A.CallTo(() =>
                 _documentHydrator.HydrateAsync(
                     A<ResourceReadPlan>._,
@@ -6034,7 +6041,11 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], totalCount ? 0 : null));
+        result
+            .Should()
+            .BeEquivalentTo(
+                new QueryResult.QuerySuccess([], totalCount ? 0 : null) { SelectionSkipped = true }
+            );
         A.CallTo(() => _referenceResolver.ResolveAsync(A<ReferenceResolverRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
         A.CallTo(() =>
@@ -6894,7 +6905,11 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], totalCount ? 0 : null));
+        result
+            .Should()
+            .BeEquivalentTo(
+                new QueryResult.QuerySuccess([], totalCount ? 0 : null) { SelectionSkipped = true }
+            );
         capturedValidationSql
             .Should()
             .ContainSingle(sql =>
@@ -6936,7 +6951,11 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], totalCount ? 0 : null));
+        result
+            .Should()
+            .BeEquivalentTo(
+                new QueryResult.QuerySuccess([], totalCount ? 0 : null) { SelectionSkipped = true }
+            );
         A.CallTo(() => _referenceResolver.ResolveAsync(A<ReferenceResolverRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
         A.CallTo(() =>
@@ -7744,7 +7763,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         capturedValidationSql
             .Should()
             .ContainSingle(sql =>
@@ -7799,7 +7818,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         capturedValidationSql
             .Should()
             .ContainSingle(sql =>
@@ -8376,7 +8395,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], null));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], null) { SelectionSkipped = true });
         A.CallTo(() =>
                 _documentHydrator.HydrateAsync(
                     A<ResourceReadPlan>._,
@@ -8442,7 +8461,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], null));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], null) { SelectionSkipped = true });
         A.CallTo(() =>
                 _documentHydrator.HydrateAsync(
                     A<ResourceReadPlan>._,
@@ -8604,7 +8623,11 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], totalCount ? 0 : null));
+        result
+            .Should()
+            .BeEquivalentTo(
+                new QueryResult.QuerySuccess([], totalCount ? 0 : null) { SelectionSkipped = true }
+            );
         readAccelerationCoordinator.QueryAttempts.Should().Be(1);
         readAccelerationCoordinator.SelectedQueryRequest.Should().BeNull();
         readAccelerationCoordinator.SelectedQueryCandidatePage.Should().BeNull();
@@ -8685,6 +8708,9 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
+        // The candidate command executed and matched nothing, which is not the same fact as a
+        // short-circuit that issued no command at all. The default false on the expected result is the
+        // assertion; without it a shape-based classification of this page would go unnoticed.
         result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], totalCount ? 7 : null));
         readAccelerationCoordinator.QueryAttempts.Should().Be(1);
         readAccelerationCoordinator.SelectedQueryRequest.Should().BeNull();
@@ -8750,7 +8776,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.QueryDocuments(queryRequest);
 
-        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0));
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], 0) { SelectionSkipped = true });
         A.CallTo(() => _referenceResolver.ResolveAsync(A<ReferenceResolverRequest>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalPartitionResultMappingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalPartitionResultMappingTests.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// The query-to-partition restatement of shared read-path outcomes.
+/// </summary>
+/// <remarks>
+/// Exercised directly rather than only through the repository because this is the single seam where a
+/// query outcome becomes a partition one, so a fact dropped here is dropped for every partition request
+/// that reaches the shared capability, authorization, or budget path.
+/// </remarks>
+[TestFixture]
+public class Given_RelationalPartitionResultMapping
+{
+    // Whether a selection command was issued is a fact about the request, not about the result shape, so
+    // it has to survive the restatement in both directions. If only the true case were covered, a
+    // mapping that hardcoded true would pass.
+    [TestCase(true)]
+    [TestCase(false)]
+    public void It_carries_the_selection_skipped_fact_across_the_restatement(bool selectionSkipped)
+    {
+        var queryResult = new QueryResult.QuerySuccess([], null) { SelectionSkipped = selectionSkipped };
+
+        var result = RelationalPartitionResultMapping.FromQueryResult(queryResult);
+
+        var success = result.Should().BeOfType<PartitionResult.PartitionSuccess>().Subject;
+
+        success.Ranges.Should().BeEmpty();
+        success.SelectionSkipped.Should().Be(selectionSkipped);
+    }
+
+    // A shared empty success with a compiled total count still restates as an empty boundary set: the
+    // count describes the page contract the partition operation does not have.
+    [Test]
+    public void It_restates_a_total_count_bearing_empty_success_as_an_empty_executed_boundary_set()
+    {
+        var result = RelationalPartitionResultMapping.FromQueryResult(new QueryResult.QuerySuccess([], 0));
+
+        var success = result.Should().BeOfType<PartitionResult.PartitionSuccess>().Subject;
+
+        success.Ranges.Should().BeEmpty();
+        success.SelectionSkipped.Should().BeFalse();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -981,6 +981,9 @@ internal sealed class DescriptorReadHandler(
 
             return new DescriptorQueryPreparationResult.Complete(
                 new QueryResult.QuerySuccess([], request.Paging.IncludesTotalCount ? 0 : null)
+                {
+                    SelectionSkipped = true,
+                }
             );
         }
 
@@ -1215,7 +1218,7 @@ internal sealed class DescriptorReadHandler(
                 .ConfigureAwait(false);
 
             return new DescriptorPartitionPreparationResult.Complete(
-                new PartitionResult.PartitionSuccess([])
+                new PartitionResult.PartitionSuccess([]) { SelectionSkipped = true }
             );
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -580,6 +580,18 @@ internal sealed class DescriptorReadHandler(
 
         var rowsPage = (DescriptorQueryCandidateSelectionReadResult.CandidatePage)candidateReadResult;
 
+        // Resolved ahead of the empty check so both branches report the same continuation facts. A
+        // selection that returned nothing is still a selection that ran under an ordering, and a
+        // traditional page over a max-bearing change-version window cannot anchor a DocumentId
+        // continuation whether or not it selected rows. Deriving it in only the non-empty branch would
+        // leave the empty one on the permissive default and answer the same request differently from
+        // the regular-resource path.
+        var continuationBoundary = PageContinuationBoundary.For(
+            request.Paging,
+            _orderingPolicy.ResolveForLiveQuery(request.ChangeVersionRange),
+            SelectedMaximumOf(rowsPage.Page.Rows)
+        );
+
         if (rowsPage.Page.Rows.Count == 0)
         {
             QueryResult.QuerySuccess relationalSuccess = new(
@@ -590,19 +602,19 @@ internal sealed class DescriptorReadHandler(
                         rowsPage.Page.TotalCount,
                         "descriptor query"
                     )
-                    : null
-            );
+                    : null,
+                continuationBoundary.SelectedMaximum
+            )
+            {
+                AllowsDocumentIdContinuation = continuationBoundary.AllowsDocumentIdContinuation,
+            };
 
             return new DocumentCacheReadAccelerationQuerySelectionResult.Complete(relationalSuccess);
         }
 
         var candidatePage = CreateDescriptorReadAccelerationCandidatePage(
             rowsPage.Page,
-            PageContinuationBoundary.For(
-                request.Paging,
-                _orderingPolicy.ResolveForLiveQuery(request.ChangeVersionRange),
-                SelectedMaximumOf(rowsPage.Page.Rows)
-            ),
+            continuationBoundary,
             request.Paging.IncludesTotalCount
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -1363,6 +1363,9 @@ public sealed class RelationalDocumentStoreRepository(
 
             return new RelationalQueryPreparationResult.Complete(
                 new QueryResult.QuerySuccess([], queryRequest.Paging.IncludesTotalCount ? 0 : null)
+                {
+                    SelectionSkipped = true,
+                }
             );
         }
 
@@ -1417,6 +1420,9 @@ public sealed class RelationalDocumentStoreRepository(
 
                 return new RelationalQueryPreparationResult.Complete(
                     new QueryResult.QuerySuccess([], queryRequest.Paging.IncludesTotalCount ? 0 : null)
+                    {
+                        SelectionSkipped = true,
+                    }
                 );
             }
         }
@@ -1676,7 +1682,7 @@ public sealed class RelationalDocumentStoreRepository(
                 )
                 .ConfigureAwait(false);
 
-            return PartitionComplete(new PartitionResult.PartitionSuccess([]));
+            return PartitionComplete(new PartitionResult.PartitionSuccess([]) { SelectionSkipped = true });
         }
 
         ResourceReadPlan readPlan;
@@ -1723,7 +1729,9 @@ public sealed class RelationalDocumentStoreRepository(
                     )
                     .ConfigureAwait(false);
 
-                return PartitionComplete(new PartitionResult.PartitionSuccess([]));
+                return PartitionComplete(
+                    new PartitionResult.PartitionSuccess([]) { SelectionSkipped = true }
+                );
             }
 
             partitionPlan = new PartitionWindowPlanner(mappingSet.Key.Dialect).Plan(
@@ -2464,7 +2472,7 @@ public sealed class RelationalDocumentStoreRepository(
                     mappingSet,
                     adaptedCustomViewChecks,
                     new QueryAuthorizationResolution.Complete(
-                        new QueryResult.QuerySuccess([], totalCount ? 0 : null)
+                        new QueryResult.QuerySuccess([], totalCount ? 0 : null) { SelectionSkipped = true }
                     ),
                     cancellationToken
                 );

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalPartitionResultMapping.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalPartitionResultMapping.cs
@@ -34,8 +34,12 @@ internal static class RelationalPartitionResultMapping
         return queryResult switch
         {
             // Every empty success the shared path produces means no accessible candidates, which is the
-            // same thing an empty boundary set means.
-            QueryResult.QuerySuccess { EdfiDocs.Count: 0 } => new PartitionResult.PartitionSuccess([]),
+            // same thing an empty boundary set means. Whether selection was skipped carries across with
+            // it: a partition request short-circuited inside the shared authorization resolution issued
+            // no boundary command, and restating it as an executed empty result would claim database
+            // work that never happened.
+            QueryResult.QuerySuccess { EdfiDocs.Count: 0 } emptySuccess =>
+                new PartitionResult.PartitionSuccess([]) { SelectionSkipped = emptySuccess.SelectionSkipped },
 
             QueryResult.QueryFailureNotImplemented notImplemented =>
                 new PartitionResult.PartitionFailureNotImplemented(notImplemented.FailureMessage),

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/PartitionResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/PartitionResult.cs
@@ -35,7 +35,18 @@ public abstract record PartitionResult
     /// The inclusive DocumentId ranges a client can walk independently. Every range but the last is
     /// bounded above, so a later insert cannot move into a completed partition.
     /// </param>
-    public sealed record PartitionSuccess(IReadOnlyList<CursorRange> Ranges) : PartitionResult;
+    public sealed record PartitionSuccess(IReadOnlyList<CursorRange> Ranges) : PartitionResult
+    {
+        /// <summary>
+        /// No candidate selection command was issued; this empty success is a short-circuit.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to false, so a boundary command that executed and found no starts stays correct
+        /// without edits. Only the deliberate short-circuits set it true, which is what separates
+        /// "no database work was done" from "the command ran and matched nothing".
+        /// </remarks>
+        public bool SelectionSkipped { get; init; }
+    }
 
     /// <summary>
     /// A failure because the requested partition operation is intentionally not implemented, for

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/QueryResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/QueryResult.cs
@@ -42,6 +42,17 @@ public record QueryResult
         /// ContentVersion anchor in later work.
         /// </remarks>
         public bool AllowsDocumentIdContinuation { get; init; } = true;
+
+        /// <summary>
+        /// No candidate selection command was issued; this empty success is a short-circuit.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to false, so every site that actually selected is already correct — including the
+        /// executed pages that legitimately return nothing. Only the deliberate short-circuits set it
+        /// true. Without it, an empty success from a real selection is indistinguishable from one where
+        /// no command ran at all, and the two are different facts about the request.
+        /// </remarks>
+        public bool SelectionSkipped { get; init; }
     }
 
     /// <summary>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
@@ -438,6 +438,24 @@ public class PartitionRequestHandlerTests
             telemetry.Single.Returned.Should().Be(0);
         }
 
+        // The companion to the case above: both halves of what early_empty asserts are checked, not the
+        // flag alone. A success carrying ranges was calculated by a boundary command whatever the flag
+        // says, so it is reported as the boundary work it did rather than as a skipped selection.
+        [Test]
+        public async Task It_does_not_record_early_empty_for_a_skipped_selection_that_returned_ranges()
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteAsync(
+                new PartitionResult.PartitionSuccess([new CursorRange(1, long.MaxValue)])
+                {
+                    SelectionSkipped = true,
+                }
+            );
+
+            telemetry.Single.Outcome.Should().Be("success");
+            telemetry.Single.CommandCategory.Should().Be("boundary");
+            telemetry.Single.Returned.Should().Be(1);
+        }
+
         private static readonly TestCaseData[] _failureOutcomes =
         [
             new TestCaseData(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
@@ -12,6 +12,7 @@ using EdFi.DataManagementService.Core.Handler;
 using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Response;
+using EdFi.DataManagementService.Core.Telemetry;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -65,7 +66,8 @@ public class PartitionRequestHandlerTests
 
     private static async Task<RequestInfo> Execute(
         Handler partitionQueryHandler,
-        int? requestedPartitionCount = RequestedPartitionCount
+        int? requestedPartitionCount = RequestedPartitionCount,
+        ICollectionPagingTelemetry? collectionPagingTelemetry = null
     )
     {
         var serviceProvider = A.Fake<IServiceProvider>();
@@ -82,7 +84,8 @@ public class PartitionRequestHandlerTests
         await new PartitionRequestHandler(
             NullLogger.Instance,
             ResiliencePipeline.Empty,
-            MaximumPageSize
+            MaximumPageSize,
+            collectionPagingTelemetry ?? NoOpCollectionPagingTelemetry.Instance
         ).Execute(requestInfo, NullNext);
 
         return requestInfo;

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
@@ -9,10 +9,12 @@ using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.External.Security;
 using EdFi.DataManagementService.Core.Handler;
+using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Response;
 using EdFi.DataManagementService.Core.Telemetry;
+using EdFi.DataManagementService.Core.Tests.Unit.TestSupport;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -315,6 +317,279 @@ public class PartitionRequestHandlerTests
 
             await action.Should().ThrowAsync<InvalidOperationException>();
             handler.CallCount.Should().Be(0);
+        }
+    }
+
+    /// <summary>
+    /// What each partitions outcome contributes to the collection-paging metric.
+    /// </summary>
+    /// <remarks>
+    /// There is no terminal-page outcome here: a boundary set has no successor, so the continuation
+    /// question a GET-many page answers does not arise.
+    /// </remarks>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Collection_Paging_Telemetry_For_Partitions : PartitionRequestHandlerTests
+    {
+        /// <summary>
+        /// A count distinct from <see cref="RequestedPartitionCount" />, standing for the configured
+        /// default the validating middleware substitutes when a request names none. The handler sees
+        /// only the resolved value, so this is what "requested" means for such a request.
+        /// </summary>
+        private const int ResolvedDefaultPartitionCount = 4;
+
+        private sealed class ThrowingHandler(Exception fault) : IPartitionQueryHandler
+        {
+            public Task<PartitionResult> QueryPartitions(
+                IPartitionRequest partitionRequest,
+                CancellationToken cancellationToken = default
+            ) => throw fault;
+        }
+
+        private static async Task<RecordingCollectionPagingTelemetry> ExecuteAsync(
+            PartitionResult result,
+            int? requestedPartitionCount = RequestedPartitionCount
+        )
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+
+            await Execute(new Handler(result), requestedPartitionCount, telemetry);
+
+            return telemetry;
+        }
+
+        private static async Task<(
+            Exception? Fault,
+            RecordingCollectionPagingTelemetry Telemetry
+        )> ExecuteThrowingAsync(Exception fault, CancellationToken requestCancellationToken = default)
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+            var serviceProvider = A.Fake<IServiceProvider>();
+            A.CallTo(() => serviceProvider.GetService(typeof(IPartitionQueryHandler)))
+                .Returns(new ThrowingHandler(fault));
+
+            RequestInfo requestInfo = RequestInfoWithRelationalMappingSet();
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            requestInfo.RequestedPartitionCount = RequestedPartitionCount;
+            requestInfo.RequestCancellationToken = requestCancellationToken;
+
+            try
+            {
+                await new PartitionRequestHandler(
+                    NullLogger.Instance,
+                    ResiliencePipeline.Empty,
+                    MaximumPageSize,
+                    telemetry
+                ).Execute(requestInfo, NullNext);
+
+                return (null, telemetry);
+            }
+            catch (Exception caught)
+            {
+                return (caught, telemetry);
+            }
+        }
+
+        [Test]
+        public async Task It_records_a_calculated_boundary_set()
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteAsync(
+                new PartitionResult.PartitionSuccess([
+                    new CursorRange(1, 99),
+                    new CursorRange(100, long.MaxValue),
+                ])
+            );
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Kind.Should().Be(CollectionPagingMeasurementKind.Partitions);
+            measurement.PagingMode.Should().Be("partition");
+            measurement.CommandCategory.Should().Be("boundary");
+            measurement.Provider.Should().Be("postgresql");
+            measurement.Outcome.Should().Be("success");
+            measurement.Requested.Should().Be(RequestedPartitionCount);
+            measurement.Returned.Should().Be(2);
+            measurement.Duration.Should().NotBeNull().And.BeGreaterThanOrEqualTo(TimeSpan.Zero);
+        }
+
+        // The boundary command executed and found no starts. That is a success with a returned count of
+        // zero, and it must not be reported as the short-circuit that issued no command at all.
+        [Test]
+        public async Task It_records_an_executed_empty_boundary_set_as_success()
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteAsync(
+                new PartitionResult.PartitionSuccess([])
+            );
+
+            telemetry.Single.Outcome.Should().Be("success");
+            telemetry.Single.CommandCategory.Should().Be("boundary");
+            telemetry.Single.Returned.Should().Be(0);
+        }
+
+        [Test]
+        public async Task It_records_a_skipped_selection_as_early_empty()
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteAsync(
+                new PartitionResult.PartitionSuccess([]) { SelectionSkipped = true }
+            );
+
+            telemetry.Single.Outcome.Should().Be("early_empty");
+            telemetry.Single.CommandCategory.Should().Be("none");
+            telemetry.Single.Returned.Should().Be(0);
+        }
+
+        private static readonly TestCaseData[] _failureOutcomes =
+        [
+            new TestCaseData(
+                new PartitionResult.PartitionFailureNotImplemented("no capability"),
+                "not_implemented"
+            ).SetName("{m}(not_implemented)"),
+            new TestCaseData(
+                new PartitionResult.PartitionFailureSecurityConfiguration(["bad metadata"]),
+                "security_configuration"
+            ).SetName("{m}(security_configuration)"),
+            new TestCaseData(
+                new PartitionResult.PartitionFailureNamespaceNotAuthorized(
+                    new NamespaceAuthorizationFailure(
+                        NamespaceAuthorizationFailureKind.NoPrefixesConfigured,
+                        NamespaceAuthorizationFailureValueSource.Stored,
+                        EmittedAuth1Index: 0,
+                        AuthorizationStrategyNameConstants.NamespaceBased,
+                        []
+                    )
+                ),
+                "not_authorized"
+            ).SetName("{m}(not_authorized)"),
+            new TestCaseData(new PartitionResult.PartitionFailureRetryable(), "retry_exhausted").SetName(
+                "{m}(retry_exhausted)"
+            ),
+            new TestCaseData(new PartitionResult.UnknownPartitionFailure("boom"), "unknown_failure").SetName(
+                "{m}(unknown_failure)"
+            ),
+        ];
+
+        [TestCaseSource(nameof(_failureOutcomes))]
+        public async Task It_records_every_failure_with_no_command_category(
+            PartitionResult failure,
+            string expectedOutcome
+        )
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteAsync(failure);
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Outcome.Should().Be(expectedOutcome);
+            measurement.CommandCategory.Should().Be("none");
+            measurement.Returned.Should().BeNull();
+            measurement.Requested.Should().Be(RequestedPartitionCount);
+        }
+
+        [Test]
+        public async Task It_records_an_execution_exception_and_still_propagates_it()
+        {
+            InvalidOperationException fault = new("custom view is not conforming");
+
+            var (caught, telemetry) = await ExecuteThrowingAsync(fault);
+
+            caught.Should().BeSameAs(fault);
+            telemetry.Single.Outcome.Should().Be("execution_exception");
+            telemetry.Single.CommandCategory.Should().Be("none");
+            telemetry.Single.Returned.Should().BeNull();
+        }
+
+        [Test]
+        public async Task It_records_nothing_when_the_request_token_was_cancelled()
+        {
+            using CancellationTokenSource cancellationSource = new();
+            await cancellationSource.CancelAsync();
+
+            var (caught, telemetry) = await ExecuteThrowingAsync(
+                new OperationCanceledException(cancellationSource.Token),
+                cancellationSource.Token
+            );
+
+            caught.Should().BeOfType<OperationCanceledException>();
+            telemetry.Measurements.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task It_records_an_execution_exception_for_a_cancellation_the_request_did_not_ask_for()
+        {
+            var (caught, telemetry) = await ExecuteThrowingAsync(new OperationCanceledException());
+
+            caught.Should().BeOfType<OperationCanceledException>();
+            telemetry.Single.Outcome.Should().Be("execution_exception");
+        }
+
+        // The count a request omitted is the configured default the validating middleware substituted,
+        // which is what the client will be served and therefore what it asked for.
+        [Test]
+        public async Task It_records_the_validated_count_the_middleware_resolved()
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteAsync(
+                new PartitionResult.PartitionSuccess([new CursorRange(1, long.MaxValue)]),
+                requestedPartitionCount: ResolvedDefaultPartitionCount
+            );
+
+            telemetry.Single.Requested.Should().Be(ResolvedDefaultPartitionCount);
+            telemetry.Single.Returned.Should().Be(1);
+        }
+
+        [TestCase(SqlDialect.Pgsql, "postgresql")]
+        [TestCase(SqlDialect.Mssql, "sqlserver")]
+        public async Task It_reports_the_provider_of_the_resolved_mapping_set(
+            SqlDialect dialect,
+            string expectedProvider
+        )
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+            var serviceProvider = A.Fake<IServiceProvider>();
+            A.CallTo(() => serviceProvider.GetService(typeof(IPartitionQueryHandler)))
+                .Returns(new Handler(new PartitionResult.PartitionSuccess([new CursorRange(1, 99)])));
+
+            RequestInfo requestInfo = No.RequestInfo();
+            requestInfo.MappingSet = RelationalWriteSeamFixture.Create().CreateSupportedMappingSet(dialect);
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            requestInfo.RequestedPartitionCount = RequestedPartitionCount;
+
+            await new PartitionRequestHandler(
+                NullLogger.Instance,
+                ResiliencePipeline.Empty,
+                MaximumPageSize,
+                telemetry
+            ).Execute(requestInfo, NullNext);
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Provider.Should().Be(expectedProvider);
+            measurement.PagingMode.Should().Be("partition");
+            measurement.CommandCategory.Should().Be("boundary");
+            measurement.Outcome.Should().Be("success");
+            measurement.Requested.Should().Be(RequestedPartitionCount);
+            measurement.Returned.Should().Be(1);
+        }
+
+        [Test]
+        public async Task It_leaves_the_response_exactly_as_it_would_be_without_instrumentation()
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+
+            RequestInfo requestInfo = await Execute(
+                new Handler(
+                    new PartitionResult.PartitionSuccess([
+                        new CursorRange(1, 99),
+                        new CursorRange(100, long.MaxValue),
+                    ])
+                ),
+                RequestedPartitionCount,
+                telemetry
+            );
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(200);
+            requestInfo.FrontendResponse.ContentType.Should().Be("application/json");
+            requestInfo.FrontendResponse.Body!["pageTokens"]!.AsArray().Should().HaveCount(2);
+            requestInfo.FrontendResponse.Headers.Should().BeEmpty();
+            telemetry.Single.Outcome.Should().Be("success");
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
@@ -20,6 +20,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Polly;
+using Polly.CircuitBreaker;
 using static EdFi.DataManagementService.Core.Tests.Unit.TestHelper;
 
 namespace EdFi.DataManagementService.Core.Tests.Unit.Handler;
@@ -513,6 +514,52 @@ public class PartitionRequestHandlerTests
             telemetry.Single.Outcome.Should().Be("execution_exception");
             telemetry.Single.CommandCategory.Should().Be("none");
             telemetry.Single.Returned.Should().BeNull();
+        }
+
+        // The GET-many twin of this runs in QueryRequestHandlerTests. Both are pinned because the
+        // breaker is one shared pipeline instance: when it opens, /partitions is refused alongside
+        // GET-many, and each handler classifies that refusal in its own catch.
+        [Test]
+        public async Task It_records_an_execution_exception_when_the_circuit_is_open()
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+            CircuitBreakerManualControl manualControl = new();
+            ResiliencePipeline openCircuit = new ResiliencePipelineBuilder()
+                .AddCircuitBreaker(new CircuitBreakerStrategyOptions { ManualControl = manualControl })
+                .Build();
+
+            await manualControl.IsolateAsync();
+
+            var serviceProvider = A.Fake<IServiceProvider>();
+            A.CallTo(() => serviceProvider.GetService(typeof(IPartitionQueryHandler)))
+                .Returns(
+                    new ThrowingHandler(
+                        new InvalidOperationException("The partition handler must not be reached.")
+                    )
+                );
+
+            RequestInfo requestInfo = RequestInfoWithRelationalMappingSet();
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            requestInfo.RequestedPartitionCount = RequestedPartitionCount;
+
+            var execute = async () =>
+                await new PartitionRequestHandler(
+                    NullLogger.Instance,
+                    openCircuit,
+                    MaximumPageSize,
+                    telemetry
+                ).Execute(requestInfo, NullNext);
+
+            // The breaker's own exception rather than the backend's: the boundary command was refused
+            // before it reached the database.
+            await execute.Should().ThrowAsync<BrokenCircuitException>();
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Outcome.Should().Be("execution_exception");
+            measurement.CommandCategory.Should().Be("none");
+            measurement.Returned.Should().BeNull();
+            measurement.Requested.Should().Be(RequestedPartitionCount);
         }
 
         [Test]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
@@ -591,5 +591,55 @@ public class PartitionRequestHandlerTests
             requestInfo.FrontendResponse.Headers.Should().BeEmpty();
             telemetry.Single.Outcome.Should().Be("success");
         }
+
+        // The other half of "instrumentation must not participate": recording runs after the response is
+        // assembled, so a measurement callback that throws would discard a boundary set the request had
+        // already earned and answer a system error instead.
+        [Test]
+        public async Task It_serves_the_boundary_set_when_recording_throws()
+        {
+            RequestInfo requestInfo = await Execute(
+                new Handler(
+                    new PartitionResult.PartitionSuccess([
+                        new CursorRange(1, 99),
+                        new CursorRange(100, long.MaxValue),
+                    ])
+                ),
+                RequestedPartitionCount,
+                new ThrowingCollectionPagingTelemetry()
+            );
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(200);
+            requestInfo.FrontendResponse.Body!["pageTokens"]!.AsArray().Should().HaveCount(2);
+        }
+
+        // The execution-exception emission runs from inside a catch that is about to rethrow. A telemetry
+        // fault there would replace the fault being reported, which is exactly the diagnosis that catch
+        // exists to preserve.
+        [Test]
+        public async Task It_propagates_the_execution_fault_when_recording_throws()
+        {
+            InvalidOperationException executionFault = new("A configured custom view is not conforming.");
+
+            var serviceProvider = A.Fake<IServiceProvider>();
+            A.CallTo(() => serviceProvider.GetService(typeof(IPartitionQueryHandler)))
+                .Returns(new ThrowingHandler(executionFault));
+
+            RequestInfo requestInfo = RequestInfoWithRelationalMappingSet();
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            requestInfo.RequestedPartitionCount = RequestedPartitionCount;
+
+            Func<Task> execute = () =>
+                new PartitionRequestHandler(
+                    NullLogger.Instance,
+                    ResiliencePipeline.Empty,
+                    MaximumPageSize,
+                    new ThrowingCollectionPagingTelemetry()
+                ).Execute(requestInfo, NullNext);
+
+            (await execute.Should().ThrowAsync<InvalidOperationException>())
+                .Which.Should()
+                .BeSameAs(executionFault);
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -25,6 +25,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Polly;
+using Polly.CircuitBreaker;
 using static EdFi.DataManagementService.Core.Handler.Utility;
 using static EdFi.DataManagementService.Core.Tests.Unit.TestHelper;
 
@@ -1630,6 +1631,55 @@ public class QueryRequestHandlerTests
             telemetry.Single.Outcome.Should().Be("execution_exception");
             telemetry.Single.CommandCategory.Should().Be("none");
             telemetry.Single.Returned.Should().BeNull();
+        }
+
+        // While the circuit is open every collection read lands here, so this is the outcome's dominant
+        // population in production rather than an edge of it - which is what the operator documentation
+        // now says, and what this pins. The breaker is the outermost strategy on the pipeline these
+        // handlers share, so the refusal comes from the pipeline itself and the repository is never
+        // reached; a fault handed to the throwing repository would exercise the same catch but not that
+        // shape, so the pipeline here is a real breaker held open. Narrowing the handler to let a broken
+        // circuit past the general catch would stop counting the outage-dominant population, and this is
+        // what fails when it does.
+        [Test]
+        public async Task It_records_an_execution_exception_when_the_circuit_is_open()
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+            CircuitBreakerManualControl manualControl = new();
+            ResiliencePipeline openCircuit = new ResiliencePipelineBuilder()
+                .AddCircuitBreaker(new CircuitBreakerStrategyOptions { ManualControl = manualControl })
+                .Build();
+
+            await manualControl.IsolateAsync();
+
+            RequestInfo requestInfo = RequestInfoWithRelationalMappingSet();
+            requestInfo.CollectionPaging = _traditionalPaging;
+
+            var serviceProvider = A.Fake<IServiceProvider>();
+            A.CallTo(() => serviceProvider.GetService(typeof(IQueryHandler)))
+                .Returns(
+                    new ThrowingRepository(
+                        new InvalidOperationException("The repository must not be reached.")
+                    )
+                );
+            requestInfo.ScopedServiceProvider = serviceProvider;
+
+            var execute = async () =>
+                await new QueryRequestHandler(NullLogger.Instance, openCircuit, telemetry).Execute(
+                    requestInfo,
+                    NullNext
+                );
+
+            // The breaker's own exception rather than the repository's, which is the "refused before it
+            // reached the database" half of what this outcome is documented to cover. Reaching the
+            // repository would surface as its InvalidOperationException here instead.
+            await execute.Should().ThrowAsync<BrokenCircuitException>();
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Outcome.Should().Be("execution_exception");
+            measurement.CommandCategory.Should().Be("none");
+            measurement.Returned.Should().BeNull();
         }
 
         // A disconnected client is the absence of a completed read, not a kind of one, and its duration

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -17,6 +17,7 @@ using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.Response;
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Core.Tests.Unit.TestSupport;
 using FakeItEasy;
 using FluentAssertions;
@@ -35,13 +36,18 @@ public class QueryRequestHandlerTests
 {
     internal static (IPipelineStep handler, IServiceProvider serviceProvider) Handler(
         IQueryHandler queryHandler,
-        ILogger? logger = null
+        ILogger? logger = null,
+        ICollectionPagingTelemetry? collectionPagingTelemetry = null
     )
     {
         var serviceProvider = A.Fake<IServiceProvider>();
         A.CallTo(() => serviceProvider.GetService(typeof(IQueryHandler))).Returns(queryHandler);
 
-        var handler = new QueryRequestHandler(logger ?? NullLogger.Instance, ResiliencePipeline.Empty);
+        var handler = new QueryRequestHandler(
+            logger ?? NullLogger.Instance,
+            ResiliencePipeline.Empty,
+            collectionPagingTelemetry ?? NoOpCollectionPagingTelemetry.Instance
+        );
 
         return (handler, serviceProvider);
     }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -1790,5 +1790,51 @@ public class QueryRequestHandlerTests
             DecodeNextPageToken(requestInfo).Should().Be(new CursorRange(2510, long.MaxValue));
             telemetry.Single.Outcome.Should().Be("success");
         }
+
+        // The other half of "instrumentation must not participate": recording runs after the response is
+        // assembled, so a measurement callback that throws would discard a page the request had already
+        // earned and answer a system error instead.
+        [Test]
+        public async Task It_serves_the_page_when_recording_throws()
+        {
+            RequestInfo requestInfo = RequestInfoWithRelationalMappingSet();
+            requestInfo.CollectionPaging = _traditionalPaging;
+
+            var (queryHandler, serviceProvider) = Handler(
+                new Repository(new QueryResult.QuerySuccess(Documents(2), null, 2509L)),
+                collectionPagingTelemetry: new ThrowingCollectionPagingTelemetry()
+            );
+            requestInfo.ScopedServiceProvider = serviceProvider;
+
+            await queryHandler.Execute(requestInfo, NullNext);
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(200);
+            requestInfo.FrontendResponse.Body!.AsArray().Should().HaveCount(2);
+            DecodeNextPageToken(requestInfo).Should().Be(new CursorRange(2510, long.MaxValue));
+        }
+
+        // The execution-exception emission runs from inside a catch that is about to rethrow. A telemetry
+        // fault there would replace the fault being reported, which is exactly the diagnosis that catch
+        // exists to preserve.
+        [Test]
+        public async Task It_propagates_the_execution_fault_when_recording_throws()
+        {
+            InvalidOperationException executionFault = new("A configured custom view is not conforming.");
+
+            RequestInfo requestInfo = RequestInfoWithRelationalMappingSet();
+            requestInfo.CollectionPaging = _traditionalPaging;
+
+            var (queryHandler, serviceProvider) = Handler(
+                new ThrowingRepository(executionFault),
+                collectionPagingTelemetry: new ThrowingCollectionPagingTelemetry()
+            );
+            requestInfo.ScopedServiceProvider = serviceProvider;
+
+            Func<Task> execute = () => queryHandler.Execute(requestInfo, NullNext);
+
+            (await execute.Should().ThrowAsync<InvalidOperationException>())
+                .Which.Should()
+                .BeSameAs(executionFault);
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -1553,6 +1553,23 @@ public class QueryRequestHandlerTests
             telemetry.Single.Returned.Should().Be(0);
         }
 
+        // early_empty names an empty result no selection command produced, so both halves are checked
+        // rather than the flag alone. A page carrying documents was built from rows something selected,
+        // and reporting it as the short-circuit would attach the one outcome whose name is a claim about
+        // database work to a request that plainly did some — and then hide it from the size-gap
+        // comparisons, which exclude command_category=none on both sides.
+        [Test]
+        public async Task It_does_not_record_early_empty_for_a_skipped_selection_that_served_documents()
+        {
+            var (_, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(3), null, 2509L) { SelectionSkipped = true }
+            );
+
+            telemetry.Single.Outcome.Should().Be("success");
+            telemetry.Single.CommandCategory.Should().Be("page");
+            telemetry.Single.Returned.Should().Be(3);
+        }
+
         private static readonly TestCaseData[] _failureOutcomes =
         [
             new TestCaseData(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -1374,4 +1374,421 @@ public class QueryRequestHandlerTests
             _repository.CapturedRequest!.ChangeVersionRange.Should().Be(ChangeVersionRange.None);
         }
     }
+
+    /// <summary>
+    /// What each GET-many outcome contributes to the collection-paging metric.
+    /// </summary>
+    /// <remarks>
+    /// One request contributes exactly one measurement set, which every test here asserts by reading
+    /// <see cref="RecordingCollectionPagingTelemetry.Single" />. Instrument names, units, and tag-set
+    /// cardinality are pinned in the telemetry component's own tests; what is under test here is which
+    /// outcome and command category this handler chose for a given backend result.
+    /// </remarks>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Collection_Paging_Telemetry_For_A_Query : QueryRequestHandlerTests
+    {
+        private sealed class Repository(QueryResult result) : NotImplementedDocumentStoreRepository
+        {
+            public override Task<QueryResult> QueryDocuments(
+                IQueryRequest queryRequest,
+                CancellationToken cancellationToken = default
+            ) => Task.FromResult(result);
+        }
+
+        private sealed class ThrowingRepository(Exception fault) : NotImplementedDocumentStoreRepository
+        {
+            public override Task<QueryResult> QueryDocuments(
+                IQueryRequest queryRequest,
+                CancellationToken cancellationToken = default
+            ) => throw fault;
+        }
+
+        private static readonly CollectionPaging _traditionalPaging = new CollectionPaging.Traditional(
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+        );
+
+        private static readonly CollectionPaging _cursorPaging = new CollectionPaging.Cursor(
+            new CursorRange(7, 4200),
+            new PageSize(64)
+        );
+
+        private static JsonArray Documents(int count) =>
+            [.. Enumerable.Range(0, count).Select(index => (JsonNode)new JsonObject { ["i"] = index })];
+
+        private static async Task<(
+            RequestInfo RequestInfo,
+            RecordingCollectionPagingTelemetry Telemetry
+        )> ExecuteAsync(QueryResult result, CollectionPaging? paging = null, RequestInfo? requestInfo = null)
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+
+            requestInfo ??= RequestInfoWithRelationalMappingSet();
+            requestInfo.CollectionPaging = paging ?? _traditionalPaging;
+
+            var (queryHandler, serviceProvider) = Handler(
+                new Repository(result),
+                collectionPagingTelemetry: telemetry
+            );
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            await queryHandler.Execute(requestInfo, NullNext);
+
+            return (requestInfo, telemetry);
+        }
+
+        private static async Task<(
+            Exception? Fault,
+            RecordingCollectionPagingTelemetry Telemetry
+        )> ExecuteThrowingAsync(Exception fault, CancellationToken requestCancellationToken = default)
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+
+            RequestInfo requestInfo = RequestInfoWithRelationalMappingSet();
+            requestInfo.CollectionPaging = _traditionalPaging;
+            requestInfo.RequestCancellationToken = requestCancellationToken;
+
+            var (queryHandler, serviceProvider) = Handler(
+                new ThrowingRepository(fault),
+                collectionPagingTelemetry: telemetry
+            );
+            requestInfo.ScopedServiceProvider = serviceProvider;
+
+            try
+            {
+                await queryHandler.Execute(requestInfo, NullNext);
+                return (null, telemetry);
+            }
+            catch (Exception caught)
+            {
+                return (caught, telemetry);
+            }
+        }
+
+        [Test]
+        public async Task It_records_a_served_page_that_can_be_walked_from()
+        {
+            var (_, telemetry) = await ExecuteAsync(new QueryResult.QuerySuccess(Documents(3), null, 2509L));
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Kind.Should().Be(CollectionPagingMeasurementKind.Page);
+            measurement.PagingMode.Should().Be("traditional");
+            measurement.CommandCategory.Should().Be("page");
+            measurement.Provider.Should().Be("postgresql");
+            measurement.Outcome.Should().Be("success");
+            measurement.Requested.Should().Be(25);
+            measurement.Returned.Should().Be(3);
+            measurement.Duration.Should().NotBeNull().And.BeGreaterThanOrEqualTo(TimeSpan.Zero);
+        }
+
+        // The total count is compiled into the same selection command, which is the command-shape
+        // difference the category exists to separate.
+        [Test]
+        public async Task It_records_page_with_count_when_the_request_asked_for_a_total_count()
+        {
+            var (_, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(2), 7, 2509L),
+                new CollectionPaging.Traditional(
+                    new PaginationParameters(Limit: 25, Offset: 0, TotalCount: true, MaximumPageSize: 500)
+                )
+            );
+
+            telemetry.Single.CommandCategory.Should().Be("page_with_count");
+            telemetry.Single.Outcome.Should().Be("success");
+        }
+
+        // First of the three terminal-page boundaries: selection chose nothing, so there is nothing
+        // after it.
+        [Test]
+        public async Task It_records_terminal_page_when_selection_chose_nothing()
+        {
+            var (_, telemetry) = await ExecuteAsync(new QueryResult.QuerySuccess([], null));
+
+            telemetry.Single.Outcome.Should().Be("terminal_page");
+            telemetry.Single.CommandCategory.Should().Be("page");
+            telemetry.Single.Returned.Should().Be(0);
+        }
+
+        // Second: the codec cannot advance past Int64.MaxValue, so no next range can be named.
+        [Test]
+        public async Task It_records_terminal_page_at_the_maximum_document_id()
+        {
+            var (_, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(1), null, long.MaxValue)
+            );
+
+            telemetry.Single.Outcome.Should().Be("terminal_page");
+        }
+
+        // Third, and the regression guard: a traditional page over a max-bearing change-version window
+        // is ordered by ContentVersion, is served with rows, and the client keeps paging it with limit
+        // and offset. It withholds a token without ending a walk, so reporting it as terminal would tell
+        // operators a healthy walk had stopped.
+        [Test]
+        public async Task It_records_success_for_a_page_that_cannot_anchor_a_continuation()
+        {
+            var (requestInfo, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(4), null, 2509L)
+                {
+                    AllowsDocumentIdContinuation = false,
+                }
+            );
+
+            requestInfo.FrontendResponse.Headers.Should().NotContainKey("Next-Page-Token");
+            telemetry.Single.Outcome.Should().Be("success");
+            telemetry.Single.Returned.Should().Be(4);
+        }
+
+        // Early-empty outranks the terminal-page question: no command was issued, so no command shape
+        // can be attributed to it.
+        [Test]
+        public async Task It_records_early_empty_ahead_of_terminal_page_for_a_skipped_selection()
+        {
+            var (_, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess([], null) { SelectionSkipped = true }
+            );
+
+            telemetry.Single.Outcome.Should().Be("early_empty");
+            telemetry.Single.CommandCategory.Should().Be("none");
+            telemetry.Single.Returned.Should().Be(0);
+        }
+
+        private static readonly TestCaseData[] _failureOutcomes =
+        [
+            new TestCaseData(
+                new QueryResult.QueryFailureNotImplemented("not implemented"),
+                "not_implemented"
+            ).SetName("{m}(not_implemented)"),
+            new TestCaseData(
+                new QueryResult.QueryFailureSecurityConfiguration(["invalid metadata"]),
+                "security_configuration"
+            ).SetName("{m}(security_configuration)"),
+            new TestCaseData(
+                new QueryResult.QueryFailureNamespaceNotAuthorized(
+                    Given_A_Repository_That_Returns_Namespace_Not_Authorized.Failure
+                ),
+                "not_authorized"
+            ).SetName("{m}(not_authorized)"),
+            new TestCaseData(new QueryResult.QueryFailureRetryable(), "retry_exhausted").SetName(
+                "{m}(retry_exhausted)"
+            ),
+            new TestCaseData(new QueryResult.UnknownFailure("unknown"), "unknown_failure").SetName(
+                "{m}(unknown_failure)"
+            ),
+            // A known error reports query terms that evaded validation. The bounded outcome set has no
+            // value of its own for it, and counting it as validation_rejected would dilute the
+            // middleware-rejection rate operators watch, so it is an unclassified backend failure.
+            new TestCaseData(
+                new QueryResult.QueryFailureKnownError("invalid query terms"),
+                "unknown_failure"
+            ).SetName("{m}(known_error)"),
+        ];
+
+        [TestCaseSource(nameof(_failureOutcomes))]
+        public async Task It_records_every_failure_with_no_command_category(
+            QueryResult failure,
+            string expectedOutcome
+        )
+        {
+            var (_, telemetry) = await ExecuteAsync(failure);
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Outcome.Should().Be(expectedOutcome);
+            measurement.CommandCategory.Should().Be("none");
+
+            // No page was produced, so nothing may be contributed to the returned-size histogram: a zero
+            // there would be indistinguishable from a successful empty page.
+            measurement.Returned.Should().BeNull();
+        }
+
+        [Test]
+        public async Task It_records_an_execution_exception_and_still_propagates_it()
+        {
+            InvalidOperationException fault = new("custom view is not conforming");
+
+            var (caught, telemetry) = await ExecuteThrowingAsync(fault);
+
+            caught.Should().BeSameAs(fault);
+            telemetry.Single.Outcome.Should().Be("execution_exception");
+            telemetry.Single.CommandCategory.Should().Be("none");
+            telemetry.Single.Returned.Should().BeNull();
+        }
+
+        // A disconnected client is the absence of a completed read, not a kind of one, and its duration
+        // would measure how long the client waited rather than how long a read took.
+        [Test]
+        public async Task It_records_nothing_when_the_request_token_was_cancelled()
+        {
+            using CancellationTokenSource cancellationSource = new();
+            await cancellationSource.CancelAsync();
+
+            var (caught, telemetry) = await ExecuteThrowingAsync(
+                new OperationCanceledException(cancellationSource.Token),
+                cancellationSource.Token
+            );
+
+            caught.Should().BeOfType<OperationCanceledException>();
+            telemetry.Measurements.Should().BeEmpty();
+        }
+
+        // The companion to the test above: the filter narrows the case to a client disconnect rather
+        // than opening a hole for every cancellation. A cancellation the request did not ask for is a
+        // genuine internal fault.
+        [Test]
+        public async Task It_records_an_execution_exception_for_a_cancellation_the_request_did_not_ask_for()
+        {
+            var (caught, telemetry) = await ExecuteThrowingAsync(new OperationCanceledException());
+
+            caught.Should().BeOfType<OperationCanceledException>();
+            telemetry.Single.Outcome.Should().Be("execution_exception");
+        }
+
+        [Test]
+        public async Task It_records_the_cursor_page_size_as_requested()
+        {
+            var (_, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(1), null, 21L),
+                _cursorPaging
+            );
+
+            telemetry.Single.PagingMode.Should().Be("cursor");
+            telemetry.Single.Requested.Should().Be(64);
+        }
+
+        // A traditional request that named no limit will be served at most the configured maximum, so
+        // that is the size it asked for.
+        [Test]
+        public async Task It_records_the_configured_maximum_when_traditional_paging_named_no_limit()
+        {
+            var (_, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(1), null, 21L),
+                new CollectionPaging.Traditional(
+                    new PaginationParameters(Limit: null, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+                )
+            );
+
+            telemetry.Single.Requested.Should().Be(500);
+        }
+
+        [TestCase(SqlDialect.Pgsql, "postgresql")]
+        [TestCase(SqlDialect.Mssql, "sqlserver")]
+        public async Task It_reports_the_provider_of_the_resolved_mapping_set(
+            SqlDialect dialect,
+            string expectedProvider
+        )
+        {
+            RequestInfo requestInfo = No.RequestInfo();
+            requestInfo.MappingSet = RelationalWriteSeamFixture.Create().CreateSupportedMappingSet(dialect);
+
+            var (_, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(2), null, 2509L),
+                requestInfo: requestInfo
+            );
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Provider.Should().Be(expectedProvider);
+
+            // Only the provider differs across dialects. Everything else about the same operation has to
+            // match, or an operator could not compare the two engines on one dashboard.
+            measurement.PagingMode.Should().Be("traditional");
+            measurement.CommandCategory.Should().Be("page");
+            measurement.Outcome.Should().Be("success");
+            measurement.Requested.Should().Be(25);
+            measurement.Returned.Should().Be(2);
+        }
+
+        // The metric describes traffic shape, never who asked or what they asked for. Sentinels stand in
+        // for every request-derived value the emission site can reach.
+        [Test]
+        public async Task It_carries_no_request_data_into_any_label()
+        {
+            const string ResourceNameSentinel = "SentinelResourceName";
+            const string TenantSentinel = "SentinelTenantKey";
+            const string NamespaceSentinel = "uri://sentinel-namespace.org";
+            const string ClientSentinel = "SentinelClientId";
+            const string FilterValueSentinel = "SentinelFilterValue";
+            const string PageTokenSentinel = "SentinelPageToken";
+
+            RequestInfo requestInfo = RequestInfoWithRelationalMappingSet();
+            requestInfo.ResourceInfo = requestInfo.ResourceInfo with
+            {
+                ResourceName = new ResourceName(ResourceNameSentinel),
+            };
+            requestInfo.FrontendRequest = requestInfo.FrontendRequest with
+            {
+                Tenant = TenantSentinel,
+                QueryParameters = new Dictionary<string, string>
+                {
+                    ["pageToken"] = PageTokenSentinel,
+                    ["name"] = FilterValueSentinel,
+                },
+            };
+            requestInfo.ClientAuthorizations = new ClientAuthorizations(
+                ClientId: ClientSentinel,
+                TokenId: "sentinel-token",
+                ClaimSetName: "SentinelClaimSet",
+                EducationOrganizationIds: [],
+                NamespacePrefixes: [new NamespacePrefix(NamespaceSentinel)],
+                DataStoreIds: []
+            );
+            requestInfo.QueryElements =
+            [
+                new QueryElement("name", [new JsonPath("$.name")], FilterValueSentinel, "string"),
+            ];
+
+            var (_, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(1), null, 21L),
+                requestInfo: requestInfo
+            );
+
+            string[] sentinels =
+            [
+                ResourceNameSentinel,
+                TenantSentinel,
+                NamespaceSentinel,
+                ClientSentinel,
+                FilterValueSentinel,
+                PageTokenSentinel,
+            ];
+            CollectionPagingMeasurement measurement = telemetry.Single;
+            string[] labels =
+            [
+                measurement.PagingMode,
+                measurement.CommandCategory,
+                measurement.Provider,
+                measurement.Outcome,
+            ];
+
+            foreach (string label in labels)
+            {
+                foreach (string sentinel in sentinels)
+                {
+                    label.Should().NotContain(sentinel);
+                }
+            }
+        }
+
+        // Instrumentation observes; it must not participate. The full response contract is asserted
+        // alongside an emission so a change that recorded a measurement by altering a header or a body
+        // could not pass.
+        [Test]
+        public async Task It_leaves_the_response_exactly_as_it_would_be_without_instrumentation()
+        {
+            var (requestInfo, telemetry) = await ExecuteAsync(
+                new QueryResult.QuerySuccess(Documents(2), 7, 2509L),
+                new CollectionPaging.Traditional(
+                    new PaginationParameters(Limit: 25, Offset: 0, TotalCount: true, MaximumPageSize: 500)
+                )
+            );
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(200);
+            requestInfo.FrontendResponse.ContentType.Should().Be("application/json");
+            requestInfo.FrontendResponse.Body!.AsArray().Should().HaveCount(2);
+            requestInfo.FrontendResponse.Headers["Total-Count"].Should().Be("7");
+            DecodeNextPageToken(requestInfo).Should().Be(new CursorRange(2510, long.MaxValue));
+            telemetry.Single.Outcome.Should().Be("success");
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ParsePathMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ParsePathMiddlewareTests.cs
@@ -150,6 +150,7 @@ public class ParsePathMiddlewareTests
 
         TestHelper.AddResourceKeyValidationServices(services);
         TestHelper.AddMappingSetResolutionServices(services);
+        TestHelper.AddCollectionPagingTelemetry(services);
 
         services.AddSingleton<IProfileService>(A.Fake<IProfileService>());
         services.AddTransient<ProfileResolutionMiddleware>();

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidatePartitionQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidatePartitionQueryMiddlewareTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Core.Middleware;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Telemetry;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
@@ -82,13 +83,20 @@ public class ValidatePartitionQueryMiddlewareTests
         return requestInfo;
     }
 
-    private static async Task<RequestInfo> Execute(params (string Key, string Value)[] queryParameters)
+    private static Task<RequestInfo> Execute(params (string Key, string Value)[] queryParameters) =>
+        Execute(collectionPagingTelemetry: null, queryParameters);
+
+    private static async Task<RequestInfo> Execute(
+        ICollectionPagingTelemetry? collectionPagingTelemetry,
+        params (string Key, string Value)[] queryParameters
+    )
     {
         RequestInfo requestInfo = RequestInfoFor(queryParameters);
 
         IPipelineStep middleware = new ValidatePartitionQueryMiddleware(
             NullLogger.Instance,
-            DefaultPartitionCount
+            DefaultPartitionCount,
+            collectionPagingTelemetry ?? NoOpCollectionPagingTelemetry.Instance
         );
 
         await middleware.Execute(requestInfo, NullNext);
@@ -384,7 +392,11 @@ public class ValidatePartitionQueryMiddlewareTests
             RequestInfo requestInfo = RequestInfoFor(("number", "4"));
             var reachedNext = false;
 
-            await new ValidatePartitionQueryMiddleware(NullLogger.Instance, DefaultPartitionCount).Execute(
+            await new ValidatePartitionQueryMiddleware(
+                NullLogger.Instance,
+                DefaultPartitionCount,
+                NoOpCollectionPagingTelemetry.Instance
+            ).Execute(
                 requestInfo,
                 () =>
                 {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidatePartitionQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidatePartitionQueryMiddlewareTests.cs
@@ -493,5 +493,19 @@ public class ValidatePartitionQueryMiddlewareTests
             requestInfo.FrontendResponse.Should().Be(No.FrontendResponse);
             telemetry.Measurements.Should().BeEmpty();
         }
+
+        // Counting runs ahead of the rejection this step answers with, so a measurement callback that
+        // throws would replace a 400 naming the bad parameter with a system error naming nothing.
+        [Test]
+        public async Task It_still_answers_the_rejection_when_recording_throws()
+        {
+            RequestInfo requestInfo = await Execute(new ThrowingCollectionPagingTelemetry(), ("number", "0"));
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+            requestInfo
+                .FrontendResponse.Body!.ToJsonString()
+                .Should()
+                .Contain("Number of partitions must be between 1 and 200.");
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidatePartitionQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidatePartitionQueryMiddlewareTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Model;
@@ -12,6 +13,8 @@ using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Telemetry;
+using EdFi.DataManagementService.Core.Tests.Unit.Handler;
+using EdFi.DataManagementService.Core.Tests.Unit.TestSupport;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
@@ -407,6 +410,88 @@ public class ValidatePartitionQueryMiddlewareTests
 
             reachedNext.Should().BeTrue();
             requestInfo.FrontendResponse.Should().Be(No.FrontendResponse);
+        }
+    }
+
+    /// <summary>
+    /// What a request this step answers contributes to the collection-paging metric.
+    /// </summary>
+    /// <remarks>
+    /// The paging mode is the partition literal on every exit, because this step is composed only into
+    /// the partitions pipeline. Unlike the GET-many validator it has no second construction site to
+    /// isolate.
+    /// </remarks>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Collection_Paging_Telemetry_For_A_Rejection : ValidatePartitionQueryMiddlewareTests
+    {
+        private static async Task<RecordingCollectionPagingTelemetry> ExecuteRecording(
+            params (string Key, string Value)[] queryParameters
+        )
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+
+            RequestInfo requestInfo = RequestInfoFor(queryParameters);
+            requestInfo.MappingSet = RelationalWriteSeamFixture
+                .Create()
+                .CreateSupportedMappingSet(SqlDialect.Mssql);
+
+            await new ValidatePartitionQueryMiddleware(
+                NullLogger.Instance,
+                DefaultPartitionCount,
+                telemetry
+            ).Execute(requestInfo, NullNext);
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+
+            return telemetry;
+        }
+
+        private static readonly TestCaseData[] _rejections =
+        [
+            new TestCaseData(new[] { ("number", "0") }).SetName("{m}(partition count fault)"),
+            new TestCaseData(new[] { ("minChangeVersion", "abc") }).SetName("{m}(change-version fault)"),
+            new TestCaseData(new[] { ("notAField", "1") }).SetName("{m}(unknown query field)"),
+            new TestCaseData(new[] { ("schoolId", "not-a-number") }).SetName("{m}(invalid filter value)"),
+        ];
+
+        [TestCaseSource(nameof(_rejections))]
+        public async Task It_counts_every_rejecting_exit_exactly_once(
+            (string Key, string Value)[] queryParameters
+        )
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteRecording(queryParameters);
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Kind.Should().Be(CollectionPagingMeasurementKind.ValidationRejected);
+            measurement.PagingMode.Should().Be("partition");
+            measurement.CommandCategory.Should().Be("none");
+            measurement.Provider.Should().Be("sqlserver");
+            measurement.Outcome.Should().Be("validation_rejected");
+        }
+
+        // Nothing executed, so a duration sample would report the cost of parsing a query string as a
+        // boundary-command latency.
+        [Test]
+        public async Task It_records_no_duration_or_counts_for_a_rejection()
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteRecording(("number", "0"));
+
+            telemetry.Single.Duration.Should().BeNull();
+            telemetry.Single.Requested.Should().BeNull();
+            telemetry.Single.Returned.Should().BeNull();
+        }
+
+        [Test]
+        public async Task It_counts_nothing_for_a_request_it_accepts()
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+
+            RequestInfo requestInfo = await Execute(telemetry, ("number", "4"));
+
+            requestInfo.FrontendResponse.Should().Be(No.FrontendResponse);
+            telemetry.Measurements.Should().BeEmpty();
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
@@ -595,5 +595,23 @@ public class ValidateQueryMiddlewareCursorTests
             requestInfo.FrontendResponse.Should().Be(No.FrontendResponse);
             telemetry.Measurements.Should().BeEmpty();
         }
+
+        // Counting runs ahead of the rejection this step answers with, so a measurement callback that
+        // throws would replace a 400 naming the bad parameter with a system error naming nothing.
+        [Test]
+        public async Task It_still_answers_the_rejection_when_recording_throws()
+        {
+            RequestInfo requestInfo = RequestInfoFor(("limit", "-1"));
+
+            await ValidateQueryMiddlewareTests
+                .Middleware(new ThrowingCollectionPagingTelemetry())
+                .Execute(requestInfo, NullNext);
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+            requestInfo
+                .FrontendResponse.Body!.ToJsonString()
+                .Should()
+                .Contain("Limit must be omitted or set to a numeric value between 0 and");
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
@@ -4,12 +4,15 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Tests.Unit.Handler;
+using EdFi.DataManagementService.Core.Tests.Unit.TestSupport;
 using FluentAssertions;
 using NUnit.Framework;
 using static EdFi.DataManagementService.Core.Tests.Unit.TestHelper;
@@ -477,6 +480,120 @@ public class ValidateQueryMiddlewareCursorTests
             requestInfo
                 .CollectionPaging.Should()
                 .Be(new CollectionPaging.Traditional(requestInfo.PaginationParameters));
+        }
+    }
+
+    /// <summary>
+    /// What a request this step answers contributes to the collection-paging metric.
+    /// </summary>
+    /// <remarks>
+    /// Every rejecting exit is covered here rather than split across the two GET-many test files,
+    /// because this step answers a cursor fault, a traditional fault, a change-version fault, and a
+    /// filter fault with the same measurement — and it is the difference between them, in one place,
+    /// that shows the coverage is complete.
+    /// </remarks>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Collection_Paging_Telemetry_For_A_Rejection : ValidateQueryMiddlewareCursorTests
+    {
+        /// <summary>
+        /// The live GET-many composition, recording what it counted. A mapping set is resolved onto the
+        /// request because ResolveMappingSetMiddleware runs ahead of this step in that pipeline, so the
+        /// provider a rejection reports is a real one.
+        /// </summary>
+        private static async Task<RecordingCollectionPagingTelemetry> ExecuteRecording(
+            params (string Key, string Value)[] queryParameters
+        )
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+
+            RequestInfo requestInfo = RequestInfoFor(queryParameters);
+            requestInfo.MappingSet = RelationalWriteSeamFixture
+                .Create()
+                .CreateSupportedMappingSet(SqlDialect.Pgsql);
+
+            await ValidateQueryMiddlewareTests.Middleware(telemetry).Execute(requestInfo, NullNext);
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+
+            return telemetry;
+        }
+
+        // A rejected cursor request must report cursor. RequestInfo.CollectionPaging is assigned only at
+        // the accepting exit, so reading paging mode from request state would report every rejected
+        // cursor request as traditional traffic.
+        [TestCase("!!!", TestName = "{m}(undecodable token)")]
+        [TestCase("", TestName = "{m}(empty token)")]
+        public async Task It_reports_a_rejected_cursor_request_as_cursor(string pageToken)
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteRecording(("pageToken", pageToken));
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Kind.Should().Be(CollectionPagingMeasurementKind.ValidationRejected);
+            measurement.PagingMode.Should().Be("cursor");
+            measurement.CommandCategory.Should().Be("none");
+            measurement.Provider.Should().Be("postgresql");
+            measurement.Outcome.Should().Be("validation_rejected");
+        }
+
+        // A request carrying pageSize alone is a cursor request too: it is rejected for naming no token,
+        // and it must not be counted as traditional traffic either.
+        [Test]
+        public async Task It_reports_a_page_size_without_a_token_as_cursor()
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteRecording(("pageSize", "5"));
+
+            telemetry.Single.PagingMode.Should().Be("cursor");
+        }
+
+        private static readonly TestCaseData[] _traditionalRejections =
+        [
+            new TestCaseData(new[] { ("limit", "-1") }).SetName("{m}(paging fault)"),
+            new TestCaseData(new[] { ("minChangeVersion", "abc") }).SetName("{m}(change-version fault)"),
+            new TestCaseData(new[] { ("notAField", "1") }).SetName("{m}(unknown query field)"),
+            new TestCaseData(new[] { ("schoolId", "not-a-number") }).SetName("{m}(invalid filter value)"),
+        ];
+
+        // Every rejecting exit of this step counts, not only the paging ones: the ticket says
+        // "validation rejection" without narrowing it to paging faults.
+        [TestCaseSource(nameof(_traditionalRejections))]
+        public async Task It_counts_every_rejecting_exit_exactly_once(
+            (string Key, string Value)[] queryParameters
+        )
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteRecording(queryParameters);
+
+            CollectionPagingMeasurement measurement = telemetry.Single;
+
+            measurement.Kind.Should().Be(CollectionPagingMeasurementKind.ValidationRejected);
+            measurement.PagingMode.Should().Be("traditional");
+            measurement.CommandCategory.Should().Be("none");
+            measurement.Outcome.Should().Be("validation_rejected");
+        }
+
+        // Nothing executed, so a duration sample would report the cost of parsing a query string as a
+        // read latency. The recording method that carries no duration is the one that must be called.
+        [Test]
+        public async Task It_records_no_duration_for_a_rejection()
+        {
+            RecordingCollectionPagingTelemetry telemetry = await ExecuteRecording(("limit", "-1"));
+
+            telemetry.Single.Duration.Should().BeNull();
+            telemetry.Single.Requested.Should().BeNull();
+            telemetry.Single.Returned.Should().BeNull();
+        }
+
+        [Test]
+        public async Task It_counts_nothing_for_a_request_it_accepts()
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+            RequestInfo requestInfo = RequestInfoFor(("schoolId", "1"), ("limit", "25"));
+
+            await ValidateQueryMiddlewareTests.Middleware(telemetry).Execute(requestInfo, NullNext);
+
+            requestInfo.FrontendResponse.Should().Be(No.FrontendResponse);
+            telemetry.Measurements.Should().BeEmpty();
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Middleware;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Telemetry;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
@@ -27,24 +28,28 @@ public class ValidateQueryMiddlewareTests
     /// <summary>
     /// The live GET-many composition, which recognizes the cursor parameters.
     /// </summary>
-    internal static IPipelineStep Middleware()
+    internal static IPipelineStep Middleware(ICollectionPagingTelemetry? collectionPagingTelemetry = null)
     {
         return new ValidateQueryMiddleware(
             NullLogger.Instance,
             _maxPageSize,
-            _cursorParametersRecognized: true
+            _cursorParametersRecognized: true,
+            collectionPagingTelemetry ?? NoOpCollectionPagingTelemetry.Instance
         );
     }
 
     /// <summary>
-    /// The Change Query composition, which does not recognize the cursor parameters.
+    /// The Change Query composition, which does not recognize the cursor parameters and does not count
+    /// its faults as collection-paging traffic. Both arguments are fixed here rather than defaulted, so
+    /// this factory stays a faithful copy of how CreateGetTrackedChangesPipeline composes the step.
     /// </summary>
     internal static IPipelineStep MiddlewareWithoutCursorRecognition()
     {
         return new ValidateQueryMiddleware(
             NullLogger.Instance,
             _maxPageSize,
-            _cursorParametersRecognized: false
+            _cursorParametersRecognized: false,
+            NoOpCollectionPagingTelemetry.Instance
         );
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Frontend;
+using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Handler;
 using EdFi.DataManagementService.Core.Middleware;
 using EdFi.DataManagementService.Core.Model;
@@ -14,6 +16,8 @@ using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.ResourceLoadOrder;
 using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Core.Telemetry;
+using EdFi.DataManagementService.Core.Tests.Unit.TestSupport;
 using EdFi.DataManagementService.Core.Validation;
 using FakeItEasy;
 using FluentAssertions;
@@ -488,7 +492,16 @@ public class PipelineOrderingTests
     /// Builds a routed-resource pipeline through the real ApiService factory, so the composed sequence
     /// under test is the one production builds.
     /// </summary>
-    private static List<Type> GetRoutedResourcePipelineStepTypes(string factoryMethodName)
+    private static List<Type> GetRoutedResourcePipelineStepTypes(string factoryMethodName) =>
+        GetStepTypes(BuildRoutedResourceApiService(), factoryMethodName);
+
+    /// <summary>
+    /// The real ApiService, with <paramref name="collectionPagingTelemetry" /> registered as the
+    /// telemetry its pipeline factories resolve.
+    /// </summary>
+    private static ApiService BuildRoutedResourceApiService(
+        ICollectionPagingTelemetry? collectionPagingTelemetry = null
+    )
     {
         var services = new ServiceCollection();
 
@@ -521,7 +534,7 @@ public class PipelineOrderingTests
         TestHelper.AddResourceKeyValidationServices(services);
         TestHelper.AddMappingSetResolutionServices(services);
 
-        TestHelper.AddCollectionPagingTelemetry(services);
+        services.AddSingleton(collectionPagingTelemetry ?? NoOpCollectionPagingTelemetry.Instance);
 
         services.AddSingleton<IProfileService>(A.Fake<IProfileService>());
         services.AddTransient<ProfileResolutionMiddleware>();
@@ -537,7 +550,7 @@ public class PipelineOrderingTests
 
         var serviceProvider = services.BuildServiceProvider();
 
-        var apiService = new ApiService(
+        return new ApiService(
             A.Fake<IApiSchemaProvider>(),
             A.Fake<IEffectiveApiSchemaProvider>(),
             A.Fake<IClaimSetProvider>(),
@@ -557,8 +570,76 @@ public class PipelineOrderingTests
             A.Fake<IProfileService>(),
             new CircuitBreakerSettings()
         );
+    }
 
-        return GetStepTypes(apiService, factoryMethodName);
+    /// <summary>
+    /// The query-validation step is the only instrumented type with two construction sites, and the
+    /// Change Query one must stay uncounted: those endpoints do not page by cursor at all, so a
+    /// /deletes?limit=abc fault is not a collection read.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_The_Shared_Query_Validation_Step : PipelineOrderingTests
+    {
+        /// <summary>
+        /// Whether the query-validation step a pipeline factory composed counts its rejections as
+        /// collection-paging traffic.
+        /// </summary>
+        /// <remarks>
+        /// Exercises the instance the real factory produced, which is the only way to see a difference
+        /// that lives entirely in a constructor argument. The step is executed directly rather than
+        /// through the whole pipeline so the assertion depends on nothing before it.
+        /// </remarks>
+        private static async Task<IReadOnlyList<CollectionPagingMeasurement>> RecordRejectionFrom(
+            string factoryMethodName
+        )
+        {
+            RecordingCollectionPagingTelemetry telemetry = new();
+            List<IPipelineStep> steps = GetSteps(BuildRoutedResourceApiService(telemetry), factoryMethodName);
+            IPipelineStep validation = steps.OfType<ValidateQueryMiddleware>().Single();
+
+            FrontendRequest frontendRequest = new(
+                Path: "/ed-fi/academicWeeks",
+                Body: null,
+                Form: null,
+                Headers: [],
+                QueryParameters: new Dictionary<string, string>(StringComparer.Ordinal) { ["limit"] = "-1" },
+                TraceId: new TraceId("pipeline-composition"),
+                RouteQualifiers: []
+            );
+            RequestInfo requestInfo = new(frontendRequest, RequestMethod.GET, No.ServiceProvider);
+
+            await validation.Execute(requestInfo, TestHelper.NullNext);
+
+            // Proves the step really answered the request. Without this an empty recorder could mean
+            // the fault never reached a rejecting exit at all.
+            requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+
+            return telemetry.Measurements;
+        }
+
+        [Test]
+        public async Task It_counts_a_get_many_rejection()
+        {
+            IReadOnlyList<CollectionPagingMeasurement> measurements = await RecordRejectionFrom(
+                "CreateQueryPipeline"
+            );
+
+            measurements.Should().ContainSingle().Which.Outcome.Should().Be("validation_rejected");
+        }
+
+        // The guard against a wiring change at the tracked-changes construction site silently folding
+        // Change Query faults into the collection-paging rejection rate, which would move every
+        // dashboard built on it with no other symptom.
+        [Test]
+        public async Task It_counts_nothing_for_a_change_query_rejection()
+        {
+            IReadOnlyList<CollectionPagingMeasurement> measurements = await RecordRejectionFrom(
+                "CreateGetTrackedChangesPipeline"
+            );
+
+            measurements.Should().BeEmpty();
+        }
     }
 
     [TestFixture]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
@@ -100,6 +100,8 @@ public class PipelineOrderingTests
 
             TestHelper.AddMappingSetResolutionServices(services);
 
+            TestHelper.AddCollectionPagingTelemetry(services);
+
             services.AddSingleton<IProfileService>(A.Fake<IProfileService>());
             services.AddTransient<ProfileResolutionMiddleware>();
             services.AddTransient<ILogger<ProfileResolutionMiddleware>>(_ =>
@@ -380,6 +382,8 @@ public class PipelineOrderingTests
 
             TestHelper.AddMappingSetResolutionServices(services);
 
+            TestHelper.AddCollectionPagingTelemetry(services);
+
             var serviceProvider = services.BuildServiceProvider();
 
             var apiService = new ApiService(
@@ -516,6 +520,8 @@ public class PipelineOrderingTests
 
         TestHelper.AddResourceKeyValidationServices(services);
         TestHelper.AddMappingSetResolutionServices(services);
+
+        TestHelper.AddCollectionPagingTelemetry(services);
 
         services.AddSingleton<IProfileService>(A.Fake<IProfileService>());
         services.AddTransient<ProfileResolutionMiddleware>();

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
@@ -367,37 +367,90 @@ public class Given_CollectionPagingTelemetry
             .And.OnlyContain(measurement => HasExactlyTheAllowedTags(measurement));
     }
 
-    // The bound this layer guarantees: no control characters, no structured-log template syntax, and no
-    // label longer than 128 characters, whatever a caller passes. Keeping request-derived values out of
-    // labels entirely is a property of the emission sites, which pass only the constants above, and is
-    // asserted there against sentinel request data.
+    // The bound this layer guarantees: a label outside the dimension's allowed set never becomes a tag.
+    // Length and character class are not the property that matters — a caller passing request-derived
+    // text would add one tag set per distinct value however short and clean each one was — so the check
+    // is membership and the answer is refusal rather than a reshaped label.
     [Test]
-    public void It_sanitizes_and_bounds_a_label_whatever_a_caller_passes()
+    public void It_refuses_a_label_outside_the_bounded_set()
     {
-        using MetricCollector collector = new();
-        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
-        CollectionPagingTelemetryContext context = CollectionPagingTelemetryContext.ForPagingMode(
-            CollectionPagingTelemetryLabel.CursorPagingMode,
-            CollectionPagingTelemetryLabel.NoCommandCategory,
-            SqlDialect.Pgsql,
-            "Unsafe\r\n\t{template}" + new string('x', 200)
-        );
-
-        telemetry.RecordValidationRejected(context);
-
-        MetricMeasurement rejection = collector.Single(CollectionPagingTelemetry.RequestCounterName);
-        rejection
-            .Tags.Values.OfType<string>()
-            .Should()
-            .OnlyContain(label =>
-                label.Length <= 128
-                && !label.Contains('\n')
-                && !label.Contains('\r')
-                && !label.Contains('\t')
-                && !label.Contains('{')
-                && !label.Contains('}')
+        var act = () =>
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.CursorPagingMode,
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                SqlDialect.Pgsql,
+                "Unsafe\r\n\t{template}" + new string('x', 200)
             );
-        context.Outcome.Should().HaveLength(128);
+
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("outcome");
+    }
+
+    // The refused label reaches the message the emission sites log, so it carries neither structured-log
+    // template syntax nor the whole of an arbitrarily long value.
+    [Test]
+    public void It_sanitizes_and_bounds_a_refused_label_before_naming_it()
+    {
+        var act = () =>
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.CursorPagingMode,
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                SqlDialect.Pgsql,
+                "Unsafe\r\n\t{template}" + new string('x', 200)
+            );
+
+        string message = act.Should().Throw<ArgumentException>().Which.Message;
+
+        message.Should().NotContain("\n").And.NotContain("\r").And.NotContain("\t");
+        message.Should().NotContain("{").And.NotContain("}");
+        message.Should().NotContain(new string('x', 65));
+    }
+
+    // Each dimension carries its own set, so a value that is bounded but belongs to another dimension is
+    // refused too. Without this a reordered argument list would emit a tag set the contract never
+    // describes while every cardinality assertion still passed.
+    [Test]
+    public void It_refuses_a_bounded_label_belonging_to_another_dimension()
+    {
+        var act = () =>
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.SuccessOutcome,
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                SqlDialect.Pgsql,
+                CollectionPagingTelemetryLabel.ValidationRejectedOutcome
+            );
+
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("pagingMode");
+    }
+
+    // The sets are the contract's Dimensions table. A constant added to the label class but left out of
+    // its set would be refused at every emission site and lost as a swallowed warning, so the two are
+    // pinned to each other here rather than left to agree by inspection.
+    [Test]
+    public void It_allows_exactly_the_documented_dimension_values()
+    {
+        CollectionPagingTelemetryLabel
+            .PagingModes.Should()
+            .BeEquivalentTo("traditional", "cursor", "partition");
+        CollectionPagingTelemetryLabel
+            .CommandCategories.Should()
+            .BeEquivalentTo("page", "page_with_count", "boundary", "none");
+        CollectionPagingTelemetryLabel
+            .Providers.Should()
+            .BeEquivalentTo("postgresql", "sqlserver", "unknown");
+        CollectionPagingTelemetryLabel
+            .Outcomes.Should()
+            .BeEquivalentTo(
+                "success",
+                "terminal_page",
+                "early_empty",
+                "validation_rejected",
+                "not_authorized",
+                "not_implemented",
+                "security_configuration",
+                "retry_exhausted",
+                "unknown_failure",
+                "execution_exception"
+            );
     }
 
     [TestCase(null)]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
@@ -598,16 +598,24 @@ public class Given_CollectionPagingTelemetry
         var nullPartitionContext = () => telemetry.RecordPartitions(null!, TimeSpan.Zero, 4, 4);
         var nullRejectionContext = () => telemetry.RecordValidationRejected(null!);
 
-        negativeDuration.Should().Throw<ArgumentOutOfRangeException>();
-        negativeRequestedPageSize.Should().Throw<ArgumentOutOfRangeException>();
-        negativeReturnedPageSize.Should().Throw<ArgumentOutOfRangeException>();
-        negativePartitionDuration.Should().Throw<ArgumentOutOfRangeException>();
-        negativeRequestedPartitionCount.Should().Throw<ArgumentOutOfRangeException>();
-        negativeReturnedPartitionCount.Should().Throw<ArgumentOutOfRangeException>();
-        nullPageContext.Should().Throw<ArgumentNullException>();
-        nullPartitionContext.Should().Throw<ArgumentNullException>();
-        nullRejectionContext.Should().Throw<ArgumentNullException>();
+        // The parameter each fault names, not merely that one was raised. This helper runs against both
+        // the recording implementation and the no-op, so asserting the name here is what makes "the
+        // no-op validates exactly as the recording implementation does" a checked claim rather than a
+        // comment — and a shared validation helper inside either one, which would have to name its
+        // parameters something neither caller uses, fails this.
+        AssertParamName(negativeDuration, "duration");
+        AssertParamName(negativeRequestedPageSize, "requestedPageSize");
+        AssertParamName(negativeReturnedPageSize, "returnedPageSize");
+        AssertParamName(negativePartitionDuration, "duration");
+        AssertParamName(negativeRequestedPartitionCount, "requestedPartitionCount");
+        AssertParamName(negativeReturnedPartitionCount, "returnedPartitionCount");
+        nullPageContext.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("context");
+        nullPartitionContext.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("context");
+        nullRejectionContext.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("context");
     }
+
+    private static void AssertParamName(Action act, string expectedParameterName) =>
+        act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be(expectedParameterName);
 
     private static CollectionPagingTelemetryContext FailureContext(string pagingMode) =>
         CollectionPagingTelemetryContext.ForPagingMode(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
@@ -453,6 +453,68 @@ public class Given_CollectionPagingTelemetry
             );
     }
 
+    // The strings an operator types into an AddMeter call and into every dashboard query. They are the
+    // one part of the published contract that reading a constant back cannot check: every other test
+    // here reaches an instrument through the same constant that named it, so both sides of the
+    // comparison move together under a rename and no assertion notices. Spelled as literals from the
+    // Instruments table and the Collecting These Metrics section of docs/PAGING-TELEMETRY.md, for the
+    // same reason the dimension values above are.
+    [Test]
+    public void It_publishes_exactly_the_documented_meter_and_instrument_names()
+    {
+        CollectionPagingTelemetry.MeterName.Should().Be("EdFi.DataManagementService.CollectionPaging");
+        CollectionPagingTelemetry.RequestCounterName.Should().Be("edfi.dms.collection_paging.requests");
+        CollectionPagingTelemetry.DurationName.Should().Be("edfi.dms.collection_paging.duration");
+        CollectionPagingTelemetry
+            .RequestedPageSizeName.Should()
+            .Be("edfi.dms.collection_paging.page_size.requested");
+        CollectionPagingTelemetry
+            .ReturnedPageSizeName.Should()
+            .Be("edfi.dms.collection_paging.page_size.returned");
+        CollectionPagingTelemetry
+            .RequestedPartitionCountName.Should()
+            .Be("edfi.dms.collection_paging.partition_count.requested");
+        CollectionPagingTelemetry
+            .ReturnedPartitionCountName.Should()
+            .Be("edfi.dms.collection_paging.partition_count.returned");
+    }
+
+    // The meter name is published only by the parameterless constructor, which is the one dependency
+    // injection selects and the only one that reaches the process-static meter. Every other test here
+    // supplies its own meter, so pinning the constant alone would prove a constant has a value without
+    // proving the meter an operator subscribes to carries it.
+    [Test]
+    public void It_publishes_on_the_documented_meter_from_the_production_constructor()
+    {
+        List<string> observedMeterNames = [];
+        using MeterListener listener = new()
+        {
+            InstrumentPublished = static (instrument, listener) =>
+            {
+                if (instrument.Name == CollectionPagingTelemetry.RequestCounterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>(
+            (instrument, _, _, _) => observedMeterNames.Add(instrument.Meter.Name)
+        );
+        listener.Start();
+
+        CollectionPagingTelemetry telemetry = new();
+        telemetry.RecordValidationRejected(
+            FailureContext(CollectionPagingTelemetryLabel.TraditionalPagingMode)
+        );
+
+        // OnlyContain rather than a single expected element: the meter is process-static, so a
+        // concurrent test recording on it would be observed here too — and would carry this same name.
+        observedMeterNames
+            .Should()
+            .NotBeEmpty("the production constructor must publish the request counter")
+            .And.OnlyContain(name => name == "EdFi.DataManagementService.CollectionPaging");
+    }
+
     [TestCase(null)]
     [TestCase("")]
     [TestCase("   ")]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
@@ -1,0 +1,611 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Diagnostics.Metrics;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Telemetry;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Serilog;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Telemetry;
+
+/// <summary>
+/// The bounded collection-paging metric contract.
+/// </summary>
+/// <remarks>
+/// Asserts the contract an operator builds dashboards and alerts from — instrument names, units, and the
+/// complete allowed value list for each dimension — because a rename or a new dimension breaks queries
+/// silently rather than breaking a response.
+/// </remarks>
+[TestFixture]
+[Parallelizable]
+[Category("CollectionPagingTelemetry")]
+public class Given_CollectionPagingTelemetry
+{
+    private static readonly string[] AllowedTagKeys =
+    [
+        "paging_mode",
+        "command_category",
+        "provider",
+        "outcome",
+    ];
+
+    private static readonly CollectionPaging TraditionalPaging = new CollectionPaging.Traditional(
+        new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+    );
+
+    private static readonly CollectionPaging CursorPaging = new CollectionPaging.Cursor(
+        new CursorRange(1L, 1000L),
+        new PageSize(100)
+    );
+
+    [Test]
+    public void It_records_the_get_many_instruments_with_documented_names_units_and_tags()
+    {
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        telemetry.RecordPage(
+            CollectionPagingTelemetryContext.ForPaging(
+                CursorPaging,
+                CollectionPagingTelemetryLabel.PageCommandCategory,
+                SqlDialect.Pgsql,
+                CollectionPagingTelemetryLabel.SuccessOutcome
+            ),
+            TimeSpan.FromMilliseconds(37),
+            requestedPageSize: 100,
+            returnedPageSize: 42
+        );
+
+        MetricMeasurement request = collector.Single(CollectionPagingTelemetry.RequestCounterName);
+        request.LongValue.Should().Be(1);
+        request.Unit.Should().Be("{request}");
+        request.Tags["paging_mode"].Should().Be("cursor");
+        request.Tags["command_category"].Should().Be("page");
+        request.Tags["provider"].Should().Be("postgresql");
+        request.Tags["outcome"].Should().Be("success");
+
+        MetricMeasurement duration = collector.Single(CollectionPagingTelemetry.DurationName);
+        duration.DoubleValue.Should().Be(37);
+        duration.Unit.Should().Be("ms");
+
+        MetricMeasurement requestedPageSize = collector.Single(
+            CollectionPagingTelemetry.RequestedPageSizeName
+        );
+        requestedPageSize.IntValue.Should().Be(100);
+        requestedPageSize.Unit.Should().Be("{item}");
+
+        MetricMeasurement returnedPageSize = collector.Single(CollectionPagingTelemetry.ReturnedPageSizeName);
+        returnedPageSize.IntValue.Should().Be(42);
+        returnedPageSize.Unit.Should().Be("{item}");
+
+        // Page-size and partition-count instruments measure different things, so a GET-many emission must
+        // not contribute to a histogram whose unit is partitions.
+        collector.MeasurementsFor(CollectionPagingTelemetry.RequestedPartitionCountName).Should().BeEmpty();
+        collector.MeasurementsFor(CollectionPagingTelemetry.ReturnedPartitionCountName).Should().BeEmpty();
+
+        collector.AllMeasurements.Should().OnlyContain(measurement => HasExactlyTheAllowedTags(measurement));
+    }
+
+    [Test]
+    public void It_records_the_partition_instruments_with_documented_names_units_and_tags()
+    {
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        telemetry.RecordPartitions(
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.PartitionPagingMode,
+                CollectionPagingTelemetryLabel.BoundaryCommandCategory,
+                SqlDialect.Mssql,
+                CollectionPagingTelemetryLabel.SuccessOutcome
+            ),
+            TimeSpan.FromMilliseconds(12),
+            requestedPartitionCount: 8,
+            returnedPartitionCount: 3
+        );
+
+        MetricMeasurement request = collector.Single(CollectionPagingTelemetry.RequestCounterName);
+        request.LongValue.Should().Be(1);
+        request.Tags["paging_mode"].Should().Be("partition");
+        request.Tags["command_category"].Should().Be("boundary");
+        request.Tags["provider"].Should().Be("sqlserver");
+        request.Tags["outcome"].Should().Be("success");
+
+        collector.Single(CollectionPagingTelemetry.DurationName).DoubleValue.Should().Be(12);
+
+        MetricMeasurement requestedPartitionCount = collector.Single(
+            CollectionPagingTelemetry.RequestedPartitionCountName
+        );
+        requestedPartitionCount.IntValue.Should().Be(8);
+        requestedPartitionCount.Unit.Should().Be("{partition}");
+
+        MetricMeasurement returnedPartitionCount = collector.Single(
+            CollectionPagingTelemetry.ReturnedPartitionCountName
+        );
+        returnedPartitionCount.IntValue.Should().Be(3);
+        returnedPartitionCount.Unit.Should().Be("{partition}");
+
+        collector.MeasurementsFor(CollectionPagingTelemetry.RequestedPageSizeName).Should().BeEmpty();
+        collector.MeasurementsFor(CollectionPagingTelemetry.ReturnedPageSizeName).Should().BeEmpty();
+
+        collector.AllMeasurements.Should().OnlyContain(measurement => HasExactlyTheAllowedTags(measurement));
+    }
+
+    // A rejection did no backend work, so a duration sample from it would report microseconds as a read
+    // latency and drag every percentile down.
+    [Test]
+    public void It_records_only_the_request_counter_for_a_validation_rejection()
+    {
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        telemetry.RecordValidationRejected(
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.CursorPagingMode,
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                SqlDialect.Pgsql,
+                CollectionPagingTelemetryLabel.ValidationRejectedOutcome
+            )
+        );
+
+        MetricMeasurement request = collector.Single(CollectionPagingTelemetry.RequestCounterName);
+        request.Tags["outcome"].Should().Be("validation_rejected");
+        request.Tags["command_category"].Should().Be("none");
+
+        collector.MeasurementsFor(CollectionPagingTelemetry.DurationName).Should().BeEmpty();
+        collector.MeasurementsFor(CollectionPagingTelemetry.RequestedPageSizeName).Should().BeEmpty();
+        collector.MeasurementsFor(CollectionPagingTelemetry.ReturnedPageSizeName).Should().BeEmpty();
+        collector.MeasurementsFor(CollectionPagingTelemetry.RequestedPartitionCountName).Should().BeEmpty();
+        collector.MeasurementsFor(CollectionPagingTelemetry.ReturnedPartitionCountName).Should().BeEmpty();
+    }
+
+    // A failure produced no page, and recording zero returned items for it would be indistinguishable
+    // from a successful empty page in the requested-versus-returned gap operators watch.
+    [Test]
+    public void It_suppresses_the_returned_histograms_when_nothing_was_produced()
+    {
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        telemetry.RecordPage(
+            FailureContext(CollectionPagingTelemetryLabel.TraditionalPagingMode),
+            TimeSpan.FromMilliseconds(5),
+            requestedPageSize: 25,
+            returnedPageSize: null
+        );
+        telemetry.RecordPartitions(
+            FailureContext(CollectionPagingTelemetryLabel.PartitionPagingMode),
+            TimeSpan.FromMilliseconds(5),
+            requestedPartitionCount: 4,
+            returnedPartitionCount: null
+        );
+
+        collector.MeasurementsFor(CollectionPagingTelemetry.RequestedPageSizeName).Should().ContainSingle();
+        collector.MeasurementsFor(CollectionPagingTelemetry.ReturnedPageSizeName).Should().BeEmpty();
+        collector
+            .MeasurementsFor(CollectionPagingTelemetry.RequestedPartitionCountName)
+            .Should()
+            .ContainSingle();
+        collector.MeasurementsFor(CollectionPagingTelemetry.ReturnedPartitionCountName).Should().BeEmpty();
+        collector.MeasurementsFor(CollectionPagingTelemetry.RequestCounterName).Should().HaveCount(2);
+    }
+
+    // An empty page that really executed is a success with zero items, which is a different fact from a
+    // failure that produced no page at all. Zero must therefore be recorded, not suppressed.
+    [Test]
+    public void It_records_a_zero_returned_count_that_a_successful_empty_result_produced()
+    {
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        telemetry.RecordPage(
+            CollectionPagingTelemetryContext.ForPaging(
+                TraditionalPaging,
+                CollectionPagingTelemetryLabel.PageCommandCategory,
+                SqlDialect.Pgsql,
+                CollectionPagingTelemetryLabel.SuccessOutcome
+            ),
+            TimeSpan.Zero,
+            requestedPageSize: 25,
+            returnedPageSize: 0
+        );
+
+        collector.Single(CollectionPagingTelemetry.ReturnedPageSizeName).IntValue.Should().Be(0);
+        collector.Single(CollectionPagingTelemetry.DurationName).DoubleValue.Should().Be(0);
+    }
+
+    [TestCase(false, "traditional")]
+    [TestCase(true, "cursor")]
+    public void It_maps_the_paging_mode_from_the_resolved_collection_paging(bool cursor, string expected)
+    {
+        CollectionPagingTelemetryContext context = CollectionPagingTelemetryContext.ForPaging(
+            cursor ? CursorPaging : TraditionalPaging,
+            CollectionPagingTelemetryLabel.PageCommandCategory,
+            SqlDialect.Pgsql,
+            CollectionPagingTelemetryLabel.SuccessOutcome
+        );
+
+        context.PagingMode.Should().Be(expected);
+    }
+
+    [Test]
+    public void It_maps_every_provider_including_the_unresolved_mapping_set()
+    {
+        CollectionPagingTelemetryContext.ProviderLabel(SqlDialect.Pgsql).Should().Be("postgresql");
+        CollectionPagingTelemetryContext.ProviderLabel(SqlDialect.Mssql).Should().Be("sqlserver");
+        CollectionPagingTelemetryContext.ProviderLabel(null).Should().Be("unknown");
+    }
+
+    // A dialect the contract does not name must fail rather than mint a new provider label, which would
+    // silently widen the dimension past what the operator documentation lists.
+    [Test]
+    public void It_rejects_a_dialect_outside_the_documented_provider_set()
+    {
+        var act = () =>
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.CursorPagingMode,
+                CollectionPagingTelemetryLabel.PageCommandCategory,
+                (SqlDialect)999,
+                CollectionPagingTelemetryLabel.SuccessOutcome
+            );
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void It_round_trips_every_documented_outcome_to_a_tag_value()
+    {
+        string[] outcomes =
+        [
+            CollectionPagingTelemetryLabel.SuccessOutcome,
+            CollectionPagingTelemetryLabel.TerminalPageOutcome,
+            CollectionPagingTelemetryLabel.EarlyEmptyOutcome,
+            CollectionPagingTelemetryLabel.ValidationRejectedOutcome,
+            CollectionPagingTelemetryLabel.NotAuthorizedOutcome,
+            CollectionPagingTelemetryLabel.NotImplementedOutcome,
+            CollectionPagingTelemetryLabel.SecurityConfigurationOutcome,
+            CollectionPagingTelemetryLabel.RetryExhaustedOutcome,
+            CollectionPagingTelemetryLabel.UnknownFailureOutcome,
+            CollectionPagingTelemetryLabel.ExecutionExceptionOutcome,
+        ];
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        foreach (string outcome in outcomes)
+        {
+            telemetry.RecordValidationRejected(
+                CollectionPagingTelemetryContext.ForPagingMode(
+                    CollectionPagingTelemetryLabel.TraditionalPagingMode,
+                    CollectionPagingTelemetryLabel.NoCommandCategory,
+                    SqlDialect.Pgsql,
+                    outcome
+                )
+            );
+        }
+
+        collector
+            .MeasurementsFor(CollectionPagingTelemetry.RequestCounterName)
+            .Select(measurement => measurement.Tags["outcome"])
+            .Should()
+            .BeEquivalentTo(outcomes);
+    }
+
+    [Test]
+    public void It_round_trips_every_documented_command_category_to_a_tag_value()
+    {
+        string[] commandCategories =
+        [
+            CollectionPagingTelemetryLabel.PageCommandCategory,
+            CollectionPagingTelemetryLabel.PageWithCountCommandCategory,
+            CollectionPagingTelemetryLabel.BoundaryCommandCategory,
+            CollectionPagingTelemetryLabel.NoCommandCategory,
+        ];
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        foreach (string commandCategory in commandCategories)
+        {
+            telemetry.RecordValidationRejected(
+                CollectionPagingTelemetryContext.ForPagingMode(
+                    CollectionPagingTelemetryLabel.TraditionalPagingMode,
+                    commandCategory,
+                    SqlDialect.Pgsql,
+                    CollectionPagingTelemetryLabel.SuccessOutcome
+                )
+            );
+        }
+
+        collector
+            .MeasurementsFor(CollectionPagingTelemetry.RequestCounterName)
+            .Select(measurement => measurement.Tags["command_category"])
+            .Should()
+            .BeEquivalentTo(commandCategories);
+    }
+
+    // The cardinality guard. A fifth dimension multiplies every stored time series, so adding one has to
+    // be a deliberate edit here rather than something a caller can do by passing another tag.
+    [Test]
+    public void It_emits_exactly_the_four_documented_dimensions_on_every_instrument()
+    {
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        telemetry.RecordPage(
+            CollectionPagingTelemetryContext.ForPaging(
+                TraditionalPaging,
+                CollectionPagingTelemetryLabel.PageWithCountCommandCategory,
+                SqlDialect.Pgsql,
+                CollectionPagingTelemetryLabel.TerminalPageOutcome
+            ),
+            TimeSpan.FromMilliseconds(9),
+            requestedPageSize: 25,
+            returnedPageSize: 25
+        );
+        telemetry.RecordPartitions(
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.PartitionPagingMode,
+                CollectionPagingTelemetryLabel.BoundaryCommandCategory,
+                SqlDialect.Mssql,
+                CollectionPagingTelemetryLabel.EarlyEmptyOutcome
+            ),
+            TimeSpan.FromMilliseconds(9),
+            requestedPartitionCount: 4,
+            returnedPartitionCount: 0
+        );
+        telemetry.RecordValidationRejected(FailureContext(CollectionPagingTelemetryLabel.CursorPagingMode));
+
+        collector
+            .AllMeasurements.Should()
+            .HaveCount(9)
+            .And.OnlyContain(measurement => HasExactlyTheAllowedTags(measurement));
+    }
+
+    // The bound this layer guarantees: no control characters, no structured-log template syntax, and no
+    // label longer than 128 characters, whatever a caller passes. Keeping request-derived values out of
+    // labels entirely is a property of the emission sites, which pass only the constants above, and is
+    // asserted there against sentinel request data.
+    [Test]
+    public void It_sanitizes_and_bounds_a_label_whatever_a_caller_passes()
+    {
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+        CollectionPagingTelemetryContext context = CollectionPagingTelemetryContext.ForPagingMode(
+            CollectionPagingTelemetryLabel.CursorPagingMode,
+            CollectionPagingTelemetryLabel.NoCommandCategory,
+            SqlDialect.Pgsql,
+            "Unsafe\r\n\t{template}" + new string('x', 200)
+        );
+
+        telemetry.RecordValidationRejected(context);
+
+        MetricMeasurement rejection = collector.Single(CollectionPagingTelemetry.RequestCounterName);
+        rejection
+            .Tags.Values.OfType<string>()
+            .Should()
+            .OnlyContain(label =>
+                label.Length <= 128
+                && !label.Contains('\n')
+                && !label.Contains('\r')
+                && !label.Contains('\t')
+                && !label.Contains('{')
+                && !label.Contains('}')
+            );
+        context.Outcome.Should().HaveLength(128);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void It_rejects_a_missing_label(string? label)
+    {
+        var act = () =>
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.CursorPagingMode,
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                SqlDialect.Pgsql,
+                label!
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void It_rejects_a_negative_duration_and_negative_counts()
+    {
+        using MetricCollector collector = new();
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+        CollectionPagingTelemetryContext context = FailureContext(
+            CollectionPagingTelemetryLabel.TraditionalPagingMode
+        );
+
+        AssertRejectsInvalidMeasurements(telemetry, context);
+        collector.AllMeasurements.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_validates_identically_and_emits_nothing_on_the_no_op()
+    {
+        using MetricCollector collector = new();
+        NoOpCollectionPagingTelemetry telemetry = NoOpCollectionPagingTelemetry.Instance;
+        CollectionPagingTelemetryContext context = FailureContext(
+            CollectionPagingTelemetryLabel.TraditionalPagingMode
+        );
+
+        AssertRejectsInvalidMeasurements(telemetry, context);
+
+        telemetry.RecordPage(context, TimeSpan.FromMilliseconds(5), 25, 25);
+        telemetry.RecordPartitions(context, TimeSpan.FromMilliseconds(5), 4, 4);
+        telemetry.RecordValidationRejected(context);
+
+        collector.AllMeasurements.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_resolves_the_telemetry_as_a_singleton_from_the_core_registration()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+        var services = new ServiceCollection();
+
+        services.AddDmsDefaultConfiguration(
+            new LoggerConfiguration().CreateLogger(),
+            configuration.GetSection("CircuitBreaker"),
+            configuration.GetSection("DeadlockRetry"),
+            false
+        );
+
+        using var provider = services.BuildServiceProvider();
+        var telemetry = provider.GetRequiredService<ICollectionPagingTelemetry>();
+
+        telemetry.Should().BeOfType<CollectionPagingTelemetry>();
+        provider.GetRequiredService<ICollectionPagingTelemetry>().Should().BeSameAs(telemetry);
+    }
+
+    private static void AssertRejectsInvalidMeasurements(
+        ICollectionPagingTelemetry telemetry,
+        CollectionPagingTelemetryContext context
+    )
+    {
+        var negativeDuration = () => telemetry.RecordPage(context, TimeSpan.FromMilliseconds(-1), 25, 25);
+        var negativeRequestedPageSize = () => telemetry.RecordPage(context, TimeSpan.Zero, -1, 25);
+        var negativeReturnedPageSize = () => telemetry.RecordPage(context, TimeSpan.Zero, 25, -1);
+        var negativePartitionDuration = () =>
+            telemetry.RecordPartitions(context, TimeSpan.FromMilliseconds(-1), 4, 4);
+        var negativeRequestedPartitionCount = () => telemetry.RecordPartitions(context, TimeSpan.Zero, -1, 4);
+        var negativeReturnedPartitionCount = () => telemetry.RecordPartitions(context, TimeSpan.Zero, 4, -1);
+        var nullPageContext = () => telemetry.RecordPage(null!, TimeSpan.Zero, 25, 25);
+        var nullPartitionContext = () => telemetry.RecordPartitions(null!, TimeSpan.Zero, 4, 4);
+        var nullRejectionContext = () => telemetry.RecordValidationRejected(null!);
+
+        negativeDuration.Should().Throw<ArgumentOutOfRangeException>();
+        negativeRequestedPageSize.Should().Throw<ArgumentOutOfRangeException>();
+        negativeReturnedPageSize.Should().Throw<ArgumentOutOfRangeException>();
+        negativePartitionDuration.Should().Throw<ArgumentOutOfRangeException>();
+        negativeRequestedPartitionCount.Should().Throw<ArgumentOutOfRangeException>();
+        negativeReturnedPartitionCount.Should().Throw<ArgumentOutOfRangeException>();
+        nullPageContext.Should().Throw<ArgumentNullException>();
+        nullPartitionContext.Should().Throw<ArgumentNullException>();
+        nullRejectionContext.Should().Throw<ArgumentNullException>();
+    }
+
+    private static CollectionPagingTelemetryContext FailureContext(string pagingMode) =>
+        CollectionPagingTelemetryContext.ForPagingMode(
+            pagingMode,
+            CollectionPagingTelemetryLabel.NoCommandCategory,
+            SqlDialect.Pgsql,
+            CollectionPagingTelemetryLabel.UnknownFailureOutcome
+        );
+
+    private static bool HasExactlyTheAllowedTags(MetricMeasurement measurement) =>
+        measurement.Tags.Count == AllowedTagKeys.Length
+        && Array.TrueForAll(AllowedTagKeys, measurement.Tags.ContainsKey);
+
+    /// <summary>
+    /// A MeterListener-backed collector over a per-test meter.
+    /// </summary>
+    /// <remarks>
+    /// Carries an int callback alongside the long and double ones because the page-size and
+    /// partition-count instruments are <c>Histogram&lt;int&gt;</c>; without it those measurements would be
+    /// invisible and every assertion about them would pass vacuously. The unit is captured from the
+    /// instrument so a unit change is a test failure rather than a dashboard that silently rescales.
+    /// </remarks>
+    private sealed class MetricCollector : IDisposable
+    {
+        private readonly Meter _meter = new($"CollectionPagingTelemetryTests.{Guid.NewGuid()}");
+        private readonly MeterListener _listener = new();
+        private readonly List<MetricMeasurement> _measurements = [];
+
+        public MetricCollector()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == _meter.Name)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>(
+                (instrument, measurement, tags, _) =>
+                    _measurements.Add(
+                        new MetricMeasurement(
+                            instrument.Name,
+                            instrument.Unit,
+                            LongValue: measurement,
+                            DoubleValue: null,
+                            IntValue: null,
+                            Tags: CopyTags(tags)
+                        )
+                    )
+            );
+            _listener.SetMeasurementEventCallback<double>(
+                (instrument, measurement, tags, _) =>
+                    _measurements.Add(
+                        new MetricMeasurement(
+                            instrument.Name,
+                            instrument.Unit,
+                            LongValue: null,
+                            DoubleValue: measurement,
+                            IntValue: null,
+                            Tags: CopyTags(tags)
+                        )
+                    )
+            );
+            _listener.SetMeasurementEventCallback<int>(
+                (instrument, measurement, tags, _) =>
+                    _measurements.Add(
+                        new MetricMeasurement(
+                            instrument.Name,
+                            instrument.Unit,
+                            LongValue: null,
+                            DoubleValue: null,
+                            IntValue: measurement,
+                            Tags: CopyTags(tags)
+                        )
+                    )
+            );
+            _listener.Start();
+        }
+
+        public CollectionPagingTelemetry CreateTelemetry() => new(_meter);
+
+        public IReadOnlyList<MetricMeasurement> AllMeasurements => _measurements;
+
+        public MetricMeasurement[] MeasurementsFor(string instrumentName) =>
+            [.. _measurements.Where(measurement => measurement.InstrumentName == instrumentName)];
+
+        public MetricMeasurement Single(string instrumentName) =>
+            MeasurementsFor(instrumentName).Should().ContainSingle().Which;
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+            _meter.Dispose();
+        }
+
+        private static Dictionary<string, object?> CopyTags(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            Dictionary<string, object?> result = [];
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                result[tag.Key] = tag.Value;
+            }
+
+            return result;
+        }
+    }
+
+    private sealed record MetricMeasurement(
+        string InstrumentName,
+        string? Unit,
+        long? LongValue,
+        double? DoubleValue,
+        int? IntValue,
+        Dictionary<string, object?> Tags
+    );
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Telemetry/CollectionPagingTelemetryTests.cs
@@ -138,6 +138,69 @@ public class Given_CollectionPagingTelemetry
         collector.AllMeasurements.Should().OnlyContain(measurement => HasExactlyTheAllowedTags(measurement));
     }
 
+    // The request counter is emitted after every measurement it accounts for. A .NET instrument invokes
+    // its subscribers synchronously on the recording thread, and the operator guidance for these metrics
+    // asks the host to register exactly such a subscriber, so one that throws is reachable. Counting
+    // first would leave a counted request carrying no duration, and the published aggregation intent
+    // reads `requests` as the validation rejections plus the duration samples. Counting last inverts
+    // which side the loss falls on: a request may go uncounted, but a counted one was measured.
+    [Test]
+    public void It_counts_a_page_only_after_the_measurements_it_accounts_for()
+    {
+        using MetricCollector collector = new(failOnRequestCounter: true);
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        var record = () =>
+            telemetry.RecordPage(
+                CollectionPagingTelemetryContext.ForPaging(
+                    TraditionalPaging,
+                    CollectionPagingTelemetryLabel.PageCommandCategory,
+                    SqlDialect.Pgsql,
+                    CollectionPagingTelemetryLabel.SuccessOutcome
+                ),
+                TimeSpan.FromMilliseconds(37),
+                requestedPageSize: 25,
+                returnedPageSize: 25
+            );
+
+        // Swallowing a subscriber fault is the emission site's job, not this component's.
+        record.Should().Throw<InvalidOperationException>();
+
+        collector.Single(CollectionPagingTelemetry.DurationName).DoubleValue.Should().Be(37);
+        collector.Single(CollectionPagingTelemetry.RequestedPageSizeName).IntValue.Should().Be(25);
+        collector.Single(CollectionPagingTelemetry.ReturnedPageSizeName).IntValue.Should().Be(25);
+        collector.MeasurementsFor(CollectionPagingTelemetry.RequestCounterName).Should().BeEmpty();
+    }
+
+    // The partition twin, pinned separately because the ordering lives in each method rather than in
+    // anything shared between them, so one can be reordered without the other.
+    [Test]
+    public void It_counts_partitions_only_after_the_measurements_it_accounts_for()
+    {
+        using MetricCollector collector = new(failOnRequestCounter: true);
+        CollectionPagingTelemetry telemetry = collector.CreateTelemetry();
+
+        var record = () =>
+            telemetry.RecordPartitions(
+                CollectionPagingTelemetryContext.ForPagingMode(
+                    CollectionPagingTelemetryLabel.PartitionPagingMode,
+                    CollectionPagingTelemetryLabel.BoundaryCommandCategory,
+                    SqlDialect.Mssql,
+                    CollectionPagingTelemetryLabel.SuccessOutcome
+                ),
+                TimeSpan.FromMilliseconds(12),
+                requestedPartitionCount: 8,
+                returnedPartitionCount: 3
+            );
+
+        record.Should().Throw<InvalidOperationException>();
+
+        collector.Single(CollectionPagingTelemetry.DurationName).DoubleValue.Should().Be(12);
+        collector.Single(CollectionPagingTelemetry.RequestedPartitionCountName).IntValue.Should().Be(8);
+        collector.Single(CollectionPagingTelemetry.ReturnedPartitionCountName).IntValue.Should().Be(3);
+        collector.MeasurementsFor(CollectionPagingTelemetry.RequestCounterName).Should().BeEmpty();
+    }
+
     // A rejection did no backend work, so a duration sample from it would report microseconds as a read
     // latency and drag every percentile down.
     [Test]
@@ -638,13 +701,19 @@ public class Given_CollectionPagingTelemetry
     /// invisible and every assertion about them would pass vacuously. The unit is captured from the
     /// instrument so a unit change is a test failure rather than a dashboard that silently rescales.
     /// </remarks>
+    /// <param name="failOnRequestCounter">
+    /// Stands in for a subscriber the host registered that throws. The request counter is the only
+    /// <c>long</c> instrument the contract publishes, so failing the long callback fails on exactly it
+    /// and leaves the duration and size callbacks working — which is what makes the emission order
+    /// observable from outside the component.
+    /// </param>
     private sealed class MetricCollector : IDisposable
     {
         private readonly Meter _meter = new($"CollectionPagingTelemetryTests.{Guid.NewGuid()}");
         private readonly MeterListener _listener = new();
         private readonly List<MetricMeasurement> _measurements = [];
 
-        public MetricCollector()
+        public MetricCollector(bool failOnRequestCounter = false)
         {
             _listener.InstrumentPublished = (instrument, listener) =>
             {
@@ -655,6 +724,12 @@ public class Given_CollectionPagingTelemetry
             };
             _listener.SetMeasurementEventCallback<long>(
                 (instrument, measurement, tags, _) =>
+                {
+                    if (failOnRequestCounter)
+                    {
+                        throw new InvalidOperationException("A subscribed measurement callback failed.");
+                    }
+
                     _measurements.Add(
                         new MetricMeasurement(
                             instrument.Name,
@@ -664,7 +739,8 @@ public class Given_CollectionPagingTelemetry
                             IntValue: null,
                             Tags: CopyTags(tags)
                         )
-                    )
+                    );
+                }
             );
             _listener.SetMeasurementEventCallback<double>(
                 (instrument, measurement, tags, _) =>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestHelper.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestHelper.cs
@@ -12,6 +12,7 @@ using EdFi.DataManagementService.Core.Middleware;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Startup;
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Core.Tests.Unit.Handler;
 using FakeItEasy;
 using FluentAssertions;
@@ -86,6 +87,15 @@ public static class TestHelper
         services.AddTransient<ILogger<ResolveMappingSetMiddleware>>(_ =>
             NullLogger<ResolveMappingSetMiddleware>.Instance
         );
+    }
+
+    /// <summary>
+    /// Registers the collection-paging telemetry the query and partitions pipelines resolve, for tests
+    /// composing those pipelines where the emitted metrics are not under test.
+    /// </summary>
+    public static void AddCollectionPagingTelemetry(IServiceCollection services)
+    {
+        services.AddSingleton<ICollectionPagingTelemetry>(NoOpCollectionPagingTelemetry.Instance);
     }
 
     /// <summary>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestSupport/RecordingCollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestSupport/RecordingCollectionPagingTelemetry.cs
@@ -51,6 +51,12 @@ internal sealed record CollectionPagingMeasurement(
 /// telemetry component's own tests. What is under test here is the classification each call site
 /// chose, so recording the arguments directly keeps these assertions readable and keeps a meter
 /// listener out of handler tests.
+/// <para>
+/// Every method validates through <see cref="NoOpCollectionPagingTelemetry" /> before capturing.
+/// That type exists to validate exactly as the recording implementation does, and this is the double
+/// every handler and middleware test runs against — so accepting a call production would reject
+/// would make these tests the place an argument fault goes unnoticed.
+/// </para>
 /// </remarks>
 internal sealed class RecordingCollectionPagingTelemetry : ICollectionPagingTelemetry
 {
@@ -69,7 +75,15 @@ internal sealed class RecordingCollectionPagingTelemetry : ICollectionPagingTele
         TimeSpan duration,
         int requestedPageSize,
         int? returnedPageSize
-    ) =>
+    )
+    {
+        NoOpCollectionPagingTelemetry.Instance.RecordPage(
+            context,
+            duration,
+            requestedPageSize,
+            returnedPageSize
+        );
+
         _measurements.Add(
             new CollectionPagingMeasurement(
                 CollectionPagingMeasurementKind.Page,
@@ -79,13 +93,22 @@ internal sealed class RecordingCollectionPagingTelemetry : ICollectionPagingTele
                 returnedPageSize
             )
         );
+    }
 
     public void RecordPartitions(
         CollectionPagingTelemetryContext context,
         TimeSpan duration,
         int requestedPartitionCount,
         int? returnedPartitionCount
-    ) =>
+    )
+    {
+        NoOpCollectionPagingTelemetry.Instance.RecordPartitions(
+            context,
+            duration,
+            requestedPartitionCount,
+            returnedPartitionCount
+        );
+
         _measurements.Add(
             new CollectionPagingMeasurement(
                 CollectionPagingMeasurementKind.Partitions,
@@ -95,8 +118,12 @@ internal sealed class RecordingCollectionPagingTelemetry : ICollectionPagingTele
                 returnedPartitionCount
             )
         );
+    }
 
-    public void RecordValidationRejected(CollectionPagingTelemetryContext context) =>
+    public void RecordValidationRejected(CollectionPagingTelemetryContext context)
+    {
+        NoOpCollectionPagingTelemetry.Instance.RecordValidationRejected(context);
+
         _measurements.Add(
             new CollectionPagingMeasurement(
                 CollectionPagingMeasurementKind.ValidationRejected,
@@ -106,6 +133,7 @@ internal sealed class RecordingCollectionPagingTelemetry : ICollectionPagingTele
                 Returned: null
             )
         );
+    }
 }
 
 /// <summary>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestSupport/RecordingCollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestSupport/RecordingCollectionPagingTelemetry.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Telemetry;
+using FluentAssertions;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.TestSupport;
+
+/// <summary>
+/// Which recording method produced a measurement.
+/// </summary>
+/// <remarks>
+/// Carried so a test can assert that a rejection went through the method that records no duration,
+/// rather than through a handler method with a zero duration passed in. The two are indistinguishable
+/// from the tag values alone.
+/// </remarks>
+internal enum CollectionPagingMeasurementKind
+{
+    Page,
+    Partitions,
+    ValidationRejected,
+}
+
+/// <summary>
+/// One recorded call, with everything the emission site chose.
+/// </summary>
+internal sealed record CollectionPagingMeasurement(
+    CollectionPagingMeasurementKind Kind,
+    CollectionPagingTelemetryContext Context,
+    TimeSpan? Duration,
+    int? Requested,
+    int? Returned
+)
+{
+    public string PagingMode => Context.PagingMode;
+
+    public string CommandCategory => Context.CommandCategory;
+
+    public string Provider => Context.Provider;
+
+    public string Outcome => Context.Outcome;
+}
+
+/// <summary>
+/// Captures what an emission site classified, rather than what the meter did with it.
+/// </summary>
+/// <remarks>
+/// Instrument names, units, and tag-set cardinality are pinned against a real MeterListener in the
+/// telemetry component's own tests. What is under test here is the classification each call site
+/// chose, so recording the arguments directly keeps these assertions readable and keeps a meter
+/// listener out of handler tests.
+/// </remarks>
+internal sealed class RecordingCollectionPagingTelemetry : ICollectionPagingTelemetry
+{
+    private readonly List<CollectionPagingMeasurement> _measurements = [];
+
+    public IReadOnlyList<CollectionPagingMeasurement> Measurements => _measurements;
+
+    /// <summary>
+    /// The single measurement this request contributed. Fails when a call site recorded none or more
+    /// than one, which is itself part of the contract: one request is one measurement set.
+    /// </summary>
+    public CollectionPagingMeasurement Single => _measurements.Should().ContainSingle().Subject;
+
+    public void RecordPage(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPageSize,
+        int? returnedPageSize
+    ) =>
+        _measurements.Add(
+            new CollectionPagingMeasurement(
+                CollectionPagingMeasurementKind.Page,
+                context,
+                duration,
+                requestedPageSize,
+                returnedPageSize
+            )
+        );
+
+    public void RecordPartitions(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPartitionCount,
+        int? returnedPartitionCount
+    ) =>
+        _measurements.Add(
+            new CollectionPagingMeasurement(
+                CollectionPagingMeasurementKind.Partitions,
+                context,
+                duration,
+                requestedPartitionCount,
+                returnedPartitionCount
+            )
+        );
+
+    public void RecordValidationRejected(CollectionPagingTelemetryContext context) =>
+        _measurements.Add(
+            new CollectionPagingMeasurement(
+                CollectionPagingMeasurementKind.ValidationRejected,
+                context,
+                Duration: null,
+                Requested: null,
+                Returned: null
+            )
+        );
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestSupport/RecordingCollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestSupport/RecordingCollectionPagingTelemetry.cs
@@ -107,3 +107,39 @@ internal sealed class RecordingCollectionPagingTelemetry : ICollectionPagingTele
             )
         );
 }
+
+/// <summary>
+/// Fails every recording call, standing in for a measurement callback the host subscribed that throws.
+/// </summary>
+/// <remarks>
+/// A .NET instrument invokes its listeners' callbacks synchronously on the recording thread, and the
+/// operator guidance for these metrics asks for exactly such a listener to be registered in the API
+/// host. So third-party code that can throw sits between an emission site and the meter, and every
+/// emission site has to survive it without changing what the client receives.
+/// </remarks>
+internal sealed class ThrowingCollectionPagingTelemetry : ICollectionPagingTelemetry
+{
+    /// <summary>
+    /// The single fault every call raises, stated once so the message names the cause being simulated
+    /// rather than reading as three unrelated test artifacts.
+    /// </summary>
+    private static readonly InvalidOperationException _fault = new(
+        "A subscribed measurement callback failed."
+    );
+
+    public void RecordPage(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPageSize,
+        int? returnedPageSize
+    ) => throw _fault;
+
+    public void RecordPartitions(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPartitionCount,
+        int? returnedPartitionCount
+    ) => throw _fault;
+
+    public void RecordValidationRejected(CollectionPagingTelemetryContext context) => throw _fault;
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
@@ -299,7 +299,8 @@ internal class ApiService : IApiService
             new ValidateQueryMiddleware(
                 _logger,
                 _appSettings.Value.MaximumPageSize,
-                _cursorParametersRecognized: true
+                _cursorParametersRecognized: true,
+                _serviceProvider.GetRequiredService<ICollectionPagingTelemetry>()
             ),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
@@ -336,7 +337,11 @@ internal class ApiService : IApiService
                 _logger,
                 _appSettings.Value.AllowIdentityUpdateOverrides.Split(',').ToList()
             ),
-            new ValidatePartitionQueryMiddleware(_logger, _appSettings.Value.DefaultPartitionCount),
+            new ValidatePartitionQueryMiddleware(
+                _logger,
+                _appSettings.Value.DefaultPartitionCount,
+                _serviceProvider.GetRequiredService<ICollectionPagingTelemetry>()
+            ),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
             new PartitionRequestHandler(
@@ -462,10 +467,14 @@ internal class ApiService : IApiService
                 _logger,
                 _appSettings.Value.AllowIdentityUpdateOverrides.Split(',').ToList()
             ),
+            // Change Query endpoints do not page by cursor at all — they read PaginationParameters
+            // directly — so a /deletes?limit=abc fault is not a collection-paging event, and counting it
+            // would pollute a metric that describes live collection reads.
             new ValidateQueryMiddleware(
                 _logger,
                 _appSettings.Value.MaximumPageSize,
-                _cursorParametersRecognized: false
+                _cursorParametersRecognized: false,
+                NoOpCollectionPagingTelemetry.Instance
             ),
             new ValidateTrackedChangeQueryMiddleware(_logger),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),

--- a/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
@@ -18,6 +18,7 @@ using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.ResourceLoadOrder;
 using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Core.Validation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -302,7 +303,11 @@ internal class ApiService : IApiService
             ),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
-            new QueryRequestHandler(_logger, _resiliencePipeline),
+            new QueryRequestHandler(
+                _logger,
+                _resiliencePipeline,
+                _serviceProvider.GetRequiredService<ICollectionPagingTelemetry>()
+            ),
         ]);
 
         return new PipelineProvider(steps);

--- a/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
@@ -339,7 +339,12 @@ internal class ApiService : IApiService
             new ValidatePartitionQueryMiddleware(_logger, _appSettings.Value.DefaultPartitionCount),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
-            new PartitionRequestHandler(_logger, _resiliencePipeline, _appSettings.Value.MaximumPageSize),
+            new PartitionRequestHandler(
+                _logger,
+                _resiliencePipeline,
+                _appSettings.Value.MaximumPageSize,
+                _serviceProvider.GetRequiredService<ICollectionPagingTelemetry>()
+            ),
         ]);
 
         return new PipelineProvider(steps);

--- a/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
@@ -15,6 +15,7 @@ using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.ResourceLoadOrder;
 using EdFi.DataManagementService.Core.Security;
 using EdFi.DataManagementService.Core.Startup;
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Core.Validation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -130,7 +131,9 @@ public static class DmsCoreServiceExtensions
             .AddTransient<ProfileWritePipelineMiddleware>()
             .AddSingleton<ITokenInfoRelationalMappingSetResolver, TokenInfoRelationalMappingSetResolver>()
             .AddSingleton<GetTokenInfoHandler>()
-            .AddSingleton<AvailableChangeVersionsHandler>();
+            .AddSingleton<AvailableChangeVersionsHandler>()
+            // Collection-read observability
+            .AddSingleton<ICollectionPagingTelemetry, CollectionPagingTelemetry>();
 
         return services;
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
@@ -92,7 +92,7 @@ internal class PartitionRequestHandler(
         {
             // CustomViewAuthorizationValidationException escapes execution as an exception rather than a
             // result, and the boundary command selects through the configured views.
-            RecordOutcome(
+            Record(
                 requestInfo,
                 Stopwatch.GetElapsedTime(startTimestamp),
                 requestedPartitionCount,
@@ -203,7 +203,7 @@ internal class PartitionRequestHandler(
             _ => FailureClassification(CollectionPagingTelemetryLabel.UnknownFailureOutcome),
         };
 
-        RecordOutcome(
+        Record(
             requestInfo,
             duration,
             requestedPartitionCount,
@@ -230,7 +230,7 @@ internal class PartitionRequestHandler(
     /// and the tests are what catch those.
     /// </para>
     /// </remarks>
-    private void RecordOutcome(
+    private void Record(
         RequestInfo requestInfo,
         TimeSpan duration,
         int requestedPartitionCount,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
@@ -175,7 +175,10 @@ internal class PartitionRequestHandler(
     {
         (string commandCategory, string outcome, int? returnedPartitionCount) = partitionResult switch
         {
-            PartitionSuccess { SelectionSkipped: true } skipped => (
+            // Both halves of what early_empty asserts, not the flag alone. A success carrying ranges was
+            // built by a boundary command whatever the flag says, so it falls through to the arm below
+            // and is reported as the boundary work it did.
+            PartitionSuccess { SelectionSkipped: true, Ranges.Count: 0 } skipped => (
                 CollectionPagingTelemetryLabel.NoCommandCategory,
                 CollectionPagingTelemetryLabel.EarlyEmptyOutcome,
                 (int?)skipped.Ranges.Count

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
@@ -210,6 +210,23 @@ internal class PartitionRequestHandler(
         );
     }
 
+    /// <summary>
+    /// Emits one measurement set, and never lets a telemetry fault reach the client.
+    /// </summary>
+    /// <remarks>
+    /// Instrumentation observes; it must not participate. Every call arrives after the response has been
+    /// assembled, and the execution-exception call arrives from inside a catch that is about to rethrow,
+    /// so an escaping throw would either replace a served response with a system error or replace the
+    /// fault it was trying to report — the same reason the requested count above is resolved before
+    /// timing starts rather than from inside that catch. Recording is not free of throwing code: label
+    /// derivation rejects a request state the bounded dimension set cannot describe, and an instrument
+    /// invokes whatever measurement callbacks the host has subscribed, which is third-party code on this
+    /// thread.
+    /// <para>
+    /// Validation on the recording side stays fail-fast: it can only report a defect in this handler,
+    /// and the tests are what catch those.
+    /// </para>
+    /// </remarks>
     private void RecordOutcome(
         RequestInfo requestInfo,
         TimeSpan duration,
@@ -217,18 +234,32 @@ internal class PartitionRequestHandler(
         string commandCategory,
         string outcome,
         int? returnedPartitionCount
-    ) =>
-        _collectionPagingTelemetry.RecordPartitions(
-            CollectionPagingTelemetryContext.ForPagingMode(
-                CollectionPagingTelemetryLabel.PartitionPagingMode,
-                commandCategory,
-                requestInfo.MappingSet?.Key.Dialect,
-                outcome
-            ),
-            duration,
-            requestedPartitionCount,
-            returnedPartitionCount
-        );
+    )
+    {
+        try
+        {
+            _collectionPagingTelemetry.RecordPartitions(
+                CollectionPagingTelemetryContext.ForPagingMode(
+                    CollectionPagingTelemetryLabel.PartitionPagingMode,
+                    commandCategory,
+                    requestInfo.MappingSet?.Key.Dialect,
+                    outcome
+                ),
+                duration,
+                requestedPartitionCount,
+                returnedPartitionCount
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Collection paging telemetry was not recorded for outcome {Outcome} - {TraceId}",
+                outcome,
+                requestInfo.FrontendRequest.TraceId.Value
+            );
+        }
+    }
 
     /// <summary>
     /// Every failure carries no command category. Core cannot prove, for most of them, whether the

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Diagnostics;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.Backend;
@@ -11,6 +12,7 @@ using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Response;
+using EdFi.DataManagementService.Core.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Polly;
@@ -35,7 +37,8 @@ namespace EdFi.DataManagementService.Core.Handler;
 internal class PartitionRequestHandler(
     ILogger _logger,
     ResiliencePipeline _resiliencePipeline,
-    int _maximumPageSize
+    int _maximumPageSize,
+    ICollectionPagingTelemetry _collectionPagingTelemetry
 ) : IPipelineStep
 {
     /// <summary>The response member carrying one token per partition.</summary>
@@ -53,16 +56,54 @@ internal class PartitionRequestHandler(
         var partitionQueryHandler =
             requestInfo.ScopedServiceProvider.GetRequiredService<IPartitionQueryHandler>();
 
-        var partitionResult = await ExecuteWithRetryLogging(
-            _resiliencePipeline,
-            _logger,
-            "partitions",
-            requestInfo.FrontendRequest.TraceId,
-            r => IsRetryableResult(r),
-            r => r is PartitionSuccess,
-            async ct => await partitionQueryHandler.QueryPartitions(CreatePartitionRequest(requestInfo), ct),
-            requestInfo
-        );
+        // Resolved before timing starts. Its absence is a pipeline composition fault rather than a
+        // collection read, so it must not be rediscovered from inside the recording catch, where the
+        // throw it raises would replace the fault it was trying to report.
+        int requestedPartitionCount = RequireRequestedPartitionCount(requestInfo);
+
+        long startTimestamp = Stopwatch.GetTimestamp();
+        PartitionResult partitionResult;
+
+        try
+        {
+            partitionResult = await ExecuteWithRetryLogging(
+                _resiliencePipeline,
+                _logger,
+                "partitions",
+                requestInfo.FrontendRequest.TraceId,
+                r => IsRetryableResult(r),
+                r => r is PartitionSuccess,
+                async ct =>
+                    await partitionQueryHandler.QueryPartitions(
+                        CreatePartitionRequest(requestInfo, requestedPartitionCount),
+                        ct
+                    ),
+                requestInfo
+            );
+        }
+        catch (OperationCanceledException) when (requestInfo.RequestCancellationToken.IsCancellationRequested)
+        {
+            // A disconnected client is the absence of a completed boundary calculation, not a kind of
+            // one, and its duration would measure how long the client waited rather than how long the
+            // boundary command took.
+            throw;
+        }
+        catch
+        {
+            // CustomViewAuthorizationValidationException escapes execution as an exception rather than a
+            // result, and the boundary command selects through the configured views.
+            RecordOutcome(
+                requestInfo,
+                Stopwatch.GetElapsedTime(startTimestamp),
+                requestedPartitionCount,
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                CollectionPagingTelemetryLabel.ExecutionExceptionOutcome,
+                returnedPartitionCount: null
+            );
+            throw;
+        }
+
+        TimeSpan duration = Stopwatch.GetElapsedTime(startTimestamp);
 
         _logger.LogDebug(
             "PartitionQueryHandler returned {PartitionResult}- {TraceId}",
@@ -112,7 +153,94 @@ internal class PartitionRequestHandler(
                 Headers: []
             ),
         };
+
+        ClassifyAndRecord(requestInfo, partitionResult, duration, requestedPartitionCount);
     }
+
+    /// <summary>
+    /// Records the one measurement set this request contributes.
+    /// </summary>
+    /// <remarks>
+    /// There is no terminal-page outcome here: a boundary set has no successor, so the question a
+    /// GET-many page answers about continuation does not arise. An executed boundary command that found
+    /// no starts is a success with a returned count of zero, which is a different fact from a
+    /// short-circuit that issued no command at all.
+    /// </remarks>
+    private void ClassifyAndRecord(
+        RequestInfo requestInfo,
+        PartitionResult partitionResult,
+        TimeSpan duration,
+        int requestedPartitionCount
+    )
+    {
+        (string commandCategory, string outcome, int? returnedPartitionCount) = partitionResult switch
+        {
+            PartitionSuccess { SelectionSkipped: true } skipped => (
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                CollectionPagingTelemetryLabel.EarlyEmptyOutcome,
+                (int?)skipped.Ranges.Count
+            ),
+            PartitionSuccess success => (
+                CollectionPagingTelemetryLabel.BoundaryCommandCategory,
+                CollectionPagingTelemetryLabel.SuccessOutcome,
+                success.Ranges.Count
+            ),
+            PartitionFailureNotImplemented => FailureClassification(
+                CollectionPagingTelemetryLabel.NotImplementedOutcome
+            ),
+            PartitionFailureSecurityConfiguration => FailureClassification(
+                CollectionPagingTelemetryLabel.SecurityConfigurationOutcome
+            ),
+            PartitionFailureNamespaceNotAuthorized => FailureClassification(
+                CollectionPagingTelemetryLabel.NotAuthorizedOutcome
+            ),
+            PartitionFailureRetryable => FailureClassification(
+                CollectionPagingTelemetryLabel.RetryExhaustedOutcome
+            ),
+            _ => FailureClassification(CollectionPagingTelemetryLabel.UnknownFailureOutcome),
+        };
+
+        RecordOutcome(
+            requestInfo,
+            duration,
+            requestedPartitionCount,
+            commandCategory,
+            outcome,
+            returnedPartitionCount
+        );
+    }
+
+    private void RecordOutcome(
+        RequestInfo requestInfo,
+        TimeSpan duration,
+        int requestedPartitionCount,
+        string commandCategory,
+        string outcome,
+        int? returnedPartitionCount
+    ) =>
+        _collectionPagingTelemetry.RecordPartitions(
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.PartitionPagingMode,
+                commandCategory,
+                requestInfo.MappingSet?.Key.Dialect,
+                outcome
+            ),
+            duration,
+            requestedPartitionCount,
+            returnedPartitionCount
+        );
+
+    /// <summary>
+    /// Every failure carries no command category. Core cannot prove, for most of them, whether the
+    /// boundary command ran, and attributing a command shape — and therefore a duration — to a request
+    /// that may never have issued that command is the failure mode the dimension exists to avoid.
+    /// </summary>
+    private static (
+        string CommandCategory,
+        string Outcome,
+        int? ReturnedPartitionCount
+    ) FailureClassification(string outcome) =>
+        (CollectionPagingTelemetryLabel.NoCommandCategory, outcome, null);
 
     /// <summary>
     /// Encodes each boundary range as a page token. Always <c>application/json</c> and never a profile
@@ -143,7 +271,7 @@ internal class PartitionRequestHandler(
     /// assigned on this pipeline, and the size a partition is measured against must be the same page
     /// size a walk of that partition will use.
     /// </summary>
-    private IPartitionRequest CreatePartitionRequest(RequestInfo requestInfo)
+    private IPartitionRequest CreatePartitionRequest(RequestInfo requestInfo, int requestedPartitionCount)
     {
         var mappingSet = RequireMappingSet(requestInfo, "partitions");
 
@@ -153,7 +281,7 @@ internal class PartitionRequestHandler(
             MappingSet: mappingSet,
             QueryElements: requestInfo.QueryElements,
             AuthorizationStrategyEvaluators: requestInfo.AuthorizationStrategyEvaluators,
-            RequestedPartitionCount: RequireRequestedPartitionCount(requestInfo),
+            RequestedPartitionCount: requestedPartitionCount,
             MinimumPartitionSize: CursorPagingLimits.MinimumPartitionSize(_maximumPageSize),
             TraceId: requestInfo.FrontendRequest.TraceId,
             ChangeVersionRange: requestInfo.ChangeVersionRange,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.Backend;
@@ -13,6 +14,7 @@ using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.Response;
+using EdFi.DataManagementService.Core.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Polly;
@@ -21,7 +23,11 @@ using static EdFi.DataManagementService.Core.Handler.Utility;
 
 namespace EdFi.DataManagementService.Core.Handler;
 
-internal class QueryRequestHandler(ILogger _logger, ResiliencePipeline _resiliencePipeline) : IPipelineStep
+internal class QueryRequestHandler(
+    ILogger _logger,
+    ResiliencePipeline _resiliencePipeline,
+    ICollectionPagingTelemetry _collectionPagingTelemetry
+) : IPipelineStep
 {
     /// <summary>
     /// The response header carrying the token for the page after this one, as published by the Ed-Fi
@@ -39,25 +45,52 @@ internal class QueryRequestHandler(ILogger _logger, ResiliencePipeline _resilien
         // Resolve query handler from the per-request scoped service provider
         var queryHandler = requestInfo.ScopedServiceProvider.GetRequiredService<IQueryHandler>();
 
-        var queryResult = await ExecuteWithRetryLogging(
-            _resiliencePipeline,
-            _logger,
-            "query",
-            requestInfo.FrontendRequest.TraceId,
-            r => IsRetryableResult(r),
-            r => r is QuerySuccess,
-            async ct => await queryHandler.QueryDocuments(CreateQueryRequest(requestInfo), ct),
-            requestInfo
-        );
+        long startTimestamp = Stopwatch.GetTimestamp();
+        QueryResult queryResult;
+
+        try
+        {
+            queryResult = await ExecuteWithRetryLogging(
+                _resiliencePipeline,
+                _logger,
+                "query",
+                requestInfo.FrontendRequest.TraceId,
+                r => IsRetryableResult(r),
+                r => r is QuerySuccess,
+                async ct => await queryHandler.QueryDocuments(CreateQueryRequest(requestInfo), ct),
+                requestInfo
+            );
+        }
+        catch (OperationCanceledException) when (requestInfo.RequestCancellationToken.IsCancellationRequested)
+        {
+            // A disconnected client is the absence of a completed collection read, not a kind of one.
+            // Counting it would report client disconnects as backend execution failures, and its
+            // duration would measure how long the client waited rather than how long a read took. The
+            // same filter guards the logging middlewares this pipeline already runs through.
+            throw;
+        }
+        catch
+        {
+            // CustomViewAuthorizationValidationException escapes execution as an exception rather than a
+            // result, so without this the one fault that proves a configured view is broken would be the
+            // one outcome the metric never saw.
+            RecordExecutionException(requestInfo, Stopwatch.GetElapsedTime(startTimestamp));
+            throw;
+        }
+
+        TimeSpan duration = Stopwatch.GetElapsedTime(startTimestamp);
+
         _logger.LogDebug(
             "QueryHandler returned {QueryResult}- {TraceId}",
             queryResult.GetType().FullName,
             requestInfo.FrontendRequest.TraceId.Value
         );
 
+        bool nextPageTokenProduced = false;
+
         requestInfo.FrontendResponse = queryResult switch
         {
-            QuerySuccess success => CreateSuccessResponse(requestInfo, success),
+            QuerySuccess success => CreateSuccessResponse(requestInfo, success, out nextPageTokenProduced),
             QueryFailureNotImplemented failure => new FrontendResponse(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),
@@ -98,9 +131,144 @@ internal class QueryRequestHandler(ILogger _logger, ResiliencePipeline _resilien
                 Headers: []
             ),
         };
+
+        RecordOutcome(requestInfo, queryResult, duration, nextPageTokenProduced);
     }
 
-    private static FrontendResponse CreateSuccessResponse(RequestInfo requestInfo, QuerySuccess success)
+    /// <summary>
+    /// Records the one measurement set this request contributes, classified from what the backend
+    /// returned.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="nextPageTokenProduced" /> is reported by response shaping rather than re-derived
+    /// here, and the response header is never read: two independent derivations of the same fact would
+    /// eventually disagree, and the header is absent for a reason that is not always terminal.
+    /// </remarks>
+    private void RecordOutcome(
+        RequestInfo requestInfo,
+        QueryResult queryResult,
+        TimeSpan duration,
+        bool nextPageTokenProduced
+    )
+    {
+        (string commandCategory, string outcome, int? returnedPageSize) = queryResult switch
+        {
+            QuerySuccess success => ClassifySuccess(requestInfo, success, nextPageTokenProduced),
+            QueryFailureNotImplemented => FailureClassification(
+                CollectionPagingTelemetryLabel.NotImplementedOutcome
+            ),
+            QueryFailureSecurityConfiguration => FailureClassification(
+                CollectionPagingTelemetryLabel.SecurityConfigurationOutcome
+            ),
+            QueryFailureNamespaceNotAuthorized => FailureClassification(
+                CollectionPagingTelemetryLabel.NotAuthorizedOutcome
+            ),
+            QueryFailureRetryable => FailureClassification(
+                CollectionPagingTelemetryLabel.RetryExhaustedOutcome
+            ),
+            // A known error reports query terms that evaded validation, and the bounded outcome set has
+            // no value of its own for it. It is counted as an unclassified backend failure rather than
+            // as validation_rejected, which names the middleware rejections operators watch as a share
+            // of traffic and would be diluted by backend faults.
+            _ => FailureClassification(CollectionPagingTelemetryLabel.UnknownFailureOutcome),
+        };
+
+        _collectionPagingTelemetry.RecordPage(
+            CreateContext(requestInfo, commandCategory, outcome),
+            duration,
+            RequestedPageSize(requestInfo.CollectionPaging),
+            returnedPageSize
+        );
+    }
+
+    private void RecordExecutionException(RequestInfo requestInfo, TimeSpan duration) =>
+        _collectionPagingTelemetry.RecordPage(
+            CreateContext(
+                requestInfo,
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                CollectionPagingTelemetryLabel.ExecutionExceptionOutcome
+            ),
+            duration,
+            RequestedPageSize(requestInfo.CollectionPaging),
+            returnedPageSize: null
+        );
+
+    private static CollectionPagingTelemetryContext CreateContext(
+        RequestInfo requestInfo,
+        string commandCategory,
+        string outcome
+    ) =>
+        CollectionPagingTelemetryContext.ForPaging(
+            requestInfo.CollectionPaging,
+            commandCategory,
+            requestInfo.MappingSet?.Key.Dialect,
+            outcome
+        );
+
+    /// <summary>
+    /// The success classification, in precedence order: early-empty, then terminal page, then success.
+    /// </summary>
+    /// <remarks>
+    /// A page that cannot anchor a DocumentId continuation is <c>success</c>, never
+    /// <c>terminal_page</c>. That is a traditional page over a max-bearing change-version window: it is
+    /// ordered by ContentVersion, is served with rows, and the client keeps paging it with limit and
+    /// offset, so reporting it as an ended walk would tell operators a healthy walk had stopped.
+    /// </remarks>
+    private static (string CommandCategory, string Outcome, int? ReturnedPageSize) ClassifySuccess(
+        RequestInfo requestInfo,
+        QuerySuccess success,
+        bool nextPageTokenProduced
+    )
+    {
+        int returnedPageSize = success.EdfiDocs.Count;
+
+        if (success.SelectionSkipped)
+        {
+            return (
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                CollectionPagingTelemetryLabel.EarlyEmptyOutcome,
+                returnedPageSize
+            );
+        }
+
+        string commandCategory = requestInfo.CollectionPaging.IncludesTotalCount
+            ? CollectionPagingTelemetryLabel.PageWithCountCommandCategory
+            : CollectionPagingTelemetryLabel.PageCommandCategory;
+        string outcome =
+            success.AllowsDocumentIdContinuation && !nextPageTokenProduced
+                ? CollectionPagingTelemetryLabel.TerminalPageOutcome
+                : CollectionPagingTelemetryLabel.SuccessOutcome;
+
+        return (commandCategory, outcome, returnedPageSize);
+    }
+
+    /// <summary>
+    /// Every failure carries no command category. Core cannot prove, for most of them, whether a
+    /// selection command ran, and attributing a command shape — and therefore a duration — to a request
+    /// that may never have issued that command is the failure mode the dimension exists to avoid.
+    /// </summary>
+    private static (string CommandCategory, string Outcome, int? ReturnedPageSize) FailureClassification(
+        string outcome
+    ) => (CollectionPagingTelemetryLabel.NoCommandCategory, outcome, null);
+
+    private static int RequestedPageSize(CollectionPaging paging) =>
+        paging switch
+        {
+            CollectionPaging.Cursor cursor => cursor.PageSize.Value,
+            CollectionPaging.Traditional traditional => traditional.Parameters.Limit
+                ?? traditional.Parameters.MaximumPageSize,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(paging),
+                paging,
+                "Unsupported collection paging mode."
+            ),
+        };
+
+    private static FrontendResponse CreateSuccessResponse(
+        RequestInfo requestInfo,
+        QuerySuccess success,
+        out bool nextPageTokenProduced
+    )
     {
         var contentType = requestInfo.ProfileContext?.ResourceProfile.ReadContentType is not null
             ? ProfileHeaderParser.BuildProfileContentType(
@@ -114,8 +282,11 @@ internal class QueryRequestHandler(ILogger _logger, ResiliencePipeline _resilien
             ? new() { { "Total-Count", (success.TotalCount ?? 0).ToString() } }
             : [];
 
+        nextPageTokenProduced = false;
+
         if (TryCreateNextPageToken(requestInfo, success, out var nextPageToken))
         {
+            nextPageTokenProduced = true;
             headers.Add(NextPageTokenHeaderName, nextPageToken);
         }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
@@ -173,25 +173,61 @@ internal class QueryRequestHandler(
             _ => FailureClassification(CollectionPagingTelemetryLabel.UnknownFailureOutcome),
         };
 
-        _collectionPagingTelemetry.RecordPage(
-            CreateContext(requestInfo, commandCategory, outcome),
-            duration,
-            RequestedPageSize(requestInfo.CollectionPaging),
-            returnedPageSize
-        );
+        Record(requestInfo, duration, commandCategory, outcome, returnedPageSize);
     }
 
     private void RecordExecutionException(RequestInfo requestInfo, TimeSpan duration) =>
-        _collectionPagingTelemetry.RecordPage(
-            CreateContext(
-                requestInfo,
-                CollectionPagingTelemetryLabel.NoCommandCategory,
-                CollectionPagingTelemetryLabel.ExecutionExceptionOutcome
-            ),
+        Record(
+            requestInfo,
             duration,
-            RequestedPageSize(requestInfo.CollectionPaging),
+            CollectionPagingTelemetryLabel.NoCommandCategory,
+            CollectionPagingTelemetryLabel.ExecutionExceptionOutcome,
             returnedPageSize: null
         );
+
+    /// <summary>
+    /// Emits one measurement set, and never lets a telemetry fault reach the client.
+    /// </summary>
+    /// <remarks>
+    /// Instrumentation observes; it must not participate. Every call arrives after the response has been
+    /// assembled, and the execution-exception call arrives from inside a catch that is about to rethrow,
+    /// so an escaping throw would either replace a served response with a system error or replace the
+    /// fault it was trying to report. Recording is not free of throwing code: label derivation rejects a
+    /// request state the bounded dimension set cannot describe, and an instrument invokes whatever
+    /// measurement callbacks the host has subscribed, which is third-party code on this thread.
+    /// <para>
+    /// The guard covers the derivations as well as the instruments, because the derivations run as
+    /// arguments to them. Validation on the recording side stays fail-fast: it can only report a defect
+    /// in this handler, and the tests are what catch those.
+    /// </para>
+    /// </remarks>
+    private void Record(
+        RequestInfo requestInfo,
+        TimeSpan duration,
+        string commandCategory,
+        string outcome,
+        int? returnedPageSize
+    )
+    {
+        try
+        {
+            _collectionPagingTelemetry.RecordPage(
+                CreateContext(requestInfo, commandCategory, outcome),
+                duration,
+                RequestedPageSize(requestInfo.CollectionPaging),
+                returnedPageSize
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Collection paging telemetry was not recorded for outcome {Outcome} - {TraceId}",
+                outcome,
+                requestInfo.FrontendRequest.TraceId.Value
+            );
+        }
+    }
 
     private static CollectionPagingTelemetryContext CreateContext(
         RequestInfo requestInfo,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
@@ -132,7 +132,7 @@ internal class QueryRequestHandler(
             ),
         };
 
-        RecordOutcome(requestInfo, queryResult, duration, nextPageTokenProduced);
+        ClassifyAndRecord(requestInfo, queryResult, duration, nextPageTokenProduced);
     }
 
     /// <summary>
@@ -144,7 +144,7 @@ internal class QueryRequestHandler(
     /// here, and the response header is never read: two independent derivations of the same fact would
     /// eventually disagree, and the header is absent for a reason that is not always terminal.
     /// </remarks>
-    private void RecordOutcome(
+    private void ClassifyAndRecord(
         RequestInfo requestInfo,
         QueryResult queryResult,
         TimeSpan duration,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
@@ -258,7 +258,12 @@ internal class QueryRequestHandler(
     {
         int returnedPageSize = success.EdfiDocs.Count;
 
-        if (success.SelectionSkipped)
+        // Both halves of what early_empty asserts, not the flag alone: the outcome names an empty result
+        // that no selection command produced. A success carrying documents was built from rows something
+        // selected, so it is classified by what was served however the flag is set. Nothing produces that
+        // combination today, and checking it is what keeps the one outcome whose name is a claim about
+        // database work from ever being attached to a request that plainly did some.
+        if (success is { SelectionSkipped: true, EdfiDocs.Count: 0 })
         {
             return (
                 CollectionPagingTelemetryLabel.NoCommandCategory,

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidatePartitionQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidatePartitionQueryMiddleware.cs
@@ -187,13 +187,33 @@ internal class ValidatePartitionQueryMiddleware(
     /// this step is composed only into the partitions pipeline, so there is no other mode a request
     /// reaching it could have.
     /// </summary>
-    private void RecordValidationRejected(RequestInfo requestInfo) =>
-        _collectionPagingTelemetry.RecordValidationRejected(
-            CollectionPagingTelemetryContext.ForPagingMode(
-                CollectionPagingTelemetryLabel.PartitionPagingMode,
-                CollectionPagingTelemetryLabel.NoCommandCategory,
-                requestInfo.MappingSet?.Key.Dialect,
-                CollectionPagingTelemetryLabel.ValidationRejectedOutcome
-            )
-        );
+    /// <remarks>
+    /// A telemetry fault never reaches the client. Counting runs ahead of the rejection this step is
+    /// about to answer with, so an escaping throw would replace a 400 that names what the client got
+    /// wrong with a system error that names nothing. Recording is not free of throwing code: an
+    /// instrument invokes whatever measurement callbacks the host has subscribed, which is third-party
+    /// code on this thread.
+    /// </remarks>
+    private void RecordValidationRejected(RequestInfo requestInfo)
+    {
+        try
+        {
+            _collectionPagingTelemetry.RecordValidationRejected(
+                CollectionPagingTelemetryContext.ForPagingMode(
+                    CollectionPagingTelemetryLabel.PartitionPagingMode,
+                    CollectionPagingTelemetryLabel.NoCommandCategory,
+                    requestInfo.MappingSet?.Key.Dialect,
+                    CollectionPagingTelemetryLabel.ValidationRejectedOutcome
+                )
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Collection paging telemetry was not recorded for a validation rejection - {TraceId}",
+                requestInfo.FrontendRequest.TraceId.Value
+            );
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidatePartitionQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidatePartitionQueryMiddleware.cs
@@ -8,6 +8,7 @@ using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Response;
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Core.Validation;
 using Microsoft.Extensions.Logging;
 using static EdFi.DataManagementService.Core.Response.FailureResponse;
@@ -39,7 +40,11 @@ namespace EdFi.DataManagementService.Core.Middleware;
 /// the field first keeps this operation's unknown-field behavior identical to GET-many's.
 /// </para>
 /// </remarks>
-internal class ValidatePartitionQueryMiddleware(ILogger _logger, int _defaultPartitionCount) : IPipelineStep
+internal class ValidatePartitionQueryMiddleware(
+    ILogger _logger,
+    int _defaultPartitionCount,
+    ICollectionPagingTelemetry _collectionPagingTelemetry
+) : IPipelineStep
 {
     /// <summary>
     /// The parameter names this operation owns, matched case-sensitively. The five reserved paging
@@ -65,14 +70,19 @@ internal class ValidatePartitionQueryMiddleware(ILogger _logger, int _defaultPar
             requestInfo.FrontendRequest.TraceId.Value
         );
 
-        // Both parameter faults answer with the same shell, so they share one construction. The media
-        // type is not stated here at all; it comes from the FrontendResponse default.
-        FrontendResponse ParameterValidationFailed(string[] errors) =>
-            new(
+        // Both parameter faults answer with the same shell, so they share one construction, and counting
+        // the rejection here covers both for the same reason. The media type is not stated here at all,
+        // because it comes from the FrontendResponse default.
+        FrontendResponse ParameterValidationFailed(string[] errors)
+        {
+            RecordValidationRejected(requestInfo);
+
+            return new(
                 StatusCode: 400,
                 Body: ForParameterValidation(errors, requestInfo.FrontendRequest.TraceId),
                 Headers: []
             );
+        }
 
         ChangeVersionValidationResult changeVersionResult = ChangeVersionParameterValidator.Validate(
             requestInfo.FrontendRequest.QueryParameters
@@ -99,6 +109,8 @@ internal class ValidatePartitionQueryMiddleware(ILogger _logger, int _defaultPar
         switch (filterResult)
         {
             case ResourceQueryFilterResult.UnknownQueryField unknownQueryField:
+                RecordValidationRejected(requestInfo);
+
                 requestInfo.FrontendResponse = new FrontendResponse(
                     StatusCode: 400,
                     Body: ForBadRequest(
@@ -118,6 +130,8 @@ internal class ValidatePartitionQueryMiddleware(ILogger _logger, int _defaultPar
                     "Partition query parameter format error - {TraceId}",
                     requestInfo.FrontendRequest.TraceId.Value
                 );
+
+                RecordValidationRejected(requestInfo);
 
                 requestInfo.FrontendResponse = new FrontendResponse(
                     StatusCode: 400,
@@ -167,4 +181,19 @@ internal class ValidatePartitionQueryMiddleware(ILogger _logger, int _defaultPar
 
         await next();
     }
+
+    /// <summary>
+    /// Counts a request this step answered. The paging mode is the partition literal on every exit:
+    /// this step is composed only into the partitions pipeline, so there is no other mode a request
+    /// reaching it could have.
+    /// </summary>
+    private void RecordValidationRejected(RequestInfo requestInfo) =>
+        _collectionPagingTelemetry.RecordValidationRejected(
+            CollectionPagingTelemetryContext.ForPagingMode(
+                CollectionPagingTelemetryLabel.PartitionPagingMode,
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                requestInfo.MappingSet?.Key.Dialect,
+                CollectionPagingTelemetryLabel.ValidationRejectedOutcome
+            )
+        );
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
@@ -281,15 +281,35 @@ internal class ValidateQueryMiddleware(
     /// <summary>
     /// Counts a request this step answered. No duration is recorded: nothing executed.
     /// </summary>
-    private void RecordValidationRejected(RequestInfo requestInfo) =>
-        _collectionPagingTelemetry.RecordValidationRejected(
-            CollectionPagingTelemetryContext.ForPagingMode(
-                RejectedPagingMode(requestInfo),
-                CollectionPagingTelemetryLabel.NoCommandCategory,
-                requestInfo.MappingSet?.Key.Dialect,
-                CollectionPagingTelemetryLabel.ValidationRejectedOutcome
-            )
-        );
+    /// <remarks>
+    /// A telemetry fault never reaches the client. Counting runs ahead of the rejection this step is
+    /// about to answer with, so an escaping throw would replace a 400 that names what the client got
+    /// wrong with a system error that names nothing. Recording is not free of throwing code: an
+    /// instrument invokes whatever measurement callbacks the host has subscribed, which is third-party
+    /// code on this thread.
+    /// </remarks>
+    private void RecordValidationRejected(RequestInfo requestInfo)
+    {
+        try
+        {
+            _collectionPagingTelemetry.RecordValidationRejected(
+                CollectionPagingTelemetryContext.ForPagingMode(
+                    RejectedPagingMode(requestInfo),
+                    CollectionPagingTelemetryLabel.NoCommandCategory,
+                    requestInfo.MappingSet?.Key.Dialect,
+                    CollectionPagingTelemetryLabel.ValidationRejectedOutcome
+                )
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Collection paging telemetry was not recorded for a validation rejection - {TraceId}",
+                requestInfo.FrontendRequest.TraceId.Value
+            );
+        }
+    }
 
     /// <summary>
     /// The paging mode of a request this step is rejecting, read from the query string rather than from

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
@@ -9,6 +9,7 @@ using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Paging;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Response;
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Core.Validation;
 using Microsoft.Extensions.Logging;
 using static EdFi.DataManagementService.Core.Response.FailureResponse;
@@ -24,10 +25,17 @@ namespace EdFi.DataManagementService.Core.Middleware;
 /// Recognition is a property of pipeline composition rather than something inferred at run time, so
 /// a reader can see at the composition site which operations page by cursor.
 /// </param>
+/// <param name="_collectionPagingTelemetry">
+/// Where a rejection is counted. Required rather than defaulted to the no-op because this step is
+/// composed into the Change Query pipeline as well, whose endpoints do not page by cursor and whose
+/// faults are therefore not collection-paging events. A required parameter makes that second site a
+/// compile error that forces an explicit choice, where a default would quietly pick one.
+/// </param>
 internal class ValidateQueryMiddleware(
     ILogger _logger,
     int _maximumPageSize,
-    bool _cursorParametersRecognized
+    bool _cursorParametersRecognized,
+    ICollectionPagingTelemetry _collectionPagingTelemetry
 ) : IPipelineStep
 {
     /// <summary>
@@ -118,14 +126,19 @@ internal class ValidateQueryMiddleware(
 
         // All three parameter faults below - cursor, traditional pagination, and change-version -
         // answer with the same shell, so they share one construction rather than three copies that
-        // have to be kept in step. The media type is not stated here at all; it comes from the
-        // FrontendResponse default.
-        FrontendResponse ParameterValidationFailed(string[] errors) =>
-            new(
+        // have to be kept in step, and counting the rejection here covers all three for the same
+        // reason. The media type is not stated here at all, because it comes from the FrontendResponse
+        // default.
+        FrontendResponse ParameterValidationFailed(string[] errors)
+        {
+            RecordValidationRejected(requestInfo);
+
+            return new(
                 StatusCode: 400,
                 Body: ForParameterValidation(errors, requestInfo.FrontendRequest.TraceId),
                 Headers: []
             );
+        }
 
         // A request that supplied either cursor parameter is validated by the cursor precedence.
         // Everything else keeps the traditional parsing and its existing messages. Both paths answer
@@ -214,6 +227,8 @@ internal class ValidateQueryMiddleware(
         switch (filterResult)
         {
             case ResourceQueryFilterResult.UnknownQueryField unknownQueryField:
+                RecordValidationRejected(requestInfo);
+
                 requestInfo.FrontendResponse = new FrontendResponse(
                     StatusCode: 400,
                     Body: FailureResponse.ForBadRequest(
@@ -233,6 +248,8 @@ internal class ValidateQueryMiddleware(
                     "Query parameter format error - {TraceId}",
                     requestInfo.FrontendRequest.TraceId.Value
                 );
+
+                RecordValidationRejected(requestInfo);
 
                 requestInfo.FrontendResponse = new FrontendResponse(
                     StatusCode: 400,
@@ -260,4 +277,35 @@ internal class ValidateQueryMiddleware(
                 );
         }
     }
+
+    /// <summary>
+    /// Counts a request this step answered. No duration is recorded: nothing executed.
+    /// </summary>
+    private void RecordValidationRejected(RequestInfo requestInfo) =>
+        _collectionPagingTelemetry.RecordValidationRejected(
+            CollectionPagingTelemetryContext.ForPagingMode(
+                RejectedPagingMode(requestInfo),
+                CollectionPagingTelemetryLabel.NoCommandCategory,
+                requestInfo.MappingSet?.Key.Dialect,
+                CollectionPagingTelemetryLabel.ValidationRejectedOutcome
+            )
+        );
+
+    /// <summary>
+    /// The paging mode of a request this step is rejecting, read from the query string rather than from
+    /// request state.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="RequestInfo.CollectionPaging" /> is assigned only at the accepting exit, so a rejected
+    /// cursor request still carries the traditional default and would be counted as traditional traffic.
+    /// The same constant array the cursor validator reads is used here, so the two cannot disagree about
+    /// what makes a request a cursor request.
+    /// </remarks>
+    private static string RejectedPagingMode(RequestInfo requestInfo) =>
+        Array.Exists(
+            CursorRequestValidator.CursorParameters,
+            requestInfo.FrontendRequest.QueryParameters.ContainsKey
+        )
+            ? CollectionPagingTelemetryLabel.CursorPagingMode
+            : CollectionPagingTelemetryLabel.TraditionalPagingMode;
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EdFi.DataManagementService.Core.Telemetry;
+
+/// <summary>
+/// The complete set of allowed dimension values for collection-paging metrics.
+/// </summary>
+/// <remarks>
+/// Every tag value is one of these constants, which is what keeps tag-set cardinality bounded and keeps
+/// request data out of the metric. Nothing derived from a request — resource name, tenant key, namespace,
+/// client identity, filter names or values, page-token text, decoded cursor bounds, candidate
+/// identifiers, or exception text — may become a label.
+/// </remarks>
+internal static class CollectionPagingTelemetryLabel
+{
+    // paging_mode
+    public const string TraditionalPagingMode = "traditional";
+    public const string CursorPagingMode = "cursor";
+    public const string PartitionPagingMode = "partition";
+
+    // command_category — the selection command shape a produced result was built around.
+    public const string PageCommandCategory = "page";
+    public const string PageWithCountCommandCategory = "page_with_count";
+    public const string BoundaryCommandCategory = "boundary";
+    public const string NoCommandCategory = "none";
+
+    // provider
+    public const string PostgresqlProvider = "postgresql";
+    public const string SqlServerProvider = "sqlserver";
+    public const string UnknownProvider = "unknown";
+
+    // outcome
+    public const string SuccessOutcome = "success";
+    public const string TerminalPageOutcome = "terminal_page";
+    public const string EarlyEmptyOutcome = "early_empty";
+    public const string ValidationRejectedOutcome = "validation_rejected";
+    public const string NotAuthorizedOutcome = "not_authorized";
+    public const string NotImplementedOutcome = "not_implemented";
+    public const string SecurityConfigurationOutcome = "security_configuration";
+    public const string RetryExhaustedOutcome = "retry_exhausted";
+    public const string UnknownFailureOutcome = "unknown_failure";
+    public const string ExecutionExceptionOutcome = "execution_exception";
+}
+
+/// <summary>
+/// The four dimensions carried by every collection-paging measurement.
+/// </summary>
+/// <remarks>
+/// A single context type shared by regular resources and descriptors: their execution semantics are
+/// equivalent, so nothing in the contract splits the two apart.
+/// </remarks>
+internal sealed record CollectionPagingTelemetryContext
+{
+    private const int MaxLabelLength = 128;
+
+    private CollectionPagingTelemetryContext(
+        string pagingMode,
+        string commandCategory,
+        string provider,
+        string outcome
+    )
+    {
+        PagingMode = BoundSanitizedLabel(pagingMode, nameof(pagingMode));
+        CommandCategory = BoundSanitizedLabel(commandCategory, nameof(commandCategory));
+        Provider = BoundSanitizedLabel(provider, nameof(provider));
+        Outcome = BoundSanitizedLabel(outcome, nameof(outcome));
+    }
+
+    public string PagingMode { get; }
+
+    public string CommandCategory { get; }
+
+    public string Provider { get; }
+
+    public string Outcome { get; }
+
+    /// <summary>
+    /// A context for a GET-many request whose paging mode was resolved.
+    /// </summary>
+    public static CollectionPagingTelemetryContext ForPaging(
+        CollectionPaging paging,
+        string commandCategory,
+        SqlDialect? dialect,
+        string outcome
+    ) => ForPagingMode(PagingModeLabel(paging), commandCategory, dialect, outcome);
+
+    /// <summary>
+    /// A context built from an already-chosen paging-mode label, for the partition operation and for a
+    /// rejected request whose paging mode was never assigned.
+    /// </summary>
+    public static CollectionPagingTelemetryContext ForPagingMode(
+        string pagingMode,
+        string commandCategory,
+        SqlDialect? dialect,
+        string outcome
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pagingMode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandCategory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outcome);
+
+        return new(pagingMode, commandCategory, ProviderLabel(dialect), outcome);
+    }
+
+    public TagList ToTags()
+    {
+        return
+        [
+            new("paging_mode", PagingMode),
+            new("command_category", CommandCategory),
+            new("provider", Provider),
+            new("outcome", Outcome),
+        ];
+    }
+
+    internal static string PagingModeLabel(CollectionPaging paging)
+    {
+        ArgumentNullException.ThrowIfNull(paging);
+
+        return paging switch
+        {
+            CollectionPaging.Traditional => CollectionPagingTelemetryLabel.TraditionalPagingMode,
+            CollectionPaging.Cursor => CollectionPagingTelemetryLabel.CursorPagingMode,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(paging),
+                paging,
+                "Unsupported collection paging mode."
+            ),
+        };
+    }
+
+    /// <summary>
+    /// The provider label, <c>unknown</c> only when the request was answered before mapping-set
+    /// resolution.
+    /// </summary>
+    internal static string ProviderLabel(SqlDialect? dialect) =>
+        dialect switch
+        {
+            null => CollectionPagingTelemetryLabel.UnknownProvider,
+            SqlDialect.Pgsql => CollectionPagingTelemetryLabel.PostgresqlProvider,
+            SqlDialect.Mssql => CollectionPagingTelemetryLabel.SqlServerProvider,
+            _ => throw new ArgumentOutOfRangeException(nameof(dialect), dialect, "Unsupported SQL dialect."),
+        };
+
+    private static string BoundSanitizedLabel(string value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Metric label must be present.", parameterName);
+        }
+
+        string sanitized = LoggingSanitizer.SanitizeForLogging(value);
+        if (sanitized.Length == 0)
+        {
+            sanitized = CollectionPagingTelemetryLabel.UnknownProvider;
+        }
+
+        return sanitized.Length <= MaxLabelLength ? sanitized : sanitized[..MaxLabelLength];
+    }
+}
+
+/// <summary>
+/// Records bounded metrics for the three live collection-read shapes: traditional paging, cursor paging,
+/// and partition planning.
+/// </summary>
+/// <remarks>
+/// Page-size instruments are recorded only for GET-many and partition-count instruments only for
+/// <c>/partitions</c>, so neither histogram mixes two units of measure. Duration is recorded only where
+/// backend execution was attempted, which is why a validation rejection has its own method rather than a
+/// duration argument callers would have to zero out.
+/// </remarks>
+internal interface ICollectionPagingTelemetry
+{
+    /// <summary>
+    /// Records a classified GET-many outcome.
+    /// </summary>
+    /// <param name="returnedPageSize">
+    /// The number of documents in the response, or null when no page was produced. Null suppresses the
+    /// returned-page-size measurement so a failure never contributes a zero to that histogram.
+    /// </param>
+    void RecordPage(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPageSize,
+        int? returnedPageSize
+    );
+
+    /// <summary>
+    /// Records a classified <c>/partitions</c> outcome.
+    /// </summary>
+    /// <param name="returnedPartitionCount">
+    /// The number of boundary ranges produced, or null when no boundary set was produced.
+    /// </param>
+    void RecordPartitions(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPartitionCount,
+        int? returnedPartitionCount
+    );
+
+    /// <summary>
+    /// Records a request answered by parameter validation. No duration is recorded: nothing executed, so
+    /// a microsecond-scale sample would distort the duration distribution.
+    /// </summary>
+    void RecordValidationRejected(CollectionPagingTelemetryContext context);
+}
+
+/// <summary>
+/// Validates arguments exactly as the recording implementation does and emits nothing.
+/// </summary>
+/// <remarks>
+/// Wired explicitly at the Change Query construction of the shared query-validation middleware, whose
+/// endpoints do not page by cursor and are therefore not collection-paging events. Validating
+/// identically is what keeps that wiring from hiding an argument fault that would surface in production.
+/// </remarks>
+internal sealed class NoOpCollectionPagingTelemetry : ICollectionPagingTelemetry
+{
+    public static NoOpCollectionPagingTelemetry Instance { get; } = new();
+
+    private NoOpCollectionPagingTelemetry() { }
+
+    public void RecordPage(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPageSize,
+        int? returnedPageSize
+    ) => ValidateMeasurement(context, duration, requestedPageSize, returnedPageSize);
+
+    public void RecordPartitions(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPartitionCount,
+        int? returnedPartitionCount
+    ) => ValidateMeasurement(context, duration, requestedPartitionCount, returnedPartitionCount);
+
+    public void RecordValidationRejected(CollectionPagingTelemetryContext context) =>
+        ArgumentNullException.ThrowIfNull(context);
+
+    private static void ValidateMeasurement(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requested,
+        int? returned
+    )
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        CollectionPagingTelemetry.RequireNonNegativeMilliseconds(duration);
+        CollectionPagingTelemetry.RequireNonNegativeCount(requested, nameof(requested));
+
+        if (returned is { } returnedCount)
+        {
+            CollectionPagingTelemetry.RequireNonNegativeCount(returnedCount, nameof(returned));
+        }
+    }
+}
+
+internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
+{
+    internal const string MeterName = "EdFi.DataManagementService.CollectionPaging";
+    internal const string RequestCounterName = "edfi.dms.collection_paging.requests";
+    internal const string DurationName = "edfi.dms.collection_paging.duration";
+    internal const string RequestedPageSizeName = "edfi.dms.collection_paging.page_size.requested";
+    internal const string ReturnedPageSizeName = "edfi.dms.collection_paging.page_size.returned";
+    internal const string RequestedPartitionCountName =
+        "edfi.dms.collection_paging.partition_count.requested";
+    internal const string ReturnedPartitionCountName = "edfi.dms.collection_paging.partition_count.returned";
+
+    private static readonly Meter SharedMeter = new(MeterName);
+
+    private readonly Counter<long> _requestCounter;
+    private readonly Histogram<double> _duration;
+    private readonly Histogram<int> _requestedPageSize;
+    private readonly Histogram<int> _returnedPageSize;
+    private readonly Histogram<int> _requestedPartitionCount;
+    private readonly Histogram<int> _returnedPartitionCount;
+    private readonly ILogger<CollectionPagingTelemetry> _logger;
+
+    public CollectionPagingTelemetry(ILogger<CollectionPagingTelemetry>? logger = null)
+        : this(SharedMeter, logger) { }
+
+    internal CollectionPagingTelemetry(Meter meter, ILogger<CollectionPagingTelemetry>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(meter);
+
+        _logger = logger ?? NullLogger<CollectionPagingTelemetry>.Instance;
+        _requestCounter = meter.CreateCounter<long>(
+            RequestCounterName,
+            unit: "{request}",
+            description: "Collection read requests by paging mode, command category, provider, and outcome."
+        );
+        _duration = meter.CreateHistogram<double>(
+            DurationName,
+            unit: "ms",
+            description: "Collection read duration where backend execution was attempted."
+        );
+        _requestedPageSize = meter.CreateHistogram<int>(
+            RequestedPageSizeName,
+            unit: "{item}",
+            description: "Page size a collection read requested."
+        );
+        _returnedPageSize = meter.CreateHistogram<int>(
+            ReturnedPageSizeName,
+            unit: "{item}",
+            description: "Page size a collection read returned."
+        );
+        _requestedPartitionCount = meter.CreateHistogram<int>(
+            RequestedPartitionCountName,
+            unit: "{partition}",
+            description: "Partition count a partition request asked for."
+        );
+        _returnedPartitionCount = meter.CreateHistogram<int>(
+            ReturnedPartitionCountName,
+            unit: "{partition}",
+            description: "Partition count a partition request returned."
+        );
+    }
+
+    public void RecordPage(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPageSize,
+        int? returnedPageSize
+    )
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        double milliseconds = RequireNonNegativeMilliseconds(duration);
+        RequireNonNegativeCount(requestedPageSize, nameof(requestedPageSize));
+
+        TagList tags = context.ToTags();
+
+        _requestCounter.Add(1, tags);
+        _duration.Record(milliseconds, tags);
+        _requestedPageSize.Record(requestedPageSize, tags);
+
+        if (returnedPageSize is { } returned)
+        {
+            RequireNonNegativeCount(returned, nameof(returnedPageSize));
+            _returnedPageSize.Record(returned, tags);
+        }
+
+        LogDebug("page", context);
+    }
+
+    public void RecordPartitions(
+        CollectionPagingTelemetryContext context,
+        TimeSpan duration,
+        int requestedPartitionCount,
+        int? returnedPartitionCount
+    )
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        double milliseconds = RequireNonNegativeMilliseconds(duration);
+        RequireNonNegativeCount(requestedPartitionCount, nameof(requestedPartitionCount));
+
+        TagList tags = context.ToTags();
+
+        _requestCounter.Add(1, tags);
+        _duration.Record(milliseconds, tags);
+        _requestedPartitionCount.Record(requestedPartitionCount, tags);
+
+        if (returnedPartitionCount is { } returned)
+        {
+            RequireNonNegativeCount(returned, nameof(returnedPartitionCount));
+            _returnedPartitionCount.Record(returned, tags);
+        }
+
+        LogDebug("partitions", context);
+    }
+
+    public void RecordValidationRejected(CollectionPagingTelemetryContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        _requestCounter.Add(1, context.ToTags());
+        LogDebug("validation-rejected", context);
+    }
+
+    private void LogDebug(string metric, CollectionPagingTelemetryContext context)
+    {
+        if (!_logger.IsEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
+        _logger.LogDebug(
+            "Collection paging telemetry recorded {Metric}. PagingMode {PagingMode}; commandCategory {CommandCategory}; provider {Provider}; outcome {Outcome}.",
+            metric,
+            context.PagingMode,
+            context.CommandCategory,
+            context.Provider,
+            context.Outcome
+        );
+    }
+
+    internal static double RequireNonNegativeMilliseconds(TimeSpan duration)
+    {
+        if (duration < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(duration),
+                duration,
+                "Duration must be nonnegative."
+            );
+        }
+
+        return duration.TotalMilliseconds;
+    }
+
+    internal static void RequireNonNegativeCount(int count, string parameterName)
+    {
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, count, "Count must be nonnegative.");
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using EdFi.DataManagementService.Backend.External;
@@ -20,7 +21,8 @@ namespace EdFi.DataManagementService.Core.Telemetry;
 /// Every tag value is one of these constants, which is what keeps tag-set cardinality bounded and keeps
 /// request data out of the metric. Nothing derived from a request — resource name, tenant key, namespace,
 /// client identity, filter names or values, page-token text, decoded cursor bounds, candidate
-/// identifiers, or exception text — may become a label.
+/// identifiers, or exception text — may become a label. The per-dimension sets at the foot of this class
+/// are how that is enforced rather than merely intended.
 /// </remarks>
 internal static class CollectionPagingTelemetryLabel
 {
@@ -51,6 +53,53 @@ internal static class CollectionPagingTelemetryLabel
     public const string RetryExhaustedOutcome = "retry_exhausted";
     public const string UnknownFailureOutcome = "unknown_failure";
     public const string ExecutionExceptionOutcome = "execution_exception";
+
+    /// <summary>
+    /// The values each dimension allows, which is the bound the metric contract actually rests on.
+    /// </summary>
+    /// <remarks>
+    /// Cardinality is bounded because these sets are closed, not because a label happens to be short or
+    /// free of control characters. Checking membership is therefore what makes the published claim — that
+    /// the number of distinct dimension combinations cannot grow with traffic, with the size of the data,
+    /// or with the number of clients — a property of this component rather than only of its call sites.
+    /// Each set is one dimension rather than one flat set of every constant, so a label that is bounded
+    /// but belongs to another dimension is refused too.
+    /// </remarks>
+    public static readonly FrozenSet<string> PagingModes = new[]
+    {
+        TraditionalPagingMode,
+        CursorPagingMode,
+        PartitionPagingMode,
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    public static readonly FrozenSet<string> CommandCategories = new[]
+    {
+        PageCommandCategory,
+        PageWithCountCommandCategory,
+        BoundaryCommandCategory,
+        NoCommandCategory,
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    public static readonly FrozenSet<string> Providers = new[]
+    {
+        PostgresqlProvider,
+        SqlServerProvider,
+        UnknownProvider,
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    public static readonly FrozenSet<string> Outcomes = new[]
+    {
+        SuccessOutcome,
+        TerminalPageOutcome,
+        EarlyEmptyOutcome,
+        ValidationRejectedOutcome,
+        NotAuthorizedOutcome,
+        NotImplementedOutcome,
+        SecurityConfigurationOutcome,
+        RetryExhaustedOutcome,
+        UnknownFailureOutcome,
+        ExecutionExceptionOutcome,
+    }.ToFrozenSet(StringComparer.Ordinal);
 }
 
 /// <summary>
@@ -62,7 +111,11 @@ internal static class CollectionPagingTelemetryLabel
 /// </remarks>
 internal sealed record CollectionPagingTelemetryContext
 {
-    private const int MaxLabelLength = 128;
+    /// <summary>
+    /// How much of a refused label reaches the exception message. A label no dimension set contains is by
+    /// definition not one of the constants, so it may be arbitrary caller data on its way into a log.
+    /// </summary>
+    private const int MaxRefusedLabelLength = 64;
 
     private CollectionPagingTelemetryContext(
         string pagingMode,
@@ -71,10 +124,18 @@ internal sealed record CollectionPagingTelemetryContext
         string outcome
     )
     {
-        PagingMode = BoundSanitizedLabel(pagingMode, nameof(pagingMode));
-        CommandCategory = BoundSanitizedLabel(commandCategory, nameof(commandCategory));
-        Provider = BoundSanitizedLabel(provider, nameof(provider));
-        Outcome = BoundSanitizedLabel(outcome, nameof(outcome));
+        PagingMode = RequireAllowedLabel(
+            pagingMode,
+            CollectionPagingTelemetryLabel.PagingModes,
+            nameof(pagingMode)
+        );
+        CommandCategory = RequireAllowedLabel(
+            commandCategory,
+            CollectionPagingTelemetryLabel.CommandCategories,
+            nameof(commandCategory)
+        );
+        Provider = RequireAllowedLabel(provider, CollectionPagingTelemetryLabel.Providers, nameof(provider));
+        Outcome = RequireAllowedLabel(outcome, CollectionPagingTelemetryLabel.Outcomes, nameof(outcome));
     }
 
     public string PagingMode { get; }
@@ -153,20 +214,50 @@ internal sealed record CollectionPagingTelemetryContext
             _ => throw new ArgumentOutOfRangeException(nameof(dialect), dialect, "Unsupported SQL dialect."),
         };
 
-    private static string BoundSanitizedLabel(string value, string parameterName)
+    /// <summary>
+    /// The label, when it is one <paramref name="allowed" /> contains.
+    /// </summary>
+    /// <remarks>
+    /// Membership, not shape. A label outside the set is refused rather than reshaped into something
+    /// emittable, because sanitizing and truncating bound a label's length and that is not the property
+    /// this metric needs: a caller passing a resource name, a tenant key, or an exception category would
+    /// still add one tag set per distinct value, which is exactly the unbounded growth the bounded
+    /// dimension set exists to prevent. Refusing also removes the substitution that used to stand in for
+    /// an unusable label, which emitted the provider constant on whichever dimension was empty and could
+    /// therefore put <c>unknown</c> on a dimension that does not allow it.
+    /// <para>
+    /// Every emission site records inside a guard that logs and swallows, so a refused label costs one
+    /// measurement and a warning rather than a poisoned metric.
+    /// </para>
+    /// </remarks>
+    private static string RequireAllowedLabel(string value, FrozenSet<string> allowed, string parameterName)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
             throw new ArgumentException("Metric label must be present.", parameterName);
         }
 
-        string sanitized = LoggingSanitizer.SanitizeForLogging(value);
-        if (sanitized.Length == 0)
+        if (!allowed.Contains(value))
         {
-            sanitized = CollectionPagingTelemetryLabel.UnknownProvider;
+            throw new ArgumentException(
+                $"Metric label '{DescribeRefused(value)}' is not one of the bounded values this dimension "
+                    + "allows.",
+                parameterName
+            );
         }
 
-        return sanitized.Length <= MaxLabelLength ? sanitized : sanitized[..MaxLabelLength];
+        return value;
+    }
+
+    /// <summary>
+    /// A refused label rendered safe for the message it is about to appear in: sanitized against
+    /// structured-log template injection, then bounded so an arbitrarily long one cannot be echoed whole.
+    /// </summary>
+    private static string DescribeRefused(string value)
+    {
+        string sanitized = LoggingSanitizer.SanitizeForLogging(value);
+
+        return sanitized.Length <= MaxRefusedLabelLength ? sanitized : sanitized[..MaxRefusedLabelLength];
     }
 }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
@@ -257,11 +257,7 @@ internal sealed class NoOpCollectionPagingTelemetry : ICollectionPagingTelemetry
         ArgumentNullException.ThrowIfNull(context);
         CollectionPagingTelemetry.RequireNonNegativeMilliseconds(duration);
         CollectionPagingTelemetry.RequireNonNegativeCount(requested, nameof(requested));
-
-        if (returned is { } returnedCount)
-        {
-            CollectionPagingTelemetry.RequireNonNegativeCount(returnedCount, nameof(returned));
-        }
+        CollectionPagingTelemetry.RequireNonNegativeCount(returned, nameof(returned));
     }
 }
 
@@ -333,10 +329,14 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
         int? returnedPageSize
     )
     {
+        // Every argument is validated before the first instrument is touched: a fault discovered halfway
+        // through would leave the request counter incremented for a measurement set that was never
+        // completed, which is worse than the bad call it reports.
         ArgumentNullException.ThrowIfNull(context);
 
         double milliseconds = RequireNonNegativeMilliseconds(duration);
         RequireNonNegativeCount(requestedPageSize, nameof(requestedPageSize));
+        RequireNonNegativeCount(returnedPageSize, nameof(returnedPageSize));
 
         TagList tags = context.ToTags();
 
@@ -346,7 +346,6 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
 
         if (returnedPageSize is { } returned)
         {
-            RequireNonNegativeCount(returned, nameof(returnedPageSize));
             _returnedPageSize.Record(returned, tags);
         }
 
@@ -364,6 +363,7 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
 
         double milliseconds = RequireNonNegativeMilliseconds(duration);
         RequireNonNegativeCount(requestedPartitionCount, nameof(requestedPartitionCount));
+        RequireNonNegativeCount(returnedPartitionCount, nameof(returnedPartitionCount));
 
         TagList tags = context.ToTags();
 
@@ -373,7 +373,6 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
 
         if (returnedPartitionCount is { } returned)
         {
-            RequireNonNegativeCount(returned, nameof(returnedPartitionCount));
             _returnedPartitionCount.Record(returned, tags);
         }
 
@@ -424,6 +423,18 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
         if (count < 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, count, "Count must be nonnegative.");
+        }
+    }
+
+    /// <summary>
+    /// Validates an optional count. Null means the measurement is not recorded, which is a legitimate
+    /// state rather than a missing argument.
+    /// </summary>
+    internal static void RequireNonNegativeCount(int? count, string parameterName)
+    {
+        if (count is { } value)
+        {
+            RequireNonNegativeCount(value, parameterName);
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
@@ -312,6 +312,13 @@ internal interface ICollectionPagingTelemetry
 /// Wired explicitly at the Change Query construction of the shared query-validation middleware, whose
 /// endpoints do not page by cursor and are therefore not collection-paging events. Validating
 /// identically is what keeps that wiring from hiding an argument fault that would surface in production.
+/// <para>
+/// The two measurement methods repeat their checks rather than sharing a helper between them. A shared
+/// one has to name its parameters something neither caller uses, and the resulting
+/// <see cref="ArgumentException.ParamName" /> would then differ from the one the recording
+/// implementation reports for the very same bad argument — which is exactly the parity this type
+/// exists to hold. The tests assert that name on both implementations through one shared assertion.
+/// </para>
 /// </remarks>
 internal sealed class NoOpCollectionPagingTelemetry : ICollectionPagingTelemetry
 {
@@ -324,30 +331,35 @@ internal sealed class NoOpCollectionPagingTelemetry : ICollectionPagingTelemetry
         TimeSpan duration,
         int requestedPageSize,
         int? returnedPageSize
-    ) => ValidateMeasurement(context, duration, requestedPageSize, returnedPageSize);
+    )
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        CollectionPagingTelemetry.RequireNonNegativeMilliseconds(duration);
+        CollectionPagingTelemetry.RequireNonNegativeCount(requestedPageSize, nameof(requestedPageSize));
+        CollectionPagingTelemetry.RequireNonNegativeCount(returnedPageSize, nameof(returnedPageSize));
+    }
 
     public void RecordPartitions(
         CollectionPagingTelemetryContext context,
         TimeSpan duration,
         int requestedPartitionCount,
         int? returnedPartitionCount
-    ) => ValidateMeasurement(context, duration, requestedPartitionCount, returnedPartitionCount);
-
-    public void RecordValidationRejected(CollectionPagingTelemetryContext context) =>
-        ArgumentNullException.ThrowIfNull(context);
-
-    private static void ValidateMeasurement(
-        CollectionPagingTelemetryContext context,
-        TimeSpan duration,
-        int requested,
-        int? returned
     )
     {
         ArgumentNullException.ThrowIfNull(context);
         CollectionPagingTelemetry.RequireNonNegativeMilliseconds(duration);
-        CollectionPagingTelemetry.RequireNonNegativeCount(requested, nameof(requested));
-        CollectionPagingTelemetry.RequireNonNegativeCount(returned, nameof(returned));
+        CollectionPagingTelemetry.RequireNonNegativeCount(
+            requestedPartitionCount,
+            nameof(requestedPartitionCount)
+        );
+        CollectionPagingTelemetry.RequireNonNegativeCount(
+            returnedPartitionCount,
+            nameof(returnedPartitionCount)
+        );
     }
+
+    public void RecordValidationRejected(CollectionPagingTelemetryContext context) =>
+        ArgumentNullException.ThrowIfNull(context);
 }
 
 internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry

--- a/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
@@ -430,9 +430,8 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
         int? returnedPageSize
     )
     {
-        // Every argument is validated before the first instrument is touched: a fault discovered halfway
-        // through would leave the request counter incremented for a measurement set that was never
-        // completed, which is worse than the bad call it reports.
+        // Every argument is validated before the first instrument is touched, so a bad call emits
+        // nothing at all rather than the leading part of a measurement set.
         ArgumentNullException.ThrowIfNull(context);
 
         double milliseconds = RequireNonNegativeMilliseconds(duration);
@@ -441,7 +440,6 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
 
         TagList tags = context.ToTags();
 
-        _requestCounter.Add(1, tags);
         _duration.Record(milliseconds, tags);
         _requestedPageSize.Record(requestedPageSize, tags);
 
@@ -449,6 +447,16 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
         {
             _returnedPageSize.Record(returned, tags);
         }
+
+        // Counted last, after every measurement it accounts for. Validating up front closes the
+        // partial-set hole for an argument fault but not for the other way a call can stop halfway: an
+        // instrument invokes whatever measurement callbacks the host has subscribed, synchronously on
+        // this thread, and the operator guidance for these metrics asks for exactly such a subscriber.
+        // Counting first would let one of those throw after the counter had already moved, leaving a
+        // counted request carrying no duration - and the published aggregation intent reads `requests`
+        // as the validation rejections plus the duration samples. Counting last inverts which side the
+        // loss falls on: a request may go uncounted, but a counted one was measured.
+        _requestCounter.Add(1, tags);
 
         LogDebug("page", context);
     }
@@ -468,7 +476,6 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
 
         TagList tags = context.ToTags();
 
-        _requestCounter.Add(1, tags);
         _duration.Record(milliseconds, tags);
         _requestedPartitionCount.Record(requestedPartitionCount, tags);
 
@@ -476,6 +483,9 @@ internal sealed class CollectionPagingTelemetry : ICollectionPagingTelemetry
         {
             _returnedPartitionCount.Record(returned, tags);
         }
+
+        // Counted last, for the reason given in RecordPage.
+        _requestCounter.Add(1, tags);
 
         LogDebug("partitions", context);
     }

--- a/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Telemetry/CollectionPagingTelemetry.cs
@@ -160,19 +160,17 @@ internal sealed record CollectionPagingTelemetryContext
     /// A context built from an already-chosen paging-mode label, for the partition operation and for a
     /// rejected request whose paging mode was never assigned.
     /// </summary>
+    /// <remarks>
+    /// No presence guard here. Every label reaches <see cref="RequireAllowedLabel" />, which refuses a
+    /// missing one along with any value its dimension's set does not contain, so a check here would
+    /// restate that one and would have to be kept in step with it.
+    /// </remarks>
     public static CollectionPagingTelemetryContext ForPagingMode(
         string pagingMode,
         string commandCategory,
         SqlDialect? dialect,
         string outcome
-    )
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(pagingMode);
-        ArgumentException.ThrowIfNullOrWhiteSpace(commandCategory);
-        ArgumentException.ThrowIfNullOrWhiteSpace(outcome);
-
-        return new(pagingMode, commandCategory, ProviderLabel(dialect), outcome);
-    }
+    ) => new(pagingMode, commandCategory, ProviderLabel(dialect), outcome);
 
     public TagList ToTags()
     {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationQueryRecorder.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationQueryRecorder.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using FluentAssertions;
@@ -14,6 +15,7 @@ public sealed class ApiIntegrationQueryRecorder
 {
     private readonly object _sync = new();
     private readonly List<PageKeysetSpec> _hydrationKeysets = [];
+    private int _relationalCommandExecutions;
 
     public IReadOnlyList<PageKeysetSpec> HydrationKeysets
     {
@@ -26,12 +28,44 @@ public sealed class ApiIntegrationQueryRecorder
         }
     }
 
+    /// <summary>Number of page hydrations observed so far.</summary>
+    public int HydrationCount
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _hydrationKeysets.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Number of commands issued through <see cref="IRelationalCommandExecutor"/> so far. This is the
+    /// seam the partition boundary command, the descriptor read, and the custom-view validation probe
+    /// use, none of which are visible as a hydration.
+    /// </summary>
+    public int RelationalCommandExecutions => Volatile.Read(ref _relationalCommandExecutions);
+
+    /// <summary>
+    /// Total database commands observed so far: hydrations plus command-executor commands. The two
+    /// seams are disjoint - a document hydrator opens its own connection and runs through
+    /// <c>HydrationExecutor</c>, never through <see cref="IRelationalCommandExecutor"/> - so the sum
+    /// double-counts nothing. Snapshot it before and after a single request and assert on the delta.
+    /// </summary>
+    public int DatabaseCommands => HydrationCount + RelationalCommandExecutions;
+
     internal void Record(PageKeysetSpec keyset)
     {
         lock (_sync)
         {
             _hydrationKeysets.Add(keyset);
         }
+    }
+
+    internal void RecordRelationalCommandExecution()
+    {
+        Interlocked.Increment(ref _relationalCommandExecutions);
     }
 
     public PageKeysetSpec.Query AssertSingleQueryHydration()
@@ -65,52 +99,96 @@ internal sealed class RecordingDocumentHydrator(IDocumentHydrator inner, ApiInte
     }
 }
 
+internal sealed class RecordingRelationalCommandExecutor(
+    IRelationalCommandExecutor inner,
+    ApiIntegrationQueryRecorder recorder
+) : IRelationalCommandExecutor
+{
+    private readonly IRelationalCommandExecutor _inner =
+        inner ?? throw new ArgumentNullException(nameof(inner));
+    private readonly ApiIntegrationQueryRecorder _recorder =
+        recorder ?? throw new ArgumentNullException(nameof(recorder));
+
+    public SqlDialect Dialect => _inner.Dialect;
+
+    public Task<TResult> ExecuteReaderAsync<TResult>(
+        RelationalCommand command,
+        Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+        CancellationToken cancellationToken = default
+    )
+    {
+        _recorder.RecordRelationalCommandExecution();
+
+        return _inner.ExecuteReaderAsync(command, readAsync, cancellationToken);
+    }
+}
+
 internal static class ApiIntegrationQueryRecordingServiceCollectionExtensions
 {
     public static void ReplaceDocumentHydratorWithRecorder(this IServiceCollection services)
     {
+        services.ReplaceWithRecorder<IDocumentHydrator>(
+            static (inner, recorder) => new RecordingDocumentHydrator(inner, recorder)
+        );
+    }
+
+    public static void ReplaceRelationalCommandExecutorWithRecorder(this IServiceCollection services)
+    {
+        services.ReplaceWithRecorder<IRelationalCommandExecutor>(
+            static (inner, recorder) => new RecordingRelationalCommandExecutor(inner, recorder)
+        );
+    }
+
+    private static void ReplaceWithRecorder<TService>(
+        this IServiceCollection services,
+        Func<TService, ApiIntegrationQueryRecorder, TService> createRecordingDecorator
+    )
+        where TService : class
+    {
         var descriptor =
-            services.LastOrDefault(static service => service.ServiceType == typeof(IDocumentHydrator))
+            services.LastOrDefault(static service => service.ServiceType == typeof(TService))
             ?? throw new InvalidOperationException(
-                $"{nameof(IDocumentHydrator)} must be registered before query recording can wrap it."
+                $"{typeof(TService).Name} must be registered before query recording can wrap it."
             );
 
         services.Remove(descriptor);
         services.Add(
             ServiceDescriptor.Describe(
-                typeof(IDocumentHydrator),
-                serviceProvider => new RecordingDocumentHydrator(
-                    CreateInnerDocumentHydrator(serviceProvider, descriptor),
-                    serviceProvider.GetRequiredService<ApiIntegrationQueryRecorder>()
-                ),
+                typeof(TService),
+                serviceProvider =>
+                    createRecordingDecorator(
+                        CreateInner<TService>(serviceProvider, descriptor),
+                        serviceProvider.GetRequiredService<ApiIntegrationQueryRecorder>()
+                    ),
                 descriptor.Lifetime
             )
         );
     }
 
-    private static IDocumentHydrator CreateInnerDocumentHydrator(
+    private static TService CreateInner<TService>(
         IServiceProvider serviceProvider,
         ServiceDescriptor descriptor
     )
+        where TService : class
     {
-        if (descriptor.ImplementationInstance is IDocumentHydrator instance)
+        if (descriptor.ImplementationInstance is TService instance)
         {
             return instance;
         }
 
         if (descriptor.ImplementationFactory is not null)
         {
-            return (IDocumentHydrator)descriptor.ImplementationFactory(serviceProvider)!;
+            return (TService)descriptor.ImplementationFactory(serviceProvider)!;
         }
 
         if (descriptor.ImplementationType is not null)
         {
-            return (IDocumentHydrator)
+            return (TService)
                 ActivatorUtilities.CreateInstance(serviceProvider, descriptor.ImplementationType);
         }
 
         throw new InvalidOperationException(
-            $"{nameof(IDocumentHydrator)} registration does not have an implementation."
+            $"{typeof(TService).Name} registration does not have an implementation."
         );
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
@@ -247,6 +247,7 @@ public abstract class ApiIntegrationTestBase
                 {
                     services.AddSingleton(queryRecorder);
                     services.ReplaceDocumentHydratorWithRecorder();
+                    services.ReplaceRelationalCommandExecutorWithRecorder();
                 }
             });
         });

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/CollectionPagingMetricCollector.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/CollectionPagingMetricCollector.cs
@@ -14,12 +14,19 @@ namespace EdFi.DataManagementService.Tests.Integration;
 /// One measurement the host published on the collection-paging meter, reduced to what the metric
 /// contract actually promises: an instrument name, a value, and the four bounded dimensions.
 /// </summary>
+/// <param name="Instrument">
+/// The instrument object the measurement arrived on, not just its name. Each host builds its own
+/// instruments on the process-static meter, so this is what distinguishes two hosts publishing the same
+/// instrument name from one host publishing it twice.
+/// </param>
 internal sealed record CollectionPagingMeasurement(
-    string InstrumentName,
+    Instrument Instrument,
     double Value,
     IReadOnlyDictionary<string, string> Tags
 )
 {
+    public string InstrumentName => Instrument.Name;
+
     public string PagingMode => Tag("paging_mode");
 
     public string CommandCategory => Tag("command_category");
@@ -46,6 +53,13 @@ internal sealed record CollectionPagingMeasurement(
 /// listener the only way to prove these measurements end to end. The meter is process-static, so a
 /// collector observes whichever host is currently serving; the fixtures in this suite run one host at a
 /// time, and <see cref="Clear" /> before each asserted request keeps a window to that request alone.
+/// <para>
+/// That one-host-at-a-time assumption is checked rather than merely relied on. Each host builds its own
+/// instruments on the shared meter, so <see cref="Single" /> can tell a second host publishing the same
+/// instrument name from one host publishing twice, and says which it saw. A fixture that leaves an
+/// earlier host serving therefore fails with its own cause named instead of looking like the telemetry
+/// contract emitting more than one measurement set per request.
+/// </para>
 /// </remarks>
 internal sealed class CollectionPagingMetricCollector : IDisposable
 {
@@ -259,6 +273,20 @@ internal sealed class CollectionPagingMetricCollector : IDisposable
             )
             .ToList();
 
+        // Checked ahead of the count, because it is the one cause of a duplicate here that is not a
+        // defect in an emission site. This collector observes the whole process, so a second host still
+        // serving would deliver its own instrument under the same name and be counted too. Left to the
+        // count assertion below, that would read as the telemetry contract emitting twice per request.
+        recorded
+            .DistinctBy(measurement => measurement.Instrument)
+            .Should()
+            .HaveCountLessThanOrEqualTo(
+                1,
+                $"'{instrumentName}' must reach this collector from one host: the meter is "
+                    + "process-static, so a fixture that left an earlier host serving is observed here "
+                    + "as well and this is a fixture-lifetime fault rather than a metric one"
+            );
+
         recorded
             .Should()
             .ContainSingle(
@@ -310,7 +338,7 @@ internal sealed class CollectionPagingMetricCollector : IDisposable
         {
             _measurements.Add(
                 new CollectionPagingMeasurement(
-                    instrument.Name,
+                    instrument,
                     Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
                     tagValues
                 )

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/CollectionPagingMetricCollector.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/CollectionPagingMetricCollector.cs
@@ -180,6 +180,58 @@ internal sealed class CollectionPagingMetricCollector : IDisposable
     }
 
     /// <summary>
+    /// Asserts the measurement set of exactly one request answered by parameter validation: the request
+    /// counter, and nothing beside it.
+    /// </summary>
+    /// <remarks>
+    /// The one emission that cannot go through <see cref="AssertSingleRequest" />, because that helper
+    /// requires the duration a rejection deliberately does not record. Nothing executed, so a duration
+    /// sample would report the cost of parsing a query string as a read latency, and a size or count
+    /// measurement would report the very value that was refused. Asserting the absences by name is the
+    /// point: the counter alone is the whole contract for this outcome.
+    /// </remarks>
+    public CollectionPagingMeasurement AssertSingleValidationRejection(
+        string expectedProvider,
+        string expectedPagingMode
+    )
+    {
+        AssertDimensionsBounded();
+
+        var request = Single(CollectionPagingTelemetry.RequestCounterName);
+
+        request.Value.Should().Be(1, "the request counter counts one request per emission");
+        request.PagingMode.Should().Be(expectedPagingMode);
+        request.CommandCategory.Should().Be(CollectionPagingTelemetryLabel.NoCommandCategory);
+        request.Provider.Should().Be(expectedProvider);
+        request.Outcome.Should().Be(CollectionPagingTelemetryLabel.ValidationRejectedOutcome);
+
+        AssertNotRecorded(
+            CollectionPagingTelemetry.DurationName,
+            "is recorded only where backend execution was attempted, and a rejection would contribute "
+                + "the cost of parsing a query string as a read latency"
+        );
+
+        foreach (
+            string sizeOrCount in new[]
+            {
+                CollectionPagingTelemetry.RequestedPageSizeName,
+                CollectionPagingTelemetry.ReturnedPageSizeName,
+                CollectionPagingTelemetry.RequestedPartitionCountName,
+                CollectionPagingTelemetry.ReturnedPartitionCountName,
+            }
+        )
+        {
+            AssertNotRecorded(
+                sizeOrCount,
+                "is not recorded for a rejection, because the size or count it would carry may be the "
+                    + "value that was refused"
+            );
+        }
+
+        return request;
+    }
+
+    /// <summary>
     /// The single request-counter measurement observed, with its dimensions and the duration that must
     /// accompany a request the host actually executed.
     /// </summary>
@@ -282,13 +334,24 @@ internal sealed class CollectionPagingMetricCollector : IDisposable
         AssertNotRecorded(instrumentName);
     }
 
-    private void AssertNotRecorded(string instrumentName) =>
+    /// <summary>
+    /// Asserts an instrument carries no measurement, naming why it must not.
+    /// </summary>
+    /// <param name="because">
+    /// Completes the sentence "'&lt;instrument&gt;' …". Defaulted to the wrong-operation reason, which is
+    /// what the page and partition assertions above mean; a validation rejection excludes instruments
+    /// that do belong to its operation and says so in its own words.
+    /// </param>
+    private void AssertNotRecorded(
+        string instrumentName,
+        string because = "does not belong to this operation and would mix two units of measure"
+    ) =>
         Measurements
             .Should()
             .NotContain(
                 measurement =>
                     string.Equals(measurement.InstrumentName, instrumentName, StringComparison.Ordinal),
-                $"'{instrumentName}' does not belong to this operation and would mix two units of measure"
+                $"'{instrumentName}' {because}"
             );
 
     private void OnMeasurement<T>(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/CollectionPagingMetricCollector.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/CollectionPagingMetricCollector.cs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using EdFi.DataManagementService.Core.Telemetry;
+using FluentAssertions;
+
+namespace EdFi.DataManagementService.Tests.Integration;
+
+/// <summary>
+/// One measurement the host published on the collection-paging meter, reduced to what the metric
+/// contract actually promises: an instrument name, a value, and the four bounded dimensions.
+/// </summary>
+internal sealed record CollectionPagingMeasurement(
+    string InstrumentName,
+    double Value,
+    IReadOnlyDictionary<string, string> Tags
+)
+{
+    public string PagingMode => Tag("paging_mode");
+
+    public string CommandCategory => Tag("command_category");
+
+    public string Provider => Tag("provider");
+
+    public string Outcome => Tag("outcome");
+
+    private string Tag(string key) =>
+        Tags.TryGetValue(key, out string? value)
+            ? value
+            : throw new InvalidOperationException(
+                $"Measurement '{InstrumentName}' carries no '{key}' tag; tags present: "
+                    + $"{string.Join(", ", Tags.Keys)}."
+            );
+}
+
+/// <summary>
+/// Observes the collection-paging meter from inside the test process while an assembled host serves
+/// requests, so what the tests assert on is what a metrics pipeline in the host would collect.
+/// </summary>
+/// <remarks>
+/// .NET <c>Meter</c> instruments are observable only in-process, which is what makes an in-process
+/// listener the only way to prove these measurements end to end. The meter is process-static, so a
+/// collector observes whichever host is currently serving; the fixtures in this suite run one host at a
+/// time, and <see cref="Clear" /> before each asserted request keeps a window to that request alone.
+/// </remarks>
+internal sealed class CollectionPagingMetricCollector : IDisposable
+{
+    private static readonly string[] AllowedPagingModes =
+    [
+        CollectionPagingTelemetryLabel.TraditionalPagingMode,
+        CollectionPagingTelemetryLabel.CursorPagingMode,
+        CollectionPagingTelemetryLabel.PartitionPagingMode,
+    ];
+
+    private static readonly string[] AllowedCommandCategories =
+    [
+        CollectionPagingTelemetryLabel.PageCommandCategory,
+        CollectionPagingTelemetryLabel.PageWithCountCommandCategory,
+        CollectionPagingTelemetryLabel.BoundaryCommandCategory,
+        CollectionPagingTelemetryLabel.NoCommandCategory,
+    ];
+
+    private static readonly string[] AllowedProviders =
+    [
+        CollectionPagingTelemetryLabel.PostgresqlProvider,
+        CollectionPagingTelemetryLabel.SqlServerProvider,
+        CollectionPagingTelemetryLabel.UnknownProvider,
+    ];
+
+    private static readonly string[] AllowedOutcomes =
+    [
+        CollectionPagingTelemetryLabel.SuccessOutcome,
+        CollectionPagingTelemetryLabel.TerminalPageOutcome,
+        CollectionPagingTelemetryLabel.EarlyEmptyOutcome,
+        CollectionPagingTelemetryLabel.ValidationRejectedOutcome,
+        CollectionPagingTelemetryLabel.NotAuthorizedOutcome,
+        CollectionPagingTelemetryLabel.NotImplementedOutcome,
+        CollectionPagingTelemetryLabel.SecurityConfigurationOutcome,
+        CollectionPagingTelemetryLabel.RetryExhaustedOutcome,
+        CollectionPagingTelemetryLabel.UnknownFailureOutcome,
+        CollectionPagingTelemetryLabel.ExecutionExceptionOutcome,
+    ];
+
+    private readonly object _sync = new();
+    private readonly List<CollectionPagingMeasurement> _measurements = [];
+    private readonly MeterListener _listener;
+
+    private CollectionPagingMetricCollector()
+    {
+        _listener = new MeterListener
+        {
+            InstrumentPublished = static (instrument, listener) =>
+            {
+                if (
+                    string.Equals(
+                        instrument.Meter.Name,
+                        CollectionPagingTelemetry.MeterName,
+                        StringComparison.Ordinal
+                    )
+                )
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+
+        // Every instrument type the contract publishes: the request counter is long, duration is double,
+        // and the four size and count histograms are int. A missing callback would silently drop the
+        // instrument rather than fail, so all three are registered.
+        _listener.SetMeasurementEventCallback<long>(OnMeasurement);
+        _listener.SetMeasurementEventCallback<double>(OnMeasurement);
+        _listener.SetMeasurementEventCallback<int>(OnMeasurement);
+        _listener.Start();
+    }
+
+    public static CollectionPagingMetricCollector Start() => new();
+
+    public IReadOnlyList<CollectionPagingMeasurement> Measurements
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return [.. _measurements];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Discards everything observed so far, so the next request's measurements stand alone.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_sync)
+        {
+            _measurements.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Asserts the measurement set of exactly one GET-many emission and returns its request measurement.
+    /// </summary>
+    public CollectionPagingMeasurement AssertSinglePage(
+        string expectedProvider,
+        string expectedPagingMode,
+        string expectedCommandCategory,
+        string expectedOutcome,
+        int expectedRequestedPageSize,
+        int? expectedReturnedPageSize
+    )
+    {
+        var request = AssertSingleRequest(
+            expectedProvider,
+            expectedPagingMode,
+            expectedCommandCategory,
+            expectedOutcome
+        );
+
+        AssertSingleValue(CollectionPagingTelemetry.RequestedPageSizeName, expectedRequestedPageSize);
+        AssertOptionalValue(CollectionPagingTelemetry.ReturnedPageSizeName, expectedReturnedPageSize);
+        AssertNotRecorded(CollectionPagingTelemetry.RequestedPartitionCountName);
+        AssertNotRecorded(CollectionPagingTelemetry.ReturnedPartitionCountName);
+
+        return request;
+    }
+
+    /// <summary>
+    /// Asserts the measurement set of exactly one <c>/partitions</c> emission and returns its request
+    /// measurement.
+    /// </summary>
+    public CollectionPagingMeasurement AssertSinglePartitions(
+        string expectedProvider,
+        string expectedCommandCategory,
+        string expectedOutcome,
+        int expectedRequestedPartitionCount,
+        int? expectedReturnedPartitionCount
+    )
+    {
+        var request = AssertSingleRequest(
+            expectedProvider,
+            CollectionPagingTelemetryLabel.PartitionPagingMode,
+            expectedCommandCategory,
+            expectedOutcome
+        );
+
+        AssertSingleValue(
+            CollectionPagingTelemetry.RequestedPartitionCountName,
+            expectedRequestedPartitionCount
+        );
+        AssertOptionalValue(
+            CollectionPagingTelemetry.ReturnedPartitionCountName,
+            expectedReturnedPartitionCount
+        );
+        AssertNotRecorded(CollectionPagingTelemetry.RequestedPageSizeName);
+        AssertNotRecorded(CollectionPagingTelemetry.ReturnedPageSizeName);
+
+        return request;
+    }
+
+    /// <summary>
+    /// The single request-counter measurement observed, with its dimensions and the duration that must
+    /// accompany a request the host actually executed.
+    /// </summary>
+    private CollectionPagingMeasurement AssertSingleRequest(
+        string expectedProvider,
+        string expectedPagingMode,
+        string expectedCommandCategory,
+        string expectedOutcome
+    )
+    {
+        AssertDimensionsBounded();
+
+        var request = Single(CollectionPagingTelemetry.RequestCounterName);
+
+        request.Value.Should().Be(1, "the request counter counts one request per emission");
+        request.PagingMode.Should().Be(expectedPagingMode);
+        request.CommandCategory.Should().Be(expectedCommandCategory);
+        request.Provider.Should().Be(expectedProvider);
+        request.Outcome.Should().Be(expectedOutcome);
+
+        var duration = Single(CollectionPagingTelemetry.DurationName);
+        duration.Value.Should().BeGreaterThanOrEqualTo(0);
+        duration.Tags.Should().Equal(request.Tags, "every measurement of one emission shares its tags");
+
+        return request;
+    }
+
+    /// <summary>
+    /// No measurement carries a dimension the contract does not define, and no dimension carries a value
+    /// outside its allowed set. This is what keeps request data — resource names, tenant keys,
+    /// namespaces, client identity, filter values, page tokens — out of the metric end to end.
+    /// </summary>
+    private void AssertDimensionsBounded()
+    {
+        foreach (var measurement in Measurements)
+        {
+            measurement
+                .Tags.Keys.Should()
+                .BeEquivalentTo(
+                    new[] { "paging_mode", "command_category", "provider", "outcome" },
+                    $"'{measurement.InstrumentName}' must carry exactly the four defined dimensions"
+                );
+            measurement.PagingMode.Should().BeOneOf(AllowedPagingModes);
+            measurement.CommandCategory.Should().BeOneOf(AllowedCommandCategories);
+            measurement.Provider.Should().BeOneOf(AllowedProviders);
+            measurement.Outcome.Should().BeOneOf(AllowedOutcomes);
+        }
+    }
+
+    private CollectionPagingMeasurement Single(string instrumentName)
+    {
+        var recorded = Measurements
+            .Where(measurement =>
+                string.Equals(measurement.InstrumentName, instrumentName, StringComparison.Ordinal)
+            )
+            .ToList();
+
+        recorded
+            .Should()
+            .ContainSingle(
+                $"'{instrumentName}' must be recorded exactly once per emission; observed: "
+                    + $"{string.Join(", ", Measurements.Select(measurement => measurement.InstrumentName))}"
+            );
+
+        return recorded[0];
+    }
+
+    private void AssertSingleValue(string instrumentName, int expectedValue) =>
+        Single(instrumentName).Value.Should().Be(expectedValue);
+
+    private void AssertOptionalValue(string instrumentName, int? expectedValue)
+    {
+        if (expectedValue is { } value)
+        {
+            AssertSingleValue(instrumentName, value);
+            return;
+        }
+
+        AssertNotRecorded(instrumentName);
+    }
+
+    private void AssertNotRecorded(string instrumentName) =>
+        Measurements
+            .Should()
+            .NotContain(
+                measurement =>
+                    string.Equals(measurement.InstrumentName, instrumentName, StringComparison.Ordinal),
+                $"'{instrumentName}' does not belong to this operation and would mix two units of measure"
+            );
+
+    private void OnMeasurement<T>(
+        Instrument instrument,
+        T measurement,
+        ReadOnlySpan<KeyValuePair<string, object?>> tags,
+        object? state
+    )
+        where T : struct
+    {
+        Dictionary<string, string> tagValues = new(StringComparer.Ordinal);
+        foreach (var tag in tags)
+        {
+            tagValues[tag.Key] = tag.Value?.ToString() ?? string.Empty;
+        }
+
+        lock (_sync)
+        {
+            _measurements.Add(
+                new CollectionPagingMeasurement(
+                    instrument.Name,
+                    Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
+                    tagValues
+                )
+            );
+        }
+    }
+
+    public void Dispose() => _listener.Dispose();
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/CollectionPagingMetricCollector.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/CollectionPagingMetricCollector.cs
@@ -63,42 +63,6 @@ internal sealed record CollectionPagingMeasurement(
 /// </remarks>
 internal sealed class CollectionPagingMetricCollector : IDisposable
 {
-    private static readonly string[] AllowedPagingModes =
-    [
-        CollectionPagingTelemetryLabel.TraditionalPagingMode,
-        CollectionPagingTelemetryLabel.CursorPagingMode,
-        CollectionPagingTelemetryLabel.PartitionPagingMode,
-    ];
-
-    private static readonly string[] AllowedCommandCategories =
-    [
-        CollectionPagingTelemetryLabel.PageCommandCategory,
-        CollectionPagingTelemetryLabel.PageWithCountCommandCategory,
-        CollectionPagingTelemetryLabel.BoundaryCommandCategory,
-        CollectionPagingTelemetryLabel.NoCommandCategory,
-    ];
-
-    private static readonly string[] AllowedProviders =
-    [
-        CollectionPagingTelemetryLabel.PostgresqlProvider,
-        CollectionPagingTelemetryLabel.SqlServerProvider,
-        CollectionPagingTelemetryLabel.UnknownProvider,
-    ];
-
-    private static readonly string[] AllowedOutcomes =
-    [
-        CollectionPagingTelemetryLabel.SuccessOutcome,
-        CollectionPagingTelemetryLabel.TerminalPageOutcome,
-        CollectionPagingTelemetryLabel.EarlyEmptyOutcome,
-        CollectionPagingTelemetryLabel.ValidationRejectedOutcome,
-        CollectionPagingTelemetryLabel.NotAuthorizedOutcome,
-        CollectionPagingTelemetryLabel.NotImplementedOutcome,
-        CollectionPagingTelemetryLabel.SecurityConfigurationOutcome,
-        CollectionPagingTelemetryLabel.RetryExhaustedOutcome,
-        CollectionPagingTelemetryLabel.UnknownFailureOutcome,
-        CollectionPagingTelemetryLabel.ExecutionExceptionOutcome,
-    ];
-
     private readonly object _sync = new();
     private readonly List<CollectionPagingMeasurement> _measurements = [];
     private readonly MeterListener _listener;
@@ -248,6 +212,13 @@ internal sealed class CollectionPagingMetricCollector : IDisposable
     /// outside its allowed set. This is what keeps request data — resource names, tenant keys,
     /// namespaces, client identity, filter values, page tokens — out of the metric end to end.
     /// </summary>
+    /// <remarks>
+    /// The allowed values are read from the component rather than restated here. These are the same
+    /// per-dimension sets the emission path checks membership against, so a value arriving on this
+    /// collector that they do not contain is a breach of the published contract rather than a local copy
+    /// that fell out of step — and their contents are pinned against the operator documentation by the
+    /// component's own tests, which is where that job belongs.
+    /// </remarks>
     private void AssertDimensionsBounded()
     {
         foreach (var measurement in Measurements)
@@ -258,10 +229,10 @@ internal sealed class CollectionPagingMetricCollector : IDisposable
                     new[] { "paging_mode", "command_category", "provider", "outcome" },
                     $"'{measurement.InstrumentName}' must carry exactly the four defined dimensions"
                 );
-            measurement.PagingMode.Should().BeOneOf(AllowedPagingModes);
-            measurement.CommandCategory.Should().BeOneOf(AllowedCommandCategories);
-            measurement.Provider.Should().BeOneOf(AllowedProviders);
-            measurement.Outcome.Should().BeOneOf(AllowedOutcomes);
+            measurement.PagingMode.Should().BeOneOf(CollectionPagingTelemetryLabel.PagingModes);
+            measurement.CommandCategory.Should().BeOneOf(CollectionPagingTelemetryLabel.CommandCategories);
+            measurement.Provider.Should().BeOneOf(CollectionPagingTelemetryLabel.Providers);
+            measurement.Outcome.Should().BeOneOf(CollectionPagingTelemetryLabel.Outcomes);
         }
     }
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
@@ -290,6 +290,93 @@ internal static class CursorPagingExecutionScenario
             );
     }
 
+    /// <summary>
+    /// The one outcome whose name is a claim about database work. <c>early_empty</c> reports that the API
+    /// answered without issuing a selection command, and this is where that claim is measured rather than
+    /// stated.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A descriptor <c>id</c> filter carrying something that is not a UUID cannot match any row, and the
+    /// API determines that from the value alone. So the page is answered with no candidate selection at
+    /// all, which is what makes zero the expected count here where every other telemetry case in this
+    /// suite costs exactly one. A later change that answered this short-circuit with a real command — an
+    /// added probe, a reordered authorization check — would keep every other assertion in this suite
+    /// green while making the outcome name false, and this is the only case that would fail.
+    /// </para>
+    /// <para>
+    /// The collection is seeded first even though the filter matches none of it. Without the seed the
+    /// empty page and the zero count would both be statements about an empty database rather than about
+    /// the short-circuit, which is the property under test.
+    /// </para>
+    /// <para>
+    /// The descriptor endpoint carries this case because it is the one this fixture's ApiSchema gives an
+    /// <c>id</c> query field to. The regular resource here declares no query fields at all, so the same
+    /// request against it would be refused as an unknown field and never reach a selection decision.
+    /// </para>
+    /// </remarks>
+    public static async Task It_records_an_early_empty_without_a_database_command(
+        ApiIntegrationHarness harness,
+        string expectedProvider
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedProvider);
+
+        ApiIntegrationQueryRecorder recorder =
+            harness.QueryRecorder
+            ?? throw new InvalidOperationException(
+                "This scenario counts database commands and requires CaptureQueryPlans."
+            );
+
+        await SeedDescriptorsAsync(harness, "early-empty");
+
+        // Encoded by the codec that decodes it, so the entry token is decodable by construction.
+        string entryToken = PageTokenCodec.Encode(CursorRange.From(1));
+
+        using var metrics = CollectionPagingMetricCollector.Start();
+
+        metrics.Clear();
+        int commandsBefore = recorder.DatabaseCommands;
+
+        using (
+            HttpResponseMessage response = await harness.HttpClient.GetAsync(
+                $"{DescriptorEndpoint}?pageToken={Uri.EscapeDataString(entryToken)}&pageSize=2"
+                    + "&id=not-a-uuid"
+            )
+        )
+        {
+            string body = await response.Content.ReadAsStringAsync();
+            int databaseCommands = recorder.DatabaseCommands - commandsBefore;
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+            response.Content.Headers.ContentType!.MediaType.Should().Be(StandardJsonContentType);
+            JsonNode.Parse(body)!.AsArray().Should().BeEmpty();
+
+            // Nothing was selected, so there is no key to anchor a continuation on and the walk ends
+            // here. A short-circuit that offered a continuation would send a client back for a page the
+            // API already knows cannot exist.
+            response.Headers.Contains(NextPageTokenHeaderName).Should().BeFalse();
+
+            databaseCommands
+                .Should()
+                .Be(
+                    0,
+                    "early_empty reports that no selection command was issued, so any count above zero "
+                        + "would make the outcome name false"
+                );
+        }
+
+        metrics.AssertSinglePage(
+            expectedProvider,
+            CollectionPagingTelemetryLabel.CursorPagingMode,
+            CollectionPagingTelemetryLabel.NoCommandCategory,
+            CollectionPagingTelemetryLabel.EarlyEmptyOutcome,
+            expectedRequestedPageSize: 2,
+            expectedReturnedPageSize: 0
+        );
+    }
+
     private static async Task<CursorWalk> WalkFromFirstPageAsync(
         ApiIntegrationHarness harness,
         string endpoint,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.Json.Nodes;
@@ -154,6 +155,13 @@ internal static class CursorPagingExecutionScenario
     /// </summary>
     /// <remarks>
     /// <para>
+    /// Both paging modes are read, in the order a client meets them: a traditional first page carrying a
+    /// total count, then the cursor pages the continuation it hands back leads to. That entry request is
+    /// what covers the traditional mode and the <c>page_with_count</c> shape here rather than only in a
+    /// handler test, and it is the only place the cost of compiling a count into the selection command is
+    /// measured instead of asserted.
+    /// </para>
+    /// <para>
     /// Both resource kinds are read, because the seam that carries the single command differs between
     /// them — a regular-resource page is a hydration while a descriptor page is a command-executor
     /// command — and the quantity the design constrains is the total, not the split. Asserting the split
@@ -188,11 +196,67 @@ internal static class CursorPagingExecutionScenario
 
         using var metrics = CollectionPagingMetricCollector.Start();
 
+        // Where a client enters the walk: a traditional first page that also asks for a total count. This
+        // is the only request in the suite that reports the traditional mode and the count shape, and the
+        // only one that measures what that shape costs. page_with_count is published as "compiled a total
+        // count into the same command", so a change that answered the count with a second query would
+        // make that definition false and double the cost of the shape operators are told to hold to its
+        // own latency objective — while every other assertion here, none of which asks for a count,
+        // stayed green.
+        metrics.Clear();
+        int commandsBefore = recorder.DatabaseCommands;
+
+        using (
+            HttpResponseMessage response = await harness.HttpClient.GetAsync(
+                $"{MergeItemsEndpoint}?limit=2&totalCount=true"
+            )
+        )
+        {
+            string body = await response.Content.ReadAsStringAsync();
+            int databaseCommands = recorder.DatabaseCommands - commandsBefore;
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+            response.Content.Headers.ContentType!.MediaType.Should().Be(StandardJsonContentType);
+            JsonNode.Parse(body)!.AsArray().Should().HaveCount(2);
+
+            // The count this request asked for is served, and the page still offers the continuation that
+            // lets the client switch to token paging — so the outcome below is success rather than a walk
+            // reported as already ended.
+            int totalCount = int.Parse(
+                response.Headers.GetValues("Total-Count").Single(),
+                CultureInfo.InvariantCulture
+            );
+            totalCount
+                .Should()
+                .BeGreaterThanOrEqualTo(
+                    SeededDocumentCount,
+                    "the count describes the whole collection this scenario seeded, not the page"
+                );
+            response.Headers.GetValues(NextPageTokenHeaderName).Should().ContainSingle();
+
+            databaseCommands
+                .Should()
+                .Be(
+                    CursorPageDatabaseCommands,
+                    "a total count is compiled into the selection command rather than answered by a "
+                        + "second one, which is what command_category=page_with_count reports"
+                );
+        }
+
+        metrics.AssertSinglePage(
+            expectedProvider,
+            CollectionPagingTelemetryLabel.TraditionalPagingMode,
+            CollectionPagingTelemetryLabel.PageWithCountCommandCategory,
+            CollectionPagingTelemetryLabel.SuccessOutcome,
+            expectedRequestedPageSize: 2,
+            expectedReturnedPageSize: 2
+        );
+
         // A regular-resource cursor page, asserted on the raw response so the instrumentation is shown to
         // change nothing a client can observe: same status, same media type, a continuation, and no
         // Total-Count on a request that asked for no count.
         metrics.Clear();
-        int commandsBefore = recorder.DatabaseCommands;
+        commandsBefore = recorder.DatabaseCommands;
 
         using (
             HttpResponseMessage response = await harness.HttpClient.GetAsync(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Paging;
+using EdFi.DataManagementService.Core.Telemetry;
 using FluentAssertions;
 
 namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
@@ -54,6 +55,21 @@ internal static class CursorPagingExecutionScenario
     /// exhaust this and fail with the pages it did retrieve rather than hanging.
     /// </summary>
     private const int MaximumWalkedPages = 25;
+
+    /// <summary>
+    /// The database commands one cursor page is allowed to cost.
+    /// </summary>
+    /// <remarks>
+    /// An absolute literal from the design rather than a figure captured from a run: a baseline captured
+    /// from this same build would carry whatever extra command the instrumentation added, so both sides
+    /// would move together and the assertion could never fail for the reason it exists. The design fixes
+    /// it instead — a cursor page uses the existing single-command page-keyset architecture and adds no
+    /// database command, transaction, or roundtrip. The fixtures binding this scenario grant
+    /// <c>NoFurtherAuthorizationRequired</c>, so the design's one documented exception — a view-based
+    /// authorization strategy whose custom-view validation probe runs as a second command — does not
+    /// apply, and raising this number is a visible, deliberate edit in review.
+    /// </remarks>
+    private const int CursorPageDatabaseCommands = 1;
 
     public static async Task It_walks_a_regular_resource_collection_by_cursor(ApiIntegrationHarness harness)
     {
@@ -129,6 +145,149 @@ internal static class CursorPagingExecutionScenario
         // effect rather than an empty selection or a missing feature.
         var (_, unwindowedToken) = await ReadPageAsync(harness, $"{MergeItemsEndpoint}?limit=2");
         unwindowedToken.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// What the collection-paging metric reports for a real cursor read, and what that read is allowed to
+    /// cost. The provider dimension is proven from a live connection rather than from a dialect literal,
+    /// which is the only place it can be: nothing in Core can tell which engine actually answered.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both resource kinds are read, because the seam that carries the single command differs between
+    /// them — a regular-resource page is a hydration while a descriptor page is a command-executor
+    /// command — and the quantity the design constrains is the total, not the split. Asserting the split
+    /// would pass on one kind and fail on the other for a reason that is not a defect.
+    /// </para>
+    /// <para>
+    /// The command counters are snapshotted immediately around each asserted request, so the seeding
+    /// traffic above is excluded. That is request isolation, not a baseline: the expected value is the
+    /// design literal and is never read from a run.
+    /// </para>
+    /// </remarks>
+    public static async Task It_emits_bounded_telemetry_across_a_cursor_walk(
+        ApiIntegrationHarness harness,
+        string expectedProvider
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedProvider);
+
+        ApiIntegrationQueryRecorder recorder =
+            harness.QueryRecorder
+            ?? throw new InvalidOperationException(
+                "This scenario counts database commands and requires CaptureQueryPlans."
+            );
+
+        await SeedMergeItemsAsync(harness, "telemetry");
+        await SeedDescriptorsAsync(harness, "telemetry");
+
+        // Encoded by the codec that decodes it, so the entry token is decodable by construction.
+        string entryToken = PageTokenCodec.Encode(CursorRange.From(1));
+        string tokenParameter = $"pageToken={Uri.EscapeDataString(entryToken)}&pageSize=2";
+
+        using var metrics = CollectionPagingMetricCollector.Start();
+
+        // A regular-resource cursor page, asserted on the raw response so the instrumentation is shown to
+        // change nothing a client can observe: same status, same media type, a continuation, and no
+        // Total-Count on a request that asked for no count.
+        metrics.Clear();
+        int commandsBefore = recorder.DatabaseCommands;
+
+        using (
+            HttpResponseMessage response = await harness.HttpClient.GetAsync(
+                $"{MergeItemsEndpoint}?{tokenParameter}"
+            )
+        )
+        {
+            string body = await response.Content.ReadAsStringAsync();
+            int databaseCommands = recorder.DatabaseCommands - commandsBefore;
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+            response.Content.Headers.ContentType!.MediaType.Should().Be(StandardJsonContentType);
+            response.Headers.Contains("Total-Count").Should().BeFalse();
+            response.Headers.GetValues(NextPageTokenHeaderName).Should().ContainSingle();
+            JsonNode.Parse(body)!.AsArray().Should().HaveCount(2);
+
+            databaseCommands
+                .Should()
+                .Be(
+                    CursorPageDatabaseCommands,
+                    "a cursor page adds no database command, and the metric describing it must not "
+                        + "be answered with an extra query"
+                );
+        }
+
+        metrics.AssertSinglePage(
+            expectedProvider,
+            CollectionPagingTelemetryLabel.CursorPagingMode,
+            CollectionPagingTelemetryLabel.PageCommandCategory,
+            CollectionPagingTelemetryLabel.SuccessOutcome,
+            expectedRequestedPageSize: 2,
+            expectedReturnedPageSize: 2
+        );
+
+        // The descriptor page: the same one command, carried by the other seam.
+        metrics.Clear();
+        commandsBefore = recorder.DatabaseCommands;
+
+        var descriptorPage = await ReadPageAsync(harness, $"{DescriptorEndpoint}?{tokenParameter}");
+
+        (recorder.DatabaseCommands - commandsBefore).Should().Be(CursorPageDatabaseCommands);
+        descriptorPage.PageIds.Should().HaveCount(2);
+        metrics.AssertSinglePage(
+            expectedProvider,
+            CollectionPagingTelemetryLabel.CursorPagingMode,
+            CollectionPagingTelemetryLabel.PageCommandCategory,
+            CollectionPagingTelemetryLabel.SuccessOutcome,
+            expectedRequestedPageSize: 2,
+            expectedReturnedPageSize: 2
+        );
+
+        // Walking to the end. Each page is classified from what the response itself did with the
+        // continuation, so the page that ends the walk is the one — and the only one — reported as
+        // terminal, and no page of the walk costs more than one command however deep it is.
+        string? pageToken = entryToken;
+        CollectionPagingMeasurement? lastPage = null;
+        var walkedPages = 0;
+
+        while (pageToken is not null && walkedPages < MaximumWalkedPages)
+        {
+            metrics.Clear();
+            commandsBefore = recorder.DatabaseCommands;
+
+            var walked = await ReadPageAsync(
+                harness,
+                $"{MergeItemsEndpoint}?pageToken={Uri.EscapeDataString(pageToken)}&pageSize=2"
+            );
+
+            (recorder.DatabaseCommands - commandsBefore).Should().Be(CursorPageDatabaseCommands);
+
+            walkedPages++;
+            lastPage = metrics.AssertSinglePage(
+                expectedProvider,
+                CollectionPagingTelemetryLabel.CursorPagingMode,
+                CollectionPagingTelemetryLabel.PageCommandCategory,
+                walked.NextPageToken is null
+                    ? CollectionPagingTelemetryLabel.TerminalPageOutcome
+                    : CollectionPagingTelemetryLabel.SuccessOutcome,
+                expectedRequestedPageSize: 2,
+                expectedReturnedPageSize: walked.PageIds.Count
+            );
+
+            pageToken = walked.NextPageToken;
+        }
+
+        pageToken
+            .Should()
+            .BeNull($"a cursor walk of '{MergeItemsEndpoint}' must end within {MaximumWalkedPages} pages");
+        lastPage!
+            .Outcome.Should()
+            .Be(
+                CollectionPagingTelemetryLabel.TerminalPageOutcome,
+                "a walk that ran out of documents ended, and the metric must say so rather than "
+                    + "reporting one more served page"
+            );
     }
 
     private static async Task<CursorWalk> WalkFromFirstPageAsync(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CursorPagingExecutionScenario.cs
@@ -441,6 +441,101 @@ internal static class CursorPagingExecutionScenario
         );
     }
 
+    /// <summary>
+    /// What a request the API refuses contributes: one count, and nothing else.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The only outcome emitted from a middleware rather than a handler, through the one interface method
+    /// that records no duration, and the only one whose whole measurement set is a single counter. Every
+    /// other case in this suite reaches the meter through a handler, so none of them would notice a
+    /// rejection that stopped being counted, started carrying a duration, or contributed a page size —
+    /// and the aggregation guidance treats <c>validation_rejected</c> as a share of counted traffic,
+    /// which a duration sample of a few microseconds or a phantom size sample would both distort.
+    /// </para>
+    /// <para>
+    /// Both paging modes are exercised because the mode of a rejected request is read from the query
+    /// string, not from request state: <c>RequestInfo.CollectionPaging</c> is assigned only at the
+    /// accepting exit, so a rejected cursor request still carries the traditional default and reporting
+    /// from request state would file every one of them as traditional traffic. A unit test can only
+    /// assert that against a hand-built request; here the query string is the one the client sent.
+    /// </para>
+    /// <para>
+    /// The provider is the point of running this end to end at all. It is read from the resolved mapping
+    /// set, and the documentation publishes <c>unknown</c> as a server assembly fault that is not a
+    /// bucket to chart — a claim that rests entirely on mapping-set resolution running ahead of paging
+    /// validation in the composed pipeline. The middleware's own tests assign that mapping set
+    /// themselves, so this is the only place that ordering is actually exercised.
+    /// </para>
+    /// </remarks>
+    public static async Task It_records_a_validation_rejection_without_reaching_the_backend(
+        ApiIntegrationHarness harness,
+        string expectedProvider
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedProvider);
+
+        ApiIntegrationQueryRecorder recorder =
+            harness.QueryRecorder
+            ?? throw new InvalidOperationException(
+                "This scenario counts database commands and requires CaptureQueryPlans."
+            );
+
+        using var metrics = CollectionPagingMetricCollector.Start();
+
+        // A traditional fault: a negative limit. Neither cursor parameter is present, so the request is
+        // counted as the traditional traffic it is.
+        await AssertRejectionIsCountedAsync(
+            harness,
+            recorder,
+            metrics,
+            $"{MergeItemsEndpoint}?limit=-1",
+            expectedProvider,
+            CollectionPagingTelemetryLabel.TraditionalPagingMode
+        );
+
+        // A cursor fault: a page size with no token to apply it to. The request never reaches the
+        // accepting exit, so nothing assigned it a paging mode - and it must still be counted as cursor.
+        await AssertRejectionIsCountedAsync(
+            harness,
+            recorder,
+            metrics,
+            $"{MergeItemsEndpoint}?pageSize=2",
+            expectedProvider,
+            CollectionPagingTelemetryLabel.CursorPagingMode
+        );
+    }
+
+    private static async Task AssertRejectionIsCountedAsync(
+        ApiIntegrationHarness harness,
+        ApiIntegrationQueryRecorder recorder,
+        CollectionPagingMetricCollector metrics,
+        string requestUri,
+        string expectedProvider,
+        string expectedPagingMode
+    )
+    {
+        metrics.Clear();
+        int commandsBefore = recorder.DatabaseCommands;
+
+        using (HttpResponseMessage response = await harness.HttpClient.GetAsync(requestUri))
+        {
+            string body = await response.Content.ReadAsStringAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, body);
+            (recorder.DatabaseCommands - commandsBefore)
+                .Should()
+                .Be(
+                    0,
+                    "paging validation answers the request before the handler runs, so a rejection "
+                        + "reaches no backend seam at all"
+                );
+        }
+
+        metrics.AssertSingleValidationRejection(expectedProvider, expectedPagingMode);
+    }
+
     private static async Task<CursorWalk> WalkFromFirstPageAsync(
         ApiIntegrationHarness harness,
         string endpoint,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/PartitionEndpointScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/PartitionEndpointScenario.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.Telemetry;
 using FluentAssertions;
 
 namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
@@ -57,6 +58,27 @@ internal static class PartitionEndpointScenario
     /// runs across separate ranges rather than inside one.
     /// </summary>
     private const int SeededDocumentCount = 25;
+
+    /// <summary>
+    /// The database commands one <c>/partitions</c> request is allowed to cost.
+    /// </summary>
+    /// <remarks>
+    /// An absolute literal from the design rather than a figure captured from a run: a baseline captured
+    /// from this same build would carry whatever extra command the instrumentation added, so both sides
+    /// would move together and the assertion could never fail for the reason it exists. The design fixes
+    /// it instead — the endpoint performs exactly one database command for its boundary selection,
+    /// returns identifiers only, and hydrates nothing. The fixtures binding this scenario grant
+    /// <c>NoFurtherAuthorizationRequired</c>, so the design's one documented exception — a view-based
+    /// authorization strategy whose custom-view validation probe runs first as a second command — does
+    /// not apply, and raising this number is a visible, deliberate edit in review.
+    /// </remarks>
+    private const int PartitionsDatabaseCommands = 1;
+
+    /// <summary>
+    /// The partition count the telemetry cases request. Stated rather than omitted so the requested-count
+    /// measurement is a property of the request instead of a property of the host's configured default.
+    /// </summary>
+    private const int RequestedPartitionCount = 3;
 
     public static async Task It_covers_a_regular_resource_collection_across_its_partitions(
         ApiIntegrationHarness harness
@@ -288,6 +310,114 @@ internal static class PartitionEndpointScenario
         );
 
         fourthSegment.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    /// <summary>
+    /// What the collection-paging metric reports for a real boundary request, and what that request is
+    /// allowed to cost. The provider dimension is proven from a live connection rather than from a
+    /// dialect literal, which is the only place it can be: nothing in Core can tell which engine actually
+    /// answered.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both resource kinds are read, because the seam that carries the single command differs between
+    /// them — a descriptor boundary command goes through the command executor while a regular-resource
+    /// one does not hydrate at all — and the quantity the design constrains is the total, not the split.
+    /// On this endpoint the hydration count is always zero, which is exactly why counting hydrations
+    /// alone would prove nothing here.
+    /// </para>
+    /// <para>
+    /// The command counters are snapshotted immediately around each asserted request, so the seeding
+    /// traffic above is excluded. That is request isolation, not a baseline: the expected value is the
+    /// design literal and is never read from a run.
+    /// </para>
+    /// </remarks>
+    public static async Task It_emits_bounded_telemetry_for_partition_requests(
+        ApiIntegrationHarness harness,
+        string expectedProvider
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedProvider);
+
+        ApiIntegrationQueryRecorder recorder =
+            harness.QueryRecorder
+            ?? throw new InvalidOperationException(
+                "This scenario counts database commands and requires CaptureQueryPlans."
+            );
+
+        await SeedMergeItemsAsync(harness, "telemetry");
+        await SeedDescriptorsAsync(harness, "telemetry");
+
+        using var metrics = CollectionPagingMetricCollector.Start();
+
+        // A boundary request over a regular resource, asserted on the raw response so the instrumentation
+        // is shown to change nothing a client can observe: a boundary set is still plain JSON with no
+        // paging headers.
+        metrics.Clear();
+        int commandsBefore = recorder.DatabaseCommands;
+
+        using (
+            HttpResponseMessage response = await harness.HttpClient.GetAsync(
+                $"{MergeItemsPartitionsEndpoint}?number={RequestedPartitionCount}"
+            )
+        )
+        {
+            string body = await response.Content.ReadAsStringAsync();
+            int databaseCommands = recorder.DatabaseCommands - commandsBefore;
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+            response.Content.Headers.ContentType!.MediaType.Should().Be(StandardJsonContentType);
+            response.Headers.Contains("Total-Count").Should().BeFalse();
+            response.Headers.Contains("Next-Page-Token").Should().BeFalse();
+
+            int returnedPartitionCount = JsonNode.Parse(body)!["pageTokens"]!.AsArray().Count;
+            returnedPartitionCount
+                .Should()
+                .BeGreaterThan(
+                    1,
+                    "the seed exceeds the minimum partition size, so the returned-count measurement "
+                        + "below describes a real multi-partition plan"
+                );
+
+            databaseCommands
+                .Should()
+                .Be(
+                    PartitionsDatabaseCommands,
+                    "the partitions endpoint performs exactly one boundary command and hydrates "
+                        + "nothing, and the metric describing it must not be answered with an extra query"
+                );
+
+            metrics.AssertSinglePartitions(
+                expectedProvider,
+                CollectionPagingTelemetryLabel.BoundaryCommandCategory,
+                CollectionPagingTelemetryLabel.SuccessOutcome,
+                RequestedPartitionCount,
+                returnedPartitionCount
+            );
+        }
+
+        // A candidate set a filter emptied is a boundary command that ran and found nothing, not a
+        // selection that was skipped: the command is still issued, so the outcome is success with a
+        // returned count of zero rather than early_empty.
+        metrics.Clear();
+        commandsBefore = recorder.DatabaseCommands;
+
+        var emptyPageTokens = await ReadPageTokensAsync(
+            harness,
+            $"{DescriptorPartitionsEndpoint}?number={RequestedPartitionCount}"
+                + $"&codeValue=Partitions-telemetry-none-{Guid.NewGuid():N}"
+        );
+
+        (recorder.DatabaseCommands - commandsBefore).Should().Be(PartitionsDatabaseCommands);
+        emptyPageTokens.Should().BeEmpty();
+        metrics.AssertSinglePartitions(
+            expectedProvider,
+            CollectionPagingTelemetryLabel.BoundaryCommandCategory,
+            CollectionPagingTelemetryLabel.SuccessOutcome,
+            RequestedPartitionCount,
+            expectedReturnedPartitionCount: 0
+        );
     }
 
     private static async Task AssertMethodNotAllowedAsync(HttpResponseMessage response)

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/PartitionEndpointScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/PartitionEndpointScenario.cs
@@ -420,6 +420,96 @@ internal static class PartitionEndpointScenario
         );
     }
 
+    /// <summary>
+    /// The one outcome whose name is a claim about database work. <c>early_empty</c> reports that the API
+    /// answered without issuing a boundary command, and this is where the partitions side of that claim is
+    /// measured rather than stated.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The GET-many twin of this case lives in <see cref="CursorPagingExecutionScenario" />. Both are
+    /// needed because the two short-circuits are separate code — a partitions request prepares through its
+    /// own path and answers with its own result type — and only the collection read's was measured. A
+    /// regression in this one reports the request as an executed boundary command instead: <c>success</c>
+    /// with <c>command_category=boundary</c>, claiming database work that never happened and filing a
+    /// duration under the boundary shape. Every other assertion in this suite stays green through that,
+    /// because they all describe requests where the command really did run — including the emptied
+    /// candidate set above, which is this case's executed twin and is exactly what makes the distinction
+    /// worth measuring instead of asserting from a handed-in result in a unit test.
+    /// </para>
+    /// <para>
+    /// A descriptor <c>id</c> filter carrying something that is not a UUID cannot match any row, and the
+    /// API determines that from the value alone, so the boundaries are answered with no candidate
+    /// selection at all. That is what makes zero the expected count here where every other telemetry case
+    /// in this suite costs exactly one.
+    /// </para>
+    /// <para>
+    /// The collection is seeded first even though the filter matches none of it. Without the seed the
+    /// empty token array and the zero count would both be statements about an empty database rather than
+    /// about the short-circuit, which is the property under test.
+    /// </para>
+    /// <para>
+    /// The descriptor endpoint carries this case because it is the one this fixture's ApiSchema gives an
+    /// <c>id</c> query field to. The regular resource here declares no query fields at all, so the same
+    /// request against it would be refused as an unknown field and never reach a selection decision.
+    /// </para>
+    /// </remarks>
+    public static async Task It_records_an_early_empty_partition_request_without_a_database_command(
+        ApiIntegrationHarness harness,
+        string expectedProvider
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedProvider);
+
+        ApiIntegrationQueryRecorder recorder =
+            harness.QueryRecorder
+            ?? throw new InvalidOperationException(
+                "This scenario counts database commands and requires CaptureQueryPlans."
+            );
+
+        await SeedDescriptorsAsync(harness, "early-empty");
+
+        using var metrics = CollectionPagingMetricCollector.Start();
+
+        metrics.Clear();
+        int commandsBefore = recorder.DatabaseCommands;
+
+        using (
+            HttpResponseMessage response = await harness.HttpClient.GetAsync(
+                $"{DescriptorPartitionsEndpoint}?number={RequestedPartitionCount}&id=not-a-uuid"
+            )
+        )
+        {
+            string body = await response.Content.ReadAsStringAsync();
+            int databaseCommands = recorder.DatabaseCommands - commandsBefore;
+
+            // The response shape does not change for a short-circuit: a client walking zero tokens
+            // special-cases nothing, and the boundary set is still plain JSON with no paging headers.
+            response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+            response.Content.Headers.ContentType!.MediaType.Should().Be(StandardJsonContentType);
+            response.Headers.Contains("Total-Count").Should().BeFalse();
+            response.Headers.Contains("Next-Page-Token").Should().BeFalse();
+            JsonNode.Parse(body)!["pageTokens"]!.AsArray().Should().BeEmpty();
+
+            databaseCommands
+                .Should()
+                .Be(
+                    0,
+                    "early_empty reports that no boundary command was issued, so any count above zero "
+                        + "would make the outcome name false"
+                );
+        }
+
+        metrics.AssertSinglePartitions(
+            expectedProvider,
+            CollectionPagingTelemetryLabel.NoCommandCategory,
+            CollectionPagingTelemetryLabel.EarlyEmptyOutcome,
+            RequestedPartitionCount,
+            expectedReturnedPartitionCount: 0
+        );
+    }
+
     private static async Task AssertMethodNotAllowedAsync(HttpResponseMessage response)
     {
         using (response)

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/PartitionEndpointScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/PartitionEndpointScenario.cs
@@ -510,6 +510,70 @@ internal static class PartitionEndpointScenario
         );
     }
 
+    /// <summary>
+    /// What a <c>partitions</c> request the API refuses contributes: one count, and nothing else.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The GET-many twin of this case lives in <see cref="CursorPagingExecutionScenario" />. Both are
+    /// needed because the two rejections come from separate steps: this pipeline swaps in its own
+    /// validating middleware, which owns the partition count and reports the partition mode on every
+    /// exit, and a wiring change that left it uncounted would be invisible to the GET-many proof.
+    /// </para>
+    /// <para>
+    /// The provider is why this runs end to end rather than as a unit test. It is read from the resolved
+    /// mapping set, and the documentation publishes <c>unknown</c> as a server assembly fault that is not
+    /// a bucket to chart — a claim resting entirely on mapping-set resolution running ahead of this step
+    /// in the composed pipeline. The middleware's own tests assign that mapping set themselves.
+    /// </para>
+    /// <para>
+    /// No seeding: a rejection is answered before any collection is read, so what the collection holds
+    /// cannot change the measurement, and the zero-command assertion says exactly that.
+    /// </para>
+    /// </remarks>
+    public static async Task It_records_a_partition_validation_rejection_without_reaching_the_backend(
+        ApiIntegrationHarness harness,
+        string expectedProvider
+    )
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedProvider);
+
+        ApiIntegrationQueryRecorder recorder =
+            harness.QueryRecorder
+            ?? throw new InvalidOperationException(
+                "This scenario counts database commands and requires CaptureQueryPlans."
+            );
+
+        using var metrics = CollectionPagingMetricCollector.Start();
+
+        metrics.Clear();
+        int commandsBefore = recorder.DatabaseCommands;
+
+        using (
+            HttpResponseMessage response = await harness.HttpClient.GetAsync(
+                $"{MergeItemsPartitionsEndpoint}?number=0"
+            )
+        )
+        {
+            string body = await response.Content.ReadAsStringAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, body);
+            (recorder.DatabaseCommands - commandsBefore)
+                .Should()
+                .Be(
+                    0,
+                    "partition validation answers the request before the handler runs, so a rejection "
+                        + "reaches no backend seam at all"
+                );
+        }
+
+        metrics.AssertSingleValidationRejection(
+            expectedProvider,
+            CollectionPagingTelemetryLabel.PartitionPagingMode
+        );
+    }
+
     private static async Task AssertMethodNotAllowedAsync(HttpResponseMessage response)
     {
         using (response)

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingExecution.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingExecution.cs
@@ -58,4 +58,11 @@ public sealed class Given_Mssql_CursorPagingExecution : MssqlApiIntegrationTestB
             Harness,
             CollectionPagingTelemetryLabel.SqlServerProvider
         );
+
+    [Test]
+    public Task It_records_a_validation_rejection_without_reaching_the_backend() =>
+        CursorPagingExecutionScenario.It_records_a_validation_rejection_without_reaching_the_backend(
+            Harness,
+            CollectionPagingTelemetryLabel.SqlServerProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingExecution.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingExecution.cs
@@ -51,4 +51,11 @@ public sealed class Given_Mssql_CursorPagingExecution : MssqlApiIntegrationTestB
             Harness,
             CollectionPagingTelemetryLabel.SqlServerProvider
         );
+
+    [Test]
+    public Task It_records_an_early_empty_without_a_database_command() =>
+        CursorPagingExecutionScenario.It_records_an_early_empty_without_a_database_command(
+            Harness,
+            CollectionPagingTelemetryLabel.SqlServerProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingExecution.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CursorPagingExecution.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
 using EdFi.DataManagementService.Tests.Integration.Mssql;
 using EdFi.DataManagementService.Tests.Integration.Scenarios;
@@ -22,6 +23,12 @@ public sealed class Given_Mssql_CursorPagingExecution : MssqlApiIntegrationTestB
 {
     protected override FixtureKey Fixture => FixtureKey.DescriptorRuntime;
 
+    /// <summary>
+    /// Counts the database commands a read really issued, which is what the telemetry case below asserts
+    /// against the design's per-operation literal.
+    /// </summary>
+    protected override bool CaptureQueryPlans => true;
+
     [Test]
     public Task It_walks_a_regular_resource_collection_by_cursor() =>
         CursorPagingExecutionScenario.It_walks_a_regular_resource_collection_by_cursor(Harness);
@@ -37,4 +44,11 @@ public sealed class Given_Mssql_CursorPagingExecution : MssqlApiIntegrationTestB
     [Test]
     public Task It_withholds_a_continuation_from_a_windowed_traditional_page() =>
         CursorPagingExecutionScenario.It_withholds_a_continuation_from_a_windowed_traditional_page(Harness);
+
+    [Test]
+    public Task It_emits_bounded_telemetry_across_a_cursor_walk() =>
+        CursorPagingExecutionScenario.It_emits_bounded_telemetry_across_a_cursor_walk(
+            Harness,
+            CollectionPagingTelemetryLabel.SqlServerProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_PartitionEndpoint.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_PartitionEndpoint.cs
@@ -89,4 +89,11 @@ public sealed class Given_Mssql_PartitionEndpoint : MssqlApiIntegrationTestBase
             Harness,
             CollectionPagingTelemetryLabel.SqlServerProvider
         );
+
+    [Test]
+    public Task It_records_a_partition_validation_rejection_without_reaching_the_backend() =>
+        PartitionEndpointScenario.It_records_a_partition_validation_rejection_without_reaching_the_backend(
+            Harness,
+            CollectionPagingTelemetryLabel.SqlServerProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_PartitionEndpoint.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_PartitionEndpoint.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
 using EdFi.DataManagementService.Tests.Integration.Mssql;
 using EdFi.DataManagementService.Tests.Integration.Scenarios;
@@ -28,6 +29,12 @@ public sealed class Given_Mssql_PartitionEndpoint : MssqlApiIntegrationTestBase
     /// without ever crossing a range boundary.
     /// </summary>
     protected override int? MaximumPageSizeOverride => PartitionEndpointScenario.HostMaximumPageSize;
+
+    /// <summary>
+    /// Counts the database commands a read really issued, which is what the telemetry case below asserts
+    /// against the design's per-operation literal.
+    /// </summary>
+    protected override bool CaptureQueryPlans => true;
 
     [Test]
     public Task It_covers_a_regular_resource_collection_across_its_partitions() =>
@@ -68,4 +75,11 @@ public sealed class Given_Mssql_PartitionEndpoint : MssqlApiIntegrationTestBase
     [Test]
     public Task It_leaves_the_neighbouring_route_shapes_unchanged() =>
         PartitionEndpointScenario.It_leaves_the_neighbouring_route_shapes_unchanged(Harness);
+
+    [Test]
+    public Task It_emits_bounded_telemetry_for_partition_requests() =>
+        PartitionEndpointScenario.It_emits_bounded_telemetry_for_partition_requests(
+            Harness,
+            CollectionPagingTelemetryLabel.SqlServerProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_PartitionEndpoint.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_PartitionEndpoint.cs
@@ -82,4 +82,11 @@ public sealed class Given_Mssql_PartitionEndpoint : MssqlApiIntegrationTestBase
             Harness,
             CollectionPagingTelemetryLabel.SqlServerProvider
         );
+
+    [Test]
+    public Task It_records_an_early_empty_partition_request_without_a_database_command() =>
+        PartitionEndpointScenario.It_records_an_early_empty_partition_request_without_a_database_command(
+            Harness,
+            CollectionPagingTelemetryLabel.SqlServerProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPagingExecution.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPagingExecution.cs
@@ -52,4 +52,11 @@ public sealed class Given_Postgresql_CursorPagingExecution : PostgresqlApiIntegr
             Harness,
             CollectionPagingTelemetryLabel.PostgresqlProvider
         );
+
+    [Test]
+    public Task It_records_an_early_empty_without_a_database_command() =>
+        CursorPagingExecutionScenario.It_records_an_early_empty_without_a_database_command(
+            Harness,
+            CollectionPagingTelemetryLabel.PostgresqlProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPagingExecution.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPagingExecution.cs
@@ -59,4 +59,11 @@ public sealed class Given_Postgresql_CursorPagingExecution : PostgresqlApiIntegr
             Harness,
             CollectionPagingTelemetryLabel.PostgresqlProvider
         );
+
+    [Test]
+    public Task It_records_a_validation_rejection_without_reaching_the_backend() =>
+        CursorPagingExecutionScenario.It_records_a_validation_rejection_without_reaching_the_backend(
+            Harness,
+            CollectionPagingTelemetryLabel.PostgresqlProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPagingExecution.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CursorPagingExecution.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
 using EdFi.DataManagementService.Tests.Integration.Postgresql;
 using EdFi.DataManagementService.Tests.Integration.Scenarios;
@@ -23,6 +24,12 @@ public sealed class Given_Postgresql_CursorPagingExecution : PostgresqlApiIntegr
 {
     protected override FixtureKey Fixture => FixtureKey.DescriptorRuntime;
 
+    /// <summary>
+    /// Counts the database commands a read really issued, which is what the telemetry case below asserts
+    /// against the design's per-operation literal.
+    /// </summary>
+    protected override bool CaptureQueryPlans => true;
+
     [Test]
     public Task It_walks_a_regular_resource_collection_by_cursor() =>
         CursorPagingExecutionScenario.It_walks_a_regular_resource_collection_by_cursor(Harness);
@@ -38,4 +45,11 @@ public sealed class Given_Postgresql_CursorPagingExecution : PostgresqlApiIntegr
     [Test]
     public Task It_withholds_a_continuation_from_a_windowed_traditional_page() =>
         CursorPagingExecutionScenario.It_withholds_a_continuation_from_a_windowed_traditional_page(Harness);
+
+    [Test]
+    public Task It_emits_bounded_telemetry_across_a_cursor_walk() =>
+        CursorPagingExecutionScenario.It_emits_bounded_telemetry_across_a_cursor_walk(
+            Harness,
+            CollectionPagingTelemetryLabel.PostgresqlProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_PartitionEndpoint.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_PartitionEndpoint.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Core.Telemetry;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
 using EdFi.DataManagementService.Tests.Integration.Postgresql;
 using EdFi.DataManagementService.Tests.Integration.Scenarios;
@@ -28,6 +29,12 @@ public sealed class Given_Postgresql_PartitionEndpoint : PostgresqlApiIntegratio
     /// without ever crossing a range boundary.
     /// </summary>
     protected override int? MaximumPageSizeOverride => PartitionEndpointScenario.HostMaximumPageSize;
+
+    /// <summary>
+    /// Counts the database commands a read really issued, which is what the telemetry case below asserts
+    /// against the design's per-operation literal.
+    /// </summary>
+    protected override bool CaptureQueryPlans => true;
 
     [Test]
     public Task It_covers_a_regular_resource_collection_across_its_partitions() =>
@@ -68,4 +75,11 @@ public sealed class Given_Postgresql_PartitionEndpoint : PostgresqlApiIntegratio
     [Test]
     public Task It_leaves_the_neighbouring_route_shapes_unchanged() =>
         PartitionEndpointScenario.It_leaves_the_neighbouring_route_shapes_unchanged(Harness);
+
+    [Test]
+    public Task It_emits_bounded_telemetry_for_partition_requests() =>
+        PartitionEndpointScenario.It_emits_bounded_telemetry_for_partition_requests(
+            Harness,
+            CollectionPagingTelemetryLabel.PostgresqlProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_PartitionEndpoint.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_PartitionEndpoint.cs
@@ -82,4 +82,11 @@ public sealed class Given_Postgresql_PartitionEndpoint : PostgresqlApiIntegratio
             Harness,
             CollectionPagingTelemetryLabel.PostgresqlProvider
         );
+
+    [Test]
+    public Task It_records_an_early_empty_partition_request_without_a_database_command() =>
+        PartitionEndpointScenario.It_records_an_early_empty_partition_request_without_a_database_command(
+            Harness,
+            CollectionPagingTelemetryLabel.PostgresqlProvider
+        );
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_PartitionEndpoint.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_PartitionEndpoint.cs
@@ -89,4 +89,11 @@ public sealed class Given_Postgresql_PartitionEndpoint : PostgresqlApiIntegratio
             Harness,
             CollectionPagingTelemetryLabel.PostgresqlProvider
         );
+
+    [Test]
+    public Task It_records_a_partition_validation_rejection_without_reaching_the_backend() =>
+        PartitionEndpointScenario.It_records_a_partition_validation_rejection_without_reaching_the_backend(
+            Harness,
+            CollectionPagingTelemetryLabel.PostgresqlProvider
+        );
 }


### PR DESCRIPTION
## Summary

  - DMS-1393: adds bounded, production-safe telemetry for the three shapes a collection read takes — traditional paging, cursor paging, and partition planning — on a new meter
  `EdFi.DataManagementService.CollectionPaging`.
  - Six instruments: `requests` (counter), `duration` (histogram, ms), and requested/returned histograms for `page_size` and `partition_count`. Page-size and partition-count instruments
  are mutually exclusive per request, so neither histogram mixes units of measure.
  - Cardinality is bounded by construction: exactly four dimensions on every measurement (`paging_mode`, `command_category`, `provider`, `outcome`), each restricted to a `FrozenSet` of
  allowed literals, giving at most 240 reachable combinations. Nothing derived from a request — resource name, token text, decoded cursor bounds, filter names or values, client identity,
  candidate ids, exception text — is ever a dimension.
  - Emission from `QueryRequestHandler` and `PartitionRequestHandler` (duration, requested/returned sizes, outcome classification) and from both validating middlewares
  (`validation_rejected` at every 400 exit). Regular resources and descriptors share one contract, with no dimension distinguishing them.
  - Outcome classification covers `success`, `terminal_page`, `early_empty`, `validation_rejected`, and the failure set; circuit-breaker refusals classify as `execution_exception` since
  they never reach the database. Client disconnects emit nothing.
  - New `SelectionSkipped` on `QueryResult.QuerySuccess`/`PartitionResult.PartitionSuccess` (default `false`, set only at the deliberate short-circuits, propagated through
  `RelationalPartitionResultMapping`) is what separates `early_empty` — no selection command issued — from an executed selection that matched nothing.
  - Recording is wrapped so a throwing host measurement callback logs a warning instead of replacing the client's response; a telemetry fault never reaches the client and no status code,
  header, or body changes.
  - The Change Query pipeline is wired to `NoOpCollectionPagingTelemetry`: `/deletes` reads `PaginationParameters` directly, so a `?limit=abc` fault there is not a collection-paging
  event.
  - `DescriptorReadHandler` now resolves the continuation boundary ahead of the empty check, so an empty descriptor page reports the same continuation facts as the regular-resource path
  rather than the permissive default.
  - Operator documentation in `docs/PAGING-TELEMETRY.md` (linked from `docs/OPERATIONS.md`): instrument table with units, allowed dimension values, per-outcome semantics, aggregation
  intent with the populations to exclude when comparing requested vs. returned, and an explicit never-recorded list. Calls out that collection needs an in-process meter provider — an
  OTel Collector alone observes nothing from .NET `Meter` instruments.
  - No new configuration and no behavior flag; the singleton is registered unconditionally and is inert until a host subscribes to the meter.

  ## Test plan

  - [ ] `dotnet build --no-restore ./src/dms/EdFi.DataManagementService.sln`
  - [ ] Core unit — telemetry contract: `dotnet test src/dms/core/EdFi.DataManagementService.Core.Tests.Unit --no-build --filter "FullyQualifiedName~Given_CollectionPagingTelemetry"` —
  covers documented names/units/tags, exactly-four-dimensions on every instrument, the allowed-value sets per dimension, cross-dimension label rejection, refused-label sanitization and
  length bound, negative duration/count rejection, no-op parity, and singleton resolution from the Core registration.
  - [ ] Core unit — emission and pipeline: `dotnet test src/dms/core/EdFi.DataManagementService.Core.Tests.Unit --no-build` — handler emission for both modes, validation-rejection
  recording in `ValidateQueryMiddleware`/`ValidatePartitionQueryMiddleware`, cursor-parameter cases, and `PipelineOrderingTests`.
  - [ ] Backend unit: `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit --no-build` — `SelectionSkipped` on the skipped and executed paths, its propagation
  through `RelationalPartitionResultMapping.FromQueryResult`, and the descriptor empty-page continuation boundary.
  - [ ] API integration, PostgreSQL (needs a live PG; set `$env:ConnectionStrings__DatabaseConnection` with an inline password or the suite silently all-skips): run
  `Given_Postgresql_CursorPagingExecution` and `Given_Postgresql_PartitionEndpoint`.
  - [ ] API integration, SQL Server (needs local `dms-mssql`; set `$env:ConnectionStrings__MssqlAdmin` using the IPv4 literal, not `localhost`): run `Given_Mssql_CursorPagingExecution`
  and `Given_Mssql_PartitionEndpoint`.
  - [ ] Confirm the integration scenarios assert what the AC asks: a traditional first page with a total count reports `page_with_count`, the cursor walk reports `cursor`/`page`, the
  provider dimension comes from a live connection rather than a dialect literal, and the per-request database-command delta matches the design literal — instrumentation adds no command,
  transaction, or roundtrip.
  - [ ] Confirm `It_records_an_early_empty_partition_request_without_a_database_command` and `It_records_a_partition_validation_rejection_without_reaching_the_backend` pass — the
  end-to-end zero-command proofs.
  - [ ] Backend relational integration suites on both engines: the two short-circuit expectations per engine now carry `SelectionSkipped = true`
  (`MssqlRelationalQueryAuthorizationTests`, `PostgresqlRelationalQueryAuthorizationTests`). Note the two standing local MSSQL failures (CDC needs SQL Agent; mutex-alias) are
  pre-existing.
  - [ ] Manual, response-shape unchanged: `GET` a collection with `limit`/`offset`, with `pageToken`/`pageSize`, and a `partitions` path; compare status, headers, and body against `main`
  and confirm byte-identical responses.
  - [ ] Manual, collection actually works: add an `AddMeter("EdFi.DataManagementService.CollectionPaging")` meter provider with the console exporter to the API host, drive the three
  request shapes plus a `400` (bad `pageSize`) and confirm the instruments, units, and the four dimensions match `docs/PAGING-TELEMETRY.md`.
  - [ ] Manual, no-op path: `GET /deletes?limit=abc` returns `400` and emits nothing on the collection-paging meter.
  - [ ] Cardinality review against `docs/PAGING-TELEMETRY.md`'s never-recorded list — confirm no resource/descriptor name, tenant or namespace, client identity, filter name or value,
  token text or decoded bound, document id, or exception text appears in any tag.