### PR TITLE
[DMS-1464] Remove the Push-to-Main Trigger from the DMS and Config Pull Request Workflows

### DIFF
--- a/.github/workflows/cleanup-dms-ci-ghcr-images.yml
+++ b/.github/workflows/cleanup-dms-ci-ghcr-images.yml
@@ -13,51 +13,182 @@ on:
 permissions:
   packages: write
 
+env:
+  PACKAGE_OWNER: Ed-Fi-Alliance-OSS
+  DMS_CI_PACKAGE: data-management-service-ed-fi-api-ci
+  CONFIG_CI_PACKAGE: data-management-service-ed-fi-api-config-ci
+  # Tag holding the buildx registry cache that the image builds in On DMS Pull Request and On
+  # Config Pull Request restore from. Only a non-pull_request run of On DMS Pull Request writes
+  # it.
+  BUILD_CACHE_TAG: buildcache
+
 jobs:
   cleanup:
     name: Cleanup DMS CI GHCR Images
     runs-on: ubuntu-latest
+    permissions:
+      # Write to delete versions; the same scope covers reading them to find the build cache
+      # version that must survive the prune.
+      packages: write
     steps:
+      - name: Resolve the shared build cache versions
+        id: cache-versions
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+
+          # min-versions-to-keep protects the newest 100 versions by creation date and nothing
+          # else, so a stretch of per-commit CI image pushes with no merge in between can push
+          # the build cache version out of that window and delete it. Evicting it costs every
+          # pull request a cold build until a non-pull_request run of On DMS Pull Request
+          # rewrites the tag, so the delete steps below are given that version explicitly to
+          # skip.
+          #
+          # ignore-versions is a regex tested against the package version *name*. For a
+          # container package that name is the manifest digest, not a tag -
+          # actions/delete-package-versions reads tags from a separate metadata field - so a
+          # regex naming the tag would never match and would silently protect nothing. The
+          # digest has to be resolved here and pinned into the regex on every run.
+          resolve_cache_version() {
+            # Prints "<digest><TAB><created_at>" for the version currently carrying the build
+            # cache tag, or nothing at all. The organization endpoint is the documented one;
+            # the user endpoint is the one actions/delete-package-versions itself calls, so
+            # both are tried before concluding the tag is absent.
+            local package="$1" endpoint raw match
+            for endpoint in orgs users; do
+              raw="$(gh api --paginate \
+                "/${endpoint}/${PACKAGE_OWNER}/packages/container/${package}/versions?per_page=100" \
+                --jq '.[] | select(.metadata.container.tags // [] | index(env.BUILD_CACHE_TAG)) | "\(.name)\t\(.created_at)"' \
+                2>/dev/null)" || raw=""
+              match="$(printf '%s\n' "$raw" | grep -m 1 '^sha256:')" || match=""
+              if [[ -n "$match" ]]; then
+                printf '%s' "$match"
+                return 0
+              fi
+            done
+          }
+
+          now="$(date -u +%s)"
+
+          for entry in "dms:${DMS_CI_PACKAGE}" "config:${CONFIG_CI_PACKAGE}"; do
+            key="${entry%%:*}"
+            package="${entry#*:}"
+
+            found="$(resolve_cache_version "$package")"
+            digest="${found%%$'\t'*}"
+            created="${found#*$'\t'}"
+
+            if [[ -z "$digest" ]]; then
+              # Nothing to protect. ^$ is the action's own default and matches no version name,
+              # so the prune behaves exactly as it did before this step existed.
+              echo "${key}_ignore=^\$" >> "$GITHUB_OUTPUT"
+              echo "::warning::No ${BUILD_CACHE_TAG} tag found on ${package}. Re-seed it with a workflow_dispatch run of On DMS Pull Request on main."
+              continue
+            fi
+
+            echo "${package}: ${BUILD_CACHE_TAG} -> ${digest} (created ${created})"
+            echo "${key}_ignore=^${digest}\$" >> "$GITHUB_OUTPUT"
+
+            age_days=$(( (now - $(date -u -d "$created" +%s)) / 86400 ))
+            if (( age_days > 14 )); then
+              echo "::warning::The ${BUILD_CACHE_TAG} tag on ${package} is ${age_days} days old. Either nothing has merged since, or the export is failing - it is non-fatal by design, so a failing export leaves no other signal. Check that the repository variable REBUILD_DOWNSTREAM_IMAGES is unset or false, because setting it stops Build CI Docker Images building at all and therefore stops the export."
+            fi
+          done
+
       - name: Keep recent DMS CI images
         uses: actions/delete-package-versions@25ad4af5be03aef10e0b3376b248688b7a44c40b # v5
         with:
-          owner: Ed-Fi-Alliance-OSS
-          package-name: data-management-service-ed-fi-api-ci
+          # Named from the same variables the resolve step above reads, so the version it
+          # excludes can never drift from the package this step prunes.
+          owner: ${{ env.PACKAGE_OWNER }}
+          package-name: ${{ env.DMS_CI_PACKAGE }}
           package-type: container
           min-versions-to-keep: 100
+          ignore-versions: ${{ steps.cache-versions.outputs.dms_ignore }}
 
       - name: Keep recent Config CI images
         uses: actions/delete-package-versions@25ad4af5be03aef10e0b3376b248688b7a44c40b # v5
         with:
-          owner: Ed-Fi-Alliance-OSS
-          package-name: data-management-service-ed-fi-api-config-ci
+          owner: ${{ env.PACKAGE_OWNER }}
+          package-name: ${{ env.CONFIG_CI_PACKAGE }}
           package-type: container
           min-versions-to-keep: 100
+          ignore-versions: ${{ steps.cache-versions.outputs.config_ignore }}
+
+  verify-build-cache:
+    name: Verify Shared Build Cache
+    runs-on: ubuntu-latest
+    needs: cleanup
+    if: always()
+    # The build cache is deliberately non-fatal wherever it is used: the export carries
+    # ignore-error=true so that a registry blip cannot eject an entry from the merge queue, and
+    # an unreadable import only makes buildx build cold. That leaves no failing signal for a
+    # cache that was pruned, was never written, or that the workflow token cannot read - the
+    # builds stay green and only get slower. This job is that signal. It sits on a schedule
+    # rather than in either pull request workflow precisely so that asserting the cache can
+    # never block a merge.
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Verify each build cache tag is present and readable
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          owner="${PACKAGE_OWNER,,}"
+          status=0
+
+          for package in "$DMS_CI_PACKAGE" "$CONFIG_CI_PACKAGE"; do
+            ref="ghcr.io/${owner}/${package}:${BUILD_CACHE_TAG}"
+            echo "::group::${ref}"
+            # Resolves the tag through the registry with the same workflow token the restoring
+            # builds use, so an access problem or a missing tag fails here instead of silently
+            # slowing every build. The printed MediaType records the manifest form the registry
+            # is actually serving.
+            if ! docker buildx imagetools inspect "$ref"; then
+              echo "::error::${ref} is missing or unreadable. Every image build that restores it is building cold. Re-seed it with a workflow_dispatch run of On DMS Pull Request on main."
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+
+          exit $status
 
   notify-results:
     name: Notify Results
     runs-on: ubuntu-latest
-    needs: cleanup
+    needs: [cleanup, verify-build-cache]
     if: always()
+    # Posts through a webhook secret, so it needs nothing from the workflow token.
+    permissions: {}
     steps:
       - name: Notify Slack on success
-        if: needs.cleanup.result == 'success'
+        if: needs.cleanup.result == 'success' && needs.verify-build-cache.result == 'success'
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           payload: |
             {
-              "text": ":heavy_check_mark: DMS CI GHCR image cleanup passed"
+              "text": ":heavy_check_mark: DMS CI GHCR image cleanup passed, shared build cache verified"
             }
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
 
       - name: Notify Slack on failure
-        if: needs.cleanup.result != 'success'
+        if: needs.cleanup.result != 'success' || needs.verify-build-cache.result != 'success'
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           payload: |
             {
-              "text": ":x: DMS CI GHCR image cleanup failed"
+              "text": ":x: DMS CI GHCR image cleanup failed (cleanup: ${{ needs.cleanup.result }}, build cache: ${{ needs.verify-build-cache.result }}). A missing build cache tag is re-seeded by a workflow_dispatch run of On DMS Pull Request on main."
             }
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/on-config-pullrequest.yml
+++ b/.github/workflows/on-config-pullrequest.yml
@@ -46,6 +46,16 @@ jobs:
       # a container registry reference must be lowercase and the expression language has no
       # lowercase function. The E2E jobs consume it; fresh-rebuild-docker-image does not,
       # because it deliberately builds with --no-cache.
+      #
+      # This workflow only ever restores from the tag. On DMS Pull Request writes it, from its
+      # Build CI Docker Images job, on non-pull_request runs only - which is why no job here
+      # needs packages: write. Two things stop that writer, and neither fails anything here:
+      # setting the repository variable REBUILD_DOWNSTREAM_IMAGES skips that job's build steps
+      # altogether, and the GHCR pruner could evict the tag. The recovery for both is a
+      # workflow_dispatch run of On DMS Pull Request on main, which is also eligible to export.
+      # Cleanup DMS CI GHCR Images excludes the tag from its own prune and fails when the tag
+      # stops resolving, so an evicted or unwritten cache surfaces there instead of silently
+      # slowing every build in this file.
       config_cache_ref: ${{ steps.cache-ref.outputs.config_cache_ref }}
     steps:
       - name: Resolve the build cache reference
@@ -337,6 +347,12 @@ jobs:
       github.event_name != 'pull_request' ||
       needs.detect-fresh-build-changes.outputs.config_relevant == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      # packages: read is load-bearing here, not boilerplate: the CI packages are private, so
+      # restoring the build cache below authenticates with this token. Narrowing this block to
+      # contents: read alone would silently make every build in this job cold.
+      contents: read
+      packages: read
     defaults:
       run:
         shell: pwsh
@@ -372,10 +388,11 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          # Restore only, from the tag the merge queue run of On DMS Pull Request writes. That
-          # workflow builds this same image from the same context, Dockerfile and build
-          # contexts, so its layers are reusable here and no job in this workflow needs
-          # packages: write. An unreadable or absent cache import logs an ERROR vertex but does
+          # Restore only, from the tag On DMS Pull Request writes; the writer, the conditions
+          # that stop it writing and the recovery for each are described on the
+          # config_cache_ref output of detect-fresh-build-changes. That workflow builds this
+          # same image from the same context, Dockerfile and build contexts, so its layers are
+          # reusable here. An unreadable or absent cache import logs an ERROR vertex but does
           # not fail the build, so a cold build still succeeds.
           cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
@@ -424,6 +441,12 @@ jobs:
       github.event_name != 'pull_request' ||
       needs.detect-fresh-build-changes.outputs.config_relevant == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      # packages: read is load-bearing here, not boilerplate: the CI packages are private, so
+      # restoring the build cache below authenticates with this token. Narrowing this block to
+      # contents: read alone would silently make every build in this job cold.
+      contents: read
+      packages: read
     defaults:
       run:
         shell: pwsh
@@ -459,10 +482,11 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          # Restore only, from the tag the merge queue run of On DMS Pull Request writes. That
-          # workflow builds this same image from the same context, Dockerfile and build
-          # contexts, so its layers are reusable here and no job in this workflow needs
-          # packages: write. An unreadable or absent cache import logs an ERROR vertex but does
+          # Restore only, from the tag On DMS Pull Request writes; the writer, the conditions
+          # that stop it writing and the recovery for each are described on the
+          # config_cache_ref output of detect-fresh-build-changes. That workflow builds this
+          # same image from the same context, Dockerfile and build contexts, so its layers are
+          # reusable here. An unreadable or absent cache import logs an ERROR vertex but does
           # not fail the build, so a cold build still succeeds.
           cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
@@ -511,6 +535,12 @@ jobs:
       github.event_name != 'pull_request' ||
       needs.detect-fresh-build-changes.outputs.config_relevant == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      # packages: read is load-bearing here, not boilerplate: the CI packages are private, so
+      # restoring the build cache below authenticates with this token. Narrowing this block to
+      # contents: read alone would silently make every build in this job cold.
+      contents: read
+      packages: read
     defaults:
       run:
         shell: pwsh
@@ -546,10 +576,11 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          # Restore only, from the tag the merge queue run of On DMS Pull Request writes. That
-          # workflow builds this same image from the same context, Dockerfile and build
-          # contexts, so its layers are reusable here and no job in this workflow needs
-          # packages: write. An unreadable or absent cache import logs an ERROR vertex but does
+          # Restore only, from the tag On DMS Pull Request writes; the writer, the conditions
+          # that stop it writing and the recovery for each are described on the
+          # config_cache_ref output of detect-fresh-build-changes. That workflow builds this
+          # same image from the same context, Dockerfile and build contexts, so its layers are
+          # reusable here. An unreadable or absent cache import logs an ERROR vertex but does
           # not fail the build, so a cold build still succeeds.
           cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 

--- a/.github/workflows/on-config-pullrequest.yml
+++ b/.github/workflows/on-config-pullrequest.yml
@@ -44,7 +44,8 @@ jobs:
       config_relevant: ${{ steps.detect.outputs.config_relevant }}
       # Registry reference for the shared Config image build cache. Computed once here because
       # a container registry reference must be lowercase and the expression language has no
-      # lowercase function; every job that builds the image consumes this output.
+      # lowercase function. The E2E jobs consume it; fresh-rebuild-docker-image does not,
+      # because it deliberately builds with --no-cache.
       config_cache_ref: ${{ steps.cache-ref.outputs.config_cache_ref }}
     steps:
       - name: Resolve the build cache reference
@@ -52,7 +53,7 @@ jobs:
         shell: bash
         run: |
           owner="${GITHUB_REPOSITORY_OWNER,,}"
-          echo "config_cache_ref=ghcr.io/${owner}/data-management-service-ed-fi-api-config-ci:e2e-buildcache" >> "$GITHUB_OUTPUT"
+          echo "config_cache_ref=ghcr.io/${owner}/data-management-service-ed-fi-api-config-ci:buildcache" >> "$GITHUB_OUTPUT"
 
       - name: Checkout the Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -87,13 +88,11 @@ jobs:
               exit 0
             fi
           else
-            before="${{ github.event.before }}"
-
-            if [[ "$before" == "0000000000000000000000000000000000000000" ]]; then
-              changed_files="$(git diff-tree --no-commit-id --no-renames --name-only -r HEAD)"
-            else
-              changed_files="$(git diff --no-renames --name-only "$before" "${{ github.sha }}")"
-            fi
+            # Unreachable with the current triggers: workflow_dispatch returned above and the
+            # only other events are pull_request and merge_group. Run the full suite rather
+            # than infer a diff base for an event this script does not model.
+            emit true true
+            exit 0
           fi
 
           fresh_build_required=false
@@ -353,8 +352,9 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         # Only needed to restore the build cache. A fork pull request token may not be able to
-        # read the cache package, and buildx treats an unreadable cache as a warning rather than
-        # an error, so a failure here must degrade to a cold build instead of failing the job.
+        # read the cache package; buildx logs an ERROR vertex for a cache import it cannot read
+        # but still completes the build, so a failure here must degrade to a cold build rather
+        # than fail the job.
         continue-on-error: true
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
@@ -372,9 +372,11 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          # Restore only. seed-config-build-cache is the sole writer, so no job that runs pull
-          # request code needs packages: write. An absent or unreadable cache is a warning in
-          # buildx, not a failure, so a cold build still succeeds.
+          # Restore only, from the tag the merge queue run of On DMS Pull Request writes. That
+          # workflow builds this same image from the same context, Dockerfile and build
+          # contexts, so its layers are reusable here and no job in this workflow needs
+          # packages: write. An unreadable or absent cache import logs an ERROR vertex but does
+          # not fail the build, so a cold build still succeeds.
           cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
       - name: Cache Nuget packages
@@ -437,8 +439,9 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         # Only needed to restore the build cache. A fork pull request token may not be able to
-        # read the cache package, and buildx treats an unreadable cache as a warning rather than
-        # an error, so a failure here must degrade to a cold build instead of failing the job.
+        # read the cache package; buildx logs an ERROR vertex for a cache import it cannot read
+        # but still completes the build, so a failure here must degrade to a cold build rather
+        # than fail the job.
         continue-on-error: true
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
@@ -456,9 +459,11 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          # Restore only. seed-config-build-cache is the sole writer, so no job that runs pull
-          # request code needs packages: write. An absent or unreadable cache is a warning in
-          # buildx, not a failure, so a cold build still succeeds.
+          # Restore only, from the tag the merge queue run of On DMS Pull Request writes. That
+          # workflow builds this same image from the same context, Dockerfile and build
+          # contexts, so its layers are reusable here and no job in this workflow needs
+          # packages: write. An unreadable or absent cache import logs an ERROR vertex but does
+          # not fail the build, so a cold build still succeeds.
           cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
       - name: Cache Nuget packages
@@ -521,8 +526,9 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         # Only needed to restore the build cache. A fork pull request token may not be able to
-        # read the cache package, and buildx treats an unreadable cache as a warning rather than
-        # an error, so a failure here must degrade to a cold build instead of failing the job.
+        # read the cache package; buildx logs an ERROR vertex for a cache import it cannot read
+        # but still completes the build, so a failure here must degrade to a cold build rather
+        # than fail the job.
         continue-on-error: true
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
@@ -540,9 +546,11 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          # Restore only. seed-config-build-cache is the sole writer, so no job that runs pull
-          # request code needs packages: write. An absent or unreadable cache is a warning in
-          # buildx, not a failure, so a cold build still succeeds.
+          # Restore only, from the tag the merge queue run of On DMS Pull Request writes. That
+          # workflow builds this same image from the same context, Dockerfile and build
+          # contexts, so its layers are reusable here and no job in this workflow needs
+          # packages: write. An unreadable or absent cache import logs an ERROR vertex but does
+          # not fail the build, so a cold build still succeeds.
           cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
       - name: Cache Nuget packages
@@ -618,48 +626,6 @@ jobs:
         working-directory: eng/docker-compose
         run: |
           docker compose -f postgresql.yml -f local-config.yml -f keycloak.yml --env-file "./.env.config.e2e" -p cs-local build --no-cache
-
-  # Sole writer of the shared Config image build cache. A container registry cache is not
-  # branch-scoped, so one reference serves every event: the GitHub Actions cache backend scopes
-  # entries by ref, which means only a run on the default branch could seed an entry every pull
-  # request is able to restore. Restricting the export to non-pull_request events keeps
-  # packages: write out of every job that executes pull request code, and lets the merge queue -
-  # which builds the tree that is about to become main - refresh the cache without adding a run
-  # to the pull request path. Deliberately omitted from config-ci-gate, like event_file: this is
-  # a build-time optimization and a registry hiccup must never block a merge.
-  seed-config-build-cache:
-    name: Seed Config Build Cache
-    needs: detect-fresh-build-changes
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout the Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Build the Config image and export its build cache
-        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
-        with:
-          context: ./src/config
-          file: ./src/config/Dockerfile
-          build-contexts: |
-            parentdir=./src
-          # No load or push: this job exists to populate the cache, not to produce an image.
-          push: false
-          cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
-          cache-to: type=registry,mode=max,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
   event_file:
     name: Upload Event File

--- a/.github/workflows/on-config-pullrequest.yml
+++ b/.github/workflows/on-config-pullrequest.yml
@@ -6,19 +6,7 @@
 name: On Config Pull Request
 
 on:
-  push:
-    # Running on push to main to support CodeQL on C#
-    branches:
-      - main
-    paths:
-      - ".github/workflows/**"
-      - "build-config.ps1"
-      - "eng/**"
-      - "src/Directory.Packages.props"
-      - "src/nuget.config"
-      - "src/config/**"
-
-  # No paths filter here (unlike push above): the merge queue requires an aggregate status
+  # No paths filter here: the merge queue requires an aggregate status
   # check (config-ci-gate) that must report on every pull request, so this workflow runs for
   # all PRs regardless of which files changed. detect-fresh-build-changes computes
   # config_relevant and the heavy jobs skip when no config-relevant file changed, so idle PRs
@@ -54,7 +42,18 @@ jobs:
       # jobs gate on this so that a PR touching only unrelated areas (e.g. DMS-only) skips the
       # config suite while this workflow still runs and reports config-ci-gate.
       config_relevant: ${{ steps.detect.outputs.config_relevant }}
+      # Registry reference for the shared Config image build cache. Computed once here because
+      # a container registry reference must be lowercase and the expression language has no
+      # lowercase function; every job that builds the image consumes this output.
+      config_cache_ref: ${{ steps.cache-ref.outputs.config_cache_ref }}
     steps:
+      - name: Resolve the build cache reference
+        id: cache-ref
+        shell: bash
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "config_cache_ref=ghcr.io/${owner}/data-management-service-ed-fi-api-config-ci:e2e-buildcache" >> "$GITHUB_OUTPUT"
+
       - name: Checkout the Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -70,7 +69,7 @@ jobs:
             echo "config_relevant=$2" >> "$GITHUB_OUTPUT"
           }
 
-          # Non-pull_request events (push, merge_group, workflow_dispatch) always run the full
+          # Non-pull_request events (merge_group, workflow_dispatch) always run the full
           # suite, so config_relevant is reported true and only fresh_build_required matters.
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             emit true true
@@ -98,7 +97,7 @@ jobs:
           fi
 
           fresh_build_required=false
-          # For merge_group and push, force config_relevant true so nothing is skipped when
+          # For merge_group, force config_relevant true so nothing is skipped when
           # validating the merged result; only pull_request narrows to the changed area.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             config_relevant=false
@@ -352,13 +351,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
-      - name: Cache Docker layers
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
+      - name: Log in to GitHub Container Registry
+        # Only needed to restore the build cache. A fork pull request token may not be able to
+        # read the cache package, and buildx treats an unreadable cache as a warning rather than
+        # an error, so a failure here must degrade to a cold build instead of failing the job.
+        continue-on-error: true
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('src/Directory.Packages.props', 'src/nuget.config', 'src/config/Dockerfile', 'src/config/**') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Build Config Docker image
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
@@ -370,8 +372,10 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # Restore only. seed-config-build-cache is the sole writer, so no job that runs pull
+          # request code needs packages: write. An absent or unreadable cache is a warning in
+          # buildx, not a failure, so a cold build still succeeds.
+          cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
       - name: Cache Nuget packages
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
@@ -431,13 +435,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
-      - name: Cache Docker layers
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
+      - name: Log in to GitHub Container Registry
+        # Only needed to restore the build cache. A fork pull request token may not be able to
+        # read the cache package, and buildx treats an unreadable cache as a warning rather than
+        # an error, so a failure here must degrade to a cold build instead of failing the job.
+        continue-on-error: true
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('src/Directory.Packages.props', 'src/nuget.config', 'src/config/Dockerfile', 'src/config/**') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Build Config Docker image
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
@@ -449,8 +456,10 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # Restore only. seed-config-build-cache is the sole writer, so no job that runs pull
+          # request code needs packages: write. An absent or unreadable cache is a warning in
+          # buildx, not a failure, so a cold build still succeeds.
+          cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
       - name: Cache Nuget packages
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
@@ -510,13 +519,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
-      - name: Cache Docker layers
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
+      - name: Log in to GitHub Container Registry
+        # Only needed to restore the build cache. A fork pull request token may not be able to
+        # read the cache package, and buildx treats an unreadable cache as a warning rather than
+        # an error, so a failure here must degrade to a cold build instead of failing the job.
+        continue-on-error: true
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('src/Directory.Packages.props', 'src/nuget.config', 'src/config/Dockerfile', 'src/config/**') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Build Config Docker image
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
@@ -528,8 +540,10 @@ jobs:
             parentdir=./src
           push: false
           tags: ed-fi-api-config-local:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # Restore only. seed-config-build-cache is the sole writer, so no job that runs pull
+          # request code needs packages: write. An absent or unreadable cache is a warning in
+          # buildx, not a failure, so a cold build still succeeds.
+          cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
       - name: Cache Nuget packages
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
@@ -604,6 +618,48 @@ jobs:
         working-directory: eng/docker-compose
         run: |
           docker compose -f postgresql.yml -f local-config.yml -f keycloak.yml --env-file "./.env.config.e2e" -p cs-local build --no-cache
+
+  # Sole writer of the shared Config image build cache. A container registry cache is not
+  # branch-scoped, so one reference serves every event: the GitHub Actions cache backend scopes
+  # entries by ref, which means only a run on the default branch could seed an entry every pull
+  # request is able to restore. Restricting the export to non-pull_request events keeps
+  # packages: write out of every job that executes pull request code, and lets the merge queue -
+  # which builds the tree that is about to become main - refresh the cache without adding a run
+  # to the pull request path. Deliberately omitted from config-ci-gate, like event_file: this is
+  # a build-time optimization and a registry hiccup must never block a merge.
+  seed-config-build-cache:
+    name: Seed Config Build Cache
+    needs: detect-fresh-build-changes
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout the Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build the Config image and export its build cache
+        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
+        with:
+          context: ./src/config
+          file: ./src/config/Dockerfile
+          build-contexts: |
+            parentdir=./src
+          # No load or push: this job exists to populate the cache, not to produce an image.
+          push: false
+          cache-from: type=registry,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
+          cache-to: type=registry,mode=max,ref=${{ needs.detect-fresh-build-changes.outputs.config_cache_ref }}
 
   event_file:
     name: Upload Event File

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -116,6 +116,10 @@ jobs:
                 fresh_build_required=true
                 ;;
             esac
+            # src/config counts as DMS-relevant: the DMS E2E lanes (incl. the DS 6.1
+            # version-coupled lane) bring up the Config Service built from src/config, so
+            # config-only changes (e.g. ds61 Claims.json, ClaimsProvider, ResourceClaim
+            # seeding) must still trigger this workflow's DMS + DS 6.1 validation.
             case "$file" in
               .github/actions/*|.github/workflows/*|build-dms.ps1|eng/*|src/Directory.Packages.props|src/nuget.config|src/dms/*|src/config/*)
                 dms_relevant=true
@@ -645,6 +649,8 @@ jobs:
           image_sha="${PULL_REQUEST_HEAD_SHA:-$GITHUB_SHA}"
           dms_image="ghcr.io/${owner}/data-management-service-ed-fi-api-ci:${image_sha}"
           config_image="ghcr.io/${owner}/data-management-service-ed-fi-api-config-ci:${image_sha}"
+          dms_cache_ref="ghcr.io/${owner}/data-management-service-ed-fi-api-ci:buildcache"
+          config_cache_ref="ghcr.io/${owner}/data-management-service-ed-fi-api-config-ci:buildcache"
 
           dms_compose_image=""
           config_compose_image=""
@@ -657,6 +663,8 @@ jobs:
             echo "use_prebuilt_images=$use_prebuilt_images"
             echo "dms_image=$dms_image"
             echo "config_image=$config_image"
+            echo "dms_cache_ref=$dms_cache_ref"
+            echo "config_cache_ref=$config_cache_ref"
             echo "dms_compose_image=$dms_compose_image"
             echo "config_compose_image=$config_compose_image"
           } >> "$GITHUB_OUTPUT"
@@ -687,8 +695,12 @@ jobs:
             parentdir=./src
           push: true
           tags: ${{ steps.prepare-images.outputs.dms_image }}
-          cache-from: type=gha,scope=dms-pr-dms-image
-          cache-to: type=gha,mode=max,scope=dms-pr-dms-image
+          # A registry cache is not branch-scoped, so one shared ref serves every event and any
+          # run can restore it. Only non-pull_request runs export to it: the merge queue builds
+          # the tree that is about to become main, while concurrent pull request exports would
+          # race on the same tag and fill it with branch-specific layers.
+          cache-from: type=registry,ref=${{ steps.prepare-images.outputs.dms_cache_ref }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,ref={0}', steps.prepare-images.outputs.dms_cache_ref) || '' }}
 
       - name: Build and push Config CI Docker image
         if: steps.prepare-images.outputs.use_prebuilt_images == 'true'
@@ -700,8 +712,8 @@ jobs:
             parentdir=./src
           push: true
           tags: ${{ steps.prepare-images.outputs.config_image }}
-          cache-from: type=gha,scope=dms-pr-config-image
-          cache-to: type=gha,mode=max,scope=dms-pr-config-image
+          cache-from: type=registry,ref=${{ steps.prepare-images.outputs.config_cache_ref }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,ref={0}', steps.prepare-images.outputs.config_cache_ref) || '' }}
 
   run-backend-mssql-integration-tests:
     name: Run Backend MSSQL Integration Tests (${{ matrix.shard-name }})

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -701,12 +701,20 @@ jobs:
           # run can restore it; the GitHub Actions backend scopes entries by ref, so only a run
           # on the default branch could seed one that every pull request restores. Exporting is
           # limited to non-pull_request runs: the merge queue builds the tree about to become
-          # main, and workflow_dispatch stays eligible as the manual lever for re-seeding a
-          # pruned tag. Concurrent merge queue entries can still race on this tag; last writer
-          # wins and the blobs are content-addressed, so the loser costs only a cache refresh.
+          # main, and workflow_dispatch stays eligible as the manual lever for re-seeding the
+          # tag. Concurrent merge queue entries can still race on this tag; last writer wins
+          # and the blobs are content-addressed, so the loser costs only a cache refresh.
           # ignore-error keeps a registry hiccup during export from failing a job that
           # dms-ci-gate requires; buildx still prints an ERROR vertex for the failed export, so
-          # a green run can legitimately carry one.
+          # a green run can legitimately carry one. Since that leaves a broken export looking
+          # green here, Cleanup DMS CI GHCR Images owns the failing signal instead: it excludes
+          # the version this tag points at from its own prune, and fails when the tag stops
+          # resolving.
+          #
+          # This tag is an input to every other pull request's build, and the gate deciding who
+          # writes it is a line in this file. Fork pull requests cannot reach it - they clear
+          # use_prebuilt_images - so changing it takes write access to this repository and
+          # lands in a reviewable diff.
           cache-from: type=registry,ref=${{ steps.prepare-images.outputs.dms_cache_ref }}
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,ignore-error=true,ref={0}', steps.prepare-images.outputs.dms_cache_ref) || '' }}
 

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -6,23 +6,7 @@
 name: On DMS Pull Request
 
 on:
-  push:
-    # Running on push to main to support CodeQL on C#
-    branches:
-      - main
-    paths:
-      - ".github/workflows/**"
-      - "build-dms.ps1"
-      - "eng/**"
-      - "src/Directory.Packages.props"
-      - "src/nuget.config"
-      - "src/dms/**"
-      # The DMS E2E lanes (incl. the DS 6.1 version-coupled lane) bring up the Config Service built from
-      # src/config, so config-only changes (e.g. ds61 Claims.json, ClaimsProvider, ResourceClaim seeding)
-      # must still trigger this workflow's DMS + DS 6.1 validation.
-      - "src/config/**"
-
-  # No paths filter here (unlike push above): the merge queue requires an aggregate status
+  # No paths filter here: the merge queue requires an aggregate status
   # check (dms-ci-gate) that must report on every pull request, so this workflow runs for all
   # PRs regardless of which files changed. detect-fresh-build-changes computes dms_relevant and
   # the heavy jobs skip when no DMS-relevant file changed, so idle PRs stay cheap and the gate
@@ -90,7 +74,7 @@ jobs:
             echo "dms_relevant=$2" >> "$GITHUB_OUTPUT"
           }
 
-          # Non-pull_request events (push, merge_group, workflow_dispatch) always run the full
+          # Non-pull_request events (merge_group, workflow_dispatch) always run the full
           # suite, so dms_relevant is reported true and only fresh_build_required is meaningful.
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             emit true true
@@ -118,7 +102,7 @@ jobs:
           fi
 
           fresh_build_required=false
-          # For merge_group and push, force dms_relevant true so nothing is skipped when
+          # For merge_group, force dms_relevant true so nothing is skipped when
           # validating the merged result; only pull_request narrows to the changed area.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             dms_relevant=false

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -55,8 +55,9 @@ jobs:
     outputs:
       fresh_build_required: ${{ steps.detect.outputs.fresh_build_required }}
       # True when the pull request changed a file relevant to DMS validation. The heavy jobs
-      # gate on this so that a PR touching only unrelated areas (e.g. config-only) skips the
-      # DMS suite while this workflow still runs and reports dms-ci-gate.
+      # gate on this so that a PR touching only unrelated areas (e.g. docs-only) skips the DMS
+      # suite while this workflow still runs and reports dms-ci-gate. src/config counts as
+      # DMS-relevant, so a config-only PR does not skip.
       dms_relevant: ${{ steps.detect.outputs.dms_relevant }}
     steps:
       - name: Checkout the Repo
@@ -92,13 +93,11 @@ jobs:
               exit 0
             fi
           else
-            before="${{ github.event.before }}"
-
-            if [[ "$before" == "0000000000000000000000000000000000000000" ]]; then
-              changed_files="$(git diff-tree --no-commit-id --no-renames --name-only -r HEAD)"
-            else
-              changed_files="$(git diff --no-renames --name-only "$before" "${{ github.sha }}")"
-            fi
+            # Unreachable with the current triggers: workflow_dispatch returned above and the
+            # only other events are pull_request and merge_group. Run the full suite rather
+            # than infer a diff base for an event this script does not model.
+            emit true true
+            exit 0
           fi
 
           fresh_build_required=false
@@ -623,6 +622,9 @@ jobs:
     env:
       # Set repository variable REBUILD_DOWNSTREAM_IMAGES=true to keep downstream
       # E2E/OpenAPI jobs rebuilding local images while rolling this change back or forward.
+      # Doing so also stops this job building at all, which stops the shared build cache tags
+      # from refreshing - for this workflow and for On Config Pull Request, which restores the
+      # Config tag. Both degrade to cold builds rather than failing.
       REBUILD_DOWNSTREAM_IMAGES: ${{ vars.REBUILD_DOWNSTREAM_IMAGES }}
       IS_FORK_PULL_REQUEST: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -696,11 +698,17 @@ jobs:
           push: true
           tags: ${{ steps.prepare-images.outputs.dms_image }}
           # A registry cache is not branch-scoped, so one shared ref serves every event and any
-          # run can restore it. Only non-pull_request runs export to it: the merge queue builds
-          # the tree that is about to become main, while concurrent pull request exports would
-          # race on the same tag and fill it with branch-specific layers.
+          # run can restore it; the GitHub Actions backend scopes entries by ref, so only a run
+          # on the default branch could seed one that every pull request restores. Exporting is
+          # limited to non-pull_request runs: the merge queue builds the tree about to become
+          # main, and workflow_dispatch stays eligible as the manual lever for re-seeding a
+          # pruned tag. Concurrent merge queue entries can still race on this tag; last writer
+          # wins and the blobs are content-addressed, so the loser costs only a cache refresh.
+          # ignore-error keeps a registry hiccup during export from failing a job that
+          # dms-ci-gate requires; buildx still prints an ERROR vertex for the failed export, so
+          # a green run can legitimately carry one.
           cache-from: type=registry,ref=${{ steps.prepare-images.outputs.dms_cache_ref }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,ref={0}', steps.prepare-images.outputs.dms_cache_ref) || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,ignore-error=true,ref={0}', steps.prepare-images.outputs.dms_cache_ref) || '' }}
 
       - name: Build and push Config CI Docker image
         if: steps.prepare-images.outputs.use_prebuilt_images == 'true'
@@ -712,8 +720,11 @@ jobs:
             parentdir=./src
           push: true
           tags: ${{ steps.prepare-images.outputs.config_image }}
+          # Same export rules as the DMS image above. On Config Pull Request restores this same
+          # tag for its E2E jobs rather than writing its own, which is why that workflow needs
+          # no packages: write anywhere.
           cache-from: type=registry,ref=${{ steps.prepare-images.outputs.config_cache_ref }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,ref={0}', steps.prepare-images.outputs.config_cache_ref) || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,ignore-error=true,ref={0}', steps.prepare-images.outputs.config_cache_ref) || '' }}
 
   run-backend-mssql-integration-tests:
     name: Run Backend MSSQL Integration Tests (${{ matrix.shard-name }})

--- a/docs/NUGET-LOCK-FILES.md
+++ b/docs/NUGET-LOCK-FILES.md
@@ -62,8 +62,9 @@ Each PR workflow has a dedicated `verify-lock-files` gate job that runs
 [Config](../.github/workflows/on-config-pullrequest.yml)). `--locked-mode` fails
 fast if a committed lock file is out of sync with the `.csproj` /
 `Directory.Packages.props` state — for example, if a package reference is added
-without regenerating. No `paths:` change is needed: lock files live under
-`src/dms/**` / `src/config/**`, which the existing filters already match.
+without regenerating. No `paths:` change is needed: neither PR workflow
+filters `pull_request` by path, and lock files live under `src/dms/**` /
+`src/config/**`, which the relevance detection already matches.
 
 ### 3. Locked mode in the source Docker image builds
 

--- a/reference/design/backend-redesign/epics/07-relational-write-path/07-semantic-identity-presence-fidelity.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/07-semantic-identity-presence-fidelity.md
@@ -31,7 +31,7 @@ This follow-on owns making the distinction explicit, validated, and durable for 
 - Contract or plan changes required to preserve absent-vs-explicit-null information through executor-facing metadata
 - Deterministic validation and failure behavior when required presence fidelity is missing or inconsistent
 - Test coverage for null-identity and presence-sensitive matching cases on both PostgreSQL and SQL Server
-- CI E2E scope adjustment for this branch: normal DMS PR/push CI should run only relational-backend DMS E2E coverage from the main DMS E2E suite, while scheduled workflows retain the legacy-backend DMS E2E lane.
+- CI E2E scope adjustment for this branch: normal DMS PR CI should run only relational-backend DMS E2E coverage from the main DMS E2E suite, while scheduled workflows retain the legacy-backend DMS E2E lane.
 
 ## Out Of Scope
 
@@ -49,15 +49,15 @@ This follow-on owns making the distinction explicit, validated, and durable for 
 - Profile-aware and no-profile collection matching behave consistently for presence-sensitive identity cases.
 - Missing or inconsistent presence-fidelity metadata fails deterministically rather than silently matching the wrong row.
 - PostgreSQL and SQL Server coverage exists for representative presence-sensitive identity cases.
-- Normal DMS PR/push CI no longer runs the legacy-backend lane from `EdFi.DataManagementService.Tests.E2E` (`Category!=@relational-backend`).
-- Normal DMS PR/push CI still runs `EdFi.DataManagementService.Tests.E2E` scenarios tagged `@relational-backend` with the relational E2E environment.
-- Normal DMS PR/push CI still runs the DMS instance-management / multi-tenant E2E suite.
+- Normal DMS PR CI no longer runs the legacy-backend lane from `EdFi.DataManagementService.Tests.E2E` (`Category!=@relational-backend`).
+- Normal DMS PR CI still runs `EdFi.DataManagementService.Tests.E2E` scenarios tagged `@relational-backend` with the relational E2E environment.
+- Normal DMS PR CI still runs the DMS instance-management / multi-tenant E2E suite.
 - CMS PR CI still runs CMS E2E coverage unchanged.
 - Scheduled DMS workflows still run legacy-backend DMS E2E coverage.
 
 ## CI E2E Scope Requirement
 
-The DMS PR/push workflow currently runs both DMS E2E lanes:
+The DMS PR workflow currently runs both DMS E2E lanes:
 
 - legacy lane: `build-dms.ps1 E2ETest -EnvironmentFile './.env.e2e' -TestFilter 'Category!=@relational-backend'`
 - relational lane: `build-dms.ps1 E2ETest -EnvironmentFile './.env.e2e.relational' -TestFilter 'Category=@relational-backend'`
@@ -91,7 +91,7 @@ Do not weaken `build-dms.ps1` E2E lane guardrails. The script should continue re
 
 ### CI/workflow validation
 
-- The diff to `.github/workflows/on-dms-pullrequest.yml` is reviewed to confirm the normal DMS PR/push workflow no longer invokes `build-dms.ps1 E2ETest` with `Category!=@relational-backend`, still invokes `build-dms.ps1 E2ETest` with `Category=@relational-backend`, and still invokes `build-dms.ps1 InstanceE2ETest`.
+- The diff to `.github/workflows/on-dms-pullrequest.yml` is reviewed to confirm the normal DMS PR workflow no longer invokes `build-dms.ps1 E2ETest` with `Category!=@relational-backend`, still invokes `build-dms.ps1 E2ETest` with `Category=@relational-backend`, and still invokes `build-dms.ps1 InstanceE2ETest`.
 - Existing `build-dms.ps1` runtime lane guardrail tests (`Given_Build_Dms_E2E_Guardrails`) remain valid and are not relaxed.
 
 ## Tasks
@@ -100,4 +100,4 @@ Do not weaken `build-dms.ps1` E2E lane guardrails. The script should continue re
 2. Update matching logic to consume the preserved presence information without introducing backend-owned profile inference.
 3. Add deterministic validation/failure behavior when presence-sensitive identity metadata is missing or inconsistent.
 4. Add unit and integration coverage for representative absent-vs-explicit-null identity cases on both dialects.
-5. Update normal DMS PR/push CI to run only relational-tagged DMS E2E coverage from the main DMS E2E suite, while preserving CMS E2E, DMS instance-management E2E, and scheduled legacy DMS E2E coverage.
+5. Update normal DMS PR CI to run only relational-tagged DMS E2E coverage from the main DMS E2E suite, while preserving CMS E2E, DMS instance-management E2E, and scheduled legacy DMS E2E coverage.


### PR DESCRIPTION
## What

Removes the push-to-main trigger from **both** pull request workflows, so each runs on `pull_request`, `merge_group`, and `workflow_dispatch` only — and moves the image build caches onto a backend that does not depend on a push-to-main run.

| File | Change |
|---|---|
| `on-dms-pullrequest.yml` | delete the `on.push` block; move the two CI image builds from `type=gha` to a registry build cache; correct the comments the deletion falsified |
| `on-config-pullrequest.yml` | delete the `on.push` block; replace `actions/cache` + `type=local` in the three E2E jobs with a restore-only registry cache; declare the `packages: read` those restores depend on |
| `cleanup-dms-ci-ghcr-images.yml` | exclude the live build cache version from the prune, and verify daily that both cache tags still resolve |
| `docs/NUGET-LOCK-FILES.md` | correct the lock-file note that the removed path filters falsified |
| `…/07-semantic-identity-presence-fidelity.md` | drop seven stale "DMS PR/push CI" references |

In both workflows `pull_request` keeps `branches: [main]` with **no** `paths` filter, and `merge_group`, `workflow_dispatch`, job definitions, `concurrency`, and `env` are otherwise untouched.

## Why

The push-to-main run duplicated validation the merge queue had already performed on the same tree — with one exception, described below, which this PR also fixes rather than leaving behind.

- **CodeQL**, the stated reason for the trigger, is owned independently by `codeql-analysis.yml`, which has its own push-to-main trigger filtered to C# sources.
- **Prerelease creation** is owned independently by `on-dms-merge-or-tag.yml`, which has its own push-to-main trigger filtered to `src/dms/**`.
- **Nothing outside this workflow consumes its artifacts.** The only `test-timings-*` consumer is the in-run aggregate download in this same file; `after-pullrequest.yml` listens for the workflow named `On Pull Request`, not `On DMS Pull Request`, and that `workflows:` list is string equality, not prefix matching. Organization-wide code search found no consumers in other repositories.
- A `merge_group` run on the same tree produces the same 26 artifacts, including `test-timings-aggregate` — confirmed by comparing run 32908561318 (merge_group) with run 32911518305 (push), both at head SHA `90be9e30a`.

`pull_request` deliberately keeps no `paths` filter: the merge queue requires `dms-ci-gate` to report on **every** pull request. `detect-fresh-build-changes` computes `dms_relevant`, and the heavy jobs skip when nothing DMS-relevant changed, so idle PRs stay cheap while the gate still reports.

## The push run was not purely redundant — the build cache

The push-to-main run was the run that seeded a build cache every pull request restored from. Removing the trigger alone would have silently regressed CI build times, so this PR fixes the cause rather than accepting it.

The GitHub Actions cache backend scopes entries by ref. A run restores from its own branch or from the default branch, so an entry every PR can read has to be written by a run **on `main`**. Any event on that ref qualifies — a `workflow_dispatch` on `main` writes the same scope — but the push run is the one that had actually been doing it, 93 generations deep. Confirmed against the live cache API before the change:

```
refs/heads/main        index-dms-pr-dms-image-1-f921bd05#93      <- written by push-to-main, 93 generations
refs/heads/main        index-dms-pr-config-image-1-f921bd05#93
refs/pull/1195/merge   index-dms-pr-dms-image-1-fe5cd09c#1       <- per-PR, unreadable by other PRs
refs/pull/1201/merge   index-dms-pr-config-image-1-de19e57a#1
```

PR runs write to `refs/pull/N/merge`; merge queue runs write to an ephemeral `refs/heads/gh-readonly-queue/…` ref that is deleted on merge. Neither is restorable by anything else. Without a writer on `main` the shared entry would have frozen at its last push run, decayed as the Dockerfiles and dependencies drifted, and — once evicted under the repository cache limit — could never have been rebuilt.

**The fix:** both CI image builds now use a registry cache, held under a `buildcache` tag in the same ghcr package as the images themselves. A registry cache is not branch-scoped, so any run can restore it regardless of ref.

Export is restricted to non-`pull_request` events:

```yaml
cache-from: type=registry,ref=${{ steps.prepare-images.outputs.dms_cache_ref }}
cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,ignore-error=true,ref={0}', steps.prepare-images.outputs.dms_cache_ref) || '' }}
```

The merge queue already builds these images on every merge, on the tree about to become `main`, so it takes over as the cache writer **without adding a run** — which is the point of the ticket. `workflow_dispatch` also passes the gate, deliberately: it is the manual lever for re-seeding the tag. Restricting export also stops concurrent PRs racing on the same tag and filling the shared cache with branch-specific layers.

`ignore-error=true` keeps a registry blip during export from failing `build-ci-docker-images`, which `dms-ci-gate` requires — without it a transient GHCR failure would eject an approved entry from the merge queue. Verified on buildx v0.26.1 with the exact attribute order committed here: exporting to an unwritable ref exits 1 without the attribute and exits 0 with it, printing the same 403 ERROR vertex either way. buildx prints that vertex on a failed *import* too, so a green run can legitimately carry one.

No new permission, secret, or workflow is needed: the job already authenticates to ghcr.io, already pushes these images there, and already holds `packages: write`. Fork PRs are unaffected — `IS_FORK_PULL_REQUEST` clears `use_prebuilt_images`, and every step in this block is gated on it.

## The Config workflow had the same dependency, and now shares the same tag

`on-config-pullrequest.yml` carried the identical push block, the identical CodeQL comment, and the same three `push`-referencing comments. It had the **same** cache-seeding dependency, reached through a different backend: its three E2E jobs persisted `/tmp/.buildx-cache` with `actions/cache`, which is the same ref-scoped Actions cache. Same consequence, so it is fixed here rather than deferred.

Those three jobs now **restore only**, from the very tag `on-dms-pullrequest.yml` writes. That workflow builds the same Config image from the same context, Dockerfile, and build contexts, and it runs on every `merge_group` regardless of which files changed, so its layers are reusable and no second exporter is needed. `on-config-pullrequest.yml` therefore has **zero** `packages: write` entries — matching its state on `main` — and no job in it that runs PR-authored code gained a write capability.

| Job | Cache role | Permission |
|---|---|---|
| `run-e2e-tests`, `run-e2e-tests-mssql`, `run-e2e-tests-mssql-multitenant` | restore only | `contents: read`, `packages: read` |
| `build-ci-docker-images` in `on-dms-pullrequest.yml` | sole exporter, on non-`pull_request` events | `packages: write`, unchanged |

The cache reference is computed once as an output of `detect-fresh-build-changes`, which every consuming job already depends on, because a registry reference must be lowercase and the expression language has no lowercase function.

### `packages: read` is now declared, not inherited

The CI packages are private (401 anonymous, against 200 for a public control), so the restore authenticates with the workflow token. Those three jobs previously had no job-level `permissions:` block at all and reached the packages through the file's workflow-level `read-all`. That made a load-bearing capability invisible: anyone tightening those jobs — a reasonable thing to do to a job that runs PR code — would have silently turned every build in them cold.

They now declare `contents: read` + `packages: read` explicitly, with a comment saying why. That is also what this repository already does elsewhere: every one of the eight jobs in `on-dms-pullrequest.yml` that pulls from GHCR declares exactly that pair.

## Keeping the shared tag alive

Consolidating onto one tag makes it more load-bearing than it was: one job, in one workflow, now writes the tag that every image build in both workflows restores. Three things could take it away, and none of them fails anything, because the cache is non-fatal by design at every use site.

**1. The pruner could evict it.** `cleanup-dms-ci-ghcr-images.yml` keeps the newest 100 versions of exactly these two packages by creation date. The cache version is refreshed on every merge, but a long enough run of per-commit CI image pushes with no merge in between pushes it out of that window.

The obvious fix — an `ignore-versions` regex naming the tag — does not work, and would have been worse than nothing. Read from the action's source at the pinned SHA `25ad4af`:

```ts
// src/version/get-versions.ts — what ignore-versions is tested against
return { id: version.id, version: version.name, created_at: …, tagged: … }
// src/delete.ts
value = value.filter(info => !input.ignoreVersions.test(info.version))
```

`version` is the package version **name**, which for a container package is the manifest digest — the action reads tags from a separate `metadata.container.tags` field, and computes `tagged` from it. A regex naming `buildcache` would never match, would silently protect nothing, and would read in review as though the invariant were enforced.

So a step resolves the digest the tag currently points at and pins it into the regex on every run:

```yaml
ignore-versions: ${{ steps.cache-versions.outputs.dms_ignore }}   # ^sha256:…$
```

When the tag is absent or the lookup fails, the step emits `^$` — the action's own default, matching no version name — so the prune behaves exactly as it does today, and logs a warning naming the re-seed lever. The delete steps take `owner` and `package-name` from the same workflow-level variables the resolve step reads, so the version excluded can never drift from the package pruned.

**2. It could stop being written, or stop being readable, with no failing signal anywhere.** `ignore-error=true` on the export and a non-fatal import mean an ACL problem, a media-type rejection, and a never-written tag all produce a green run, and the comment on `cache-to` pre-declares the one distinguishing signal — the ERROR vertex — as expected noise. So a new `verify-build-cache` job resolves both tags through the registry with the same workflow token the restoring builds use, and fails if either is missing or unreadable. `notify-results` now gates on both jobs, and the failure message names the recovery lever.

It sits in the scheduled cleanup workflow, not in either PR workflow, deliberately: asserting the cache must never be able to block a merge. That is the same reasoning `ignore-error=true` rests on.

**3. `REBUILD_DOWNSTREAM_IMAGES` starves it silently.** Setting that repository variable — the documented rollback lever — clears `use_prebuilt_images`, which skips the build steps in `build-ci-docker-images` entirely, which stops the export for *both* workflows. Now recorded on the variable itself, on the Config side's `config_cache_ref` output, and surfaced by a staleness warning in the daily cleanup run that names the variable by name.

The recovery for all three is the same and is now stated in all four places it could be needed: a `workflow_dispatch` run of **On DMS Pull Request** on `main`, which passes the export gate.

## On the GHCR write path

`cache-to: type=registry` with the exact attributes shipped here emits `application/vnd.oci.image.manifest.v1+json` — an OCI image *manifest*, not an index, which is the form `image-manifest=true` exists to force for registries that reject the buildkit-specific type. GHCR serves OCI media types natively. Locally, the export prints `writing cache image manifest sha256:…`.

Writing to GHCR could not be exercised from a workstation — no available token carries `write:packages`. The first `merge_group` run's **Build CI Docker Images** log is what closes it: that same `writing cache image manifest` line. The new `verify-build-cache` job then prints the MediaType the registry is actually serving, every scheduled run, from then on.

## Verification

- **Parsed trigger structure.** PyYAML assertions: event set is exactly `{merge_group, pull_request, workflow_dispatch}`; `push` absent; `pull_request` key set exactly `{branches}` with no `paths`; `merge_group` exactly `{types: [checks_requested]}`; the `workflow_dispatch` input keeps its description, `required: false`, `default: "2"`; 34 jobs and `permissions: read-all` retained.
- **Cache configuration asserted from the parsed document**, not by grep: both DMS build steps carry `type=registry` `cache-from`, an event-gated `type=registry,mode=max,ignore-error=true` `cache-to`, and `push: true`. No `type=gha` and no `dms-pr-*-image` scope remains anywhere under `.github/`. In Config: `packages: write` on no job, every `cache-from` a registry reference, no `type=local` or `/tmp/.buildx-cache` anywhere.
- **The pruner's new logic was exercised, not just read.** The resolve step was extracted and run against a stubbed `gh` for three cases: tag present (emits `^sha256:…$`), tag absent and API returning `null` (emits `^$` plus the re-seed warning), and a stale tag (emits the `REBUILD_DOWNSTREAM_IMAGES` warning). The `jq` selector was run through `gh`'s own gojq against representative version shapes — tagged, multi-tagged, untagged, and metadata-less — and selects only the `buildcache` version without erroring on the others. `env.` interpolation was confirmed against the real `gh` binary. Both embedded scripts pass `bash -n`.
- **`eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1`** and **`BuildScriptTestGuards.Tests.ps1`** — 33 passed, 0 failed, 0 skipped, re-run after every change.
- **Line endings** — LF preserved, 0 CR bytes in every touched workflow.
- No new automated test was added over workflow contents. Trigger and cache wiring are declarative CI configuration whose regression surface is the Actions run list and the registry; the new `verify-build-cache` job is the runtime assertion that a source-text test could not make.

**What local verification cannot show:** the export itself. The first `merge_group` run after this lands demonstrates it; the PR runs after that demonstrate the restore. Expect one cold build on the first merge.

## Known and intentional

The `else` arm in `detect-fresh-build-changes` that read `github.event.before` is now unreachable — only `pull_request`, `merge_group`, and `workflow_dispatch` remain, and `workflow_dispatch` returns earlier — and has been replaced in both files with the conservative full-suite result, which is behaviour-neutral for every reachable event.

The export gate is a line in `on-dms-pullrequest.yml`, and the tag it guards is an input to every other PR's build. A fork PR cannot reach it — forks clear `use_prebuilt_images` — so changing it requires write access to this repository and lands in a reviewable diff. That is the trust level the repository already grants, and it is now stated in the comment.

`codeql-analysis.yml`'s push filter is narrower than the block removed here (C# sources only — not `.github/workflows/**`, `build-dms.ps1`, `eng/**`, or `src/nuget.config`). After this change no workflow runs the DMS suite on a *direct* push to `main`. That is the intent, and it holds as long as changes reach `main` through the merge queue.

### NuGet caches lose default-branch seeding, and that one cannot be fixed here

Both workflows also cache `~/.nuget/packages` with `actions/cache` (11 steps in DMS, 6 in Config, none gated by event). Those ran on push-to-main too, so removing the trigger ends default-branch seeding for them as well.

**This one has no clean fix, and it is worth being explicit about why.** There is no registry equivalent for a package folder cache, and moving the export into a merge-queue-gated job does not help: `actions/cache` saves under the run's ref, and a merge-queue ref is deleted on merge. Any `actions/cache` entry written outside `main` is unreachable from other PRs by construction.

The impact is materially smaller than the Docker layer cache, which is why it is accepted rather than blocking:

- the key is `hashFiles('**/Directory.Packages.props')`, so while dependencies are unchanged the frozen `main` entry is still an **exact** hit;
- when dependencies do change, `restore-keys: ${{ runner.os }}-nuget-` falls back to the older `main` entry and NuGet restores only the delta.

The steady-state cost is a delta restore on PRs after a dependency bump, measured in seconds. Recorded here so the trade is visible rather than discovered later.

### DMS carries two cache mechanisms by design

`build-ci-docker-images` uses the registry cache described above. The E2E Docker layer caches still use `actions/cache` + `type=local`, and are deliberately left alone: every one is gated on `use_prebuilt_images != 'true'`, the fallback lane for fork PRs and the `REBUILD_DOWNSTREAM_IMAGES` rollback switch. Because push runs had `use_prebuilt_images=true`, those steps never executed on push, so they were never seeded from `main` and this PR does not regress them.

## Post-merge verification

```bash
# Expect: one merge_group run, zero push runs
gh run list --workflow "on-dms-pullrequest.yml" --limit 20 --json event,headSha,conclusion,createdAt,url

# Expect: a successful push run that creates the prerelease
gh run list --workflow "on-dms-merge-or-tag.yml" --limit 10 --json event,headSha,conclusion,createdAt,url

# Expect: a push run, confirming CodeQL still covers main
gh run list --workflow "codeql-analysis.yml" --limit 10 --json event,headSha,conclusion,createdAt,url

# Expect: none left — the type=gha entries are no longer written
gh api "repos/Ed-Fi-Alliance-OSS/Data-Management-Service/actions/caches?per_page=100" \
  --jq '.actions_caches[] | select(.key|test("dms-pr-")) | "\(.ref)\t\(.key)"'
```

In the first `merge_group` run's **Build CI Docker Images** log, expect `writing cache image manifest sha256:…` for both images. In the next scheduled **Cleanup DMS CI GHCR Images** run, expect the resolve step to print a `buildcache -> sha256:…` line per package and **Verify Shared Build Cache** to print `MediaType: application/vnd.oci.image.manifest.v1+json`.
