### PR TITLE
[DMS-1339] Validate and preserve data store connection strings

### DIFF
--- a/docs/DATABASE-SEGMENTATION-STRATEGY.md
+++ b/docs/DATABASE-SEGMENTATION-STRATEGY.md
@@ -173,6 +173,27 @@ Content-Type: application/json
 
 The response will include an `id` field that you'll use to associate route contexts.
 
+#### How `connectionString` Is Handled
+
+A `GET` of a data store returns `connectionString` as an encrypted, Base64-encoded
+value, not as the text that was submitted. That is deliberate: the Data Management
+Service decrypts it, and the Configuration Service never returns the plain text
+again. The write rules follow from it:
+
+- `POST` accepts a valid plaintext connection string for the configured database
+  engine. The field may also be omitted or `null`, which registers a data store
+  with no connection string.
+- `PUT` with `connectionString` omitted or `null` leaves the stored value
+  unchanged. This is how a client that read a data store updates its other fields.
+- `PUT` with a non-empty value validates that value and replaces the stored one.
+- A value taken from a `GET` response is rejected with `400`, because it is
+  encrypted text rather than a connection string. Send the plaintext connection
+  string, or leave the field out to keep the stored one.
+- An empty or whitespace-only value is rejected with `400`.
+
+There is no request that clears a stored connection string. Delete and re-create
+the data store if it must be registered without one.
+
 ### Step 3: Define Route Contexts
 
 For each data store, create route context entries that define how URL segments map

--- a/docs/MULTI-TENANCY-GETTING-STARTED.md
+++ b/docs/MULTI-TENANCY-GETTING-STARTED.md
@@ -263,6 +263,13 @@ Content-Type: application/json
 Create another data store for `2025` by repeating the last two requests with a
 different database and `contextValue`.
 
+A `GET` of a data store returns `connectionString` as an encrypted, Base64-encoded
+value rather than the text that was submitted, so a `PUT` cannot send that value
+back: it is rejected with `400`. Leave the field out of a `PUT` to keep the stored
+connection string, or send a plaintext connection string to replace it. See
+[How `connectionString` Is Handled](DATABASE-SEGMENTATION-STRATEGY.md#how-connectionstring-is-handled)
+for the full contract.
+
 After creating data stores and route contexts, continue to Step 5 to provision
 the tenant databases before restarting DMS.
 

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeTests.cs
@@ -1125,4 +1125,92 @@ public class DataStoreDerivativeTests : DatabaseTest
                 .Be(_sourceDataStoreId);
         }
     }
+
+    /// <summary>
+    /// A get returns the stored cipher text and the write path refuses cipher text, so leaving the
+    /// field out of an update is how a client keeps the connection string it cannot resend. The
+    /// stored bytes have to come through that update untouched.
+    /// </summary>
+    [TestFixture]
+    public class Given_update_data_store_derivative_without_a_connection_string : DataStoreDerivativeTests
+    {
+        private const string OriginalConnectionString = "Server=replica;Database=ReplicaDb;";
+
+        private int _dataStoreId;
+        private int _derivativeId;
+        private string _storedValueBeforeUpdate = null!;
+        private string _storedValueAfterUpdate = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var instanceResult = await _instanceRepository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Development",
+                    Name = "Parent Instance",
+                    ConnectionString = "Server=parent;Database=ParentDb;",
+                }
+            );
+            instanceResult.Should().BeOfType<DataStoreInsertResult.Success>();
+            _dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
+
+            var insertResult = await _repository.InsertDataStoreDerivative(
+                new DataStoreDerivativeInsertCommand
+                {
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = "ReadReplica",
+                    ConnectionString = OriginalConnectionString,
+                }
+            );
+            insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+            _derivativeId = ((DataStoreDerivativeInsertResult.Success)insertResult).Id;
+
+            _storedValueBeforeUpdate = await StoredConnectionString(_derivativeId);
+
+            var updateResult = await _repository.UpdateDataStoreDerivative(
+                new DataStoreDerivativeUpdateCommand
+                {
+                    Id = _derivativeId,
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = "Snapshot",
+                    ConnectionString = null,
+                }
+            );
+            updateResult.Should().BeOfType<DataStoreDerivativeUpdateResult.Success>();
+
+            _storedValueAfterUpdate = await StoredConnectionString(_derivativeId);
+        }
+
+        private async Task<string> StoredConnectionString(int id)
+        {
+            var getResult = await _repository.GetDataStoreDerivative(id);
+            getResult.Should().BeOfType<DataStoreDerivativeGetResult.Success>();
+
+            string? storedValue = ((DataStoreDerivativeGetResult.Success)getResult)
+                .DataStoreDerivativeResponse
+                .ConnectionString;
+            storedValue.Should().NotBeNullOrEmpty();
+            return storedValue!;
+        }
+
+        [Test]
+        public void It_leaves_the_stored_cipher_text_unchanged() =>
+            _storedValueAfterUpdate.Should().Be(_storedValueBeforeUpdate);
+
+        [Test]
+        public void It_still_decrypts_to_the_original_connection_string() =>
+            AssertIsValidEncryptedBase64(_storedValueAfterUpdate, OriginalConnectionString);
+
+        [Test]
+        public async Task It_applies_the_other_changes()
+        {
+            var getResult = await _repository.GetDataStoreDerivative(_derivativeId);
+            getResult.Should().BeOfType<DataStoreDerivativeGetResult.Success>();
+
+            ((DataStoreDerivativeGetResult.Success)getResult)
+                .DataStoreDerivativeResponse.DerivativeType.Should()
+                .Be("Snapshot");
+        }
+    }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreTests.cs
@@ -1114,4 +1114,78 @@ public class DataStoreTests : DatabaseTest
                 );
         }
     }
+
+    /// <summary>
+    /// A get returns the stored cipher text and the write path refuses cipher text, so leaving the
+    /// field out of an update is how a client keeps the connection string it cannot resend. The
+    /// stored bytes have to come through that update untouched.
+    /// </summary>
+    [TestFixture]
+    public class Given_update_data_store_without_a_connection_string : DataStoreTests
+    {
+        private const string OriginalConnectionString = "Server=original;Database=OriginalDb;";
+
+        private int _id;
+        private string _storedValueBeforeUpdate = null!;
+        private string _storedValueAfterUpdate = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var insertResult = await _repository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Staging",
+                    Name = "Original Instance",
+                    ConnectionString = OriginalConnectionString,
+                }
+            );
+            insertResult.Should().BeOfType<DataStoreInsertResult.Success>();
+            _id = ((DataStoreInsertResult.Success)insertResult).Id;
+
+            _storedValueBeforeUpdate = await StoredConnectionString(_id);
+
+            var updateResult = await _repository.UpdateDataStore(
+                new DataStoreUpdateCommand
+                {
+                    Id = _id,
+                    DataStoreType = "Production",
+                    Name = "Renamed Instance",
+                    ConnectionString = null,
+                }
+            );
+            updateResult.Should().BeOfType<DataStoreUpdateResult.Success>();
+
+            _storedValueAfterUpdate = await StoredConnectionString(_id);
+        }
+
+        private async Task<string> StoredConnectionString(int id)
+        {
+            var getResult = await _repository.GetDataStore(id);
+            getResult.Should().BeOfType<DataStoreGetResult.Success>();
+
+            string? storedValue = ((DataStoreGetResult.Success)getResult).DataStoreResponse.ConnectionString;
+            storedValue.Should().NotBeNullOrEmpty();
+            return storedValue!;
+        }
+
+        [Test]
+        public void It_leaves_the_stored_cipher_text_unchanged() =>
+            _storedValueAfterUpdate.Should().Be(_storedValueBeforeUpdate);
+
+        [Test]
+        public void It_still_decrypts_to_the_original_connection_string() =>
+            AssertIsValidEncryptedBase64(_storedValueAfterUpdate, OriginalConnectionString);
+
+        [Test]
+        public async Task It_applies_the_other_changes()
+        {
+            var getResult = await _repository.GetDataStore(_id);
+            getResult.Should().BeOfType<DataStoreGetResult.Success>();
+
+            var dataStoreFromDb = ((DataStoreGetResult.Success)getResult).DataStoreResponse;
+            dataStoreFromDb.Name.Should().Be("Renamed Instance");
+            dataStoreFromDb.DataStoreType.Should().Be("Production");
+        }
+    }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/MssqlDataStoreConnectionStringValidator.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/MssqlDataStoreConnectionStringValidator.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DmsConfigurationService.Backend.Services;
+using Microsoft.Data.SqlClient;
+
+namespace EdFi.DmsConfigurationService.Backend.Mssql;
+
+/// <summary>
+/// Reads a submitted data store connection string with Microsoft.Data.SqlClient's own parser, so what
+/// the API accepts is what the SQL Server provider accepts.
+/// </summary>
+public class MssqlDataStoreConnectionStringValidator : DataStoreConnectionStringValidator
+{
+    protected override DbConnectionStringBuilder CreateBuilder(string connectionString) =>
+        new SqlConnectionStringBuilder(connectionString);
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/DataStoreDerivativeRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/DataStoreDerivativeRepository.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data;
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
@@ -208,9 +209,19 @@ public class DataStoreDerivativeRepository(
         await connection.OpenAsync();
         try
         {
+            bool preserveConnectionString = ConnectionStringWrite.PreservesExistingValue(
+                command.ConnectionString
+            );
+
+            // Left out of the SET clause when the caller provided no connection string, so the row
+            // keeps the cipher text a reader can still decrypt.
+            string connectionStringAssignment = preserveConnectionString
+                ? string.Empty
+                : "ConnectionString = @ConnectionString, ";
+
             var sql = $"""
                 UPDATE dd
-                SET DataStoreId = @DataStoreId, DerivativeType = @DerivativeType, ConnectionString = @ConnectionString,
+                SET DataStoreId = @DataStoreId, DerivativeType = @DerivativeType, {connectionStringAssignment}
                     LastModifiedAt = @LastModifiedAt, ModifiedBy = @ModifiedBy
                 FROM dmscs.DataStoreDerivative dd
                 INNER JOIN dmscs.DataStore ds ON dd.DataStoreId = ds.Id
@@ -222,16 +233,27 @@ public class DataStoreDerivativeRepository(
                   );
                 """;
 
-            var parameters = new
+            var parameters = new DynamicParameters(
+                new
+                {
+                    command.Id,
+                    command.DataStoreId,
+                    command.DerivativeType,
+                    LastModifiedAt = auditContext.GetCurrentTimestamp(),
+                    ModifiedBy = auditContext.GetCurrentUser(),
+                    TenantId,
+                }
+            );
+
+            if (!preserveConnectionString)
             {
-                command.Id,
-                command.DataStoreId,
-                command.DerivativeType,
-                ConnectionString = encryptionService.Encrypt(command.ConnectionString),
-                LastModifiedAt = auditContext.GetCurrentTimestamp(),
-                ModifiedBy = auditContext.GetCurrentUser(),
-                TenantId,
-            };
+                // Typed explicitly: a null byte[] carries no type the provider can infer.
+                parameters.Add(
+                    "ConnectionString",
+                    encryptionService.Encrypt(command.ConnectionString),
+                    DbType.Binary
+                );
+            }
 
             var affectedRows = await connection.ExecuteAsync(sql, parameters);
             if (affectedRows == 0)

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/DataStoreRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/DataStoreRepository.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data;
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
@@ -275,23 +276,44 @@ public class DataStoreRepository(
         await using var connection = new SqlConnection(databaseOptions.Value.DatabaseConnection);
         try
         {
+            bool preserveConnectionString = ConnectionStringWrite.PreservesExistingValue(
+                command.ConnectionString
+            );
+
+            // Left out of the SET clause when the caller provided no connection string, so the row
+            // keeps the cipher text a reader can still decrypt.
+            string connectionStringAssignment = preserveConnectionString
+                ? string.Empty
+                : "ConnectionString = @ConnectionString, ";
+
             var sql = $"""
                 UPDATE dmscs.DataStore
-                SET DataStoreType = @DataStoreType, Name = @Name, ConnectionString = @ConnectionString,
+                SET DataStoreType = @DataStoreType, Name = @Name, {connectionStringAssignment}
                     LastModifiedAt = @LastModifiedAt, ModifiedBy = @ModifiedBy
                 WHERE Id = @Id AND {TenantContext.TenantWhereClause()};
                 """;
 
-            var parameters = new
+            var parameters = new DynamicParameters(
+                new
+                {
+                    command.Id,
+                    command.DataStoreType,
+                    command.Name,
+                    LastModifiedAt = auditContext.GetCurrentTimestamp(),
+                    ModifiedBy = auditContext.GetCurrentUser(),
+                    TenantId,
+                }
+            );
+
+            if (!preserveConnectionString)
             {
-                command.Id,
-                command.DataStoreType,
-                command.Name,
-                ConnectionString = encryptionService.Encrypt(command.ConnectionString),
-                LastModifiedAt = auditContext.GetCurrentTimestamp(),
-                ModifiedBy = auditContext.GetCurrentUser(),
-                TenantId,
-            };
+                // Typed explicitly: a null byte[] carries no type the provider can infer.
+                parameters.Add(
+                    "ConnectionString",
+                    encryptionService.Encrypt(command.ConnectionString),
+                    DbType.Binary
+                );
+            }
 
             var affectedRows = await connection.ExecuteAsync(sql, parameters);
             if (affectedRows == 0)

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeTests.cs
@@ -1125,4 +1125,92 @@ public class DataStoreDerivativeTests : DatabaseTest
                 .Be(_sourceDataStoreId);
         }
     }
+
+    /// <summary>
+    /// A get returns the stored cipher text and the write path refuses cipher text, so leaving the
+    /// field out of an update is how a client keeps the connection string it cannot resend. The
+    /// stored bytes have to come through that update untouched.
+    /// </summary>
+    [TestFixture]
+    public class Given_update_data_store_derivative_without_a_connection_string : DataStoreDerivativeTests
+    {
+        private const string OriginalConnectionString = "Server=replica;Database=ReplicaDb;";
+
+        private int _dataStoreId;
+        private int _derivativeId;
+        private string _storedValueBeforeUpdate = null!;
+        private string _storedValueAfterUpdate = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var instanceResult = await _instanceRepository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Development",
+                    Name = "Parent Instance",
+                    ConnectionString = "Server=parent;Database=ParentDb;",
+                }
+            );
+            instanceResult.Should().BeOfType<DataStoreInsertResult.Success>();
+            _dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
+
+            var insertResult = await _repository.InsertDataStoreDerivative(
+                new DataStoreDerivativeInsertCommand
+                {
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = "ReadReplica",
+                    ConnectionString = OriginalConnectionString,
+                }
+            );
+            insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+            _derivativeId = ((DataStoreDerivativeInsertResult.Success)insertResult).Id;
+
+            _storedValueBeforeUpdate = await StoredConnectionString(_derivativeId);
+
+            var updateResult = await _repository.UpdateDataStoreDerivative(
+                new DataStoreDerivativeUpdateCommand
+                {
+                    Id = _derivativeId,
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = "Snapshot",
+                    ConnectionString = null,
+                }
+            );
+            updateResult.Should().BeOfType<DataStoreDerivativeUpdateResult.Success>();
+
+            _storedValueAfterUpdate = await StoredConnectionString(_derivativeId);
+        }
+
+        private async Task<string> StoredConnectionString(int id)
+        {
+            var getResult = await _repository.GetDataStoreDerivative(id);
+            getResult.Should().BeOfType<DataStoreDerivativeGetResult.Success>();
+
+            string? storedValue = ((DataStoreDerivativeGetResult.Success)getResult)
+                .DataStoreDerivativeResponse
+                .ConnectionString;
+            storedValue.Should().NotBeNullOrEmpty();
+            return storedValue!;
+        }
+
+        [Test]
+        public void It_leaves_the_stored_cipher_text_unchanged() =>
+            _storedValueAfterUpdate.Should().Be(_storedValueBeforeUpdate);
+
+        [Test]
+        public void It_still_decrypts_to_the_original_connection_string() =>
+            AssertIsValidEncryptedBase64(_storedValueAfterUpdate, OriginalConnectionString);
+
+        [Test]
+        public async Task It_applies_the_other_changes()
+        {
+            var getResult = await _repository.GetDataStoreDerivative(_derivativeId);
+            getResult.Should().BeOfType<DataStoreDerivativeGetResult.Success>();
+
+            ((DataStoreDerivativeGetResult.Success)getResult)
+                .DataStoreDerivativeResponse.DerivativeType.Should()
+                .Be("Snapshot");
+        }
+    }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreTests.cs
@@ -1033,4 +1033,78 @@ public class DataStoreTests : DatabaseTest
                 );
         }
     }
+
+    /// <summary>
+    /// A get returns the stored cipher text and the write path refuses cipher text, so leaving the
+    /// field out of an update is how a client keeps the connection string it cannot resend. The
+    /// stored bytes have to come through that update untouched.
+    /// </summary>
+    [TestFixture]
+    public class Given_update_data_store_without_a_connection_string : DataStoreTests
+    {
+        private const string OriginalConnectionString = "Server=original;Database=OriginalDb;";
+
+        private int _id;
+        private string _storedValueBeforeUpdate = null!;
+        private string _storedValueAfterUpdate = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var insertResult = await _repository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Staging",
+                    Name = "Original Instance",
+                    ConnectionString = OriginalConnectionString,
+                }
+            );
+            insertResult.Should().BeOfType<DataStoreInsertResult.Success>();
+            _id = ((DataStoreInsertResult.Success)insertResult).Id;
+
+            _storedValueBeforeUpdate = await StoredConnectionString(_id);
+
+            var updateResult = await _repository.UpdateDataStore(
+                new DataStoreUpdateCommand
+                {
+                    Id = _id,
+                    DataStoreType = "Production",
+                    Name = "Renamed Instance",
+                    ConnectionString = null,
+                }
+            );
+            updateResult.Should().BeOfType<DataStoreUpdateResult.Success>();
+
+            _storedValueAfterUpdate = await StoredConnectionString(_id);
+        }
+
+        private async Task<string> StoredConnectionString(int id)
+        {
+            var getResult = await _repository.GetDataStore(id);
+            getResult.Should().BeOfType<DataStoreGetResult.Success>();
+
+            string? storedValue = ((DataStoreGetResult.Success)getResult).DataStoreResponse.ConnectionString;
+            storedValue.Should().NotBeNullOrEmpty();
+            return storedValue!;
+        }
+
+        [Test]
+        public void It_leaves_the_stored_cipher_text_unchanged() =>
+            _storedValueAfterUpdate.Should().Be(_storedValueBeforeUpdate);
+
+        [Test]
+        public void It_still_decrypts_to_the_original_connection_string() =>
+            AssertIsValidEncryptedBase64(_storedValueAfterUpdate, OriginalConnectionString);
+
+        [Test]
+        public async Task It_applies_the_other_changes()
+        {
+            var getResult = await _repository.GetDataStore(_id);
+            getResult.Should().BeOfType<DataStoreGetResult.Success>();
+
+            var dataStoreFromDb = ((DataStoreGetResult.Success)getResult).DataStoreResponse;
+            dataStoreFromDb.Name.Should().Be("Renamed Instance");
+            dataStoreFromDb.DataStoreType.Should().Be("Production");
+        }
+    }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/PostgresqlDataStoreConnectionStringValidator.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/PostgresqlDataStoreConnectionStringValidator.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DmsConfigurationService.Backend.Services;
+using Npgsql;
+
+namespace EdFi.DmsConfigurationService.Backend.Postgresql;
+
+/// <summary>
+/// Reads a submitted data store connection string with Npgsql's own parser, so what the API accepts
+/// is what the PostgreSQL provider accepts.
+/// </summary>
+public class PostgresqlDataStoreConnectionStringValidator : DataStoreConnectionStringValidator
+{
+    protected override DbConnectionStringBuilder CreateBuilder(string connectionString) =>
+        new NpgsqlConnectionStringBuilder(connectionString);
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/DataStoreDerivativeRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/DataStoreDerivativeRepository.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data;
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
@@ -213,9 +214,19 @@ public class DataStoreDerivativeRepository(
         await connection.OpenAsync();
         try
         {
+            bool preserveConnectionString = ConnectionStringWrite.PreservesExistingValue(
+                command.ConnectionString
+            );
+
+            // Left out of the SET clause when the caller provided no connection string, so the row
+            // keeps the cipher text a reader can still decrypt.
+            string connectionStringAssignment = preserveConnectionString
+                ? string.Empty
+                : "\"ConnectionString\" = @ConnectionString, ";
+
             var sql = $"""
                 UPDATE "dmscs"."DataStoreDerivative" dd
-                SET "DataStoreId" = @DataStoreId, "DerivativeType" = @DerivativeType, "ConnectionString" = @ConnectionString,
+                SET "DataStoreId" = @DataStoreId, "DerivativeType" = @DerivativeType, {connectionStringAssignment}
                     "LastModifiedAt" = @LastModifiedAt, "ModifiedBy" = @ModifiedBy
                 FROM "dmscs"."DataStore" ds
                 WHERE dd."Id" = @Id
@@ -227,16 +238,27 @@ public class DataStoreDerivativeRepository(
                   );
                 """;
 
-            var parameters = new
+            var parameters = new DynamicParameters(
+                new
+                {
+                    command.Id,
+                    command.DataStoreId,
+                    command.DerivativeType,
+                    LastModifiedAt = auditContext.GetCurrentTimestamp(),
+                    ModifiedBy = auditContext.GetCurrentUser(),
+                    TenantId,
+                }
+            );
+
+            if (!preserveConnectionString)
             {
-                command.Id,
-                command.DataStoreId,
-                command.DerivativeType,
-                ConnectionString = encryptionService.Encrypt(command.ConnectionString),
-                LastModifiedAt = auditContext.GetCurrentTimestamp(),
-                ModifiedBy = auditContext.GetCurrentUser(),
-                TenantId,
-            };
+                // Typed explicitly: a null byte[] carries no type the provider can infer.
+                parameters.Add(
+                    "ConnectionString",
+                    encryptionService.Encrypt(command.ConnectionString),
+                    DbType.Binary
+                );
+            }
 
             var affectedRows = await connection.ExecuteAsync(sql, parameters);
             if (affectedRows == 0)

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/DataStoreRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/DataStoreRepository.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data;
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
@@ -275,23 +276,44 @@ public class DataStoreRepository(
         await using var connection = new NpgsqlConnection(databaseOptions.Value.DatabaseConnection);
         try
         {
+            bool preserveConnectionString = ConnectionStringWrite.PreservesExistingValue(
+                command.ConnectionString
+            );
+
+            // Left out of the SET clause when the caller provided no connection string, so the row
+            // keeps the cipher text a reader can still decrypt.
+            string connectionStringAssignment = preserveConnectionString
+                ? string.Empty
+                : "\"ConnectionString\" = @ConnectionString, ";
+
             var sql = $"""
                 UPDATE "dmscs"."DataStore"
-                SET "DataStoreType" = @DataStoreType, "Name" = @Name, "ConnectionString" = @ConnectionString,
+                SET "DataStoreType" = @DataStoreType, "Name" = @Name, {connectionStringAssignment}
                     "LastModifiedAt" = @LastModifiedAt, "ModifiedBy" = @ModifiedBy
                 WHERE "Id" = @Id AND {TenantContext.TenantWhereClause()};
                 """;
 
-            var parameters = new
+            var parameters = new DynamicParameters(
+                new
+                {
+                    command.Id,
+                    command.DataStoreType,
+                    command.Name,
+                    LastModifiedAt = auditContext.GetCurrentTimestamp(),
+                    ModifiedBy = auditContext.GetCurrentUser(),
+                    TenantId,
+                }
+            );
+
+            if (!preserveConnectionString)
             {
-                command.Id,
-                command.DataStoreType,
-                command.Name,
-                ConnectionString = encryptionService.Encrypt(command.ConnectionString),
-                LastModifiedAt = auditContext.GetCurrentTimestamp(),
-                ModifiedBy = auditContext.GetCurrentUser(),
-                TenantId,
-            };
+                // Typed explicitly: a null byte[] carries no type the provider can infer.
+                parameters.Add(
+                    "ConnectionString",
+                    encryptionService.Encrypt(command.ConnectionString),
+                    DbType.Binary
+                );
+            }
 
             var affectedRows = await connection.ExecuteAsync(sql, parameters);
             if (affectedRows == 0)

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/DmsInstance/DataStoreInsertCommandTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/DmsInstance/DataStoreInsertCommandTests.cs
@@ -3,7 +3,10 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStore;
+using FakeItEasy;
+using FluentAssertions;
 using FluentValidation.TestHelper;
 
 namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.DataStore;
@@ -11,12 +14,18 @@ namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.DataStore;
 [TestFixture]
 public class DataStoreInsertCommandTests
 {
+    private IDataStoreConnectionStringValidator _connectionStringValidator = null!;
     private DataStoreInsertCommand.Validator _validator = null!;
 
     [SetUp]
     public void Setup()
     {
-        _validator = new DataStoreInsertCommand.Validator();
+        // Stubbed so these fixtures keep testing the command's own rules. What each engine accepts
+        // is covered by the validator's own tests.
+        _connectionStringValidator = A.Fake<IDataStoreConnectionStringValidator>();
+        A.CallTo(() => _connectionStringValidator.Validate(A<string?>._))
+            .Returns(new ConnectionStringValidationResult.Valid());
+        _validator = new DataStoreInsertCommand.Validator(_connectionStringValidator);
     }
 
     [TestFixture]
@@ -178,5 +187,70 @@ public class DataStoreInsertCommandTests
         {
             _validator.TestValidate(_command).ShouldHaveValidationErrorFor(x => x.ConnectionString);
         }
+    }
+
+    /// <summary>
+    /// Whatever the configured engine rejected reaches the response as a ConnectionString failure.
+    /// </summary>
+    [TestFixture]
+    public class Given_the_configured_engine_rejects_the_connection_string : DataStoreInsertCommandTests
+    {
+        private const string RejectionMessage = "'Connection String' was rejected by the engine.";
+
+        private TestValidationResult<DataStoreInsertCommand> _result = null!;
+
+        [SetUp]
+        public void SetUpRejection()
+        {
+            A.CallTo(() => _connectionStringValidator.Validate(A<string?>._))
+                .Returns(new ConnectionStringValidationResult.Invalid(RejectionMessage));
+
+            _result = _validator.TestValidate(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Production",
+                    Name = "Test Instance",
+                    ConnectionString = "Server=localhost;Database=TestDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_reports_the_engine_message_on_the_connection_string() =>
+            _result.ShouldHaveValidationErrorFor(x => x.ConnectionString).WithErrorMessage(RejectionMessage);
+    }
+
+    /// <summary>
+    /// An over-long value stops at the length rule, so the engine is never asked and the response
+    /// keeps the single message it has always carried.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_connection_string_longer_than_the_limit : DataStoreInsertCommandTests
+    {
+        private TestValidationResult<DataStoreInsertCommand> _result = null!;
+
+        [SetUp]
+        public void SetUpTooLong()
+        {
+            _result = _validator.TestValidate(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Production",
+                    Name = "Test Instance",
+                    ConnectionString = new string('A', 1001),
+                }
+            );
+        }
+
+        [Test]
+        public void It_reports_one_connection_string_error() =>
+            _result
+                .Errors.Count(error => error.PropertyName == nameof(DataStoreInsertCommand.ConnectionString))
+                .Should()
+                .Be(1);
+
+        [Test]
+        public void It_does_not_ask_the_configured_engine() =>
+            A.CallTo(() => _connectionStringValidator.Validate(A<string?>._)).MustNotHaveHappened();
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/DmsInstance/DataStoreUpdateCommandTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/DmsInstance/DataStoreUpdateCommandTests.cs
@@ -3,7 +3,10 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStore;
+using FakeItEasy;
+using FluentAssertions;
 using FluentValidation.TestHelper;
 
 namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.DataStore;
@@ -11,12 +14,18 @@ namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.DataStore;
 [TestFixture]
 public class DataStoreUpdateCommandTests
 {
+    private IDataStoreConnectionStringValidator _connectionStringValidator = null!;
     private DataStoreUpdateCommand.Validator _validator = null!;
 
     [SetUp]
     public void Setup()
     {
-        _validator = new DataStoreUpdateCommand.Validator();
+        // Stubbed so these fixtures keep testing the command's own rules. What each engine accepts
+        // is covered by the validator's own tests.
+        _connectionStringValidator = A.Fake<IDataStoreConnectionStringValidator>();
+        A.CallTo(() => _connectionStringValidator.Validate(A<string?>._))
+            .Returns(new ConnectionStringValidationResult.Valid());
+        _validator = new DataStoreUpdateCommand.Validator(_connectionStringValidator);
     }
 
     [TestFixture]
@@ -183,5 +192,72 @@ public class DataStoreUpdateCommandTests
 
             _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.ConnectionString);
         }
+    }
+
+    /// <summary>
+    /// Whatever the configured engine rejected reaches the response as a ConnectionString failure.
+    /// </summary>
+    [TestFixture]
+    public class Given_the_configured_engine_rejects_the_connection_string : DataStoreUpdateCommandTests
+    {
+        private const string RejectionMessage = "'Connection String' was rejected by the engine.";
+
+        private TestValidationResult<DataStoreUpdateCommand> _result = null!;
+
+        [SetUp]
+        public void SetUpRejection()
+        {
+            A.CallTo(() => _connectionStringValidator.Validate(A<string?>._))
+                .Returns(new ConnectionStringValidationResult.Invalid(RejectionMessage));
+
+            _result = _validator.TestValidate(
+                new DataStoreUpdateCommand
+                {
+                    Id = 1,
+                    DataStoreType = "Production",
+                    Name = "Test Instance",
+                    ConnectionString = "Server=localhost;Database=TestDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_reports_the_engine_message_on_the_connection_string() =>
+            _result.ShouldHaveValidationErrorFor(x => x.ConnectionString).WithErrorMessage(RejectionMessage);
+    }
+
+    /// <summary>
+    /// An over-long value stops at the length rule, so the engine is never asked and the response
+    /// keeps the single message it has always carried.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_connection_string_longer_than_the_limit : DataStoreUpdateCommandTests
+    {
+        private TestValidationResult<DataStoreUpdateCommand> _result = null!;
+
+        [SetUp]
+        public void SetUpTooLong()
+        {
+            _result = _validator.TestValidate(
+                new DataStoreUpdateCommand
+                {
+                    Id = 1,
+                    DataStoreType = "Production",
+                    Name = "Test Instance",
+                    ConnectionString = new string('A', 1001),
+                }
+            );
+        }
+
+        [Test]
+        public void It_reports_one_connection_string_error() =>
+            _result
+                .Errors.Count(error => error.PropertyName == nameof(DataStoreUpdateCommand.ConnectionString))
+                .Should()
+                .Be(1);
+
+        [Test]
+        public void It_does_not_ask_the_configured_engine() =>
+            A.CallTo(() => _connectionStringValidator.Validate(A<string?>._)).MustNotHaveHappened();
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/DmsInstanceDerivative/DataStoreDerivativeInsertCommandTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/DmsInstanceDerivative/DataStoreDerivativeInsertCommandTests.cs
@@ -3,7 +3,10 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStoreDerivative;
+using FakeItEasy;
+using FluentAssertions;
 using FluentValidation.TestHelper;
 
 namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.DataStoreDerivative;
@@ -11,12 +14,18 @@ namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.DataStoreDerivat
 [TestFixture]
 public class DataStoreDerivativeInsertCommandTests
 {
+    private IDataStoreConnectionStringValidator _connectionStringValidator = null!;
     private DataStoreDerivativeInsertCommand.Validator _validator = null!;
 
     [SetUp]
     public void Setup()
     {
-        _validator = new DataStoreDerivativeInsertCommand.Validator();
+        // Stubbed so these fixtures keep testing the command's own rules. What each engine accepts
+        // is covered by the validator's own tests.
+        _connectionStringValidator = A.Fake<IDataStoreConnectionStringValidator>();
+        A.CallTo(() => _connectionStringValidator.Validate(A<string?>._))
+            .Returns(new ConnectionStringValidationResult.Valid());
+        _validator = new DataStoreDerivativeInsertCommand.Validator(_connectionStringValidator);
     }
 
     [TestFixture]
@@ -224,5 +233,79 @@ public class DataStoreDerivativeInsertCommandTests
         {
             _validator.TestValidate(_command).ShouldHaveValidationErrorFor(x => x.ConnectionString);
         }
+    }
+
+    /// <summary>
+    /// Whatever the configured engine rejected reaches the response as a ConnectionString failure.
+    /// </summary>
+    [TestFixture]
+    public class Given_the_configured_engine_rejects_the_connection_string
+        : DataStoreDerivativeInsertCommandTests
+    {
+        private const string RejectionMessage = "'Connection String' was rejected by the engine.";
+
+        private TestValidationResult<DataStoreDerivativeInsertCommand> _result = null!;
+
+        [SetUp]
+        public void SetUpRejection()
+        {
+            A.CallTo(() => _connectionStringValidator.Validate(A<string?>._))
+                .Returns(new ConnectionStringValidationResult.Invalid(RejectionMessage));
+
+            _result = _validator.TestValidate(
+                new DataStoreDerivativeInsertCommand
+                {
+                    DataStoreId = 1,
+                    DerivativeType = "ReadReplica",
+                    ConnectionString = "Server=localhost;Database=TestDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_reports_the_engine_message_on_the_connection_string() =>
+            _result.ShouldHaveValidationErrorFor(x => x.ConnectionString).WithErrorMessage(RejectionMessage);
+    }
+
+    /// <summary>
+    /// An over-long value stops at the length rule, so the engine is never asked and the response
+    /// keeps the one message this command publishes.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_connection_string_longer_than_the_limit : DataStoreDerivativeInsertCommandTests
+    {
+        private TestValidationResult<DataStoreDerivativeInsertCommand> _result = null!;
+
+        [SetUp]
+        public void SetUpTooLong()
+        {
+            _result = _validator.TestValidate(
+                new DataStoreDerivativeInsertCommand
+                {
+                    DataStoreId = 1,
+                    DerivativeType = "ReadReplica",
+                    ConnectionString = new string('A', 1001),
+                }
+            );
+        }
+
+        [Test]
+        public void It_reports_only_the_length_message() =>
+            _result
+                .ShouldHaveValidationErrorFor(x => x.ConnectionString)
+                .WithErrorMessage("ConnectionString must be 1000 characters or fewer.");
+
+        [Test]
+        public void It_reports_one_connection_string_error() =>
+            _result
+                .Errors.Count(error =>
+                    error.PropertyName == nameof(DataStoreDerivativeInsertCommand.ConnectionString)
+                )
+                .Should()
+                .Be(1);
+
+        [Test]
+        public void It_does_not_ask_the_configured_engine() =>
+            A.CallTo(() => _connectionStringValidator.Validate(A<string?>._)).MustNotHaveHappened();
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/DmsInstanceDerivative/DataStoreDerivativeUpdateCommandTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/DmsInstanceDerivative/DataStoreDerivativeUpdateCommandTests.cs
@@ -3,7 +3,10 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStoreDerivative;
+using FakeItEasy;
+using FluentAssertions;
 using FluentValidation.TestHelper;
 
 namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.DataStoreDerivative;
@@ -11,12 +14,18 @@ namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.DataStoreDerivat
 [TestFixture]
 public class DataStoreDerivativeUpdateCommandTests
 {
+    private IDataStoreConnectionStringValidator _connectionStringValidator = null!;
     private DataStoreDerivativeUpdateCommand.Validator _validator = null!;
 
     [SetUp]
     public void Setup()
     {
-        _validator = new DataStoreDerivativeUpdateCommand.Validator();
+        // Stubbed so these fixtures keep testing the command's own rules. What each engine accepts
+        // is covered by the validator's own tests.
+        _connectionStringValidator = A.Fake<IDataStoreConnectionStringValidator>();
+        A.CallTo(() => _connectionStringValidator.Validate(A<string?>._))
+            .Returns(new ConnectionStringValidationResult.Valid());
+        _validator = new DataStoreDerivativeUpdateCommand.Validator(_connectionStringValidator);
     }
 
     [TestFixture]
@@ -281,5 +290,81 @@ public class DataStoreDerivativeUpdateCommandTests
         {
             _validator.TestValidate(_command).ShouldHaveValidationErrorFor(x => x.ConnectionString);
         }
+    }
+
+    /// <summary>
+    /// Whatever the configured engine rejected reaches the response as a ConnectionString failure.
+    /// </summary>
+    [TestFixture]
+    public class Given_the_configured_engine_rejects_the_connection_string
+        : DataStoreDerivativeUpdateCommandTests
+    {
+        private const string RejectionMessage = "'Connection String' was rejected by the engine.";
+
+        private TestValidationResult<DataStoreDerivativeUpdateCommand> _result = null!;
+
+        [SetUp]
+        public void SetUpRejection()
+        {
+            A.CallTo(() => _connectionStringValidator.Validate(A<string?>._))
+                .Returns(new ConnectionStringValidationResult.Invalid(RejectionMessage));
+
+            _result = _validator.TestValidate(
+                new DataStoreDerivativeUpdateCommand
+                {
+                    Id = 1,
+                    DataStoreId = 1,
+                    DerivativeType = "ReadReplica",
+                    ConnectionString = "Server=localhost;Database=TestDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_reports_the_engine_message_on_the_connection_string() =>
+            _result.ShouldHaveValidationErrorFor(x => x.ConnectionString).WithErrorMessage(RejectionMessage);
+    }
+
+    /// <summary>
+    /// An over-long value stops at the length rule, so the engine is never asked and the response
+    /// keeps the one message this command publishes.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_connection_string_longer_than_the_limit : DataStoreDerivativeUpdateCommandTests
+    {
+        private TestValidationResult<DataStoreDerivativeUpdateCommand> _result = null!;
+
+        [SetUp]
+        public void SetUpTooLong()
+        {
+            _result = _validator.TestValidate(
+                new DataStoreDerivativeUpdateCommand
+                {
+                    Id = 1,
+                    DataStoreId = 1,
+                    DerivativeType = "ReadReplica",
+                    ConnectionString = new string('A', 1001),
+                }
+            );
+        }
+
+        [Test]
+        public void It_reports_only_the_length_message() =>
+            _result
+                .ShouldHaveValidationErrorFor(x => x.ConnectionString)
+                .WithErrorMessage("ConnectionString must be 1000 characters or fewer.");
+
+        [Test]
+        public void It_reports_one_connection_string_error() =>
+            _result
+                .Errors.Count(error =>
+                    error.PropertyName == nameof(DataStoreDerivativeUpdateCommand.ConnectionString)
+                )
+                .Should()
+                .Be(1);
+
+        [Test]
+        public void It_does_not_ask_the_configured_engine() =>
+            A.CallTo(() => _connectionStringValidator.Validate(A<string?>._)).MustNotHaveHappened();
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Services/ConnectionStringCipherTextTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Services/ConnectionStringCipherTextTests.cs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DmsConfigurationService.Backend.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Services;
+
+[TestFixture]
+public class ConnectionStringCipherTextTests
+{
+    private static readonly ConnectionStringEncryptionService EncryptionService = new(
+        Options.Create(
+            new DatabaseOptions
+            {
+                DatabaseConnection = "Server=test;",
+                EncryptionKey = "TestEncryptionKey123456789012345678901234567890",
+            }
+        )
+    );
+
+    private static string StoredValueFor(string plainText) =>
+        Convert.ToBase64String(EncryptionService.Encrypt(plainText)!);
+
+    /// <summary>
+    /// The sweep is the guarantee behind rejecting a resubmitted connection string: every length the
+    /// encryption service can emit has to be recognized, not most of them.
+    /// </summary>
+    [TestFixture]
+    public class Given_cipher_text_the_encryption_service_produces : ConnectionStringCipherTextTests
+    {
+        private const int LongestPlainTextLength = 200;
+
+        private readonly List<int> _lengthsNotRecognized = [];
+        private readonly List<int> _paddingCharacterCounts = [];
+
+        [SetUp]
+        public void SetUpSweep()
+        {
+            for (int length = 1; length <= LongestPlainTextLength; length++)
+            {
+                string storedValue = StoredValueFor(new string('a', length));
+
+                if (!ConnectionStringCipherText.LooksLikeCipherText(storedValue))
+                {
+                    _lengthsNotRecognized.Add(length);
+                }
+
+                _paddingCharacterCounts.Add(storedValue.Count(character => character == '='));
+            }
+        }
+
+        [Test]
+        public void It_recognizes_every_plain_text_length() => _lengthsNotRecognized.Should().BeEmpty();
+
+        /// <summary>
+        /// The single '=' shape is the one a provider parse accepts on its own, so the sweep has to
+        /// keep covering all three shapes for the assertion above to mean anything.
+        /// </summary>
+        [Test]
+        public void It_covers_all_three_base64_padding_shapes() =>
+            _paddingCharacterCounts.Distinct().Should().BeEquivalentTo(new[] { 0, 1, 2 });
+    }
+
+    [TestFixture]
+    public class Given_cipher_text_of_a_real_connection_string : ConnectionStringCipherTextTests
+    {
+        [TestCase("Server=newtest;Database=NewTestDb;")]
+        [TestCase("Server=localhost;Database=TestDb;User Id=user;Password=pass;")]
+        [TestCase("host=dms-postgresql;port=5432;username=postgres;password=p;database=edfi_dms;")]
+        [TestCase("host=localhost;database=edfi_datamanagementservice")]
+        [TestCase("Server=dms-mssql,1433;Database=edfi;User Id=sa;Password=p;TrustServerCertificate=true;")]
+        public void It_is_recognized(string plainText) =>
+            ConnectionStringCipherText.LooksLikeCipherText(StoredValueFor(plainText)).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The values the platform itself registers, including the shapes
+    /// eng/Dms-Management.psm1 builds for each engine. None of them may be mistaken for cipher text.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_connection_string_in_plain_text : ConnectionStringCipherTextTests
+    {
+        [TestCase("Server=newtest;Database=NewTestDb;")]
+        [TestCase("Server=localhost;Database=TestDb;User Id=user;Password=pass;")]
+        [TestCase("Data Source=localhost;Initial Catalog=edfi;Integrated Security=True;")]
+        [TestCase("Server=dms-mssql,1433;Database=edfi;User Id=sa;Password=p;TrustServerCertificate=true;")]
+        [TestCase("host=dms-postgresql;port=5432;username=postgres;password=p;database=edfi_dms;")]
+        [TestCase("host=dms-postgresql;port=5432;username=postgres;password=;database=edfi_dms")]
+        [TestCase(
+            "host=dms-postgresql;port=5432;username=postgres;password=p;database=edfi_dms;NoResetOnClose=true"
+        )]
+        public void It_is_not_recognized_as_cipher_text(string connectionString) =>
+            ConnectionStringCipherText.LooksLikeCipherText(connectionString).Should().BeFalse();
+    }
+
+    [TestFixture]
+    public class Given_a_value_that_is_not_cipher_text : ConnectionStringCipherTextTests
+    {
+        [TestCase("", TestName = "It_is_not_recognized_as_cipher_text(empty)")]
+        [TestCase("   ", TestName = "It_is_not_recognized_as_cipher_text(whitespace)")]
+        [TestCase("Timeout=")]
+        [TestCase("bogus=")]
+        [TestCase("AAAA==")]
+        [TestCase("not-base64-at-all")]
+        public void It_is_not_recognized_as_cipher_text(string value) =>
+            ConnectionStringCipherText.LooksLikeCipherText(value).Should().BeFalse();
+
+        [TestCase(15, TestName = "It_is_not_recognized_at_15_bytes")]
+        [TestCase(31, TestName = "It_is_not_recognized_at_31_bytes")]
+        public void It_is_not_recognized_below_the_shortest_stored_value(int byteCount) =>
+            ConnectionStringCipherText
+                .LooksLikeCipherText(Convert.ToBase64String(new byte[byteCount]))
+                .Should()
+                .BeFalse();
+
+        /// <summary>
+        /// Long enough, but not a whole number of cipher blocks, so the encryption service cannot
+        /// have written it.
+        /// </summary>
+        [TestCase(33)]
+        [TestCase(47)]
+        public void It_is_not_recognized_when_the_length_is_not_a_block_multiple(int byteCount) =>
+            ConnectionStringCipherText
+                .LooksLikeCipherText(Convert.ToBase64String(new byte[byteCount]))
+                .Should()
+                .BeFalse();
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Services/ConnectionStringWriteTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Services/ConnectionStringWriteTests.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DmsConfigurationService.Backend.Services;
+using FluentAssertions;
+
+namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Services;
+
+[TestFixture]
+public class ConnectionStringWriteTests
+{
+    [TestFixture]
+    public class Given_no_connection_string_was_provided : ConnectionStringWriteTests
+    {
+        [Test]
+        public void It_preserves_the_stored_value() =>
+            ConnectionStringWrite.PreservesExistingValue(null).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Only a missing value preserves. The empty and whitespace rows are here to pin that: the API
+    /// rejects them before an update reaches a repository, and they must never be read as an
+    /// instruction to leave the stored value alone.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_connection_string_was_provided : ConnectionStringWriteTests
+    {
+        [TestCase("Server=localhost;Database=TestDb;")]
+        [TestCase("host=localhost;port=5432;username=postgres;database=edfi_dms")]
+        [TestCase("", TestName = "It_writes_the_submitted_value(empty)")]
+        [TestCase("   ", TestName = "It_writes_the_submitted_value(whitespace)")]
+        public void It_writes_the_submitted_value(string submitted) =>
+            ConnectionStringWrite.PreservesExistingValue(submitted).Should().BeFalse();
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Services/DataStoreConnectionStringValidatorTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Services/DataStoreConnectionStringValidatorTests.cs
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DmsConfigurationService.Backend.Mssql;
+using EdFi.DmsConfigurationService.Backend.Postgresql;
+using EdFi.DmsConfigurationService.Backend.Services;
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Services;
+
+[TestFixture]
+public class DataStoreConnectionStringValidatorTests
+{
+    private static readonly IDataStoreConnectionStringValidator Postgresql =
+        new PostgresqlDataStoreConnectionStringValidator();
+
+    private static readonly IDataStoreConnectionStringValidator SqlServer =
+        new MssqlDataStoreConnectionStringValidator();
+
+    private static readonly ConnectionStringEncryptionService EncryptionService = new(
+        Options.Create(
+            new DatabaseOptions
+            {
+                DatabaseConnection = "Server=test;",
+                EncryptionKey = "TestEncryptionKey123456789012345678901234567890",
+            }
+        )
+    );
+
+    /// <summary>
+    /// What a get returns for a stored connection string, which is what a client resubmits when it
+    /// writes back an object it read.
+    /// </summary>
+    private static string StoredValueFor(string plainText) =>
+        Convert.ToBase64String(EncryptionService.Encrypt(plainText)!);
+
+    private static void ShouldBeValid(IDataStoreConnectionStringValidator validator, string? value) =>
+        validator.Validate(value).Should().BeOfType<ConnectionStringValidationResult.Valid>();
+
+    private static void ShouldBeInvalidWith(
+        IDataStoreConnectionStringValidator validator,
+        string? value,
+        string expectedMessage
+    ) =>
+        validator
+            .Validate(value)
+            .Should()
+            .BeOfType<ConnectionStringValidationResult.Invalid>()
+            .Which.ErrorMessage.Should()
+            .Be(expectedMessage);
+
+    [TestFixture]
+    public class Given_no_value_was_provided : DataStoreConnectionStringValidatorTests
+    {
+        [Test]
+        public void It_is_valid_for_postgresql() => ShouldBeValid(Postgresql, null);
+
+        [Test]
+        public void It_is_valid_for_sql_server() => ShouldBeValid(SqlServer, null);
+    }
+
+    [TestFixture]
+    public class Given_an_empty_or_whitespace_value : DataStoreConnectionStringValidatorTests
+    {
+        [TestCase("", TestName = "It_is_rejected_for_postgresql(empty)")]
+        [TestCase("   ", TestName = "It_is_rejected_for_postgresql(whitespace)")]
+        public void It_is_rejected_for_postgresql(string value) =>
+            ShouldBeInvalidWith(Postgresql, value, DataStoreConnectionStringValidator.EmptyMessage);
+
+        [TestCase("", TestName = "It_is_rejected_for_sql_server(empty)")]
+        [TestCase("   ", TestName = "It_is_rejected_for_sql_server(whitespace)")]
+        public void It_is_rejected_for_sql_server(string value) =>
+            ShouldBeInvalidWith(SqlServer, value, DataStoreConnectionStringValidator.EmptyMessage);
+    }
+
+    /// <summary>
+    /// The defect this validation exists for: the value a get returns, submitted back unchanged. The
+    /// plain text lengths below cover all three Base64 padding shapes of the stored value, including
+    /// the single '=' shape that SQL Server's parser accepts as a keyword with an empty value.
+    /// </summary>
+    [TestFixture]
+    public class Given_cipher_text_returned_by_a_previous_request : DataStoreConnectionStringValidatorTests
+    {
+        [TestCase("Server=a;Database=b")]
+        [TestCase("Server=newtest;Database=NewTestDb;")]
+        [TestCase("host=localhost;database=edfi_datamanagementservice")]
+        [TestCase("host=dms-postgresql;port=5432;username=postgres;password=p;database=edfi_dms;")]
+        [TestCase("Server=dms-mssql,1433;Database=edfi;User Id=sa;Password=p;TrustServerCertificate=true;")]
+        public void It_is_rejected_for_postgresql(string plainText) =>
+            ShouldBeInvalidWith(
+                Postgresql,
+                StoredValueFor(plainText),
+                DataStoreConnectionStringValidator.CipherTextMessage
+            );
+
+        [TestCase("Server=a;Database=b")]
+        [TestCase("Server=newtest;Database=NewTestDb;")]
+        [TestCase("host=localhost;database=edfi_datamanagementservice")]
+        [TestCase("host=dms-postgresql;port=5432;username=postgres;password=p;database=edfi_dms;")]
+        [TestCase("Server=dms-mssql,1433;Database=edfi;User Id=sa;Password=p;TrustServerCertificate=true;")]
+        public void It_is_rejected_for_sql_server(string plainText) =>
+            ShouldBeInvalidWith(
+                SqlServer,
+                StoredValueFor(plainText),
+                DataStoreConnectionStringValidator.CipherTextMessage
+            );
+    }
+
+    [TestFixture]
+    public class Given_a_value_no_engine_can_parse : DataStoreConnectionStringValidatorTests
+    {
+        [TestCase("not-a-connection-string")]
+        [TestCase("test-connection-string")]
+        [TestCase("AAAA==")]
+        [TestCase("=x")]
+        public void It_is_rejected_for_postgresql(string value) =>
+            ShouldBeInvalidWith(Postgresql, value, DataStoreConnectionStringValidator.MalformedMessage);
+
+        [TestCase("not-a-connection-string")]
+        [TestCase("test-connection-string")]
+        [TestCase("AAAA==")]
+        [TestCase("=x")]
+        public void It_is_rejected_for_sql_server(string value) =>
+            ShouldBeInvalidWith(SqlServer, value, DataStoreConnectionStringValidator.MalformedMessage);
+
+        [Test]
+        public void It_rejects_a_long_run_of_digits_for_postgresql() =>
+            ShouldBeInvalidWith(
+                Postgresql,
+                new string('0', 1001),
+                DataStoreConnectionStringValidator.MalformedMessage
+            );
+
+        [Test]
+        public void It_rejects_a_long_run_of_digits_for_sql_server() =>
+            ShouldBeInvalidWith(
+                SqlServer,
+                new string('0', 1001),
+                DataStoreConnectionStringValidator.MalformedMessage
+            );
+    }
+
+    [TestFixture]
+    public class Given_a_value_that_parses_but_assigns_nothing : DataStoreConnectionStringValidatorTests
+    {
+        [TestCase(";;;")]
+        [TestCase("host=")]
+        [TestCase("Server=")]
+        [TestCase("Server=;Database=")]
+        public void It_is_rejected_for_postgresql(string value) =>
+            ShouldBeInvalidWith(Postgresql, value, DataStoreConnectionStringValidator.NoSettingsMessage);
+
+        [TestCase(";;;")]
+        [TestCase("host=")]
+        [TestCase("Server=")]
+        [TestCase("Server=;Database=")]
+        public void It_is_rejected_for_sql_server(string value) =>
+            ShouldBeInvalidWith(SqlServer, value, DataStoreConnectionStringValidator.NoSettingsMessage);
+    }
+
+    [TestFixture]
+    public class Given_a_value_with_an_unbalanced_quote : DataStoreConnectionStringValidatorTests
+    {
+        private const string Value = "host=localhost;\"weird";
+
+        [Test]
+        public void It_is_rejected_for_postgresql() =>
+            ShouldBeInvalidWith(Postgresql, Value, DataStoreConnectionStringValidator.MalformedMessage);
+
+        [Test]
+        public void It_is_rejected_for_sql_server() =>
+            ShouldBeInvalidWith(SqlServer, Value, DataStoreConnectionStringValidator.MalformedMessage);
+    }
+
+    /// <summary>
+    /// An unrecognized keyword carrying an empty value is where the two parsers disagree, and where
+    /// Npgsql throws KeyNotFoundException rather than ArgumentException. It is pinned because
+    /// catching only the documented type would answer caller input with a 500.
+    /// </summary>
+    [TestFixture]
+    public class Given_an_unknown_keyword_with_an_empty_value : DataStoreConnectionStringValidatorTests
+    {
+        [Test]
+        public void It_is_malformed_for_postgresql() =>
+            ShouldBeInvalidWith(Postgresql, "bogus=", DataStoreConnectionStringValidator.MalformedMessage);
+
+        [Test]
+        public void It_assigns_nothing_for_sql_server() =>
+            ShouldBeInvalidWith(SqlServer, "bogus=", DataStoreConnectionStringValidator.NoSettingsMessage);
+    }
+
+    /// <summary>
+    /// The shapes this platform actually registers: the Configuration Service end to end tests, both
+    /// engine branches of the eng/Dms-Management.psm1 connection string factory, and the documented
+    /// examples.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_connection_string_the_platform_registers : DataStoreConnectionStringValidatorTests
+    {
+        [TestCase("Server=newtest;Database=NewTestDb;")]
+        [TestCase("Server=localhost;Database=TestDb;")]
+        [TestCase("host=dms-postgresql;port=5432;username=postgres;password=p;database=edfi_dms;")]
+        [TestCase("host=dms-postgresql;port=5432;username=postgres;password=;database=edfi_dms")]
+        [TestCase(
+            "host=dms-postgresql;port=5432;username=postgres;password=p;database=edfi_dms;NoResetOnClose=true"
+        )]
+        [TestCase("Server=dms-mssql,1433;Database=edfi;User Id=sa;Password=p;TrustServerCertificate=true;")]
+        public void It_is_accepted_for_postgresql(string connectionString) =>
+            ShouldBeValid(Postgresql, connectionString);
+
+        [TestCase("Server=newtest;Database=NewTestDb;")]
+        [TestCase("Server=localhost;Database=TestDb;")]
+        [TestCase("Server=dms-mssql,1433;Database=edfi;User Id=sa;Password=p;TrustServerCertificate=true;")]
+        [TestCase("Data Source=localhost;Initial Catalog=edfi;Integrated Security=True;")]
+        [TestCase("Server=localhost,1433;Database=edfi;User Id=sa;Password=p;Encrypt=True;")]
+        public void It_is_accepted_for_sql_server(string connectionString) =>
+            ShouldBeValid(SqlServer, connectionString);
+    }
+
+    /// <summary>
+    /// Each engine accepts what its own provider accepts, which is what validating against the
+    /// configured engine means.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_connection_string_for_the_other_engine : DataStoreConnectionStringValidatorTests
+    {
+        [TestCase("host=localhost;port=5432;username=postgres;password=p;database=edfi_dms")]
+        [TestCase("host=localhost;database=edfi_dms")]
+        public void It_is_rejected_by_the_sql_server_validator(string connectionString) =>
+            ShouldBeInvalidWith(
+                SqlServer,
+                connectionString,
+                DataStoreConnectionStringValidator.MalformedMessage
+            );
+
+        [TestCase("Data Source=localhost;Initial Catalog=edfi;Integrated Security=True;")]
+        [TestCase("Server=localhost,1433;Database=edfi;User Id=sa;Password=p;Encrypt=True;")]
+        public void It_is_rejected_by_the_postgresql_validator(string connectionString) =>
+            ShouldBeInvalidWith(
+                Postgresql,
+                connectionString,
+                DataStoreConnectionStringValidator.MalformedMessage
+            );
+    }
+
+    /// <summary>
+    /// A provider's own message repeats the text it could not read, so a rejection must never carry
+    /// the submitted value out of the service.
+    /// </summary>
+    [TestFixture]
+    public class Given_any_rejected_value : DataStoreConnectionStringValidatorTests
+    {
+        private static IEnumerable<string> RejectedValues()
+        {
+            yield return StoredValueFor("Server=localhost;Database=TestDb;");
+            yield return StoredValueFor("host=localhost;database=edfi_datamanagementservice");
+            yield return "not-a-connection-string";
+            yield return "host=localhost;port=5432;username=postgres;password=p;database=edfi_dms";
+            yield return "Data Source=localhost;Initial Catalog=edfi;";
+            yield return "Server=;Database=";
+            yield return "bogus=";
+        }
+
+        [TestCaseSource(nameof(RejectedValues))]
+        public void It_does_not_repeat_the_value_in_the_postgresql_message(string value) =>
+            MessageFor(Postgresql, value).Should().NotContain(value);
+
+        [TestCaseSource(nameof(RejectedValues))]
+        public void It_does_not_repeat_the_value_in_the_sql_server_message(string value) =>
+            MessageFor(SqlServer, value).Should().NotContain(value);
+
+        /// <summary>
+        /// Empty when the engine accepts the value, which some of these are for one engine and not the
+        /// other. An accepted value carries no message to leak.
+        /// </summary>
+        private static string MessageFor(IDataStoreConnectionStringValidator validator, string value) =>
+            validator.Validate(value) is ConnectionStringValidationResult.Invalid invalid
+                ? invalid.ErrorMessage
+                : string.Empty;
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Services/ConnectionStringCipherText.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Services/ConnectionStringCipherText.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DmsConfigurationService.Backend.Services;
+
+/// <summary>
+/// Recognizes the Base64 text of a connection string that <see cref="ConnectionStringEncryptionService"/>
+/// already encrypted. A get returns the stored cipher text as Base64 without decrypting it, so a
+/// client that reads a data store, edits an unrelated field and writes the object back resubmits
+/// this shape; encrypting it again would leave a value no reader can decrypt to a connection string.
+///
+/// It lives beside the encryption service because it describes that service's output format: the
+/// two must change together.
+/// </summary>
+public static class ConnectionStringCipherText
+{
+    /// <summary>
+    /// Length of the AES initialization vector <see cref="ConnectionStringEncryptionService.Encrypt"/>
+    /// writes ahead of the cipher text.
+    /// </summary>
+    private const int IvLength = 16;
+
+    /// <summary>
+    /// AES block length in bytes. CBC output is always a whole number of blocks, so the stored value
+    /// is always a whole number of blocks.
+    /// </summary>
+    private const int BlockLength = 16;
+
+    /// <summary>
+    /// The shortest value the encryption service can produce: the initialization vector plus the one
+    /// block even a single character of plain text occupies.
+    /// </summary>
+    private const int MinimumLength = IvLength + BlockLength;
+
+    /// <summary>
+    /// True when the value could be output of the encryption service. A valid connection string can
+    /// never match: it has to assign at least one setting, so it contains an '=' that is not Base64
+    /// padding, or it is a lone "keyword=" that assigns nothing and is rejected for that instead.
+    /// </summary>
+    public static bool LooksLikeCipherText(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        // Base64 text is longer than the bytes it encodes, so a buffer the length of the input
+        // always holds the decoded value.
+        byte[] decoded = new byte[value.Length];
+
+        if (!Convert.TryFromBase64String(value, decoded, out int decodedLength))
+        {
+            return false;
+        }
+
+        return decodedLength >= MinimumLength && decodedLength % BlockLength == 0;
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Services/ConnectionStringWrite.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Services/ConnectionStringWrite.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DmsConfigurationService.Backend.Services;
+
+/// <summary>
+/// Whether an update writes the connection string it was handed, or leaves the stored one alone.
+///
+/// A get returns the stored cipher text and the write path refuses cipher text, so a client that
+/// reads a data store and writes it back cannot resend the value it read. Leaving the field out is
+/// how such a client keeps the stored connection string, which is why a null value means "not
+/// provided" here rather than "clear this".
+///
+/// No submitted value clears a stored connection string through the API: an empty or whitespace
+/// value is rejected before an update reaches a repository.
+///
+/// One rule for both resources on both engines, so the four update paths cannot drift apart.
+/// </summary>
+public static class ConnectionStringWrite
+{
+    public static bool PreservesExistingValue(string? submittedConnectionString) =>
+        submittedConnectionString is null;
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Services/DataStoreConnectionStringValidator.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Services/DataStoreConnectionStringValidator.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
+
+namespace EdFi.DmsConfigurationService.Backend.Services;
+
+/// <summary>
+/// Validates a submitted data store connection string, deferring the parse itself to the provider
+/// backend. Everything except the parse is engine independent, so it is settled here and each
+/// provider supplies only its own builder.
+/// </summary>
+public abstract class DataStoreConnectionStringValidator : IDataStoreConnectionStringValidator
+{
+    /// <summary>
+    /// The messages are engine independent on purpose: the same request has to produce the same
+    /// response whichever engine is configured, and no message repeats the submitted value.
+    /// </summary>
+    public const string EmptyMessage = "'Connection String' must not be empty when provided.";
+
+    public const string CipherTextMessage =
+        "'Connection String' must be a plaintext connection string. The value provided appears to be an encrypted value previously returned by this API.";
+
+    public const string MalformedMessage =
+        "'Connection String' is not a valid connection string for the configured database engine.";
+
+    public const string NoSettingsMessage =
+        "'Connection String' must specify at least one connection setting.";
+
+    public ConnectionStringValidationResult Validate(string? connectionString)
+    {
+        // Not provided. Whether that is acceptable belongs to the caller, so it is not a failure here.
+        if (connectionString is null)
+        {
+            return new ConnectionStringValidationResult.Valid();
+        }
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return new ConnectionStringValidationResult.Invalid(EmptyMessage);
+        }
+
+        // Ahead of the parse: cipher text whose Base64 ends in a single '=' parses as a keyword with
+        // an empty value under SQL Server, so the parse alone would accept some of it. This test
+        // covers every length the encryption service can emit, and it names the mistake precisely.
+        if (ConnectionStringCipherText.LooksLikeCipherText(connectionString))
+        {
+            return new ConnectionStringValidationResult.Invalid(CipherTextMessage);
+        }
+
+        DbConnectionStringBuilder builder;
+
+        try
+        {
+            builder = CreateBuilder(connectionString);
+        }
+        catch (Exception)
+        {
+            // Any throw means the provider cannot read the submitted text, which is the answer we
+            // need. The builders parse caller input and have no infrastructure failure mode, and the
+            // types they throw are not part of their contract: Npgsql raises KeyNotFoundException for
+            // an unrecognized keyword carrying an empty value where malformed text raises
+            // ArgumentException, so listing types would turn caller input into a 500. The exception
+            // is deliberately neither logged nor surfaced, because its message repeats the submitted
+            // value.
+            return new ConnectionStringValidationResult.Invalid(MalformedMessage);
+        }
+
+        // A value can parse and still assign nothing, as ";;;" and "keyword=" do. That is never a
+        // connection the reader can open.
+        return builder.Count == 0
+            ? new ConnectionStringValidationResult.Invalid(NoSettingsMessage)
+            : new ConnectionStringValidationResult.Valid();
+    }
+
+    /// <summary>
+    /// Parses the value with the provider's own connection string builder, throwing when the provider
+    /// does not accept it.
+    /// </summary>
+    protected abstract DbConnectionStringBuilder CreateBuilder(string connectionString);
+}

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Infrastructure/ConnectionStringRuleBuilderExtensions.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Infrastructure/ConnectionStringRuleBuilderExtensions.cs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentValidation;
+
+namespace EdFi.DmsConfigurationService.DataModel.Infrastructure;
+
+/// <summary>
+/// The connection string rules the data store and data store derivative commands share. Insert and
+/// update, for both resources, run the same length limit and the same provider-aware check from one
+/// place, so the four of them cannot drift apart.
+/// </summary>
+public static class ConnectionStringRuleBuilderExtensions
+{
+    public const int MaximumConnectionStringLength = 1000;
+
+    /// <param name="maximumLengthMessage">
+    /// Replaces the default length message for a command that already publishes its own wording.
+    /// </param>
+    public static void ApplyDataStoreConnectionStringRules<T>(
+        this IRuleBuilderInitial<T, string?> ruleBuilder,
+        IDataStoreConnectionStringValidator connectionStringValidator,
+        string? maximumLengthMessage = null
+    )
+    {
+        IRuleBuilderOptions<T, string?> lengthRule = ruleBuilder
+            // Stopping at the first failure keeps an over-long value reporting only that it is too
+            // long. The check below cannot succeed on a value the length rule already rejected, and
+            // a second message would change the response every client sees for that request.
+            .Cascade(CascadeMode.Stop)
+            .MaximumLength(MaximumConnectionStringLength);
+
+        if (maximumLengthMessage is not null)
+        {
+            lengthRule.WithMessage(maximumLengthMessage);
+        }
+
+        lengthRule.Custom(
+            (connectionString, context) =>
+            {
+                if (
+                    connectionStringValidator.Validate(connectionString)
+                    is ConnectionStringValidationResult.Invalid invalid
+                )
+                {
+                    context.AddFailure(invalid.ErrorMessage);
+                }
+            }
+        );
+    }
+}

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Infrastructure/IDataStoreConnectionStringValidator.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Infrastructure/IDataStoreConnectionStringValidator.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DmsConfigurationService.DataModel.Infrastructure;
+
+/// <summary>
+/// Validates a submitted data store connection string before it is encrypted and persisted.
+/// Implementations are provider-aware and live in the provider backends, so this project stays
+/// free of provider dependencies.
+/// </summary>
+public interface IDataStoreConnectionStringValidator
+{
+    /// <summary>
+    /// Validates a connection string submitted through the API.
+    /// </summary>
+    /// <param name="connectionString">
+    /// The submitted value. A null value means "not provided" and is valid here, because whether an
+    /// absent connection string is acceptable belongs to the caller: an insert stores no value and
+    /// an update leaves the stored value alone. An empty or whitespace-only value is not valid.
+    /// </param>
+    ConnectionStringValidationResult Validate(string? connectionString);
+}
+
+public record ConnectionStringValidationResult
+{
+    public record Valid() : ConnectionStringValidationResult();
+
+    public record Invalid(string ErrorMessage) : ConnectionStringValidationResult();
+}

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/DataStore/DataStoreInsertCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/DataStore/DataStoreInsertCommand.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using FluentValidation;
 
 namespace EdFi.DmsConfigurationService.DataModel.Model.DataStore;
@@ -15,11 +16,11 @@ public class DataStoreInsertCommand
 
     public class Validator : AbstractValidator<DataStoreInsertCommand>
     {
-        public Validator()
+        public Validator(IDataStoreConnectionStringValidator connectionStringValidator)
         {
             RuleFor(x => x.DataStoreType).NotEmpty().MaximumLength(50);
             RuleFor(x => x.Name).NotEmpty().MaximumLength(256);
-            RuleFor(x => x.ConnectionString).MaximumLength(1000);
+            RuleFor(x => x.ConnectionString).ApplyDataStoreConnectionStringRules(connectionStringValidator);
         }
     }
 }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/DataStore/DataStoreUpdateCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/DataStore/DataStoreUpdateCommand.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using FluentValidation;
 
 namespace EdFi.DmsConfigurationService.DataModel.Model.DataStore;
@@ -16,12 +17,12 @@ public class DataStoreUpdateCommand
 
     public class Validator : AbstractValidator<DataStoreUpdateCommand>
     {
-        public Validator()
+        public Validator(IDataStoreConnectionStringValidator connectionStringValidator)
         {
             RuleFor(x => x.Id).GreaterThan(0);
             RuleFor(x => x.DataStoreType).NotEmpty().MaximumLength(50);
             RuleFor(x => x.Name).NotEmpty().MaximumLength(256);
-            RuleFor(x => x.ConnectionString).MaximumLength(1000);
+            RuleFor(x => x.ConnectionString).ApplyDataStoreConnectionStringRules(connectionStringValidator);
         }
     }
 }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/DataStoreDerivative/DataStoreDerivativeInsertCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/DataStoreDerivative/DataStoreDerivativeInsertCommand.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using FluentValidation;
 
 namespace EdFi.DmsConfigurationService.DataModel.Model.DataStoreDerivative;
@@ -34,7 +35,7 @@ public class DataStoreDerivativeInsertCommand
     {
         private static readonly string[] ValidDerivativeTypes = ["ReadReplica", "Snapshot"];
 
-        public Validator()
+        public Validator(IDataStoreConnectionStringValidator connectionStringValidator)
         {
             RuleFor(x => x.DataStoreId).GreaterThan(0).WithMessage("DataStoreId must be greater than 0.");
 
@@ -47,8 +48,10 @@ public class DataStoreDerivativeInsertCommand
                 .WithMessage("DerivativeType must be either 'ReadReplica' or 'Snapshot'.");
 
             RuleFor(x => x.ConnectionString)
-                .MaximumLength(1000)
-                .WithMessage("ConnectionString must be 1000 characters or fewer.");
+                .ApplyDataStoreConnectionStringRules(
+                    connectionStringValidator,
+                    "ConnectionString must be 1000 characters or fewer."
+                );
         }
     }
 }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/DataStoreDerivative/DataStoreDerivativeUpdateCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/DataStoreDerivative/DataStoreDerivativeUpdateCommand.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using FluentValidation;
 
 namespace EdFi.DmsConfigurationService.DataModel.Model.DataStoreDerivative;
@@ -39,7 +40,7 @@ public class DataStoreDerivativeUpdateCommand
     {
         private static readonly string[] ValidDerivativeTypes = ["ReadReplica", "Snapshot"];
 
-        public Validator()
+        public Validator(IDataStoreConnectionStringValidator connectionStringValidator)
         {
             RuleFor(x => x.Id).GreaterThan(0).WithMessage("Id must be greater than 0.");
 
@@ -54,8 +55,10 @@ public class DataStoreDerivativeUpdateCommand
                 .WithMessage("DerivativeType must be either 'ReadReplica' or 'Snapshot'.");
 
             RuleFor(x => x.ConnectionString)
-                .MaximumLength(1000)
-                .WithMessage("ConnectionString must be 1000 characters or fewer.");
+                .ApplyDataStoreConnectionStringRules(
+                    connectionStringValidator,
+                    "ConnectionString must be 1000 characters or fewer."
+                );
         }
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreDerivativeModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreDerivativeModuleTests.cs
@@ -5,8 +5,10 @@
 
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DmsConfigurationService.Backend.Repositories;
+using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.Authorization;
@@ -20,6 +22,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
@@ -404,6 +407,241 @@ public class DataStoreDerivativeModuleTests
         {
             _body["validationErrors"]!.AsObject().Count.Should().Be(0);
             _body["errors"]!.AsArray().Count.Should().Be(0);
+        }
+    }
+
+    /// <summary>
+    /// A get returns the derivative's stored cipher text, so a client that reads it, changes an
+    /// unrelated field and writes the object back resubmits that exact value. Encrypting it a second
+    /// time leaves a value no reader can turn back into a connection string, so the write path has to
+    /// refuse it. These fixtures run against the real validator the host registers.
+    /// </summary>
+    [TestFixture]
+    public class ConnectionStringValidationTests : DataStoreDerivativeModuleTests
+    {
+        private const string ValidConnectionString = "Server=localhost;Database=ReplicaDb;";
+
+        [SetUp]
+        public void SetUpRepository()
+        {
+            // The fake is shared by the fixture, so recorded calls are cleared to keep each test's
+            // "was the repository reached" assertion its own.
+            Fake.ClearRecordedCalls(_repository);
+
+            A.CallTo(() => _repository.InsertDataStoreDerivative(A<DataStoreDerivativeInsertCommand>._))
+                .Returns(new DataStoreDerivativeInsertResult.Success(1));
+            A.CallTo(() => _repository.UpdateDataStoreDerivative(A<DataStoreDerivativeUpdateCommand>._))
+                .Returns(new DataStoreDerivativeUpdateResult.Success());
+        }
+
+        /// <summary>
+        /// What a get returns for this plain text: the stored bytes, Base64 encoded.
+        /// </summary>
+        private static string StoredValueFor(string plainText) =>
+            Convert.ToBase64String(
+                new ConnectionStringEncryptionService(
+                    Options.Create(
+                        new EdFi.DmsConfigurationService.Backend.DatabaseOptions
+                        {
+                            DatabaseConnection = "Server=test;",
+                            EncryptionKey = "TestEncryptionKey123456789012345678901234567890",
+                        }
+                    )
+                ).Encrypt(plainText)!
+            );
+
+        private static StringContent InsertBody(string? connectionString) =>
+            new(
+                JsonSerializer.Serialize(
+                    new DataStoreDerivativeInsertCommand
+                    {
+                        DataStoreId = 1,
+                        DerivativeType = "ReadReplica",
+                        ConnectionString = connectionString,
+                    }
+                ),
+                Encoding.UTF8,
+                "application/json"
+            );
+
+        private static StringContent UpdateBody(
+            string? connectionString,
+            string derivativeType = "ReadReplica"
+        ) =>
+            new(
+                JsonSerializer.Serialize(
+                    new DataStoreDerivativeUpdateCommand
+                    {
+                        Id = 1,
+                        DataStoreId = 1,
+                        DerivativeType = derivativeType,
+                        ConnectionString = connectionString,
+                    }
+                ),
+                Encoding.UTF8,
+                "application/json"
+            );
+
+        private static async Task ShouldBeDataValidationFailure(HttpResponseMessage response)
+        {
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+            JsonNode body = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request:data");
+            body["validationErrors"]!.AsObject().Should().ContainKey("ConnectionString");
+        }
+
+        // Plain texts of different lengths, so the stored value covers more than one Base64 padding
+        // shape. The exhaustive sweep over lengths lives with the cipher text detector.
+        [TestCase("Server=a;Db=b")]
+        [TestCase("Server=localhost;Db=b")]
+        [TestCase("Server=localhost;Database=ReplicaDb;abc")]
+        public async Task It_rejects_resubmitted_cipher_text_on_post(string plainText)
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PostAsync(
+                "/v3/dataStoreDerivatives/",
+                InsertBody(StoredValueFor(plainText))
+            );
+
+            await ShouldBeDataValidationFailure(response);
+            A.CallTo(() => _repository.InsertDataStoreDerivative(A<DataStoreDerivativeInsertCommand>._))
+                .MustNotHaveHappened();
+        }
+
+        [TestCase("Server=a;Db=b")]
+        [TestCase("Server=localhost;Db=b")]
+        [TestCase("Server=localhost;Database=ReplicaDb;abc")]
+        public async Task It_rejects_resubmitted_cipher_text_on_put(string plainText)
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PutAsync(
+                "/v3/dataStoreDerivatives/1",
+                UpdateBody(StoredValueFor(plainText))
+            );
+
+            await ShouldBeDataValidationFailure(response);
+            A.CallTo(() => _repository.UpdateDataStoreDerivative(A<DataStoreDerivativeUpdateCommand>._))
+                .MustNotHaveHappened();
+        }
+
+        [TestCase("not-a-connection-string")]
+        [TestCase(";;;")]
+        [TestCase("host=")]
+        [TestCase("")]
+        [TestCase("   ")]
+        public async Task It_rejects_an_unusable_value_on_post(string connectionString)
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PostAsync("/v3/dataStoreDerivatives/", InsertBody(connectionString));
+
+            await ShouldBeDataValidationFailure(response);
+            A.CallTo(() => _repository.InsertDataStoreDerivative(A<DataStoreDerivativeInsertCommand>._))
+                .MustNotHaveHappened();
+        }
+
+        [TestCase("not-a-connection-string")]
+        [TestCase(";;;")]
+        [TestCase("host=")]
+        [TestCase("")]
+        [TestCase("   ")]
+        public async Task It_rejects_an_unusable_value_on_put(string connectionString)
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PutAsync("/v3/dataStoreDerivatives/1", UpdateBody(connectionString));
+
+            await ShouldBeDataValidationFailure(response);
+            A.CallTo(() => _repository.UpdateDataStoreDerivative(A<DataStoreDerivativeUpdateCommand>._))
+                .MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task It_accepts_a_new_connection_string_on_post()
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PostAsync(
+                "/v3/dataStoreDerivatives/",
+                InsertBody(ValidConnectionString)
+            );
+
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            A.CallTo(() =>
+                    _repository.InsertDataStoreDerivative(
+                        A<DataStoreDerivativeInsertCommand>.That.Matches(command =>
+                            command.ConnectionString == ValidConnectionString
+                        )
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task It_accepts_a_new_connection_string_on_put()
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PutAsync(
+                "/v3/dataStoreDerivatives/1",
+                UpdateBody(ValidConnectionString)
+            );
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            A.CallTo(() =>
+                    _repository.UpdateDataStoreDerivative(
+                        A<DataStoreDerivativeUpdateCommand>.That.Matches(command =>
+                            command.ConnectionString == ValidConnectionString
+                        )
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+        }
+
+        /// <summary>
+        /// The case this validation must not break: an update that is really about another field.
+        /// </summary>
+        [Test]
+        public async Task It_accepts_an_update_that_changes_another_field()
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PutAsync(
+                "/v3/dataStoreDerivatives/1",
+                UpdateBody(ValidConnectionString, derivativeType: "Snapshot")
+            );
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            A.CallTo(() =>
+                    _repository.UpdateDataStoreDerivative(
+                        A<DataStoreDerivativeUpdateCommand>.That.Matches(command =>
+                            command.DerivativeType == "Snapshot"
+                            && command.ConnectionString == ValidConnectionString
+                        )
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+        }
+
+        /// <summary>
+        /// A provider's own parse failure message repeats the text it could not read, so a rejection
+        /// must never carry the submitted value into the response.
+        /// </summary>
+        [Test]
+        public async Task It_does_not_repeat_the_submitted_value_in_the_response()
+        {
+            using var client = SetUpClient();
+            string storedValue = StoredValueFor(ValidConnectionString);
+
+            foreach (string submitted in new[] { storedValue, "not-a-connection-string", "host=" })
+            {
+                var response = await client.PostAsync("/v3/dataStoreDerivatives/", InsertBody(submitted));
+
+                (await response.Content.ReadAsStringAsync()).Should().NotContain(submitted);
+            }
         }
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreDerivativeModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreDerivativeModuleTests.cs
@@ -643,5 +643,42 @@ public class DataStoreDerivativeModuleTests
                 (await response.Content.ReadAsStringAsync()).Should().NotContain(submitted);
             }
         }
+
+        /// <summary>
+        /// The move this validation has to leave open: the client that read a derivative writes back
+        /// the fields it changed and leaves the connection string out, and the repository is asked to
+        /// keep what is stored. Whether the stored bytes actually survive is a repository concern and
+        /// is covered by the backend integration tests.
+        /// </summary>
+        [Test]
+        public async Task It_accepts_an_update_that_leaves_the_connection_string_out()
+        {
+            using var client = SetUpClient();
+
+            DataStoreDerivativeUpdateCommand? received = null;
+            A.CallTo(() => _repository.UpdateDataStoreDerivative(A<DataStoreDerivativeUpdateCommand>._))
+                .Invokes((DataStoreDerivativeUpdateCommand command) => received = command)
+                .Returns(new DataStoreDerivativeUpdateResult.Success());
+
+            var response = await client.PutAsync(
+                "/v3/dataStoreDerivatives/1",
+                new StringContent(
+                    """
+                    {
+                        "id": 1,
+                        "dataStoreId": 1,
+                        "derivativeType": "Snapshot"
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            received.Should().NotBeNull();
+            received!.ConnectionString.Should().BeNull();
+            received.DerivativeType.Should().Be("Snapshot");
+        }
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreModuleTests.cs
@@ -734,5 +734,42 @@ public class DataStoreModuleTests
                 (await response.Content.ReadAsStringAsync()).Should().NotContain(submitted);
             }
         }
+
+        /// <summary>
+        /// The move this validation has to leave open: the client that read a data store writes back
+        /// the fields it changed and leaves the connection string out, and the repository is asked to
+        /// keep what is stored. Whether the stored bytes actually survive is a repository concern and
+        /// is covered by the backend integration tests.
+        /// </summary>
+        [Test]
+        public async Task It_accepts_an_update_that_leaves_the_connection_string_out()
+        {
+            using var client = SetUpClient();
+
+            DataStoreUpdateCommand? received = null;
+            A.CallTo(() => _dataStoreRepository.UpdateDataStore(A<DataStoreUpdateCommand>._))
+                .Invokes((DataStoreUpdateCommand command) => received = command)
+                .Returns(new DataStoreUpdateResult.Success());
+
+            var response = await client.PutAsync(
+                "/v3/dataStores/1",
+                new StringContent(
+                    """
+                    {
+                        "id": 1,
+                        "dataStoreType": "Production",
+                        "name": "Renamed Instance"
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            received.Should().NotBeNull();
+            received!.ConnectionString.Should().BeNull();
+            received.Name.Should().Be("Renamed Instance");
+        }
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreModuleTests.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel;
@@ -25,6 +26,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
@@ -511,6 +513,226 @@ public class DataStoreModuleTests
             using var client = SetUpClient();
             var response = await client.GetAsync("/v3/dataStores?direction=asc");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+
+    /// <summary>
+    /// A get returns the stored cipher text, so a client that reads a data store, changes an
+    /// unrelated field and writes the object back resubmits that exact value. Encrypting it a second
+    /// time leaves a value no reader can turn back into a connection string, so the write path has to
+    /// refuse it. These fixtures run against the real validator the host registers.
+    /// </summary>
+    [TestFixture]
+    public class ConnectionStringValidationTests : DataStoreModuleTests
+    {
+        private const string ValidConnectionString = "Server=localhost;Database=TestDb;";
+
+        [SetUp]
+        public void SetUpRepository()
+        {
+            // The fake is shared by the fixture, so recorded calls are cleared to keep each test's
+            // "was the repository reached" assertion its own.
+            Fake.ClearRecordedCalls(_dataStoreRepository);
+
+            A.CallTo(() => _dataStoreRepository.InsertDataStore(A<DataStoreInsertCommand>._))
+                .Returns(new DataStoreInsertResult.Success(1));
+            A.CallTo(() => _dataStoreRepository.UpdateDataStore(A<DataStoreUpdateCommand>._))
+                .Returns(new DataStoreUpdateResult.Success());
+        }
+
+        /// <summary>
+        /// What a get returns for this plain text: the stored bytes, Base64 encoded.
+        /// </summary>
+        private static string StoredValueFor(string plainText) =>
+            Convert.ToBase64String(
+                new ConnectionStringEncryptionService(
+                    Options.Create(
+                        new EdFi.DmsConfigurationService.Backend.DatabaseOptions
+                        {
+                            DatabaseConnection = "Server=test;",
+                            EncryptionKey = "TestEncryptionKey123456789012345678901234567890",
+                        }
+                    )
+                ).Encrypt(plainText)!
+            );
+
+        private static StringContent InsertBody(string? connectionString) =>
+            new(
+                JsonSerializer.Serialize(
+                    new DataStoreInsertCommand
+                    {
+                        DataStoreType = "Production",
+                        Name = "Test Instance",
+                        ConnectionString = connectionString,
+                    }
+                ),
+                Encoding.UTF8,
+                "application/json"
+            );
+
+        private static StringContent UpdateBody(string? connectionString, string name = "Test Instance") =>
+            new(
+                JsonSerializer.Serialize(
+                    new DataStoreUpdateCommand
+                    {
+                        Id = 1,
+                        DataStoreType = "Production",
+                        Name = name,
+                        ConnectionString = connectionString,
+                    }
+                ),
+                Encoding.UTF8,
+                "application/json"
+            );
+
+        private static async Task ShouldBeDataValidationFailure(HttpResponseMessage response)
+        {
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+            JsonNode body = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request:data");
+            body["validationErrors"]!.AsObject().Should().ContainKey("ConnectionString");
+        }
+
+        // Plain texts of different lengths, so the stored value covers more than one Base64 padding
+        // shape. The exhaustive sweep over lengths lives with the cipher text detector.
+        [TestCase("Server=a;Db=b")]
+        [TestCase("Server=localhost;Db=b")]
+        [TestCase("Server=localhost;Database=TestDb;abc")]
+        public async Task It_rejects_resubmitted_cipher_text_on_post(string plainText)
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PostAsync("/v3/dataStores/", InsertBody(StoredValueFor(plainText)));
+
+            await ShouldBeDataValidationFailure(response);
+            A.CallTo(() => _dataStoreRepository.InsertDataStore(A<DataStoreInsertCommand>._))
+                .MustNotHaveHappened();
+        }
+
+        [TestCase("Server=a;Db=b")]
+        [TestCase("Server=localhost;Db=b")]
+        [TestCase("Server=localhost;Database=TestDb;abc")]
+        public async Task It_rejects_resubmitted_cipher_text_on_put(string plainText)
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PutAsync("/v3/dataStores/1", UpdateBody(StoredValueFor(plainText)));
+
+            await ShouldBeDataValidationFailure(response);
+            A.CallTo(() => _dataStoreRepository.UpdateDataStore(A<DataStoreUpdateCommand>._))
+                .MustNotHaveHappened();
+        }
+
+        [TestCase("not-a-connection-string")]
+        [TestCase(";;;")]
+        [TestCase("host=")]
+        [TestCase("")]
+        [TestCase("   ")]
+        public async Task It_rejects_an_unusable_value_on_post(string connectionString)
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PostAsync("/v3/dataStores/", InsertBody(connectionString));
+
+            await ShouldBeDataValidationFailure(response);
+            A.CallTo(() => _dataStoreRepository.InsertDataStore(A<DataStoreInsertCommand>._))
+                .MustNotHaveHappened();
+        }
+
+        [TestCase("not-a-connection-string")]
+        [TestCase(";;;")]
+        [TestCase("host=")]
+        [TestCase("")]
+        [TestCase("   ")]
+        public async Task It_rejects_an_unusable_value_on_put(string connectionString)
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PutAsync("/v3/dataStores/1", UpdateBody(connectionString));
+
+            await ShouldBeDataValidationFailure(response);
+            A.CallTo(() => _dataStoreRepository.UpdateDataStore(A<DataStoreUpdateCommand>._))
+                .MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task It_accepts_a_new_connection_string_on_post()
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PostAsync("/v3/dataStores/", InsertBody(ValidConnectionString));
+
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            A.CallTo(() =>
+                    _dataStoreRepository.InsertDataStore(
+                        A<DataStoreInsertCommand>.That.Matches(command =>
+                            command.ConnectionString == ValidConnectionString
+                        )
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task It_accepts_a_new_connection_string_on_put()
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PutAsync("/v3/dataStores/1", UpdateBody(ValidConnectionString));
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            A.CallTo(() =>
+                    _dataStoreRepository.UpdateDataStore(
+                        A<DataStoreUpdateCommand>.That.Matches(command =>
+                            command.ConnectionString == ValidConnectionString
+                        )
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+        }
+
+        /// <summary>
+        /// The case this validation must not break: an update that is really about another field.
+        /// </summary>
+        [Test]
+        public async Task It_accepts_an_update_that_changes_another_field()
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PutAsync(
+                "/v3/dataStores/1",
+                UpdateBody(ValidConnectionString, name: "Renamed Instance")
+            );
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            A.CallTo(() =>
+                    _dataStoreRepository.UpdateDataStore(
+                        A<DataStoreUpdateCommand>.That.Matches(command =>
+                            command.Name == "Renamed Instance"
+                            && command.ConnectionString == ValidConnectionString
+                        )
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+        }
+
+        /// <summary>
+        /// A provider's own parse failure message repeats the text it could not read, so a rejection
+        /// must never carry the submitted value into the response.
+        /// </summary>
+        [Test]
+        public async Task It_does_not_repeat_the_submitted_value_in_the_response()
+        {
+            using var client = SetUpClient();
+            string storedValue = StoredValueFor(ValidConnectionString);
+
+            foreach (string submitted in new[] { storedValue, "not-a-connection-string", "host=" })
+            {
+                var response = await client.PostAsync("/v3/dataStores/", InsertBody(submitted));
+
+                (await response.Content.ReadAsStringAsync()).Should().NotContain(submitted);
+            }
         }
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -147,13 +147,13 @@ public static class WebApplicationBuilderExtensions
         // Common service registration for all database backends
         webAppBuilder.Services.AddSingleton<IClaimsProvider, ClaimsProvider>();
 
-        if (
-            string.Equals(
-                webAppBuilder.Configuration.GetSection("AppSettings:Datastore").Value,
-                "postgresql",
-                StringComparison.OrdinalIgnoreCase
-            )
-        )
+        bool usePostgresql = string.Equals(
+            webAppBuilder.Configuration.GetSection("AppSettings:Datastore").Value,
+            "postgresql",
+            StringComparison.OrdinalIgnoreCase
+        );
+
+        if (usePostgresql)
         {
             logger.Information("Injecting PostgreSQL as the primary backend datastore");
             webAppBuilder.Services.AddPostgresqlDatastore(
@@ -198,10 +198,36 @@ public static class WebApplicationBuilderExtensions
             webAppBuilder.Services.AddSingleton<IDatabaseDeploy, Backend.Mssql.Deploy.DatabaseDeploy>();
         }
 
+        AddDataStoreConnectionStringValidator(webAppBuilder.Services, usePostgresql);
+
         // Token management and client-secret hashing are datastore-agnostic and required
         // by both engines
         webAppBuilder.Services.AddTransient<ITokenManager, OpenIddictTokenManager>();
         webAppBuilder.Services.AddSingleton<IClientSecretHasher, ClientSecretHasher>();
+    }
+
+    /// <summary>
+    /// The one place that decides which engine a submitted data store connection string is validated
+    /// against. It follows the configured datastore because that is the engine this deployment runs,
+    /// and it is a single seam: a setting that names the target provider per data store replaces this
+    /// method and nothing else.
+    /// </summary>
+    private static void AddDataStoreConnectionStringValidator(IServiceCollection services, bool usePostgresql)
+    {
+        if (usePostgresql)
+        {
+            services.AddSingleton<
+                IDataStoreConnectionStringValidator,
+                PostgresqlDataStoreConnectionStringValidator
+            >();
+        }
+        else
+        {
+            services.AddSingleton<
+                IDataStoreConnectionStringValidator,
+                MssqlDataStoreConnectionStringValidator
+            >();
+        }
     }
 
     private static void ConfigureIdentityProvider(

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStoreDerivatives.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStoreDerivatives.feature
@@ -405,3 +405,95 @@ Feature: DataStoreDerivatives endpoints
              Then it should respond with 201
              When a GET request is made to "/v3/dataStoreDerivatives?offset=0&limit=1"
              Then it should respond with 200
+
+        @MssqlRepresentative
+        Scenario: 21 Verify a connectionString from a previous response is rejected on POST
+             When a POST request is made to "/v3/dataStoreDerivatives" with
+                  """
+                    {
+                        "dataStoreId": {dataStoreId},
+                        "derivativeType": "ReadReplica",
+                        "connectionString": "RE1TLTEzMzkgY2lwaGVyIHRleHQgc2hhcGVkIHZhbHVlIGZvciBlMmUgdGVzdHMh"
+                    }
+                  """
+             Then it should respond with 400
+              And the response body is
+                  """
+                    {
+                        "detail": "Data validation failed. See 'validationErrors' for details.",
+                        "type": "urn:ed-fi:api:bad-request:data",
+                        "title": "Data Validation Failed",
+                        "status": 400,
+                        "validationErrors": {
+                            "ConnectionString": [
+                                "'Connection String' must be a plaintext connection string. The value provided appears to be an encrypted value previously returned by this API."
+                            ]
+                        },
+                        "errors": []
+                    }
+                  """
+
+        Scenario: 22 Verify a connectionString from a previous response is rejected on PUT
+             When a POST request is made to "/v3/dataStoreDerivatives" with
+                  """
+                    {
+                        "dataStoreId": {dataStoreId},
+                        "derivativeType": "ReadReplica",
+                        "connectionString": "Server=roundtrip;Database=RoundTripDb;"
+                    }
+                  """
+             Then it should respond with 201
+             When a PUT request is made to "/v3/dataStoreDerivatives/{dataStoreDerivativeId}" with
+                  """
+                    {
+                        "id": {dataStoreDerivativeId},
+                        "dataStoreId": {dataStoreId},
+                        "derivativeType": "Snapshot",
+                        "connectionString": "RE1TLTEzMzkgY2lwaGVyIHRleHQgc2hhcGVkIHZhbHVlIGZvciBlMmUgdGVzdHMh"
+                    }
+                  """
+             Then it should respond with 400
+              And the response body is
+                  """
+                    {
+                        "detail": "Data validation failed. See 'validationErrors' for details.",
+                        "type": "urn:ed-fi:api:bad-request:data",
+                        "title": "Data Validation Failed",
+                        "status": 400,
+                        "validationErrors": {
+                            "ConnectionString": [
+                                "'Connection String' must be a plaintext connection string. The value provided appears to be an encrypted value previously returned by this API."
+                            ]
+                        },
+                        "errors": []
+                    }
+                  """
+
+        Scenario: 23 Put an existing dataStoreDerivative without a connectionString
+             When a POST request is made to "/v3/dataStoreDerivatives" with
+                  """
+                    {
+                        "dataStoreId": {dataStoreId},
+                        "derivativeType": "ReadReplica",
+                        "connectionString": "Server=preserved;Database=PreservedDb;"
+                    }
+                  """
+             Then it should respond with 201
+             When a PUT request is made to "/v3/dataStoreDerivatives/{dataStoreDerivativeId}" with
+                  """
+                    {
+                        "id": {dataStoreDerivativeId},
+                        "dataStoreId": {dataStoreId},
+                        "derivativeType": "Snapshot"
+                    }
+                  """
+             Then it should respond with 204
+              And the record can be retrieved with a GET request
+                  """
+                    {
+                        "id": {id},
+                        "dataStoreId": {dataStoreId},
+                        "derivativeType": "Snapshot",
+                        "connectionString": "{ignore}"
+                    }
+                  """

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStores.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStores.feature
@@ -521,3 +521,123 @@ Feature: DataStores endpoints
                    "enabled": false
                   }
                   """
+
+        @MssqlRepresentative
+        Scenario: 22 Verify a connectionString from a previous response is rejected on POST
+             When a POST request is made to "/v3/dataStores" with
+                  """
+                    {
+                        "dataStoreType": "Production",
+                        "name": "Resubmitted Cipher Text Instance",
+                        "connectionString": "RE1TLTEzMzkgY2lwaGVyIHRleHQgc2hhcGVkIHZhbHVlIGZvciBlMmUgdGVzdHMh"
+                    }
+                  """
+             Then it should respond with 400
+              And the response body is
+                  """
+                    {
+                        "detail": "Data validation failed. See 'validationErrors' for details.",
+                        "type": "urn:ed-fi:api:bad-request:data",
+                        "title": "Data Validation Failed",
+                        "status": 400,
+                        "validationErrors": {
+                            "ConnectionString": [
+                                "'Connection String' must be a plaintext connection string. The value provided appears to be an encrypted value previously returned by this API."
+                            ]
+                        },
+                        "errors": []
+                    }
+                  """
+
+        Scenario: 23 Verify a connectionString from a previous response is rejected on PUT
+             When a POST request is made to "/v3/dataStores" with
+                  """
+                    {
+                        "dataStoreType": "Staging",
+                        "name": "Round Trip Instance",
+                        "connectionString": "Server=roundtrip;Database=RoundTripDb;"
+                    }
+                  """
+             Then it should respond with 201
+             When a PUT request is made to "/v3/dataStores/{dataStoreId}" with
+                  """
+                    {
+                        "id": {dataStoreId},
+                        "dataStoreType": "Staging",
+                        "name": "Round Trip Instance Renamed",
+                        "connectionString": "RE1TLTEzMzkgY2lwaGVyIHRleHQgc2hhcGVkIHZhbHVlIGZvciBlMmUgdGVzdHMh"
+                    }
+                  """
+             Then it should respond with 400
+              And the response body is
+                  """
+                    {
+                        "detail": "Data validation failed. See 'validationErrors' for details.",
+                        "type": "urn:ed-fi:api:bad-request:data",
+                        "title": "Data Validation Failed",
+                        "status": 400,
+                        "validationErrors": {
+                            "ConnectionString": [
+                                "'Connection String' must be a plaintext connection string. The value provided appears to be an encrypted value previously returned by this API."
+                            ]
+                        },
+                        "errors": []
+                    }
+                  """
+
+        Scenario: 24 Verify validation connectionString the configured engine cannot use
+             When a POST request is made to "/v3/dataStores" with
+                  """
+                    {
+                        "dataStoreType": "Production",
+                        "name": "Malformed Connection String Instance",
+                        "connectionString": "not-a-connection-string"
+                    }
+                  """
+             Then it should respond with 400
+              And the response body is
+                  """
+                    {
+                        "detail": "Data validation failed. See 'validationErrors' for details.",
+                        "type": "urn:ed-fi:api:bad-request:data",
+                        "title": "Data Validation Failed",
+                        "status": 400,
+                        "validationErrors": {
+                            "ConnectionString": [
+                                "'Connection String' is not a valid connection string for the configured database engine."
+                            ]
+                        },
+                        "errors": []
+                    }
+                  """
+
+        Scenario: 25 Put an existing dataStore without a connectionString
+             When a POST request is made to "/v3/dataStores" with
+                  """
+                    {
+                        "dataStoreType": "Staging",
+                        "name": "Preserved Instance",
+                        "connectionString": "Server=preserved;Database=PreservedDb;"
+                    }
+                  """
+             Then it should respond with 201
+             When a PUT request is made to "/v3/dataStores/{dataStoreId}" with
+                  """
+                    {
+                        "id": {dataStoreId},
+                        "dataStoreType": "Production",
+                        "name": "Preserved Instance Renamed"
+                    }
+                  """
+             Then it should respond with 204
+              And the record can be retrieved with a GET request
+                  """
+                    {
+                        "id": {id},
+                        "dataStoreType": "Production",
+                        "name": "Preserved Instance Renamed",
+                        "connectionString": "{ignore}",
+                        "dataStoreContexts": [],
+                        "dataStoreDerivatives": []
+                    }
+                  """


### PR DESCRIPTION
## What

The Configuration Service now validates a submitted data store connection string before encrypting it, and an update that omits the field keeps the stored value, so a client can no longer corrupt a connection string by writing back the object it read.

## Why

`GET /v3/dataStores` and `GET /v3/dataStoreDerivatives` return `connectionString` as the stored ciphertext, and the Data Management Service decrypts it once. The write path encrypted whatever it was handed, so a client that read a data store, changed an unrelated field and wrote the object back had that ciphertext encrypted a second time; DMS then decrypted once and held something that was not a connection string. Leaving the field out was no better: it replaced the stored value with nothing. Between the two there was no correct way to update a data store's other fields.

## Changes

- **Validation service.** A provider-neutral contract in `DataModel` (no provider package added there), the engine-independent algorithm in `Backend`, and PostgreSQL and SQL Server implementations that defer the parse to Npgsql's and Microsoft.Data.SqlClient's own connection string builders. A value that could be output of the encryption service is recognised before the parse, because a parse alone accepts some of it. Rejection messages are engine-independent and never repeat the submitted value or a provider exception message.
- **Enforcement on POST and PUT** for `dataStores` and `dataStoreDerivatives`, through the existing FluentValidation path, so failures use the existing data-validation 400 body under `validationErrors.ConnectionString`. Rejected: a value returned by a previous request, a value the configured engine's parser cannot read, a value that parses but assigns no setting, and an empty or whitespace value.
- **One shared rule** (`ApplyDataStoreConnectionStringRules`) drives insert and update for both resources so the four cannot drift. Each command keeps the length message it already published, and the cascade stops at the length failure so an over-long value still reports exactly one error.
- **One registration seam** picks the engine from `AppSettings:Datastore`. A future setting that names a target provider per data store replaces that method and nothing else.
- **Update preserves.** All four repository update methods leave the column out of the `SET` clause when no value was provided, so the stored ciphertext comes through byte for byte while the rest of the update applies. Parameters moved to Dapper `DynamicParameters` so the connection string parameter is added only when the statement names it, with an explicit `DbType.Binary`.
- **End-to-end coverage** in the two CMS features: ciphertext-shaped resubmission refused on POST and on PUT for both resources with the whole 400 body asserted, a malformed value refused, and an update that omits the field accepted. One scenario per resource carries `@MssqlRepresentative`, the tag the SQL Server lane filters on, so the rejection is exercised on both engines while that bounded lane stays bounded. No shared step definition was added.
- **Docs.** The two guides that show a `connectionString` in a `dataStores` payload now describe the write contract from a client's point of view.
- No request or response shape, endpoint signature, or generated OpenAPI content changed, and nothing under `src/dms` was touched.

## Behavior changes worth calling out

- `PUT` with `connectionString` omitted now preserves the stored value; it previously cleared it.
- `PUT` with an explicit `null` also preserves. `System.Text.Json` cannot distinguish an explicit null from an absent property on a nullable string, and the alternative - presence tracking through a wrapper type - would change the public schema. Treating both as "not provided" is deliberate, and documented.
- `POST` and `PUT` with an empty or whitespace value now return 400. They previously succeeded and stored no connection string. No caller in this repository submits that; the registration helper in `eng/Dms-Management.psm1` builds a real connection string when its parameter is blank.
- There is intentionally no update request that clears a stored connection string. Removing one requires a separate explicit API contract, or deleting and re-creating the data store where dependency constraints permit.

## Test matrix

| behavior | unit | module (HTTP pipeline) | integration PostgreSQL | integration SQL Server | E2E PostgreSQL lane | E2E SQL Server lane |
| --- | --- | --- | --- | --- | --- | --- |
| resubmitted ciphertext refused | yes, both engines and every stored length | yes, real encryption service output | | | yes | yes |
| value the engine cannot parse refused | yes, both engines | yes | | | yes | |
| parses but assigns nothing refused | yes, both engines | yes | | | | |
| empty or whitespace refused | yes | yes | | | | |
| valid value accepted and encrypted | yes, per-engine accept lists | yes | yes | yes | yes | yes |
| omitted PUT keeps the stored bytes | | yes, null reaches the repository | yes, byte for byte | yes, byte for byte | yes, 204 and retrievable | |
| unrelated-field update unaffected | | yes | yes | yes | yes | |
| over-long value reports one error | yes, all four commands | | | | yes, verbatim body | |

Both CMS E2E lanes were run against a config image built from this branch, both with non-zero totals and no failures; the per-scenario outcomes were read from the TRX rather than inferred from the summary line. Relevant unit/module tests and backend integration suites were run as gates for the commits that changed those areas; both CMS E2E lanes were run after the E2E scenarios were added. Following repo practice this description does not pin test counts - the CI jobs are the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
