### PR TITLE
[DMS-1366] Enforce CMS data store derivative invariants with complete upgrade diagnostics

### DIFF
--- a/docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md
+++ b/docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md
@@ -147,8 +147,14 @@ Stores derivative data stores (read replicas and snapshots) associated with a pa
 **Foreign Key:** CASCADE DELETE on `DataStoreId` - when a parent DataStore is
 deleted, all its derivative data stores are automatically deleted.
 
-**Index:** `idx_datastorederivative_datastoreid` on DataStoreId for efficient
-queries.
+**Constraint:** `UNIQUE (DataStoreId, DerivativeType)` ensures each data store
+has at most one ReadReplica and at most one Snapshot. Its backing index leads
+with DataStoreId, so it also serves lookups by parent data store and the
+child-side foreign-key maintenance.
+
+**Constraint:** a check constraint restricts `DerivativeType` to exactly
+"ReadReplica" or "Snapshot", compared ordinally including length, so case and
+whitespace variants are rejected in both engines.
 
 #### ApiClient
 

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeTests.cs
@@ -436,30 +436,37 @@ public class DataStoreDerivativeTests : DatabaseTest
     [TestFixture]
     public class QueryPagingTests : DataStoreDerivativeTests
     {
+        /// <summary>
+        /// A data store holds at most one derivative of each type, and only the two real type names
+        /// are storable, so a four-row paging set spans two data stores.
+        /// </summary>
         [SetUp]
         public async Task Setup()
         {
-            var instanceResult = await _instanceRepository.InsertDataStore(
-                new DataStoreInsertCommand
-                {
-                    DataStoreType = "Production",
-                    Name = "Paging Parent Instance",
-                    ConnectionString = "Server=parent;Database=ParentDb;",
-                }
-            );
-            var dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
-
-            foreach (var derivativeType in new[] { "Alpha", "Bravo", "Charlie" })
+            foreach (var name in new[] { "Paging Parent Instance A", "Paging Parent Instance B" })
             {
-                var insertResult = await _repository.InsertDataStoreDerivative(
-                    new DataStoreDerivativeInsertCommand
+                var instanceResult = await _instanceRepository.InsertDataStore(
+                    new DataStoreInsertCommand
                     {
-                        DataStoreId = dataStoreId,
-                        DerivativeType = derivativeType,
-                        ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+                        DataStoreType = "Production",
+                        Name = name,
+                        ConnectionString = "Server=parent;Database=ParentDb;",
                     }
                 );
-                insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+                var dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
+
+                foreach (var derivativeType in new[] { "ReadReplica", "Snapshot" })
+                {
+                    var insertResult = await _repository.InsertDataStoreDerivative(
+                        new DataStoreDerivativeInsertCommand
+                        {
+                            DataStoreId = dataStoreId,
+                            DerivativeType = derivativeType,
+                            ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+                        }
+                    );
+                    insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+                }
             }
         }
 
@@ -470,7 +477,7 @@ public class DataStoreDerivativeTests : DatabaseTest
             getResult.Should().BeOfType<DataStoreDerivativeQueryResult.Success>();
             ((DataStoreDerivativeQueryResult.Success)getResult)
                 .DataStoreDerivativeResponses.Should()
-                .HaveCount(3);
+                .HaveCount(4);
         }
 
         [Test]
@@ -490,37 +497,45 @@ public class DataStoreDerivativeTests : DatabaseTest
             getResult.Should().BeOfType<DataStoreDerivativeQueryResult.Success>();
             ((DataStoreDerivativeQueryResult.Success)getResult)
                 .DataStoreDerivativeResponses.Should()
-                .HaveCount(2);
+                .HaveCount(3);
         }
     }
 
     [TestFixture]
     public class QuerySortTests : DataStoreDerivativeTests
     {
+        /// <summary>
+        /// Two data stores, each holding both storable derivative types, so ordering has ties to
+        /// resolve. Rows are inserted in reverse of the expected ascending order, so the assertion
+        /// proves the ORDER BY clause rather than the insertion order.
+        /// </summary>
         [SetUp]
         public async Task Setup()
         {
-            var instanceResult = await _instanceRepository.InsertDataStore(
-                new DataStoreInsertCommand
-                {
-                    DataStoreType = "Production",
-                    Name = "Sort Parent Instance",
-                    ConnectionString = "Server=parent;Database=ParentDb;",
-                }
-            );
-            var dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
-
-            foreach (var derivativeType in new[] { "Charlie", "Alpha", "Bravo" })
+            foreach (var name in new[] { "Sort Parent Instance A", "Sort Parent Instance B" })
             {
-                var insertResult = await _repository.InsertDataStoreDerivative(
-                    new DataStoreDerivativeInsertCommand
+                var instanceResult = await _instanceRepository.InsertDataStore(
+                    new DataStoreInsertCommand
                     {
-                        DataStoreId = dataStoreId,
-                        DerivativeType = derivativeType,
-                        ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+                        DataStoreType = "Production",
+                        Name = name,
+                        ConnectionString = "Server=parent;Database=ParentDb;",
                     }
                 );
-                insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+                var dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
+
+                foreach (var derivativeType in new[] { "Snapshot", "ReadReplica" })
+                {
+                    var insertResult = await _repository.InsertDataStoreDerivative(
+                        new DataStoreDerivativeInsertCommand
+                        {
+                            DataStoreId = dataStoreId,
+                            DerivativeType = derivativeType,
+                            ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+                        }
+                    );
+                    insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+                }
             }
         }
 
@@ -534,7 +549,7 @@ public class DataStoreDerivativeTests : DatabaseTest
             var derivativeTypes = ((DataStoreDerivativeQueryResult.Success)getResult)
                 .DataStoreDerivativeResponses.Select(d => d.DerivativeType)
                 .ToList();
-            derivativeTypes.Should().ContainInOrder("Alpha", "Bravo", "Charlie");
+            derivativeTypes.Should().ContainInOrder("ReadReplica", "ReadReplica", "Snapshot", "Snapshot");
         }
 
         [Test]
@@ -547,7 +562,7 @@ public class DataStoreDerivativeTests : DatabaseTest
             var derivativeTypes = ((DataStoreDerivativeQueryResult.Success)getResult)
                 .DataStoreDerivativeResponses.Select(d => d.DerivativeType)
                 .ToList();
-            derivativeTypes.Should().ContainInOrder("Charlie", "Bravo", "Alpha");
+            derivativeTypes.Should().ContainInOrder("Snapshot", "Snapshot", "ReadReplica", "ReadReplica");
         }
     }
 

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeTests.cs
@@ -56,6 +56,34 @@ public class DataStoreDerivativeTests : DatabaseTest
         );
     }
 
+    private async Task<int> InsertParentDataStore(string name)
+    {
+        var instanceResult = await _instanceRepository.InsertDataStore(
+            new DataStoreInsertCommand
+            {
+                DataStoreType = "Production",
+                Name = name,
+                ConnectionString = "Server=parent;Database=ParentDb;",
+            }
+        );
+
+        return instanceResult.Should().BeOfType<DataStoreInsertResult.Success>().Subject.Id;
+    }
+
+    private async Task<int> InsertDerivative(int dataStoreId, string derivativeType)
+    {
+        var insertResult = await _repository.InsertDataStoreDerivative(
+            new DataStoreDerivativeInsertCommand
+            {
+                DataStoreId = dataStoreId,
+                DerivativeType = derivativeType,
+                ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+            }
+        );
+
+        return insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>().Subject.Id;
+    }
+
     [TestFixture]
     public class Given_insert_data_store_derivative : DataStoreDerivativeTests
     {
@@ -894,6 +922,207 @@ public class DataStoreDerivativeTests : DatabaseTest
             var singleTenantRepository = CreateDerivativeRepository(new TenantContextProvider());
             var result = await singleTenantRepository.GetDataStoreDerivative(_tenantADerivativeId);
             result.Should().BeOfType<DataStoreDerivativeGetResult.FailureNotFound>();
+        }
+    }
+
+    [TestFixture]
+    public class Given_a_data_store_with_both_derivative_types : DataStoreDerivativeTests
+    {
+        private int _dataStoreId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _dataStoreId = await InsertParentDataStore("Both Types Parent Instance");
+
+            await InsertDerivative(_dataStoreId, "Snapshot");
+            await InsertDerivative(_dataStoreId, "ReadReplica");
+        }
+
+        [Test]
+        public async Task It_should_store_one_derivative_of_each_type()
+        {
+            var getResult = await _repository.GetDataStoreDerivativesByDataStore(_dataStoreId);
+
+            string[] expectedDerivativeTypes = ["ReadReplica", "Snapshot"];
+
+            var derivatives = getResult
+                .Should()
+                .BeOfType<DataStoreDerivativeQueryByDataStoreResult.Success>()
+                .Subject.DataStoreDerivativeResponses;
+            derivatives
+                .Select(derivative => derivative.DerivativeType)
+                .Should()
+                .BeEquivalentTo(expectedDerivativeTypes);
+        }
+    }
+
+    [TestFixture]
+    public class Given_insert_of_a_duplicate_derivative_type : DataStoreDerivativeTests
+    {
+        private int _dataStoreId;
+        private DataStoreDerivativeInsertResult _duplicateResult = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _dataStoreId = await InsertParentDataStore("Duplicate Insert Parent Instance");
+            await InsertDerivative(_dataStoreId, "Snapshot");
+
+            _duplicateResult = await _repository.InsertDataStoreDerivative(
+                new DataStoreDerivativeInsertCommand
+                {
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = "Snapshot",
+                    ConnectionString = "Server=second;Database=SecondDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_should_return_failure_duplicate_data_store_derivative() =>
+            _duplicateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeInsertResult.FailureDuplicateDataStoreDerivative>();
+
+        [Test]
+        public void It_should_carry_the_conflicting_data_store_and_derivative_type()
+        {
+            var duplicate = _duplicateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeInsertResult.FailureDuplicateDataStoreDerivative>()
+                .Subject;
+
+            duplicate.DataStoreId.Should().Be(_dataStoreId);
+            duplicate.DerivativeType.Should().Be("Snapshot");
+        }
+
+        [Test]
+        public async Task It_should_leave_only_the_original_derivative()
+        {
+            var getResult = await _repository.GetDataStoreDerivativesByDataStore(_dataStoreId);
+
+            getResult
+                .Should()
+                .BeOfType<DataStoreDerivativeQueryByDataStoreResult.Success>()
+                .Subject.DataStoreDerivativeResponses.Should()
+                .HaveCount(1);
+        }
+    }
+
+    [TestFixture]
+    public class Given_update_changing_derivative_type_to_an_existing_sibling : DataStoreDerivativeTests
+    {
+        private int _dataStoreId;
+        private int _replicaId;
+        private DataStoreDerivativeUpdateResult _updateResult = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _dataStoreId = await InsertParentDataStore("Update Type Conflict Parent Instance");
+            await InsertDerivative(_dataStoreId, "Snapshot");
+            _replicaId = await InsertDerivative(_dataStoreId, "ReadReplica");
+
+            _updateResult = await _repository.UpdateDataStoreDerivative(
+                new DataStoreDerivativeUpdateCommand
+                {
+                    Id = _replicaId,
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = "Snapshot",
+                    ConnectionString = "Server=conflict;Database=ConflictDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_should_return_failure_duplicate_data_store_derivative() =>
+            _updateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative>();
+
+        [Test]
+        public void It_should_carry_the_conflicting_data_store_and_derivative_type()
+        {
+            var duplicate = _updateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative>()
+                .Subject;
+
+            duplicate.DataStoreId.Should().Be(_dataStoreId);
+            duplicate.DerivativeType.Should().Be("Snapshot");
+        }
+
+        [Test]
+        public async Task It_should_leave_the_derivative_type_unchanged()
+        {
+            var getResult = await _repository.GetDataStoreDerivative(_replicaId);
+
+            getResult
+                .Should()
+                .BeOfType<DataStoreDerivativeGetResult.Success>()
+                .Subject.DataStoreDerivativeResponse.DerivativeType.Should()
+                .Be("ReadReplica");
+        }
+    }
+
+    [TestFixture]
+    public class Given_update_moving_a_derivative_to_a_data_store_that_already_has_the_type
+        : DataStoreDerivativeTests
+    {
+        private int _targetDataStoreId;
+        private int _sourceDataStoreId;
+        private int _movedDerivativeId;
+        private DataStoreDerivativeUpdateResult _updateResult = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _targetDataStoreId = await InsertParentDataStore("Move Conflict Target Instance");
+            _sourceDataStoreId = await InsertParentDataStore("Move Conflict Source Instance");
+
+            await InsertDerivative(_targetDataStoreId, "Snapshot");
+            _movedDerivativeId = await InsertDerivative(_sourceDataStoreId, "Snapshot");
+
+            _updateResult = await _repository.UpdateDataStoreDerivative(
+                new DataStoreDerivativeUpdateCommand
+                {
+                    Id = _movedDerivativeId,
+                    DataStoreId = _targetDataStoreId,
+                    DerivativeType = "Snapshot",
+                    ConnectionString = "Server=moved;Database=MovedDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_should_return_failure_duplicate_data_store_derivative() =>
+            _updateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative>();
+
+        [Test]
+        public void It_should_carry_the_target_data_store_and_derivative_type()
+        {
+            var duplicate = _updateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative>()
+                .Subject;
+
+            duplicate.DataStoreId.Should().Be(_targetDataStoreId);
+            duplicate.DerivativeType.Should().Be("Snapshot");
+        }
+
+        [Test]
+        public async Task It_should_leave_the_derivative_on_its_original_data_store()
+        {
+            var getResult = await _repository.GetDataStoreDerivative(_movedDerivativeId);
+
+            getResult
+                .Should()
+                .BeOfType<DataStoreDerivativeGetResult.Success>()
+                .Subject.DataStoreDerivativeResponse.DataStoreId.Should()
+                .Be(_sourceDataStoreId);
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeUpgradeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeUpgradeTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using Dapper;
+using DbUp.Engine.Output;
 using EdFi.DmsConfigurationService.Backend.Deploy;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
@@ -253,17 +254,23 @@ public class Given_a_legacy_DataStoreDerivative_SqlServer_upgrade
         // sibling and both providers assert the same totals.
         int paddedId = await InsertDerivativeAsync(connection, _fourthDataStoreId, "Snapshot ");
 
+        int lastInvalidId = 0;
         for (int row = 0; row < 30; row++)
         {
-            await InsertDerivativeAsync(connection, _firstDataStoreId, WidestInvalidType(row));
+            lastInvalidId = await InsertDerivativeAsync(
+                connection,
+                _firstDataStoreId,
+                WidestInvalidType(row)
+            );
         }
 
+        int lastDuplicateId = 0;
         int[] duplicateHosts = [_firstDataStoreId, _secondDataStoreId, _thirdDataStoreId];
         foreach (int dataStoreId in duplicateHosts)
         {
             for (int row = 0; row < 10; row++)
             {
-                await InsertDerivativeAsync(connection, dataStoreId, "Snapshot");
+                lastDuplicateId = await InsertDerivativeAsync(connection, dataStoreId, "Snapshot");
             }
         }
 
@@ -286,8 +293,36 @@ public class Given_a_legacy_DataStoreDerivative_SqlServer_upgrade
         message
             .Length.Should()
             .BeLessThanOrEqualTo(
-                2048,
-                "the tuple budget is computed before the lists are built, so the message never needs truncating"
+                2047,
+                "THROW delivers at most 2047 characters; the bounded @message variable makes this "
+                    + "assertion true on its own, so the remediation assertions above are what actually "
+                    + "detect truncation"
+            );
+
+        // The thrown error is a bounded sample by design. These offenders sit past the cap, so the
+        // only place they can be found is the deploy log, which is the channel an operator reads
+        // when the upgrade fails.
+        string scriptOutput = _scriptOutput.Output;
+        string lastDuplicateTuple = $"({_thirdDataStoreId}, Snapshot, {lastDuplicateId})";
+        string lastInvalidTuple = $"({lastInvalidId}, {_firstDataStoreId}, '{WidestInvalidType(29)}')";
+
+        message.Should().NotContain(lastDuplicateTuple, "this offender is beyond the thrown sample's cap");
+        message.Should().NotContain(lastInvalidTuple, "this offender is beyond the thrown sample's cap");
+
+        scriptOutput
+            .Should()
+            .Contain(lastDuplicateTuple, "every duplicate tuple reaches the operator through the deploy log");
+        scriptOutput
+            .Should()
+            .Contain(
+                lastInvalidTuple,
+                "every invalid-type tuple reaches the operator through the deploy log"
+            );
+        scriptOutput
+            .Should()
+            .Contain(
+                $"({paddedId}, {_fourthDataStoreId}, 'Snapshot ')",
+                "the quoted trailing space survives the log channel too"
             );
     }
 
@@ -389,7 +424,15 @@ public class Given_a_legacy_DataStoreDerivative_SqlServer_upgrade
             new { Name = name }
         ) > 0;
 
-    private DatabaseDeployResult Deploy() => new Deploy.DatabaseDeploy().DeployDatabase(_connectionString);
+    private ScriptOutputCapture _scriptOutput = new();
+
+    private DatabaseDeployResult Deploy()
+    {
+        _scriptOutput = new ScriptOutputCapture();
+        return new Deploy.DatabaseDeploy { ScriptOutputLog = _scriptOutput }.DeployDatabase(
+            _connectionString
+        );
+    }
 
     private void DeploySuccessfully()
     {
@@ -461,4 +504,29 @@ public class Given_a_legacy_DataStoreDerivative_SqlServer_upgrade
           AND index_column_info.is_included_column = 0
         ORDER BY index_column_info.key_ordinal;
         """;
+
+    /// <summary>
+    /// Captures the script output DbUp writes for every result set an upgrade script returns. The
+    /// complete offender lists travel through this channel because they cannot fit in the thrown
+    /// error, so a test can only prove they reach the operator by reading the deploy log.
+    /// </summary>
+    private sealed class ScriptOutputCapture : IUpgradeLog
+    {
+        private readonly List<string> _lines = [];
+
+        public string Output => string.Join(Environment.NewLine, _lines);
+
+        public void WriteInformation(string format, params object[] args) => Append(format, args);
+
+        public void WriteWarning(string format, params object[] args) => Append(format, args);
+
+        public void WriteError(string format, params object[] args) => Append(format, args);
+
+        /// <summary>
+        /// DbUp passes result-set rows through with no arguments, so the row text is never treated
+        /// as a format string and a brace in the data cannot break the capture.
+        /// </summary>
+        private void Append(string format, object[] args) =>
+            _lines.Add(args.Length == 0 ? format : string.Format(format, args));
+    }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeUpgradeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreDerivativeUpgradeTests.cs
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Dapper;
+using EdFi.DmsConfigurationService.Backend.Deploy;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+
+namespace EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Exercises the DataStoreDerivative invariants upgrade against a journaled pre-upgrade database,
+/// which is the state a real deployment upgrades from. Each test reverts the isolated database to
+/// that state, seeds legacy rows directly with SQL so the API validator cannot filter them, and runs
+/// the deploy again so only the invariants script executes. Replaying every script instead would let
+/// a non-replay-safe earlier script decide the outcome.
+/// </summary>
+[TestFixture]
+[Category("MssqlIntegration")]
+public class Given_a_legacy_DataStoreDerivative_SqlServer_upgrade
+{
+    private const string JournalPattern = "%0028_Add_DataStoreDerivative_Invariants%";
+    private const string RemediationPut = "PUT /v3/dataStoreDerivatives/{id}";
+    private const string RemediationDelete = "DELETE /v3/dataStoreDerivatives/{id}";
+    private const string AllowedValues = "Allowed values are exactly 'Snapshot' and 'ReadReplica'.";
+    private const int CheckOrForeignKeyViolation = 547;
+    private const int UniqueConstraintViolation = 2627;
+
+    private string _databaseName = string.Empty;
+    private string _connectionString = string.Empty;
+    private int _firstDataStoreId;
+    private int _secondDataStoreId;
+    private int _thirdDataStoreId;
+    private int _fourthDataStoreId;
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        MssqlTestConfiguration.RequireConfiguredForCiOrSkipLocally(
+            "SQL Server integration tests require the ConnectionStrings__MssqlAdmin environment variable."
+        );
+
+        _connectionString = CreateIsolatedDatabaseConnectionString();
+        DeploySuccessfully();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTeardown()
+    {
+        if (string.IsNullOrEmpty(_databaseName))
+        {
+            return;
+        }
+
+        await using SqlConnection connection = new(CreateMasterConnectionString());
+        await connection.OpenAsync();
+        await connection.ExecuteAsync(
+            $"""
+            IF DB_ID('{_databaseName}') IS NOT NULL
+            BEGIN
+                ALTER DATABASE [{_databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                DROP DATABASE [{_databaseName}];
+            END;
+            """
+        );
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await RevertToPreUpgradeStateAsync();
+
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        _firstDataStoreId = await InsertDataStoreAsync(connection, "Legacy Data Store A");
+        _secondDataStoreId = await InsertDataStoreAsync(connection, "Legacy Data Store B");
+        _thirdDataStoreId = await InsertDataStoreAsync(connection, "Legacy Data Store C");
+        _fourthDataStoreId = await InsertDataStoreAsync(connection, "Legacy Data Store D");
+    }
+
+    [Test]
+    public async Task It_should_upgrade_a_conforming_legacy_database_and_replace_the_redundant_index()
+    {
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot");
+        await InsertDerivativeAsync(connection, _firstDataStoreId, "ReadReplica");
+        await InsertDerivativeAsync(connection, _secondDataStoreId, "Snapshot");
+
+        DatabaseDeployResult result = Deploy();
+
+        result.Should().BeOfType<DatabaseDeployResult.DatabaseDeploySuccess>();
+
+        int journaledUpgrades = await connection.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM dbo.dmscs_SchemaVersions WHERE ScriptName LIKE @Pattern;",
+            new { Pattern = JournalPattern }
+        );
+        journaledUpgrades.Should().Be(1, "the upgrade script is journaled exactly once");
+
+        (await ObjectExistsAsync(connection, "UX_DataStoreDerivative_DataStoreId_DerivativeType"))
+            .Should()
+            .BeTrue();
+        (await ObjectExistsAsync(connection, "CK_DataStoreDerivative_DerivativeType")).Should().BeTrue();
+
+        string[] uniqueKeyColumns = (
+            await connection.QueryAsync<string>(UniqueConstraintColumnsSql)
+        ).ToArray();
+        uniqueKeyColumns.Should().Equal("DataStoreId", "DerivativeType");
+
+        int redundantIndexes = await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT COUNT(*)
+            FROM sys.indexes
+            WHERE name = 'IX_DataStoreDerivative_DataStoreId'
+              AND object_id = OBJECT_ID('dmscs.DataStoreDerivative');
+            """
+        );
+        redundantIndexes.Should().Be(0, "the unique constraint's backing index leads with DataStoreId");
+    }
+
+    [Test]
+    public async Task It_should_accept_the_exact_allowed_values_and_reject_variants_after_the_upgrade()
+    {
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        Deploy().Should().BeOfType<DatabaseDeployResult.DatabaseDeploySuccess>();
+
+        await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot");
+        await InsertDerivativeAsync(connection, _firstDataStoreId, "ReadReplica");
+
+        SqlException caseVariant = await ExpectInsertFailureAsync(connection, _secondDataStoreId, "SNAPSHOT");
+        caseVariant
+            .Number.Should()
+            .Be(CheckOrForeignKeyViolation, "the binary collation makes the comparison ordinal");
+        caseVariant.Message.Should().Contain("CK_DataStoreDerivative_DerivativeType");
+
+        SqlException padded = await ExpectInsertFailureAsync(connection, _secondDataStoreId, "Snapshot ");
+        padded
+            .Number.Should()
+            .Be(CheckOrForeignKeyViolation, "DATALENGTH rejects the padded value that = and IN would accept");
+        padded.Message.Should().Contain("CK_DataStoreDerivative_DerivativeType");
+
+        SqlException unknownType = await ExpectInsertFailureAsync(connection, _secondDataStoreId, "Replica");
+        unknownType.Number.Should().Be(CheckOrForeignKeyViolation);
+
+        SqlException duplicate = await ExpectInsertFailureAsync(connection, _firstDataStoreId, "Snapshot");
+        duplicate
+            .Number.Should()
+            .Be(UniqueConstraintViolation, "a data store holds at most one derivative per type");
+        duplicate.Message.Should().Contain("UX_DataStoreDerivative_DataStoreId_DerivativeType");
+    }
+
+    [Test]
+    public async Task It_should_block_the_upgrade_when_duplicate_rows_exist()
+    {
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        int firstId = await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot");
+        int secondId = await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot");
+        await InsertDerivativeAsync(connection, _secondDataStoreId, "ReadReplica");
+
+        string message = DeployFailureMessage();
+
+        message.Should().Contain("2 duplicate (DataStoreId, DerivativeType) row(s)");
+        message.Should().Contain($"({_firstDataStoreId}, Snapshot, {firstId})");
+        message.Should().Contain($"({_firstDataStoreId}, Snapshot, {secondId})");
+        message.Should().Contain(RemediationPut);
+        message.Should().Contain(RemediationDelete);
+        message.Should().Contain(AllowedValues);
+        message
+            .Should()
+            .NotContain(
+                "row(s) with an invalid DerivativeType",
+                "no invalid-type condition is present; the remediation text names the term either way"
+            );
+    }
+
+    [Test]
+    public async Task It_should_block_the_upgrade_when_an_invalid_type_exists()
+    {
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        int invalidId = await InsertDerivativeAsync(connection, _firstDataStoreId, "Replica");
+
+        string message = DeployFailureMessage();
+
+        message.Should().Contain("1 row(s) with an invalid DerivativeType");
+        message.Should().Contain($"({invalidId}, {_firstDataStoreId}, 'Replica')");
+        message.Should().Contain(RemediationPut);
+        message.Should().Contain(RemediationDelete);
+        message.Should().Contain(AllowedValues);
+    }
+
+    [Test]
+    public async Task It_should_block_the_upgrade_when_a_case_variant_exists()
+    {
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        int caseVariantId = await InsertDerivativeAsync(connection, _firstDataStoreId, "SNAPSHOT");
+
+        string message = DeployFailureMessage();
+
+        message
+            .Should()
+            .Contain(
+                "1 row(s) with an invalid DerivativeType",
+                "a naive IN scan would miss this row under a case-insensitive collation"
+            );
+        message.Should().Contain($"({caseVariantId}, {_firstDataStoreId}, 'SNAPSHOT')");
+    }
+
+    [Test]
+    public async Task It_should_block_the_upgrade_when_a_trailing_whitespace_variant_exists()
+    {
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        int paddedId = await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot ");
+
+        string message = DeployFailureMessage();
+
+        message
+            .Should()
+            .Contain(
+                "1 row(s) with an invalid DerivativeType",
+                "SQL-92 padding would let = and IN accept this row at any collation"
+            );
+        message
+            .Should()
+            .Contain(
+                $"({paddedId}, {_firstDataStoreId}, 'Snapshot ')",
+                "quoting the value is what makes the trailing space visible to an operator"
+            );
+    }
+
+    [Test]
+    public async Task It_should_keep_every_mandatory_diagnostic_section_at_high_cardinality()
+    {
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        // Seeded first so it leads the invalid-type ordering and is therefore one of the tuples the
+        // capped list must still carry. Hosted alone on a data store that holds no other row, so
+        // SQL Server's padded, case-insensitive comparison cannot make it a duplicate of a Snapshot
+        // sibling and both providers assert the same totals.
+        int paddedId = await InsertDerivativeAsync(connection, _fourthDataStoreId, "Snapshot ");
+
+        for (int row = 0; row < 30; row++)
+        {
+            await InsertDerivativeAsync(connection, _firstDataStoreId, WidestInvalidType(row));
+        }
+
+        int[] duplicateHosts = [_firstDataStoreId, _secondDataStoreId, _thirdDataStoreId];
+        foreach (int dataStoreId in duplicateHosts)
+        {
+            for (int row = 0; row < 10; row++)
+            {
+                await InsertDerivativeAsync(connection, dataStoreId, "Snapshot");
+            }
+        }
+
+        string message = DeployFailureMessage();
+
+        message.Should().Contain("30 duplicate (DataStoreId, DerivativeType) row(s)");
+        message.Should().Contain("31 row(s) with an invalid DerivativeType");
+        message.Should().Contain($"({_firstDataStoreId}, Snapshot, ");
+        message
+            .Should()
+            .Contain(
+                $"({paddedId}, {_fourthDataStoreId}, 'Snapshot ')",
+                "the quoted trailing space stays visible even when the list is capped"
+            );
+        message.Should().Contain($"'{WidestInvalidType(0)}'", "the widest storable value is carried whole");
+        message.Should().Contain("... and ", "capped lists state how many offenders were not listed");
+        message.Should().Contain(RemediationPut);
+        message.Should().Contain(RemediationDelete);
+        message.Should().Contain(AllowedValues);
+        message
+            .Length.Should()
+            .BeLessThanOrEqualTo(
+                2048,
+                "the tuple budget is computed before the lists are built, so the message never needs truncating"
+            );
+    }
+
+    /// <summary>
+    /// A distinct value at the full 50-character width of the column, which is the widest tuple the
+    /// diagnostics can be asked to carry.
+    /// </summary>
+    private static string WidestInvalidType(int ordinal) => $"Legacy{ordinal:D2}".PadRight(50, 'x');
+
+    private async Task RevertToPreUpgradeStateAsync()
+    {
+        await using SqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        await connection.ExecuteAsync(
+            """
+            ALTER TABLE dmscs.DataStoreDerivative
+                DROP CONSTRAINT IF EXISTS UX_DataStoreDerivative_DataStoreId_DerivativeType;
+            ALTER TABLE dmscs.DataStoreDerivative
+                DROP CONSTRAINT IF EXISTS CK_DataStoreDerivative_DerivativeType;
+            IF NOT EXISTS (
+                SELECT 1
+                FROM sys.indexes
+                WHERE name = 'IX_DataStoreDerivative_DataStoreId'
+                  AND object_id = OBJECT_ID('dmscs.DataStoreDerivative')
+            )
+                CREATE INDEX IX_DataStoreDerivative_DataStoreId ON dmscs.DataStoreDerivative (DataStoreId);
+            """
+        );
+
+        int removedJournalEntries = await connection.ExecuteAsync(
+            "DELETE FROM dbo.dmscs_SchemaVersions WHERE ScriptName LIKE @Pattern;",
+            new { Pattern = JournalPattern }
+        );
+        removedJournalEntries
+            .Should()
+            .BeLessThanOrEqualTo(1, "the pattern must identify only the invariants upgrade script");
+
+        await connection.ExecuteAsync(
+            """
+            DELETE FROM dmscs.DataStoreDerivative;
+            DELETE FROM dmscs.DataStore;
+            """
+        );
+    }
+
+    private static async Task<int> InsertDataStoreAsync(SqlConnection connection, string name) =>
+        await connection.ExecuteScalarAsync<int>(
+            """
+            INSERT INTO dmscs.DataStore (DataStoreType, Name)
+            OUTPUT INSERTED.Id
+            VALUES ('Production', @Name);
+            """,
+            new { Name = name }
+        );
+
+    private static async Task<int> InsertDerivativeAsync(
+        SqlConnection connection,
+        int dataStoreId,
+        string derivativeType
+    ) =>
+        await connection.ExecuteScalarAsync<int>(
+            """
+            INSERT INTO dmscs.DataStoreDerivative (DataStoreId, DerivativeType)
+            OUTPUT INSERTED.Id
+            VALUES (@DataStoreId, @DerivativeType);
+            """,
+            new { DataStoreId = dataStoreId, DerivativeType = derivativeType }
+        );
+
+    private static async Task<SqlException> ExpectInsertFailureAsync(
+        SqlConnection connection,
+        int dataStoreId,
+        string derivativeType
+    )
+    {
+        try
+        {
+            await InsertDerivativeAsync(connection, dataStoreId, derivativeType);
+        }
+        catch (SqlException exception)
+        {
+            return exception;
+        }
+
+        throw new AssertionException(
+            $"Expected the database to reject DerivativeType '{derivativeType}' but the insert succeeded."
+        );
+    }
+
+    private static async Task<bool> ObjectExistsAsync(SqlConnection connection, string name) =>
+        await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT COUNT(*)
+            FROM sys.objects
+            WHERE name = @Name
+              AND parent_object_id = OBJECT_ID('dmscs.DataStoreDerivative');
+            """,
+            new { Name = name }
+        ) > 0;
+
+    private DatabaseDeployResult Deploy() => new Deploy.DatabaseDeploy().DeployDatabase(_connectionString);
+
+    private void DeploySuccessfully()
+    {
+        DatabaseDeployResult result = Deploy();
+
+        if (result is DatabaseDeployResult.DatabaseDeployFailure failure)
+        {
+            Assert.Fail($"Database deploy failed: {failure.Error}");
+        }
+    }
+
+    private string DeployFailureMessage()
+    {
+        DatabaseDeployResult result = Deploy();
+
+        DatabaseDeployResult.DatabaseDeployFailure failure = result
+            .Should()
+            .BeOfType<DatabaseDeployResult.DatabaseDeployFailure>()
+            .Subject;
+
+        return FindSqlException(failure.Error).Message;
+    }
+
+    private static SqlException FindSqlException(Exception exception)
+    {
+        for (Exception? candidate = exception; candidate is not null; candidate = candidate.InnerException)
+        {
+            if (candidate is SqlException sqlException)
+            {
+                return sqlException;
+            }
+        }
+
+        throw new AssertionException($"Expected a SqlException but found: {exception}");
+    }
+
+    private string CreateIsolatedDatabaseConnectionString()
+    {
+        SqlConnectionStringBuilder builder = new(MssqlTestConfiguration.AdminConnectionString)
+        {
+            InitialCatalog = $"dms1366_upgrade_{Guid.NewGuid():N}",
+            Pooling = false,
+        };
+
+        _databaseName = builder.InitialCatalog;
+        return builder.ConnectionString;
+    }
+
+    private static string CreateMasterConnectionString() =>
+        new SqlConnectionStringBuilder(MssqlTestConfiguration.AdminConnectionString)
+        {
+            InitialCatalog = "master",
+            Pooling = false,
+        }.ConnectionString;
+
+    private const string UniqueConstraintColumnsSql = """
+        SELECT column_info.name
+        FROM sys.key_constraints constraint_info
+        JOIN sys.indexes index_info
+            ON index_info.object_id = constraint_info.parent_object_id
+           AND index_info.index_id = constraint_info.unique_index_id
+        JOIN sys.index_columns index_column_info
+            ON index_column_info.object_id = index_info.object_id
+           AND index_column_info.index_id = index_info.index_id
+        JOIN sys.columns column_info
+            ON column_info.object_id = index_column_info.object_id
+           AND column_info.column_id = index_column_info.column_id
+        WHERE constraint_info.name = 'UX_DataStoreDerivative_DataStoreId_DerivativeType'
+          AND index_column_info.is_included_column = 0
+        ORDER BY index_column_info.key_ordinal;
+        """;
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreTests.cs
@@ -10,6 +10,7 @@ using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStore;
+using EdFi.DmsConfigurationService.DataModel.Model.DataStoreDerivative;
 using EdFi.DmsConfigurationService.DataModel.Model.Tenant;
 using EdFi.DmsConfigurationService.DataModel.Model.Vendor;
 using FluentAssertions;
@@ -1018,6 +1019,99 @@ public class DataStoreTests : DatabaseTest
                 .ToList();
             names.Should().HaveCount(3);
             names.Should().ContainInOrder("Charlie-Instance", "November-Instance", "Zulu-Instance");
+        }
+    }
+
+    /// <summary>
+    /// DataStoreRepository composes derivatives through a separate repository, and the two read paths
+    /// use different lookups: GetDataStore resolves a single parent while QueryDataStore resolves a
+    /// batch and groups the result. Both swallow a failed derivative lookup into an empty collection,
+    /// so only an assertion on the composed response can prove the derivatives actually arrive.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_data_store_with_both_derivative_types : DataStoreTests
+    {
+        private int _dataStoreId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var insertResult = await _repository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Production",
+                    Name = "Derivative Composition Instance",
+                    ConnectionString = "Server=localhost;Database=CompositionDb;",
+                }
+            );
+            _dataStoreId = insertResult.Should().BeOfType<DataStoreInsertResult.Success>().Subject.Id;
+
+            await InsertDerivative("Snapshot", "Server=localhost;Database=SnapshotDb;");
+            await InsertDerivative("ReadReplica", "Server=localhost;Database=ReadReplicaDb;");
+        }
+
+        private async Task InsertDerivative(string derivativeType, string connectionString)
+        {
+            var result = await _derivativeRepository.InsertDataStoreDerivative(
+                new DataStoreDerivativeInsertCommand
+                {
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = derivativeType,
+                    ConnectionString = connectionString,
+                }
+            );
+            result.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+        }
+
+        [Test]
+        public async Task It_should_include_both_derivatives_in_the_single_data_store_response()
+        {
+            var getResult = await _repository.GetDataStore(_dataStoreId);
+
+            DataStoreResponse dataStore = getResult
+                .Should()
+                .BeOfType<DataStoreGetResult.Success>()
+                .Subject.DataStoreResponse;
+
+            AssertCarriesBothDerivatives(dataStore);
+        }
+
+        [Test]
+        public async Task It_should_include_both_derivatives_in_the_queried_data_store_response()
+        {
+            var queryResult = await _repository.QueryDataStore(new DataStoreQuery { Limit = 25, Offset = 0 });
+
+            DataStoreResponse dataStore = queryResult
+                .Should()
+                .BeOfType<DataStoreQueryResult.Success>()
+                .Subject.DataStoreResponses.Should()
+                .ContainSingle(response => response.Id == _dataStoreId)
+                .Subject;
+
+            AssertCarriesBothDerivatives(dataStore);
+        }
+
+        private void AssertCarriesBothDerivatives(DataStoreResponse dataStore)
+        {
+            var derivatives = dataStore.DataStoreDerivatives.ToList();
+
+            derivatives
+                .Select(derivative => new { derivative.DataStoreId, derivative.DerivativeType })
+                .Should()
+                .BeEquivalentTo(
+                    new[]
+                    {
+                        new { DataStoreId = _dataStoreId, DerivativeType = "ReadReplica" },
+                        new { DataStoreId = _dataStoreId, DerivativeType = "Snapshot" },
+                    }
+                );
+
+            derivatives
+                .Should()
+                .OnlyContain(
+                    derivative => derivative.Id > 0,
+                    "the composed response carries each derivative's persisted identity"
+                );
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DeployTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DeployTests.cs
@@ -170,11 +170,99 @@ public class DeployTests : DatabaseTestBase
         }
     }
 
+    [Test]
+    public async Task It_removes_the_redundant_DataStoreDerivative_lookup_index()
+    {
+        await using var connection = await OpenConnectionAsync();
+
+        int redundantIndexes = await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT COUNT(*)
+            FROM sys.indexes
+            WHERE name = 'IX_DataStoreDerivative_DataStoreId'
+              AND object_id = OBJECT_ID('dmscs.DataStoreDerivative');
+            """
+        );
+
+        redundantIndexes
+            .Should()
+            .Be(
+                0,
+                "the backing index of UX_DataStoreDerivative_DataStoreId_DerivativeType leads with the "
+                    + "same column, so it serves the parent lookup and the child-side foreign-key maintenance"
+            );
+    }
+
+    [Test]
+    public async Task It_creates_the_DataStoreDerivative_unique_constraint_over_the_intended_key_columns()
+    {
+        await using var connection = await OpenConnectionAsync();
+
+        string[] keyColumns = (
+            await connection.QueryAsync<string>(DataStoreDerivativeUniqueConstraintColumnsSql)
+        ).ToArray();
+
+        keyColumns.Should().Equal("DataStoreId", "DerivativeType");
+
+        bool backingIndexIsUnique = await connection.ExecuteScalarAsync<bool>(
+            """
+            SELECT index_info.is_unique
+            FROM sys.key_constraints constraint_info
+            JOIN sys.indexes index_info
+                ON index_info.object_id = constraint_info.parent_object_id
+               AND index_info.index_id = constraint_info.unique_index_id
+            WHERE constraint_info.name = 'UX_DataStoreDerivative_DataStoreId_DerivativeType'
+              AND constraint_info.type = 'UQ';
+            """
+        );
+
+        backingIndexIsUnique.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task It_creates_the_trusted_DataStoreDerivative_type_check_constraint()
+    {
+        await using var connection = await OpenConnectionAsync();
+
+        CheckConstraintShape constraint = await connection.QuerySingleAsync<CheckConstraintShape>(
+            """
+            SELECT is_disabled AS IsDisabled, is_not_trusted AS IsNotTrusted
+            FROM sys.check_constraints
+            WHERE name = 'CK_DataStoreDerivative_DerivativeType'
+              AND parent_object_id = OBJECT_ID('dmscs.DataStoreDerivative');
+            """
+        );
+
+        constraint.IsDisabled.Should().BeFalse();
+        constraint
+            .IsNotTrusted.Should()
+            .BeFalse("the constraint is added WITH CHECK, so it has validated the existing rows");
+    }
+
     private static async Task<ColumnShape[]> QueryDmscsColumnsAsync()
     {
         await using var connection = await OpenConnectionAsync();
         return (await connection.QueryAsync<ColumnShape>(ColumnsSql)).ToArray();
     }
 
+    private const string DataStoreDerivativeUniqueConstraintColumnsSql = """
+        SELECT column_info.name
+        FROM sys.key_constraints constraint_info
+        JOIN sys.indexes index_info
+            ON index_info.object_id = constraint_info.parent_object_id
+           AND index_info.index_id = constraint_info.unique_index_id
+        JOIN sys.index_columns index_column_info
+            ON index_column_info.object_id = index_info.object_id
+           AND index_column_info.index_id = index_info.index_id
+        JOIN sys.columns column_info
+            ON column_info.object_id = index_column_info.object_id
+           AND column_info.column_id = index_column_info.column_id
+        WHERE constraint_info.name = 'UX_DataStoreDerivative_DataStoreId_DerivativeType'
+          AND index_column_info.is_included_column = 0
+        ORDER BY index_column_info.key_ordinal;
+        """;
+
     private sealed record ColumnShape(string TableName, string ColumnName, string DataType);
+
+    private sealed record CheckConstraintShape(bool IsDisabled, bool IsNotTrusted);
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Deploy/DatabaseDeploy.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Deploy/DatabaseDeploy.cs
@@ -5,12 +5,29 @@
 
 using System.Reflection;
 using DbUp;
+using DbUp.Builder;
+using DbUp.Engine.Output;
 using EdFi.DmsConfigurationService.Backend.Deploy;
 
 namespace EdFi.DmsConfigurationService.Backend.Mssql.Deploy;
 
+/// <summary>
+/// Deploys the CMS administrative database.
+/// </summary>
+/// <remarks>
+/// <see cref="ScriptOutputLog"/> exists so integration tests can observe the script output that
+/// <c>LogScriptOutput</c> captures, which is the only channel an upgrade script has for diagnostics
+/// too large to fit in the thrown error. It is internal and unset in production, where logging stays
+/// on the autodetected log.
+/// </remarks>
 public class DatabaseDeploy : IDatabaseDeploy
 {
+    /// <summary>
+    /// When set, script output is additionally written here. Tests use it to read the complete
+    /// upgrade diagnostics; production leaves it null.
+    /// </summary>
+    internal IUpgradeLog? ScriptOutputLog { get; init; }
+
     public DatabaseDeployResult DeployDatabase(string connectionString)
     {
         try
@@ -22,14 +39,20 @@ public class DatabaseDeploy : IDatabaseDeploy
             return new DatabaseDeployResult.DatabaseDeployFailure(e);
         }
 
-        var upgrader = DeployChanges
+        UpgradeEngineBuilder builder = DeployChanges
             .To.SqlDatabase(connectionString)
             .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
             .JournalToSqlTable("dbo", "dmscs_SchemaVersions")
             .WithVariablesDisabled()
             .LogScriptOutput()
-            .LogToAutodetectedLog()
-            .Build();
+            .LogToAutodetectedLog();
+
+        if (ScriptOutputLog is not null)
+        {
+            builder = builder.LogTo(ScriptOutputLog);
+        }
+
+        var upgrader = builder.Build();
 
         if (!upgrader.TryConnect(out string error))
         {

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
@@ -19,7 +19,7 @@
 -- The invalid-type preflight below negates this same expression, so a value the check constraint
 -- would reject is always diagnosed by the preflight first.
 
-DECLARE @messageLimit INT = 2048;
+DECLARE @messageLimit INT = 2047;
 DECLARE @markerReserve INT = 30;
 DECLARE @remediation NVARCHAR(400) =
     N'Correct an invalid DerivativeType with PUT /v3/dataStoreDerivatives/{id}, or remove an unwanted row with DELETE /v3/dataStoreDerivatives/{id}, then retry the upgrade. Allowed values are exactly ''Snapshot'' and ''ReadReplica''.';
@@ -33,10 +33,13 @@ DECLARE @duplicateHeader NVARCHAR(200);
 DECLARE @invalidHeader NVARCHAR(200);
 DECLARE @conditions INT;
 DECLARE @perCondition INT;
--- Declared at the thrown limit rather than MAX, so an assembly bug surfaces as a loud truncation
--- error instead of silently shortening the diagnostics. Character counts throughout use
--- DATALENGTH/2, never LEN, because LEN ignores trailing spaces and would undercount.
-DECLARE @message NVARCHAR(2048) = N'';
+-- Declared at the thrown limit. That limit is a silent one in both directions: assigning a longer
+-- string to a declared NVARCHAR(n) truncates without raising, and THROW itself delivers at most
+-- 2047 characters. Nothing reports an over-long message, so the tuple budget computed below is the
+-- only thing keeping the thrown text whole, and the result sets emitted above are what guarantee
+-- every offender is still reported. Character counts throughout use DATALENGTH/2, never LEN,
+-- because LEN ignores trailing spaces and would undercount.
+DECLARE @message NVARCHAR(2047) = N'';
 
 -- Duplicate detection deliberately uses the plain columns, which is the equality the unique
 -- constraint itself will apply, including the case and padding insensitivity of the column's own
@@ -58,6 +61,33 @@ WHERE NOT (
     (DerivativeType COLLATE Latin1_General_100_BIN2 = N'Snapshot' AND DATALENGTH(DerivativeType) = 16)
     OR (DerivativeType COLLATE Latin1_General_100_BIN2 = N'ReadReplica' AND DATALENGTH(DerivativeType) = 22)
 );
+
+-- The thrown error carries only a bounded sample, because THROW delivers at most 2047 characters.
+-- These two statements carry the complete offender sets instead. DbUp's LogScriptOutput writes
+-- every result set a script returns to the deployment log, and it does so as the reader is
+-- consumed, so rows emitted here reach the operator even though the batch aborts below. On a
+-- conforming database both statements return no rows. Ordering is deterministic and the tuple
+-- shapes match the thrown diagnostics exactly.
+SELECT CONCAT(N'(', candidate.DataStoreId, N', ', candidate.DerivativeType, N', ', candidate.Id, N')')
+    AS DuplicateDataStoreDerivative
+FROM dmscs.DataStoreDerivative candidate
+WHERE EXISTS (
+    SELECT 1
+    FROM dmscs.DataStoreDerivative other
+    WHERE other.DataStoreId = candidate.DataStoreId
+      AND other.DerivativeType = candidate.DerivativeType
+      AND other.Id <> candidate.Id
+)
+ORDER BY candidate.DataStoreId, candidate.DerivativeType, candidate.Id;
+
+SELECT CONCAT(N'(', Id, N', ', DataStoreId, N', ''', DerivativeType, N''')')
+    AS InvalidDataStoreDerivativeType
+FROM dmscs.DataStoreDerivative
+WHERE NOT (
+    (DerivativeType COLLATE Latin1_General_100_BIN2 = N'Snapshot' AND DATALENGTH(DerivativeType) = 16)
+    OR (DerivativeType COLLATE Latin1_General_100_BIN2 = N'ReadReplica' AND DATALENGTH(DerivativeType) = 22)
+)
+ORDER BY Id;
 
 IF @duplicateTotal > 0 OR @invalidTotal > 0
 BEGIN

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
@@ -1,0 +1,211 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+-- Enforce at most one derivative of each type per data store, and restrict DerivativeType to
+-- exactly 'Snapshot' or 'ReadReplica'. Both constraints are added WITH CHECK, so legacy rows that
+-- violate either one would otherwise fail the upgrade with a bare constraint-violation error. The
+-- preflight below runs first and stops the upgrade with the offending tuples and remediation
+-- guidance instead. It never deletes a row, rewrites a type, or chooses among duplicates.
+--
+-- The whole script is a single batch with no GO, so a raised error aborts everything after it.
+--
+-- The allowed-value test states its comparison semantics rather than inheriting the database or
+-- column collation: DerivativeType is NVARCHAR under a typically case-insensitive collation, and
+-- SQL Server applies SQL-92 padding to = and IN at any collation, so 'SNAPSHOT' and 'Snapshot '
+-- would both pass a naive IN check. Latin1_General_100_BIN2 makes the comparison ordinal and
+-- DATALENGTH makes the stored length exact; LEN is unusable because it ignores trailing spaces.
+-- The invalid-type preflight below negates this same expression, so a value the check constraint
+-- would reject is always diagnosed by the preflight first.
+
+DECLARE @messageLimit INT = 2048;
+DECLARE @markerReserve INT = 30;
+DECLARE @remediation NVARCHAR(400) =
+    N'Correct an invalid DerivativeType with PUT /v3/dataStoreDerivatives/{id}, or remove an unwanted row with DELETE /v3/dataStoreDerivatives/{id}, then retry the upgrade. Allowed values are exactly ''Snapshot'' and ''ReadReplica''.';
+DECLARE @duplicateTotal INT;
+DECLARE @invalidTotal INT;
+DECLARE @duplicateShown INT = 0;
+DECLARE @invalidShown INT = 0;
+DECLARE @duplicateList NVARCHAR(MAX);
+DECLARE @invalidList NVARCHAR(MAX);
+DECLARE @duplicateHeader NVARCHAR(200);
+DECLARE @invalidHeader NVARCHAR(200);
+DECLARE @conditions INT;
+DECLARE @perCondition INT;
+-- Declared at the thrown limit rather than MAX, so an assembly bug surfaces as a loud truncation
+-- error instead of silently shortening the diagnostics. Character counts throughout use
+-- DATALENGTH/2, never LEN, because LEN ignores trailing spaces and would undercount.
+DECLARE @message NVARCHAR(2048) = N'';
+
+-- Duplicate detection deliberately uses the plain columns, which is the equality the unique
+-- constraint itself will apply, including the case and padding insensitivity of the column's own
+-- collation. Forcing a binary comparison here would make the preflight less predictive than the
+-- constraint it protects.
+SELECT @duplicateTotal = COUNT(*)
+FROM dmscs.DataStoreDerivative candidate
+WHERE EXISTS (
+    SELECT 1
+    FROM dmscs.DataStoreDerivative other
+    WHERE other.DataStoreId = candidate.DataStoreId
+      AND other.DerivativeType = candidate.DerivativeType
+      AND other.Id <> candidate.Id
+);
+
+SELECT @invalidTotal = COUNT(*)
+FROM dmscs.DataStoreDerivative
+WHERE NOT (
+    (DerivativeType COLLATE Latin1_General_100_BIN2 = N'Snapshot' AND DATALENGTH(DerivativeType) = 16)
+    OR (DerivativeType COLLATE Latin1_General_100_BIN2 = N'ReadReplica' AND DATALENGTH(DerivativeType) = 22)
+);
+
+IF @duplicateTotal > 0 OR @invalidTotal > 0
+BEGIN
+    SET @duplicateHeader = CONCAT(
+        N'DataStoreDerivative upgrade blocked: ',
+        @duplicateTotal,
+        N' duplicate (DataStoreId, DerivativeType) row(s): '
+    );
+    SET @invalidHeader = CONCAT(
+        N'DataStoreDerivative upgrade blocked: ',
+        @invalidTotal,
+        N' row(s) with an invalid DerivativeType: '
+    );
+
+    -- The tuple budget is computed before either list is built, so the assembled message is within
+    -- the limit by construction and is never truncated afterwards.
+    SET @conditions = (CASE WHEN @duplicateTotal > 0 THEN 1 ELSE 0 END)
+        + (CASE WHEN @invalidTotal > 0 THEN 1 ELSE 0 END);
+    SET @perCondition = (
+        @messageLimit - DATALENGTH(@remediation) / 2 - 2
+        - (CASE WHEN @duplicateTotal > 0 THEN DATALENGTH(@duplicateHeader) / 2 + @markerReserve ELSE 0 END)
+        - (CASE WHEN @invalidTotal > 0 THEN DATALENGTH(@invalidHeader) / 2 + @markerReserve ELSE 0 END)
+    ) / @conditions;
+
+    IF @perCondition < 0
+        SET @perCondition = 0;
+
+    IF @duplicateTotal > 0
+    BEGIN
+        WITH duplicate_rows AS (
+            SELECT candidate.DataStoreId, candidate.DerivativeType, candidate.Id
+            FROM dmscs.DataStoreDerivative candidate
+            WHERE EXISTS (
+                SELECT 1
+                FROM dmscs.DataStoreDerivative other
+                WHERE other.DataStoreId = candidate.DataStoreId
+                  AND other.DerivativeType = candidate.DerivativeType
+                  AND other.Id <> candidate.Id
+            )
+        ),
+        ordered AS (
+            SELECT
+                CAST(
+                    CONCAT(N'(', DataStoreId, N', ', DerivativeType, N', ', Id, N')') AS NVARCHAR(MAX)
+                ) AS TupleText,
+                ROW_NUMBER() OVER (ORDER BY DataStoreId, DerivativeType, Id) AS Position
+            FROM duplicate_rows
+        ),
+        measured AS (
+            SELECT
+                TupleText,
+                Position,
+                SUM(DATALENGTH(TupleText) / 2 + 2) OVER (ORDER BY Position ROWS UNBOUNDED PRECEDING) AS Used
+            FROM ordered
+        )
+        SELECT
+            @duplicateList = STRING_AGG(TupleText, N', ') WITHIN GROUP (ORDER BY Position),
+            @duplicateShown = COUNT(*)
+        FROM measured
+        WHERE Position <= 20
+          AND (Position = 1 OR Used <= @perCondition);
+
+        SET @message = CONCAT(@message, @duplicateHeader, @duplicateList);
+        SET @message = @message
+            + CASE
+                WHEN @duplicateTotal > @duplicateShown
+                    THEN CONCAT(N', ... and ', @duplicateTotal - @duplicateShown, N' more.')
+                ELSE N'.'
+            END
+            + N' ';
+    END;
+
+    IF @invalidTotal > 0
+    BEGIN
+        WITH invalid_rows AS (
+            SELECT Id, DataStoreId, DerivativeType
+            FROM dmscs.DataStoreDerivative
+            WHERE NOT (
+                (DerivativeType COLLATE Latin1_General_100_BIN2 = N'Snapshot' AND DATALENGTH(DerivativeType) = 16)
+                OR (DerivativeType COLLATE Latin1_General_100_BIN2 = N'ReadReplica' AND DATALENGTH(DerivativeType) = 22)
+            )
+        ),
+        ordered AS (
+            SELECT
+                -- The type value is quoted so trailing whitespace is visible to the operator.
+                CAST(
+                    CONCAT(N'(', Id, N', ', DataStoreId, N', ''', DerivativeType, N''')') AS NVARCHAR(MAX)
+                ) AS TupleText,
+                ROW_NUMBER() OVER (ORDER BY Id) AS Position
+            FROM invalid_rows
+        ),
+        measured AS (
+            SELECT
+                TupleText,
+                Position,
+                SUM(DATALENGTH(TupleText) / 2 + 2) OVER (ORDER BY Position ROWS UNBOUNDED PRECEDING) AS Used
+            FROM ordered
+        )
+        SELECT
+            @invalidList = STRING_AGG(TupleText, N', ') WITHIN GROUP (ORDER BY Position),
+            @invalidShown = COUNT(*)
+        FROM measured
+        WHERE Position <= 20
+          AND (Position = 1 OR Used <= @perCondition);
+
+        SET @message = CONCAT(@message, @invalidHeader, @invalidList);
+        SET @message = @message
+            + CASE
+                WHEN @invalidTotal > @invalidShown
+                    THEN CONCAT(N', ... and ', @invalidTotal - @invalidShown, N' more.')
+                ELSE N'.'
+            END
+            + N' ';
+    END;
+
+    SET @message = @message + @remediation;
+
+    THROW 50000, @message, 1;
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.objects
+    WHERE name = 'UX_DataStoreDerivative_DataStoreId_DerivativeType'
+      AND parent_object_id = OBJECT_ID('dmscs.DataStoreDerivative')
+)
+    ALTER TABLE dmscs.DataStoreDerivative
+        ADD CONSTRAINT UX_DataStoreDerivative_DataStoreId_DerivativeType UNIQUE (DataStoreId, DerivativeType);
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.check_constraints
+    WHERE name = 'CK_DataStoreDerivative_DerivativeType'
+      AND parent_object_id = OBJECT_ID('dmscs.DataStoreDerivative')
+)
+    ALTER TABLE dmscs.DataStoreDerivative
+        ADD CONSTRAINT CK_DataStoreDerivative_DerivativeType CHECK (
+            (DerivativeType COLLATE Latin1_General_100_BIN2 = N'Snapshot' AND DATALENGTH(DerivativeType) = 16)
+            OR (DerivativeType COLLATE Latin1_General_100_BIN2 = N'ReadReplica' AND DATALENGTH(DerivativeType) = 22)
+        );
+
+-- The unique constraint's backing index leads with DataStoreId, so it serves the parent lookup and
+-- the child-side foreign-key maintenance that this narrower index served. Dropped only after the
+-- constraint above is in place.
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_DataStoreDerivative_DataStoreId'
+      AND object_id = OBJECT_ID('dmscs.DataStoreDerivative')
+)
+    DROP INDEX IX_DataStoreDerivative_DataStoreId ON dmscs.DataStoreDerivative;

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
@@ -36,7 +36,7 @@ DECLARE @perCondition INT;
 -- Declared at the thrown limit. That limit is a silent one in both directions: assigning a longer
 -- string to a declared NVARCHAR(n) truncates without raising, and THROW itself delivers at most
 -- 2047 characters. Nothing reports an over-long message, so the tuple budget computed below is the
--- only thing keeping the thrown text whole, and the result sets emitted above are what guarantee
+-- only thing keeping the thrown text whole, and the result sets emitted below are what guarantee
 -- every offender is still reported. Character counts throughout use DATALENGTH/2, never LEN,
 -- because LEN ignores trailing spaces and would undercount.
 DECLARE @message NVARCHAR(2047) = N'';

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/DataStoreDerivativeRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/DataStoreDerivativeRepository.cs
@@ -6,6 +6,7 @@
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
+using EdFi.DmsConfigurationService.DataModel;
 using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStoreDerivative;
@@ -85,6 +86,20 @@ public class DataStoreDerivativeRepository(
         {
             logger.LogWarning(ex, "Data store not found");
             return new DataStoreDerivativeInsertResult.FailureForeignKeyViolation();
+        }
+        catch (SqlException ex)
+            when (ex.IsUniqueViolation("UX_DataStoreDerivative_DataStoreId_DerivativeType"))
+        {
+            logger.LogWarning(
+                ex,
+                "Data store derivative already exists for DataStoreId '{DataStoreId}' and DerivativeType '{DerivativeType}'",
+                command.DataStoreId,
+                LoggingUtility.SanitizeForLog(command.DerivativeType)
+            );
+            return new DataStoreDerivativeInsertResult.FailureDuplicateDataStoreDerivative(
+                command.DataStoreId,
+                command.DerivativeType
+            );
         }
         catch (Exception ex)
         {
@@ -236,6 +251,20 @@ public class DataStoreDerivativeRepository(
         {
             logger.LogWarning(ex, "Data store not found");
             return new DataStoreDerivativeUpdateResult.FailureForeignKeyViolation();
+        }
+        catch (SqlException ex)
+            when (ex.IsUniqueViolation("UX_DataStoreDerivative_DataStoreId_DerivativeType"))
+        {
+            logger.LogWarning(
+                ex,
+                "Data store derivative already exists for DataStoreId '{DataStoreId}' and DerivativeType '{DerivativeType}'",
+                command.DataStoreId,
+                LoggingUtility.SanitizeForLog(command.DerivativeType)
+            );
+            return new DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative(
+                command.DataStoreId,
+                command.DerivativeType
+            );
         }
         catch (Exception ex)
         {

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeTests.cs
@@ -436,30 +436,37 @@ public class DataStoreDerivativeTests : DatabaseTest
     [TestFixture]
     public class QueryPagingTests : DataStoreDerivativeTests
     {
+        /// <summary>
+        /// A data store holds at most one derivative of each type, and only the two real type names
+        /// are storable, so a four-row paging set spans two data stores.
+        /// </summary>
         [SetUp]
         public async Task Setup()
         {
-            var instanceResult = await _instanceRepository.InsertDataStore(
-                new DataStoreInsertCommand
-                {
-                    DataStoreType = "Production",
-                    Name = "Paging Parent Instance",
-                    ConnectionString = "Server=parent;Database=ParentDb;",
-                }
-            );
-            var dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
-
-            foreach (var derivativeType in new[] { "Alpha", "Bravo", "Charlie" })
+            foreach (var name in new[] { "Paging Parent Instance A", "Paging Parent Instance B" })
             {
-                var insertResult = await _repository.InsertDataStoreDerivative(
-                    new DataStoreDerivativeInsertCommand
+                var instanceResult = await _instanceRepository.InsertDataStore(
+                    new DataStoreInsertCommand
                     {
-                        DataStoreId = dataStoreId,
-                        DerivativeType = derivativeType,
-                        ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+                        DataStoreType = "Production",
+                        Name = name,
+                        ConnectionString = "Server=parent;Database=ParentDb;",
                     }
                 );
-                insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+                var dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
+
+                foreach (var derivativeType in new[] { "ReadReplica", "Snapshot" })
+                {
+                    var insertResult = await _repository.InsertDataStoreDerivative(
+                        new DataStoreDerivativeInsertCommand
+                        {
+                            DataStoreId = dataStoreId,
+                            DerivativeType = derivativeType,
+                            ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+                        }
+                    );
+                    insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+                }
             }
         }
 
@@ -470,7 +477,7 @@ public class DataStoreDerivativeTests : DatabaseTest
             getResult.Should().BeOfType<DataStoreDerivativeQueryResult.Success>();
             ((DataStoreDerivativeQueryResult.Success)getResult)
                 .DataStoreDerivativeResponses.Should()
-                .HaveCount(3);
+                .HaveCount(4);
         }
 
         [Test]
@@ -490,37 +497,45 @@ public class DataStoreDerivativeTests : DatabaseTest
             getResult.Should().BeOfType<DataStoreDerivativeQueryResult.Success>();
             ((DataStoreDerivativeQueryResult.Success)getResult)
                 .DataStoreDerivativeResponses.Should()
-                .HaveCount(2);
+                .HaveCount(3);
         }
     }
 
     [TestFixture]
     public class QuerySortTests : DataStoreDerivativeTests
     {
+        /// <summary>
+        /// Two data stores, each holding both storable derivative types, so ordering has ties to
+        /// resolve. Rows are inserted in reverse of the expected ascending order, so the assertion
+        /// proves the ORDER BY clause rather than the insertion order.
+        /// </summary>
         [SetUp]
         public async Task Setup()
         {
-            var instanceResult = await _instanceRepository.InsertDataStore(
-                new DataStoreInsertCommand
-                {
-                    DataStoreType = "Production",
-                    Name = "Sort Parent Instance",
-                    ConnectionString = "Server=parent;Database=ParentDb;",
-                }
-            );
-            var dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
-
-            foreach (var derivativeType in new[] { "Charlie", "Alpha", "Bravo" })
+            foreach (var name in new[] { "Sort Parent Instance A", "Sort Parent Instance B" })
             {
-                var insertResult = await _repository.InsertDataStoreDerivative(
-                    new DataStoreDerivativeInsertCommand
+                var instanceResult = await _instanceRepository.InsertDataStore(
+                    new DataStoreInsertCommand
                     {
-                        DataStoreId = dataStoreId,
-                        DerivativeType = derivativeType,
-                        ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+                        DataStoreType = "Production",
+                        Name = name,
+                        ConnectionString = "Server=parent;Database=ParentDb;",
                     }
                 );
-                insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+                var dataStoreId = ((DataStoreInsertResult.Success)instanceResult).Id;
+
+                foreach (var derivativeType in new[] { "Snapshot", "ReadReplica" })
+                {
+                    var insertResult = await _repository.InsertDataStoreDerivative(
+                        new DataStoreDerivativeInsertCommand
+                        {
+                            DataStoreId = dataStoreId,
+                            DerivativeType = derivativeType,
+                            ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+                        }
+                    );
+                    insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+                }
             }
         }
 
@@ -534,7 +549,7 @@ public class DataStoreDerivativeTests : DatabaseTest
             var derivativeTypes = ((DataStoreDerivativeQueryResult.Success)getResult)
                 .DataStoreDerivativeResponses.Select(d => d.DerivativeType)
                 .ToList();
-            derivativeTypes.Should().ContainInOrder("Alpha", "Bravo", "Charlie");
+            derivativeTypes.Should().ContainInOrder("ReadReplica", "ReadReplica", "Snapshot", "Snapshot");
         }
 
         [Test]
@@ -547,7 +562,7 @@ public class DataStoreDerivativeTests : DatabaseTest
             var derivativeTypes = ((DataStoreDerivativeQueryResult.Success)getResult)
                 .DataStoreDerivativeResponses.Select(d => d.DerivativeType)
                 .ToList();
-            derivativeTypes.Should().ContainInOrder("Charlie", "Bravo", "Alpha");
+            derivativeTypes.Should().ContainInOrder("Snapshot", "Snapshot", "ReadReplica", "ReadReplica");
         }
     }
 

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeTests.cs
@@ -56,6 +56,34 @@ public class DataStoreDerivativeTests : DatabaseTest
         );
     }
 
+    private async Task<int> InsertParentDataStore(string name)
+    {
+        var instanceResult = await _instanceRepository.InsertDataStore(
+            new DataStoreInsertCommand
+            {
+                DataStoreType = "Production",
+                Name = name,
+                ConnectionString = "Server=parent;Database=ParentDb;",
+            }
+        );
+
+        return instanceResult.Should().BeOfType<DataStoreInsertResult.Success>().Subject.Id;
+    }
+
+    private async Task<int> InsertDerivative(int dataStoreId, string derivativeType)
+    {
+        var insertResult = await _repository.InsertDataStoreDerivative(
+            new DataStoreDerivativeInsertCommand
+            {
+                DataStoreId = dataStoreId,
+                DerivativeType = derivativeType,
+                ConnectionString = $"Server={derivativeType};Database={derivativeType}Db;",
+            }
+        );
+
+        return insertResult.Should().BeOfType<DataStoreDerivativeInsertResult.Success>().Subject.Id;
+    }
+
     [TestFixture]
     public class Given_insert_data_store_derivative : DataStoreDerivativeTests
     {
@@ -894,6 +922,207 @@ public class DataStoreDerivativeTests : DatabaseTest
             var singleTenantRepository = CreateDerivativeRepository(new TenantContextProvider());
             var result = await singleTenantRepository.GetDataStoreDerivative(_tenantADerivativeId);
             result.Should().BeOfType<DataStoreDerivativeGetResult.FailureNotFound>();
+        }
+    }
+
+    [TestFixture]
+    public class Given_a_data_store_with_both_derivative_types : DataStoreDerivativeTests
+    {
+        private int _dataStoreId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _dataStoreId = await InsertParentDataStore("Both Types Parent Instance");
+
+            await InsertDerivative(_dataStoreId, "Snapshot");
+            await InsertDerivative(_dataStoreId, "ReadReplica");
+        }
+
+        [Test]
+        public async Task It_should_store_one_derivative_of_each_type()
+        {
+            var getResult = await _repository.GetDataStoreDerivativesByDataStore(_dataStoreId);
+
+            string[] expectedDerivativeTypes = ["ReadReplica", "Snapshot"];
+
+            var derivatives = getResult
+                .Should()
+                .BeOfType<DataStoreDerivativeQueryByDataStoreResult.Success>()
+                .Subject.DataStoreDerivativeResponses;
+            derivatives
+                .Select(derivative => derivative.DerivativeType)
+                .Should()
+                .BeEquivalentTo(expectedDerivativeTypes);
+        }
+    }
+
+    [TestFixture]
+    public class Given_insert_of_a_duplicate_derivative_type : DataStoreDerivativeTests
+    {
+        private int _dataStoreId;
+        private DataStoreDerivativeInsertResult _duplicateResult = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _dataStoreId = await InsertParentDataStore("Duplicate Insert Parent Instance");
+            await InsertDerivative(_dataStoreId, "Snapshot");
+
+            _duplicateResult = await _repository.InsertDataStoreDerivative(
+                new DataStoreDerivativeInsertCommand
+                {
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = "Snapshot",
+                    ConnectionString = "Server=second;Database=SecondDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_should_return_failure_duplicate_data_store_derivative() =>
+            _duplicateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeInsertResult.FailureDuplicateDataStoreDerivative>();
+
+        [Test]
+        public void It_should_carry_the_conflicting_data_store_and_derivative_type()
+        {
+            var duplicate = _duplicateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeInsertResult.FailureDuplicateDataStoreDerivative>()
+                .Subject;
+
+            duplicate.DataStoreId.Should().Be(_dataStoreId);
+            duplicate.DerivativeType.Should().Be("Snapshot");
+        }
+
+        [Test]
+        public async Task It_should_leave_only_the_original_derivative()
+        {
+            var getResult = await _repository.GetDataStoreDerivativesByDataStore(_dataStoreId);
+
+            getResult
+                .Should()
+                .BeOfType<DataStoreDerivativeQueryByDataStoreResult.Success>()
+                .Subject.DataStoreDerivativeResponses.Should()
+                .HaveCount(1);
+        }
+    }
+
+    [TestFixture]
+    public class Given_update_changing_derivative_type_to_an_existing_sibling : DataStoreDerivativeTests
+    {
+        private int _dataStoreId;
+        private int _replicaId;
+        private DataStoreDerivativeUpdateResult _updateResult = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _dataStoreId = await InsertParentDataStore("Update Type Conflict Parent Instance");
+            await InsertDerivative(_dataStoreId, "Snapshot");
+            _replicaId = await InsertDerivative(_dataStoreId, "ReadReplica");
+
+            _updateResult = await _repository.UpdateDataStoreDerivative(
+                new DataStoreDerivativeUpdateCommand
+                {
+                    Id = _replicaId,
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = "Snapshot",
+                    ConnectionString = "Server=conflict;Database=ConflictDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_should_return_failure_duplicate_data_store_derivative() =>
+            _updateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative>();
+
+        [Test]
+        public void It_should_carry_the_conflicting_data_store_and_derivative_type()
+        {
+            var duplicate = _updateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative>()
+                .Subject;
+
+            duplicate.DataStoreId.Should().Be(_dataStoreId);
+            duplicate.DerivativeType.Should().Be("Snapshot");
+        }
+
+        [Test]
+        public async Task It_should_leave_the_derivative_type_unchanged()
+        {
+            var getResult = await _repository.GetDataStoreDerivative(_replicaId);
+
+            getResult
+                .Should()
+                .BeOfType<DataStoreDerivativeGetResult.Success>()
+                .Subject.DataStoreDerivativeResponse.DerivativeType.Should()
+                .Be("ReadReplica");
+        }
+    }
+
+    [TestFixture]
+    public class Given_update_moving_a_derivative_to_a_data_store_that_already_has_the_type
+        : DataStoreDerivativeTests
+    {
+        private int _targetDataStoreId;
+        private int _sourceDataStoreId;
+        private int _movedDerivativeId;
+        private DataStoreDerivativeUpdateResult _updateResult = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _targetDataStoreId = await InsertParentDataStore("Move Conflict Target Instance");
+            _sourceDataStoreId = await InsertParentDataStore("Move Conflict Source Instance");
+
+            await InsertDerivative(_targetDataStoreId, "Snapshot");
+            _movedDerivativeId = await InsertDerivative(_sourceDataStoreId, "Snapshot");
+
+            _updateResult = await _repository.UpdateDataStoreDerivative(
+                new DataStoreDerivativeUpdateCommand
+                {
+                    Id = _movedDerivativeId,
+                    DataStoreId = _targetDataStoreId,
+                    DerivativeType = "Snapshot",
+                    ConnectionString = "Server=moved;Database=MovedDb;",
+                }
+            );
+        }
+
+        [Test]
+        public void It_should_return_failure_duplicate_data_store_derivative() =>
+            _updateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative>();
+
+        [Test]
+        public void It_should_carry_the_target_data_store_and_derivative_type()
+        {
+            var duplicate = _updateResult
+                .Should()
+                .BeOfType<DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative>()
+                .Subject;
+
+            duplicate.DataStoreId.Should().Be(_targetDataStoreId);
+            duplicate.DerivativeType.Should().Be("Snapshot");
+        }
+
+        [Test]
+        public async Task It_should_leave_the_derivative_on_its_original_data_store()
+        {
+            var getResult = await _repository.GetDataStoreDerivative(_movedDerivativeId);
+
+            getResult
+                .Should()
+                .BeOfType<DataStoreDerivativeGetResult.Success>()
+                .Subject.DataStoreDerivativeResponse.DataStoreId.Should()
+                .Be(_sourceDataStoreId);
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeUpgradeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeUpgradeTests.cs
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Dapper;
+using EdFi.DmsConfigurationService.Backend.Deploy;
+using FluentAssertions;
+using Npgsql;
+
+namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Exercises the DataStoreDerivative invariants upgrade against a journaled pre-upgrade database,
+/// which is the state a real deployment upgrades from. Each test reverts the isolated database to
+/// that state, seeds legacy rows directly with SQL so the API validator cannot filter them, and runs
+/// the deploy again so only the invariants script executes. Replaying every script instead would let
+/// a non-replay-safe earlier script decide the outcome.
+/// </summary>
+[TestFixture]
+public class Given_a_legacy_DataStoreDerivative_PostgreSQL_upgrade
+{
+    private const string JournalPattern = "%0028_Add_DataStoreDerivative_Invariants%";
+    private const string RemediationPut = "PUT /v3/dataStoreDerivatives/{id}";
+    private const string RemediationDelete = "DELETE /v3/dataStoreDerivatives/{id}";
+    private const string AllowedValues = "Allowed values are exactly 'Snapshot' and 'ReadReplica'.";
+
+    private string _databaseName = string.Empty;
+    private string _connectionString = string.Empty;
+    private int _firstDataStoreId;
+    private int _secondDataStoreId;
+    private int _thirdDataStoreId;
+    private int _fourthDataStoreId;
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        _connectionString = CreateIsolatedDatabaseConnectionString();
+        DeploySuccessfully();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTeardown()
+    {
+        if (string.IsNullOrEmpty(_databaseName))
+        {
+            return;
+        }
+
+        await using NpgsqlConnection connection = new(CreateMaintenanceConnectionString());
+        await connection.OpenAsync();
+        await connection.ExecuteAsync($"""DROP DATABASE IF EXISTS "{_databaseName}" WITH (FORCE);""");
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await RevertToPreUpgradeStateAsync();
+
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        _firstDataStoreId = await InsertDataStoreAsync(connection, "Legacy Data Store A");
+        _secondDataStoreId = await InsertDataStoreAsync(connection, "Legacy Data Store B");
+        _thirdDataStoreId = await InsertDataStoreAsync(connection, "Legacy Data Store C");
+        _fourthDataStoreId = await InsertDataStoreAsync(connection, "Legacy Data Store D");
+    }
+
+    [Test]
+    public async Task It_should_upgrade_a_conforming_legacy_database_and_replace_the_redundant_index()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot");
+        await InsertDerivativeAsync(connection, _firstDataStoreId, "ReadReplica");
+        await InsertDerivativeAsync(connection, _secondDataStoreId, "Snapshot");
+
+        DatabaseDeployResult result = Deploy();
+
+        result.Should().BeOfType<DatabaseDeployResult.DatabaseDeploySuccess>();
+
+        int journaledUpgrades = await connection.ExecuteScalarAsync<int>(
+            """SELECT count(*) FROM public."dmscs_SchemaVersions" WHERE scriptname LIKE @Pattern;""",
+            new { Pattern = JournalPattern }
+        );
+        journaledUpgrades.Should().Be(1, "the upgrade script is journaled exactly once");
+
+        (await ConstraintExistsAsync(connection, "UX_DataStoreDerivative_DataStoreId_DerivativeType"))
+            .Should()
+            .BeTrue();
+        (await ConstraintExistsAsync(connection, "CK_DataStoreDerivative_DerivativeType")).Should().BeTrue();
+
+        string[] uniqueKeyColumns = (
+            await connection.QueryAsync<string>(UniqueConstraintColumnsSql)
+        ).ToArray();
+        uniqueKeyColumns.Should().Equal("DataStoreId", "DerivativeType");
+
+        int redundantIndexes = await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT count(*)
+            FROM pg_index index_catalog
+            JOIN pg_class index_info ON index_info.oid = index_catalog.indexrelid
+            WHERE index_info.relname = 'IX_DataStoreDerivative_DataStoreId';
+            """
+        );
+        redundantIndexes.Should().Be(0, "the unique constraint's backing index leads with DataStoreId");
+    }
+
+    [Test]
+    public async Task It_should_accept_the_exact_allowed_values_and_reject_variants_after_the_upgrade()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        Deploy().Should().BeOfType<DatabaseDeployResult.DatabaseDeploySuccess>();
+
+        await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot");
+        await InsertDerivativeAsync(connection, _firstDataStoreId, "ReadReplica");
+
+        (await TryInsertDerivativeAsync(connection, _secondDataStoreId, "SNAPSHOT"))
+            .Should()
+            .Be(PostgresErrorCodes.CheckViolation, "the check constraint compares ordinally");
+        (await TryInsertDerivativeAsync(connection, _secondDataStoreId, "Snapshot "))
+            .Should()
+            .Be(PostgresErrorCodes.CheckViolation, "the check constraint compares stored length exactly");
+        (await TryInsertDerivativeAsync(connection, _secondDataStoreId, "Replica"))
+            .Should()
+            .Be(PostgresErrorCodes.CheckViolation);
+        (await TryInsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot"))
+            .Should()
+            .Be(PostgresErrorCodes.UniqueViolation, "a data store holds at most one derivative per type");
+    }
+
+    [Test]
+    public async Task It_should_block_the_upgrade_when_duplicate_rows_exist()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        int firstId = await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot");
+        int secondId = await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot");
+        await InsertDerivativeAsync(connection, _secondDataStoreId, "ReadReplica");
+
+        string message = DeployFailureMessage();
+
+        message.Should().Contain("2 duplicate (DataStoreId, DerivativeType) row(s)");
+        message.Should().Contain($"({_firstDataStoreId}, Snapshot, {firstId})");
+        message.Should().Contain($"({_firstDataStoreId}, Snapshot, {secondId})");
+        message.Should().Contain(RemediationPut);
+        message.Should().Contain(RemediationDelete);
+        message.Should().Contain(AllowedValues);
+        message
+            .Should()
+            .NotContain(
+                "row(s) with an invalid DerivativeType",
+                "no invalid-type condition is present; the remediation text names the term either way"
+            );
+    }
+
+    [Test]
+    public async Task It_should_block_the_upgrade_when_an_invalid_type_exists()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        int invalidId = await InsertDerivativeAsync(connection, _firstDataStoreId, "Replica");
+
+        string message = DeployFailureMessage();
+
+        message.Should().Contain("1 row(s) with an invalid DerivativeType");
+        message.Should().Contain($"({invalidId}, {_firstDataStoreId}, 'Replica')");
+        message.Should().Contain(RemediationPut);
+        message.Should().Contain(RemediationDelete);
+        message.Should().Contain(AllowedValues);
+    }
+
+    [Test]
+    public async Task It_should_block_the_upgrade_when_a_case_variant_exists()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        int caseVariantId = await InsertDerivativeAsync(connection, _firstDataStoreId, "SNAPSHOT");
+
+        string message = DeployFailureMessage();
+
+        message.Should().Contain("1 row(s) with an invalid DerivativeType");
+        message.Should().Contain($"({caseVariantId}, {_firstDataStoreId}, 'SNAPSHOT')");
+    }
+
+    [Test]
+    public async Task It_should_block_the_upgrade_when_a_trailing_whitespace_variant_exists()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        int paddedId = await InsertDerivativeAsync(connection, _firstDataStoreId, "Snapshot ");
+
+        string message = DeployFailureMessage();
+
+        message.Should().Contain("1 row(s) with an invalid DerivativeType");
+        message
+            .Should()
+            .Contain(
+                $"({paddedId}, {_firstDataStoreId}, 'Snapshot ')",
+                "quoting the value is what makes the trailing space visible to an operator"
+            );
+    }
+
+    [Test]
+    public async Task It_should_keep_every_mandatory_diagnostic_section_at_high_cardinality()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        // Seeded first so it leads the invalid-type ordering and is therefore one of the tuples the
+        // capped list must still carry. Hosted alone on a data store that holds no other row, so it
+        // is a duplicate under neither engine's own equality - SQL Server's padded, case-insensitive
+        // comparison would otherwise make it a duplicate of a Snapshot sibling and the two providers
+        // could not assert the same totals.
+        int paddedId = await InsertDerivativeAsync(connection, _fourthDataStoreId, "Snapshot ");
+
+        for (int row = 0; row < 30; row++)
+        {
+            await InsertDerivativeAsync(connection, _firstDataStoreId, WidestInvalidType(row));
+        }
+
+        int[] duplicateHosts = [_firstDataStoreId, _secondDataStoreId, _thirdDataStoreId];
+        foreach (int dataStoreId in duplicateHosts)
+        {
+            for (int row = 0; row < 10; row++)
+            {
+                await InsertDerivativeAsync(connection, dataStoreId, "Snapshot");
+            }
+        }
+
+        string message = DeployFailureMessage();
+
+        message.Should().Contain("30 duplicate (DataStoreId, DerivativeType) row(s)");
+        message.Should().Contain("31 row(s) with an invalid DerivativeType");
+        message.Should().Contain($"({_firstDataStoreId}, Snapshot, ");
+        message
+            .Should()
+            .Contain(
+                $"({paddedId}, {_fourthDataStoreId}, 'Snapshot ')",
+                "the quoted trailing space stays visible even when the list is capped"
+            );
+        message.Should().Contain($"'{WidestInvalidType(0)}'", "the widest storable value is carried whole");
+        message.Should().Contain("... and ", "capped lists state how many offenders were not listed");
+        message.Should().Contain(RemediationPut);
+        message.Should().Contain(RemediationDelete);
+        message.Should().Contain(AllowedValues);
+        message
+            .Length.Should()
+            .BeLessThanOrEqualTo(
+                2048,
+                "the tuple budget is computed before the lists are built, so the message never needs truncating"
+            );
+    }
+
+    /// <summary>
+    /// A distinct value at the full 50-character width of the column, which is the widest tuple the
+    /// diagnostics can be asked to carry.
+    /// </summary>
+    private static string WidestInvalidType(int ordinal) => $"Legacy{ordinal:D2}".PadRight(50, 'x');
+
+    private async Task RevertToPreUpgradeStateAsync()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        await connection.ExecuteAsync(
+            """
+            ALTER TABLE "dmscs"."DataStoreDerivative"
+                DROP CONSTRAINT IF EXISTS "UX_DataStoreDerivative_DataStoreId_DerivativeType";
+            ALTER TABLE "dmscs"."DataStoreDerivative"
+                DROP CONSTRAINT IF EXISTS "CK_DataStoreDerivative_DerivativeType";
+            CREATE INDEX IF NOT EXISTS "IX_DataStoreDerivative_DataStoreId"
+                ON "dmscs"."DataStoreDerivative" ("DataStoreId");
+            """
+        );
+
+        int removedJournalEntries = await connection.ExecuteAsync(
+            """DELETE FROM public."dmscs_SchemaVersions" WHERE scriptname LIKE @Pattern;""",
+            new { Pattern = JournalPattern }
+        );
+        removedJournalEntries
+            .Should()
+            .BeLessThanOrEqualTo(1, "the pattern must identify only the invariants upgrade script");
+
+        await connection.ExecuteAsync(
+            """
+            DELETE FROM "dmscs"."DataStoreDerivative";
+            DELETE FROM "dmscs"."DataStore";
+            """
+        );
+    }
+
+    private static async Task<int> InsertDataStoreAsync(NpgsqlConnection connection, string name) =>
+        await connection.ExecuteScalarAsync<int>(
+            """
+            INSERT INTO "dmscs"."DataStore" ("DataStoreType", "Name")
+            VALUES ('Production', @Name)
+            RETURNING "Id";
+            """,
+            new { Name = name }
+        );
+
+    private static async Task<int> InsertDerivativeAsync(
+        NpgsqlConnection connection,
+        int dataStoreId,
+        string derivativeType
+    ) =>
+        await connection.ExecuteScalarAsync<int>(
+            """
+            INSERT INTO "dmscs"."DataStoreDerivative" ("DataStoreId", "DerivativeType")
+            VALUES (@DataStoreId, @DerivativeType)
+            RETURNING "Id";
+            """,
+            new { DataStoreId = dataStoreId, DerivativeType = derivativeType }
+        );
+
+    private static async Task<string> TryInsertDerivativeAsync(
+        NpgsqlConnection connection,
+        int dataStoreId,
+        string derivativeType
+    )
+    {
+        try
+        {
+            await InsertDerivativeAsync(connection, dataStoreId, derivativeType);
+            return string.Empty;
+        }
+        catch (PostgresException exception)
+        {
+            return exception.SqlState;
+        }
+    }
+
+    private static async Task<bool> ConstraintExistsAsync(NpgsqlConnection connection, string name) =>
+        await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT count(*)
+            FROM pg_constraint
+            WHERE conname = @Name
+              AND conrelid = '"dmscs"."DataStoreDerivative"'::regclass;
+            """,
+            new { Name = name }
+        ) > 0;
+
+    private DatabaseDeployResult Deploy() => new Deploy.DatabaseDeploy().DeployDatabase(_connectionString);
+
+    private void DeploySuccessfully()
+    {
+        DatabaseDeployResult result = Deploy();
+
+        if (result is DatabaseDeployResult.DatabaseDeployFailure failure)
+        {
+            Assert.Fail($"Database deploy failed: {failure.Error}");
+        }
+    }
+
+    private string DeployFailureMessage()
+    {
+        DatabaseDeployResult result = Deploy();
+
+        DatabaseDeployResult.DatabaseDeployFailure failure = result
+            .Should()
+            .BeOfType<DatabaseDeployResult.DatabaseDeployFailure>()
+            .Subject;
+
+        PostgresException postgresException = FindPostgresException(failure.Error);
+        return postgresException.MessageText;
+    }
+
+    private static PostgresException FindPostgresException(Exception exception)
+    {
+        for (Exception? candidate = exception; candidate is not null; candidate = candidate.InnerException)
+        {
+            if (candidate is PostgresException postgresException)
+            {
+                return postgresException;
+            }
+        }
+
+        throw new AssertionException($"Expected a PostgresException but found: {exception}");
+    }
+
+    private string CreateIsolatedDatabaseConnectionString()
+    {
+        NpgsqlConnectionStringBuilder builder = new(Configuration.DatabaseOptions.Value.DatabaseConnection)
+        {
+            Database = $"dms1366_upgrade_{Guid.NewGuid():N}",
+            Pooling = false,
+        };
+
+        _databaseName = builder.Database!;
+        return builder.ConnectionString;
+    }
+
+    private static string CreateMaintenanceConnectionString()
+    {
+        NpgsqlConnectionStringBuilder builder = new(Configuration.DatabaseOptions.Value.DatabaseConnection)
+        {
+            Database = "postgres",
+            Pooling = false,
+        };
+
+        return builder.ConnectionString;
+    }
+
+    private const string UniqueConstraintColumnsSql = """
+        SELECT attribute_info.attname
+        FROM pg_constraint constraint_info
+        JOIN LATERAL unnest(constraint_info.conkey) WITH ORDINALITY AS key_columns(attnum, ordinality)
+            ON true
+        JOIN pg_attribute attribute_info
+            ON attribute_info.attrelid = constraint_info.conrelid
+           AND attribute_info.attnum = key_columns.attnum
+        WHERE constraint_info.conname = 'UX_DataStoreDerivative_DataStoreId_DerivativeType'
+        ORDER BY key_columns.ordinality;
+        """;
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeUpgradeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreDerivativeUpgradeTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using Dapper;
+using DbUp.Engine.Output;
 using EdFi.DmsConfigurationService.Backend.Deploy;
 using FluentAssertions;
 using Npgsql;
@@ -221,17 +222,23 @@ public class Given_a_legacy_DataStoreDerivative_PostgreSQL_upgrade
         // could not assert the same totals.
         int paddedId = await InsertDerivativeAsync(connection, _fourthDataStoreId, "Snapshot ");
 
+        int lastInvalidId = 0;
         for (int row = 0; row < 30; row++)
         {
-            await InsertDerivativeAsync(connection, _firstDataStoreId, WidestInvalidType(row));
+            lastInvalidId = await InsertDerivativeAsync(
+                connection,
+                _firstDataStoreId,
+                WidestInvalidType(row)
+            );
         }
 
+        int lastDuplicateId = 0;
         int[] duplicateHosts = [_firstDataStoreId, _secondDataStoreId, _thirdDataStoreId];
         foreach (int dataStoreId in duplicateHosts)
         {
             for (int row = 0; row < 10; row++)
             {
-                await InsertDerivativeAsync(connection, dataStoreId, "Snapshot");
+                lastDuplicateId = await InsertDerivativeAsync(connection, dataStoreId, "Snapshot");
             }
         }
 
@@ -256,6 +263,32 @@ public class Given_a_legacy_DataStoreDerivative_PostgreSQL_upgrade
             .BeLessThanOrEqualTo(
                 2048,
                 "the tuple budget is computed before the lists are built, so the message never needs truncating"
+            );
+
+        // The thrown error is a bounded sample by design. These offenders sit past the cap, so the
+        // only place they can be found is the deploy log, which is the channel an operator reads
+        // when the upgrade fails.
+        string scriptOutput = _scriptOutput.Output;
+        string lastDuplicateTuple = $"({_thirdDataStoreId}, Snapshot, {lastDuplicateId})";
+        string lastInvalidTuple = $"({lastInvalidId}, {_firstDataStoreId}, '{WidestInvalidType(29)}')";
+
+        message.Should().NotContain(lastDuplicateTuple, "this offender is beyond the thrown sample's cap");
+        message.Should().NotContain(lastInvalidTuple, "this offender is beyond the thrown sample's cap");
+
+        scriptOutput
+            .Should()
+            .Contain(lastDuplicateTuple, "every duplicate tuple reaches the operator through the deploy log");
+        scriptOutput
+            .Should()
+            .Contain(
+                lastInvalidTuple,
+                "every invalid-type tuple reaches the operator through the deploy log"
+            );
+        scriptOutput
+            .Should()
+            .Contain(
+                $"({paddedId}, {_fourthDataStoreId}, 'Snapshot ')",
+                "the quoted trailing space survives the log channel too"
             );
     }
 
@@ -349,7 +382,15 @@ public class Given_a_legacy_DataStoreDerivative_PostgreSQL_upgrade
             new { Name = name }
         ) > 0;
 
-    private DatabaseDeployResult Deploy() => new Deploy.DatabaseDeploy().DeployDatabase(_connectionString);
+    private ScriptOutputCapture _scriptOutput = new();
+
+    private DatabaseDeployResult Deploy()
+    {
+        _scriptOutput = new ScriptOutputCapture();
+        return new Deploy.DatabaseDeploy { ScriptOutputLog = _scriptOutput }.DeployDatabase(
+            _connectionString
+        );
+    }
 
     private void DeploySuccessfully()
     {
@@ -421,4 +462,29 @@ public class Given_a_legacy_DataStoreDerivative_PostgreSQL_upgrade
         WHERE constraint_info.conname = 'UX_DataStoreDerivative_DataStoreId_DerivativeType'
         ORDER BY key_columns.ordinality;
         """;
+
+    /// <summary>
+    /// Captures the script output DbUp writes for every result set an upgrade script returns. The
+    /// complete offender lists travel through this channel because they cannot fit in the thrown
+    /// error, so a test can only prove they reach the operator by reading the deploy log.
+    /// </summary>
+    private sealed class ScriptOutputCapture : IUpgradeLog
+    {
+        private readonly List<string> _lines = [];
+
+        public string Output => string.Join(Environment.NewLine, _lines);
+
+        public void WriteInformation(string format, params object[] args) => Append(format, args);
+
+        public void WriteWarning(string format, params object[] args) => Append(format, args);
+
+        public void WriteError(string format, params object[] args) => Append(format, args);
+
+        /// <summary>
+        /// DbUp passes result-set rows through with no arguments, so the row text is never treated
+        /// as a format string and a brace in the data cannot break the capture.
+        /// </summary>
+        private void Append(string format, object[] args) =>
+            _lines.Add(args.Length == 0 ? format : string.Format(format, args));
+    }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreTests.cs
@@ -10,6 +10,7 @@ using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStore;
+using EdFi.DmsConfigurationService.DataModel.Model.DataStoreDerivative;
 using EdFi.DmsConfigurationService.DataModel.Model.Vendor;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -937,6 +938,99 @@ public class DataStoreTests : DatabaseTest
                 .ToList();
             names.Should().HaveCount(3);
             names.Should().ContainInOrder("Charlie-Instance", "November-Instance", "Zulu-Instance");
+        }
+    }
+
+    /// <summary>
+    /// DataStoreRepository composes derivatives through a separate repository, and the two read paths
+    /// use different lookups: GetDataStore resolves a single parent while QueryDataStore resolves a
+    /// batch and groups the result. Both swallow a failed derivative lookup into an empty collection,
+    /// so only an assertion on the composed response can prove the derivatives actually arrive.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_data_store_with_both_derivative_types : DataStoreTests
+    {
+        private int _dataStoreId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var insertResult = await _repository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Production",
+                    Name = "Derivative Composition Instance",
+                    ConnectionString = "Server=localhost;Database=CompositionDb;",
+                }
+            );
+            _dataStoreId = insertResult.Should().BeOfType<DataStoreInsertResult.Success>().Subject.Id;
+
+            await InsertDerivative("Snapshot", "Server=localhost;Database=SnapshotDb;");
+            await InsertDerivative("ReadReplica", "Server=localhost;Database=ReadReplicaDb;");
+        }
+
+        private async Task InsertDerivative(string derivativeType, string connectionString)
+        {
+            var result = await _derivativeRepository.InsertDataStoreDerivative(
+                new DataStoreDerivativeInsertCommand
+                {
+                    DataStoreId = _dataStoreId,
+                    DerivativeType = derivativeType,
+                    ConnectionString = connectionString,
+                }
+            );
+            result.Should().BeOfType<DataStoreDerivativeInsertResult.Success>();
+        }
+
+        [Test]
+        public async Task It_should_include_both_derivatives_in_the_single_data_store_response()
+        {
+            var getResult = await _repository.GetDataStore(_dataStoreId);
+
+            DataStoreResponse dataStore = getResult
+                .Should()
+                .BeOfType<DataStoreGetResult.Success>()
+                .Subject.DataStoreResponse;
+
+            AssertCarriesBothDerivatives(dataStore);
+        }
+
+        [Test]
+        public async Task It_should_include_both_derivatives_in_the_queried_data_store_response()
+        {
+            var queryResult = await _repository.QueryDataStore(new DataStoreQuery { Limit = 25, Offset = 0 });
+
+            DataStoreResponse dataStore = queryResult
+                .Should()
+                .BeOfType<DataStoreQueryResult.Success>()
+                .Subject.DataStoreResponses.Should()
+                .ContainSingle(response => response.Id == _dataStoreId)
+                .Subject;
+
+            AssertCarriesBothDerivatives(dataStore);
+        }
+
+        private void AssertCarriesBothDerivatives(DataStoreResponse dataStore)
+        {
+            var derivatives = dataStore.DataStoreDerivatives.ToList();
+
+            derivatives
+                .Select(derivative => new { derivative.DataStoreId, derivative.DerivativeType })
+                .Should()
+                .BeEquivalentTo(
+                    new[]
+                    {
+                        new { DataStoreId = _dataStoreId, DerivativeType = "ReadReplica" },
+                        new { DataStoreId = _dataStoreId, DerivativeType = "Snapshot" },
+                    }
+                );
+
+            derivatives
+                .Should()
+                .OnlyContain(
+                    derivative => derivative.Id > 0,
+                    "the composed response carries each derivative's persisted identity"
+                );
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DatabaseShapeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DatabaseShapeTests.cs
@@ -93,6 +93,14 @@ public class Given_CMS_PostgreSQL_database_shape
             false
         ),
         new("UX_OpenIddictApplication_ClientId", "OpenIddictApplication", "u", ["ClientId"], false),
+        new(
+            "UX_DataStoreDerivative_DataStoreId_DerivativeType",
+            "DataStoreDerivative",
+            "u",
+            ["DataStoreId", "DerivativeType"],
+            false
+        ),
+        new("CK_DataStoreDerivative_DerivativeType", "DataStoreDerivative", "c", ["DerivativeType"], false),
     ];
 
     private static readonly string[] ExpectedNonUniqueLookupIndexes =
@@ -102,7 +110,6 @@ public class Given_CMS_PostgreSQL_database_shape
         "IX_AuthorizationStrategy_TenantId",
         "IX_ResourceClaim_TenantId",
         "IX_DataStore_TenantId",
-        "IX_DataStoreDerivative_DataStoreId",
         "IX_OpenIddictToken_ApplicationId",
         "IX_OpenIddictToken_Subject",
         "IX_OpenIddictToken_ReferenceId",
@@ -151,6 +158,12 @@ public class Given_CMS_PostgreSQL_database_shape
         "Vendor",
     ];
 
+    /// <summary>
+    /// Indexes that earlier scripts created and a later upgrade removed. IX_DataStoreDerivative_DataStoreId
+    /// is redundant with the backing index of UX_DataStoreDerivative_DataStoreId_DerivativeType, whose
+    /// leading key is the same column, so the unique constraint serves the parent lookup and the
+    /// child-side foreign-key maintenance on its own.
+    /// </summary>
     private static readonly string[] RemovedRedundantIndexNames =
     [
         "idx_Company",
@@ -158,6 +171,7 @@ public class Given_CMS_PostgreSQL_database_shape
         "idx_vendor_applicationname",
         "idx_datastore_context_unique",
         "ix_profile_name",
+        "IX_DataStoreDerivative_DataStoreId",
     ];
 
     private string _databaseName = string.Empty;

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/DatabaseDeploy.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/DatabaseDeploy.cs
@@ -5,12 +5,29 @@
 
 using System.Reflection;
 using DbUp;
+using DbUp.Builder;
+using DbUp.Engine.Output;
 using EdFi.DmsConfigurationService.Backend.Deploy;
 
 namespace EdFi.DmsConfigurationService.Backend.Postgresql.Deploy;
 
+/// <summary>
+/// Deploys the CMS administrative database.
+/// </summary>
+/// <remarks>
+/// <see cref="ScriptOutputLog"/> exists so integration tests can observe the script output that
+/// <c>LogScriptOutput</c> captures, which is the only channel an upgrade script has for diagnostics
+/// too large to fit in the thrown error. It is internal and unset in production, where logging stays
+/// on the autodetected log.
+/// </remarks>
 public class DatabaseDeploy : IDatabaseDeploy
 {
+    /// <summary>
+    /// When set, script output is additionally written here. Tests use it to read the complete
+    /// upgrade diagnostics; production leaves it null.
+    /// </summary>
+    internal IUpgradeLog? ScriptOutputLog { get; init; }
+
     public DatabaseDeployResult DeployDatabase(string connectionString)
     {
         try
@@ -22,14 +39,20 @@ public class DatabaseDeploy : IDatabaseDeploy
             return new DatabaseDeployResult.DatabaseDeployFailure(e);
         }
 
-        var upgrader = DeployChanges
+        UpgradeEngineBuilder builder = DeployChanges
             .To.PostgresqlDatabase(connectionString)
             .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
             .JournalToPostgresqlTable("public", "dmscs_SchemaVersions")
             .WithVariablesDisabled()
             .LogScriptOutput()
-            .LogToAutodetectedLog()
-            .Build();
+            .LogToAutodetectedLog();
+
+        if (ScriptOutputLog is not null)
+        {
+            builder = builder.LogTo(ScriptOutputLog);
+        }
+
+        var upgrader = builder.Build();
 
         if (!upgrader.TryConnect(out string error))
         {

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
@@ -1,0 +1,199 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+-- Enforce at most one derivative of each type per data store, and restrict DerivativeType to
+-- exactly 'Snapshot' or 'ReadReplica'. Both constraints are added WITH CHECK, so legacy rows that
+-- violate either one would otherwise fail the upgrade with a bare constraint-violation error. The
+-- preflight below runs first and stops the upgrade with the offending tuples and remediation
+-- guidance instead. It never deletes a row, rewrites a type, or chooses among duplicates.
+
+-- The allowed-value test states its comparison semantics rather than inheriting the database or
+-- column collation: "C" is a built-in deterministic collation, so equality under it is ordinal, and
+-- octet_length makes the stored-length contract explicit so trailing whitespace is rejected. The
+-- invalid-type preflight below negates this same expression, so a value the check constraint would
+-- reject is always diagnosed by the preflight first.
+DO $$
+DECLARE
+    message_limit CONSTANT INT := 2048;
+    marker_reserve CONSTANT INT := 30;
+    remediation CONSTANT TEXT :=
+        'Correct an invalid DerivativeType with PUT /v3/dataStoreDerivatives/{id}, or remove an unwanted row with DELETE /v3/dataStoreDerivatives/{id}, then retry the upgrade. Allowed values are exactly ''Snapshot'' and ''ReadReplica''.';
+    duplicate_total INT;
+    invalid_total INT;
+    duplicate_shown INT := 0;
+    invalid_shown INT := 0;
+    duplicate_list TEXT;
+    invalid_list TEXT;
+    duplicate_header TEXT;
+    invalid_header TEXT;
+    conditions INT;
+    per_condition INT;
+    message_text TEXT := '';
+BEGIN
+    -- Duplicate detection deliberately uses the plain columns, which is the equality the unique
+    -- constraint itself will apply. Forcing a binary comparison here would make the preflight less
+    -- predictive than the constraint it protects.
+    SELECT count(*)
+    INTO duplicate_total
+    FROM "dmscs"."DataStoreDerivative" candidate
+    WHERE EXISTS (
+        SELECT 1
+        FROM "dmscs"."DataStoreDerivative" other
+        WHERE other."DataStoreId" = candidate."DataStoreId"
+          AND other."DerivativeType" = candidate."DerivativeType"
+          AND other."Id" <> candidate."Id"
+    );
+
+    SELECT count(*)
+    INTO invalid_total
+    FROM "dmscs"."DataStoreDerivative"
+    WHERE NOT (
+        ("DerivativeType" COLLATE "C" = 'Snapshot' AND octet_length("DerivativeType") = 8)
+        OR ("DerivativeType" COLLATE "C" = 'ReadReplica' AND octet_length("DerivativeType") = 11)
+    );
+
+    IF duplicate_total = 0 AND invalid_total = 0 THEN
+        RETURN;
+    END IF;
+
+    duplicate_header := format(
+        'DataStoreDerivative upgrade blocked: %s duplicate (DataStoreId, DerivativeType) row(s): ',
+        duplicate_total
+    );
+    invalid_header := format(
+        'DataStoreDerivative upgrade blocked: %s row(s) with an invalid DerivativeType: ',
+        invalid_total
+    );
+
+    -- The tuple budget is computed before either list is built, so the assembled message is within
+    -- the limit by construction and is never truncated afterwards.
+    conditions := (CASE WHEN duplicate_total > 0 THEN 1 ELSE 0 END)
+        + (CASE WHEN invalid_total > 0 THEN 1 ELSE 0 END);
+    per_condition := GREATEST(
+        (
+            message_limit - length(remediation) - 2
+            - (CASE WHEN duplicate_total > 0 THEN length(duplicate_header) + marker_reserve ELSE 0 END)
+            - (CASE WHEN invalid_total > 0 THEN length(invalid_header) + marker_reserve ELSE 0 END)
+        ) / conditions,
+        0
+    );
+
+    IF duplicate_total > 0 THEN
+        WITH duplicate_rows AS (
+            SELECT candidate."DataStoreId", candidate."DerivativeType", candidate."Id"
+            FROM "dmscs"."DataStoreDerivative" candidate
+            WHERE EXISTS (
+                SELECT 1
+                FROM "dmscs"."DataStoreDerivative" other
+                WHERE other."DataStoreId" = candidate."DataStoreId"
+                  AND other."DerivativeType" = candidate."DerivativeType"
+                  AND other."Id" <> candidate."Id"
+            )
+        ),
+        ordered AS (
+            SELECT
+                format('(%s, %s, %s)', "DataStoreId", "DerivativeType", "Id") AS tuple_text,
+                row_number() OVER (ORDER BY "DataStoreId", "DerivativeType", "Id") AS position
+            FROM duplicate_rows
+        ),
+        measured AS (
+            SELECT
+                tuple_text,
+                position,
+                sum(length(tuple_text) + 2) OVER (ORDER BY position ROWS UNBOUNDED PRECEDING) AS used
+            FROM ordered
+        )
+        SELECT string_agg(tuple_text, ', ' ORDER BY position), count(*)
+        INTO duplicate_list, duplicate_shown
+        FROM measured
+        WHERE position <= 20
+          AND (position = 1 OR used <= per_condition);
+
+        message_text := message_text || duplicate_header || duplicate_list;
+        IF duplicate_total > duplicate_shown THEN
+            message_text := message_text || format(', ... and %s more.', duplicate_total - duplicate_shown);
+        ELSE
+            message_text := message_text || '.';
+        END IF;
+        message_text := message_text || ' ';
+    END IF;
+
+    IF invalid_total > 0 THEN
+        WITH invalid_rows AS (
+            SELECT "Id", "DataStoreId", "DerivativeType"
+            FROM "dmscs"."DataStoreDerivative"
+            WHERE NOT (
+                ("DerivativeType" COLLATE "C" = 'Snapshot' AND octet_length("DerivativeType") = 8)
+                OR ("DerivativeType" COLLATE "C" = 'ReadReplica' AND octet_length("DerivativeType") = 11)
+            )
+        ),
+        ordered AS (
+            SELECT
+                -- The type value is quoted so trailing whitespace is visible to the operator.
+                format('(%s, %s, ''%s'')', "Id", "DataStoreId", "DerivativeType") AS tuple_text,
+                row_number() OVER (ORDER BY "Id") AS position
+            FROM invalid_rows
+        ),
+        measured AS (
+            SELECT
+                tuple_text,
+                position,
+                sum(length(tuple_text) + 2) OVER (ORDER BY position ROWS UNBOUNDED PRECEDING) AS used
+            FROM ordered
+        )
+        SELECT string_agg(tuple_text, ', ' ORDER BY position), count(*)
+        INTO invalid_list, invalid_shown
+        FROM measured
+        WHERE position <= 20
+          AND (position = 1 OR used <= per_condition);
+
+        message_text := message_text || invalid_header || invalid_list;
+        IF invalid_total > invalid_shown THEN
+            message_text := message_text || format(', ... and %s more.', invalid_total - invalid_shown);
+        ELSE
+            message_text := message_text || '.';
+        END IF;
+        message_text := message_text || ' ';
+    END IF;
+
+    RAISE EXCEPTION '%', message_text || remediation;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'UX_DataStoreDerivative_DataStoreId_DerivativeType'
+          AND conrelid = '"dmscs"."DataStoreDerivative"'::regclass
+    ) THEN
+        ALTER TABLE "dmscs"."DataStoreDerivative"
+            ADD CONSTRAINT "UX_DataStoreDerivative_DataStoreId_DerivativeType" UNIQUE ("DataStoreId", "DerivativeType");
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'CK_DataStoreDerivative_DerivativeType'
+          AND conrelid = '"dmscs"."DataStoreDerivative"'::regclass
+    ) THEN
+        ALTER TABLE "dmscs"."DataStoreDerivative"
+            ADD CONSTRAINT "CK_DataStoreDerivative_DerivativeType" CHECK (
+                ("DerivativeType" COLLATE "C" = 'Snapshot' AND octet_length("DerivativeType") = 8)
+                OR ("DerivativeType" COLLATE "C" = 'ReadReplica' AND octet_length("DerivativeType") = 11)
+            );
+    END IF;
+END$$;
+
+-- The unique constraint's backing index leads with DataStoreId, so it serves the parent lookup and
+-- the child-side foreign-key maintenance that this narrower index served. Dropped only after the
+-- constraint above is in place.
+DROP INDEX IF EXISTS "dmscs"."IX_DataStoreDerivative_DataStoreId";
+
+COMMENT ON CONSTRAINT "UX_DataStoreDerivative_DataStoreId_DerivativeType" ON "dmscs"."DataStoreDerivative" IS
+    'Each data store has at most one derivative of each type';
+
+COMMENT ON CONSTRAINT "CK_DataStoreDerivative_DerivativeType" ON "dmscs"."DataStoreDerivative" IS
+    'DerivativeType is exactly "Snapshot" or "ReadReplica", compared ordinally including length';

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0028_Add_DataStoreDerivative_Invariants.sql
@@ -14,6 +14,35 @@
 -- octet_length makes the stored-length contract explicit so trailing whitespace is rejected. The
 -- invalid-type preflight below negates this same expression, so a value the check constraint would
 -- reject is always diagnosed by the preflight first.
+-- The thrown error carries only a bounded sample, because SQL Server's THROW delivers at most 2047
+-- characters and the two engines keep one diagnostic contract. These two statements carry the
+-- complete offender sets instead. DbUp's LogScriptOutput writes every result set a script returns
+-- to the deployment log, and it does so as the reader is consumed, so rows emitted here reach the
+-- operator even though the statement that follows aborts the upgrade. A RAISE NOTICE would not:
+-- notices are not part of a result set and never reach the DbUp log. On a conforming database both
+-- statements return no rows. Ordering is deterministic and the tuple shapes match the thrown
+-- diagnostics exactly.
+SELECT format('(%s, %s, %s)', candidate."DataStoreId", candidate."DerivativeType", candidate."Id")
+    AS "DuplicateDataStoreDerivative"
+FROM "dmscs"."DataStoreDerivative" candidate
+WHERE EXISTS (
+    SELECT 1
+    FROM "dmscs"."DataStoreDerivative" other
+    WHERE other."DataStoreId" = candidate."DataStoreId"
+      AND other."DerivativeType" = candidate."DerivativeType"
+      AND other."Id" <> candidate."Id"
+)
+ORDER BY candidate."DataStoreId", candidate."DerivativeType", candidate."Id";
+
+SELECT format('(%s, %s, ''%s'')', "Id", "DataStoreId", "DerivativeType")
+    AS "InvalidDataStoreDerivativeType"
+FROM "dmscs"."DataStoreDerivative"
+WHERE NOT (
+    ("DerivativeType" COLLATE "C" = 'Snapshot' AND octet_length("DerivativeType") = 8)
+    OR ("DerivativeType" COLLATE "C" = 'ReadReplica' AND octet_length("DerivativeType") = 11)
+)
+ORDER BY "Id";
+
 DO $$
 DECLARE
     message_limit CONSTANT INT := 2048;

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/DataStoreDerivativeRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/DataStoreDerivativeRepository.cs
@@ -6,6 +6,7 @@
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
+using EdFi.DmsConfigurationService.DataModel;
 using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStoreDerivative;
@@ -88,6 +89,22 @@ public class DataStoreDerivativeRepository(
         {
             logger.LogWarning(ex, "Data store not found");
             return new DataStoreDerivativeInsertResult.FailureForeignKeyViolation();
+        }
+        catch (PostgresException ex)
+            when (ex.SqlState == PostgresErrorCodes.UniqueViolation
+                && ex.ConstraintName == "UX_DataStoreDerivative_DataStoreId_DerivativeType"
+            )
+        {
+            logger.LogWarning(
+                ex,
+                "Data store derivative already exists for DataStoreId '{DataStoreId}' and DerivativeType '{DerivativeType}'",
+                command.DataStoreId,
+                LoggingUtility.SanitizeForLog(command.DerivativeType)
+            );
+            return new DataStoreDerivativeInsertResult.FailureDuplicateDataStoreDerivative(
+                command.DataStoreId,
+                command.DerivativeType
+            );
         }
         catch (Exception ex)
         {
@@ -242,6 +259,22 @@ public class DataStoreDerivativeRepository(
         {
             logger.LogWarning(ex, "Data store not found");
             return new DataStoreDerivativeUpdateResult.FailureForeignKeyViolation();
+        }
+        catch (PostgresException ex)
+            when (ex.SqlState == PostgresErrorCodes.UniqueViolation
+                && ex.ConstraintName == "UX_DataStoreDerivative_DataStoreId_DerivativeType"
+            )
+        {
+            logger.LogWarning(
+                ex,
+                "Data store derivative already exists for DataStoreId '{DataStoreId}' and DerivativeType '{DerivativeType}'",
+                command.DataStoreId,
+                LoggingUtility.SanitizeForLog(command.DerivativeType)
+            );
+            return new DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative(
+                command.DataStoreId,
+                command.DerivativeType
+            );
         }
         catch (Exception ex)
         {

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Repositories/IDataStoreDerivativeRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Repositories/IDataStoreDerivativeRepository.cs
@@ -35,6 +35,12 @@ public record DataStoreDerivativeInsertResult
     public record FailureForeignKeyViolation() : DataStoreDerivativeInsertResult();
 
     /// <summary>
+    /// The data store already has a derivative of this type
+    /// </summary>
+    public record FailureDuplicateDataStoreDerivative(int DataStoreId, string DerivativeType)
+        : DataStoreDerivativeInsertResult();
+
+    /// <summary>
     /// Unexpected exception thrown and caught
     /// </summary>
     public record FailureUnknown(string FailureMessage) : DataStoreDerivativeInsertResult();
@@ -89,6 +95,12 @@ public record DataStoreDerivativeUpdateResult
     /// Update failed due to foreign key violation (invalid DataStoreId)
     /// </summary>
     public record FailureForeignKeyViolation() : DataStoreDerivativeUpdateResult();
+
+    /// <summary>
+    /// The target data store already has a derivative of this type
+    /// </summary>
+    public record FailureDuplicateDataStoreDerivative(int DataStoreId, string DerivativeType)
+        : DataStoreDerivativeUpdateResult();
 
     /// <summary>
     /// Unexpected exception thrown and caught

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreDerivativeModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/DataStoreDerivativeModuleTests.cs
@@ -286,4 +286,124 @@ public class DataStoreDerivativeModuleTests
             responseContent.Should().Contain("Request body id must match the id in the url.");
         }
     }
+
+    [TestFixture]
+    public class Given_insert_returns_a_duplicate_derivative : DataStoreDerivativeModuleTests
+    {
+        private HttpResponseMessage _response = null!;
+        private JsonNode _body = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            A.CallTo(() => _repository.InsertDataStoreDerivative(A<DataStoreDerivativeInsertCommand>.Ignored))
+                .Returns(
+                    new DataStoreDerivativeInsertResult.FailureDuplicateDataStoreDerivative(1, "ReadReplica")
+                );
+
+            using var client = SetUpClient();
+            using var content = new StringContent(
+                """{"dataStoreId":1,"derivativeType":"ReadReplica"}""",
+                Encoding.UTF8,
+                "application/json"
+            );
+            _response = await client.PostAsync("/v3/dataStoreDerivatives/", content);
+            _body = JsonNode.Parse(await _response.Content.ReadAsStringAsync())!;
+        }
+
+        [Test]
+        public void It_returns_409() => _response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        [Test]
+        public void It_uses_the_application_json_content_type() =>
+            _response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        [Test]
+        public void It_uses_the_conflict_type() =>
+            _body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:conflict");
+
+        [Test]
+        public void It_has_the_conflict_title() => _body["title"]!.GetValue<string>().Should().Be("Conflict");
+
+        [Test]
+        public void It_has_the_expected_detail() =>
+            _body["detail"]!
+                .GetValue<string>()
+                .Should()
+                .Be("A DataStoreDerivative of type ReadReplica already exists for DataStore 1.");
+
+        [Test]
+        public void It_has_a_body_status_of_409() => _body["status"]!.GetValue<int>().Should().Be(409);
+
+        [Test]
+        public void It_includes_a_non_empty_correlation_id() =>
+            _body["correlationId"]!.GetValue<string>().Should().NotBeNullOrEmpty();
+
+        [Test]
+        public void It_includes_empty_extension_members()
+        {
+            _body["validationErrors"]!.AsObject().Count.Should().Be(0);
+            _body["errors"]!.AsArray().Count.Should().Be(0);
+        }
+    }
+
+    [TestFixture]
+    public class Given_update_returns_a_duplicate_derivative : DataStoreDerivativeModuleTests
+    {
+        private HttpResponseMessage _response = null!;
+        private JsonNode _body = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            A.CallTo(() => _repository.UpdateDataStoreDerivative(A<DataStoreDerivativeUpdateCommand>.Ignored))
+                .Returns(
+                    new DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative(2, "Snapshot")
+                );
+
+            using var client = SetUpClient();
+            using var content = new StringContent(
+                """{"id":1,"dataStoreId":2,"derivativeType":"Snapshot"}""",
+                Encoding.UTF8,
+                "application/json"
+            );
+            _response = await client.PutAsync("/v3/dataStoreDerivatives/1", content);
+            _body = JsonNode.Parse(await _response.Content.ReadAsStringAsync())!;
+        }
+
+        [Test]
+        public void It_returns_409() => _response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        [Test]
+        public void It_uses_the_application_json_content_type() =>
+            _response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        [Test]
+        public void It_uses_the_conflict_type() =>
+            _body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:conflict");
+
+        [Test]
+        public void It_has_the_conflict_title() => _body["title"]!.GetValue<string>().Should().Be("Conflict");
+
+        [Test]
+        public void It_has_the_expected_detail() =>
+            _body["detail"]!
+                .GetValue<string>()
+                .Should()
+                .Be("A DataStoreDerivative of type Snapshot already exists for DataStore 2.");
+
+        [Test]
+        public void It_has_a_body_status_of_409() => _body["status"]!.GetValue<int>().Should().Be(409);
+
+        [Test]
+        public void It_includes_a_non_empty_correlation_id() =>
+            _body["correlationId"]!.GetValue<string>().Should().NotBeNullOrEmpty();
+
+        [Test]
+        public void It_includes_empty_extension_members()
+        {
+            _body["validationErrors"]!.AsObject().Count.Should().Be(0);
+            _body["errors"]!.AsArray().Count.Should().Be(0);
+        }
+    }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/DataStoreDerivativeModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/DataStoreDerivativeModule.cs
@@ -53,6 +53,13 @@ public class DataStoreDerivativeModule : IEndpointModule
                 ),
                 statusCode: (int)HttpStatusCode.Conflict
             ),
+            DataStoreDerivativeInsertResult.FailureDuplicateDataStoreDerivative duplicate => Results.Json(
+                FailureResponse.ForConflict(
+                    DuplicateDerivativeDetail(duplicate.DataStoreId, duplicate.DerivativeType),
+                    httpContext.TraceIdentifier
+                ),
+                statusCode: (int)HttpStatusCode.Conflict
+            ),
             _ => FailureResults.Unknown(httpContext.TraceIdentifier),
         };
     }
@@ -127,9 +134,19 @@ public class DataStoreDerivativeModule : IEndpointModule
                 ),
                 statusCode: (int)HttpStatusCode.Conflict
             ),
+            DataStoreDerivativeUpdateResult.FailureDuplicateDataStoreDerivative duplicate => Results.Json(
+                FailureResponse.ForConflict(
+                    DuplicateDerivativeDetail(duplicate.DataStoreId, duplicate.DerivativeType),
+                    httpContext.TraceIdentifier
+                ),
+                statusCode: (int)HttpStatusCode.Conflict
+            ),
             _ => FailureResults.Unknown(httpContext.TraceIdentifier),
         };
     }
+
+    private static string DuplicateDerivativeDetail(int dataStoreId, string derivativeType) =>
+        $"A DataStoreDerivative of type {derivativeType} already exists for DataStore {dataStoreId}.";
 
     private static async Task<IResult> Delete(
         int id,


### PR DESCRIPTION
Implements [DMS-1366](https://edfi.atlassian.net/browse/DMS-1366), the CMS administrative-database
changes required by the DMS-1190 snapshot and read-replica design.

CMS already stores `Snapshot` and `ReadReplica` rows in `dmscs.DataStoreDerivative`, but the database
enforced neither one derivative of each type per data store nor a valid type value, and a duplicate
had no representation above the repository. This adds those invariants for both engines, fails an
upgrade with actionable diagnostics when legacy data violates them, and maps insert and update
conflicts to HTTP 409.

## Database invariants

A new embedded upgrade script per provider, `0028_Add_DataStoreDerivative_Invariants.sql`. The
already-journaled `0023` scripts are untouched, because editing them would not add the constraints or
remove the index on a deployed database. Each script:

- adds `UX_DataStoreDerivative_DataStoreId_DerivativeType` and
  `CK_DataStoreDerivative_DerivativeType`, then drops `IX_DataStoreDerivative_DataStoreId`. The unique
  constraint's backing index leads with the same column, so it serves the parent lookup and the
  child-side foreign-key maintenance; the index is dropped only after the constraint is in place;
- states its comparison semantics rather than inheriting the database or column collation:
  `COLLATE "C"` with `octet_length` on PostgreSQL, `COLLATE Latin1_General_100_BIN2` with `DATALENGTH`
  on SQL Server. `LEN` is not used anywhere, because it ignores trailing spaces. `SNAPSHOT` and
  `Snapshot ` are rejected by both engines — the first is what a naive `IN` accepts under a
  case-insensitive collation, the second what SQL Server's SQL-92 padding accepts at any collation;
- is replay-safe: every add is existence-guarded and the drop is conditional, so the PostgreSQL
  shape test's replay-every-script assertion passes.

## Upgrade preflight

Both constraints are added `WITH CHECK`, so legacy rows that violate either one would otherwise fail
the upgrade with a bare constraint-violation error. A preflight runs first and hard-stops the upgrade.
It never deletes a row, rewrites a type, or chooses among duplicates.

Diagnostics travel on two channels, because one of them has a hard ceiling.

**The thrown error** carries the true totals over the whole table, a bounded sample of offender
tuples, an `... and N more.` marker when the sample is capped, and the
`PUT /v3/dataStoreDerivatives/{id}` / `DELETE /v3/dataStoreDerivatives/{id}` remediation with the
allowed values. It is bounded because SQL Server's `THROW` delivers at most **2047** characters —
verified against SQL Server 2025, where a 3000-character message arrives as 2047. The tuple budget is
computed before the lists are built, so the message fits by construction. This matters because the
ceiling is silent in both directions: assigning an over-length string to a declared `NVARCHAR(n)`
truncates without raising, and errors 8152/2628 apply only to column writes, so nothing would report
an over-long message.

**The deployment log** carries the complete offender sets. Each script emits, immediately before the
throwing block, two ordered result sets whose tuple shapes and predicates are identical to the thrown
diagnostics: duplicates as `(DataStoreId, DerivativeType, Id)`, invalid types as
`(Id, DataStoreId, 'DerivativeType')` with the value single-quoted so a trailing space stays visible.
DbUp's `LogScriptOutput` writes every result set a script returns to the log as the reader is
consumed, so these rows reach the operator even though the script aborts immediately afterwards. On a
conforming database both statements return no rows. Without this an operator with more offenders than
the sample cap could not apply the documented remediation to all of them.

A result set is the channel rather than `PRINT` or `RAISE NOTICE` because it is the only one that
works on both engines. `LogScriptOutput` is not a notice subscription — in dbup-core it routes the
executor through `ExecuteAndLogOutput`/`WriteReaderToLog`, and `PostgresqlConnectionManager` wires no
notice handler, so a PostgreSQL notice never reaches the log. Both were probed against the real stack:

| channel | PostgreSQL | SQL Server |
| --- | --- | --- |
| `SELECT` result set | logged | logged |
| `RAISE NOTICE` / `PRINT` | **never logged** | logged |
| thrown error message | logged | logged |

Each preflight arm mirrors the constraint it protects: the invalid-type arm negates the same ordinal
expression the check constraint uses, while duplicate detection uses the engine's own equality, which
is what the unique constraint applies. Forcing a binary comparison into the duplicate arm would miss
a `Snapshot` / `Snapshot ` pair that SQL Server's padded unique constraint does treat as duplicate.

To let integration tests observe the log channel, each provider's `DatabaseDeploy` gains an internal
`ScriptOutputLog` property. It is unset in production, where the builder chain is unchanged and
logging stays on `LogScriptOutput().LogToAutodetectedLog()`. `IDatabaseDeploy` and every other shared
contract are untouched.

## API surface

`DataStoreDerivativeInsertResult` and `DataStoreDerivativeUpdateResult` gain
`FailureDuplicateDataStoreDerivative(int DataStoreId, string DerivativeType)`. Both provider
repositories recognize the conflict by constraint name only, never by generic failure text, and
`DataStoreDerivativeModule` maps each to `FailureResponse.ForConflict` with HTTP 409 instead of the
unknown-error response. Updating either `DataStoreId` or `DerivativeType` reaches the same conflict as
inserting a duplicate.

The foreign key and its cascade delete, the nullable connection-string contract, connection-string
encryption, tenant scoping, and auditing are unchanged. The accepted derivative types are unchanged:
the FluentValidation validators already accept exactly `ReadReplica` and `Snapshot` ordinally, so this
aligns the database with the existing API contract.

## Testing

New `DataStoreDerivativeUpgradeTests` for both providers deploy an isolated database, revert it to the
pre-upgrade shape, remove only that script's journal entry, seed legacy rows with raw SQL so the API
validator cannot filter them, and run the real upgrade — rather than replaying every script, which
would let a non-replay-safe earlier script decide the outcome. Cases: conforming upgrade with journal,
constraint, key-column and dropped-index assertions; duplicate rows; invalid type; case variant;
trailing whitespace; and exact-value acceptance with variant and duplicate rejection after the
upgrade.

The high-cardinality case seeds 30 duplicates and 31 invalid rows at the full 50-character column
width and proves both channels at once: the thrown message keeps every mandatory section within its
limit, and the offenders past the sample cap — the final seeded duplicate and the final seeded invalid
row — are absent from the thrown message and present in the captured deploy log. Asserting both
directions is what makes it meaningful, since it establishes those tuples could only have come from
the log channel.

`DataStoreTests` in both providers gains a fixture covering derivative inclusion in data-store
responses through the real `DataStoreRepository`, for both `GetDataStore` and `QueryDataStore`. Those
are separate lookups — single-parent versus batch-and-group — and both swallow a failed derivative
lookup into an empty collection, so a regression there would return a response silently reporting zero
derivatives with nothing failing. The frontend `DataStoreModuleTests` fake `DataStoreResponse` and
cannot reach that composition.

PostgreSQL `DatabaseShapeTests` moves `IX_DataStoreDerivative_DataStoreId` to the
removed-redundant-index inventory and expects both new constraints. SQL Server `DeployTests` gains
equivalent shape coverage: old index absent, unique constraint over exactly
`(DataStoreId, DerivativeType)` with a unique backing index, and an enabled, trusted check constraint.

Both provider suites cover the conflict result for insert and for updates that change either field,
and `DataStoreDerivativeModuleTests` proves the 409 mapping that repository tests cannot — against the
previous fall-through those fixtures fail on status 500, title "Internal Server Error", an empty
detail, and `application/problem+json`.

The paging and sorting fixtures in both provider `DataStoreDerivativeTests` seeded `Alpha`, `Bravo`
and `Charlie` derivatives on one data store. Every one of those rows violates the new check
constraint, and three rows on one data store cannot satisfy the unique constraint under any renaming,
so both fixtures now span two data stores holding the two storable types.

Local results on the final rebased tree: config solution build succeeded with 0 errors; PostgreSQL
config integration 381/381; SQL Server 2025 config integration 395/395; backend unit 482/482; frontend
unit 990/990; `git diff --check` clean. Removing the diagnostic result sets from the PostgreSQL script
turns the high-cardinality upgrade test red, confirming the added coverage is not vacuous. CSharpier
applied to all 15 changed C# files.

## Documentation

The `DataStoreDerivative` section of `docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md` documented the
index this upgrade removes. It now documents the unique and check constraints and the backing index
that replaces it.

## Follow-ups, out of scope here

- `DataStoreContextModule` answers its own duplicate case with a 400 `ValidationException` while this
  module now answers 409. Worth a decision about Management API consistency.
- `DataStoreContextRepository` interpolates `ContextKey` into its warning log unsanitized; the new
  derivative handlers use `LoggingUtility.SanitizeForLog`.
- `MssqlExceptionExtensions.IsUniqueViolation` matches an error number plus a case-insensitive
  `Message.Contains(name)`. No current constraint name contains another as a substring, but it is a
  latent misattribution risk in the shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DMS-1366]: https://edfi.atlassian.net/browse/DMS-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
