### PR TITLE
[DMS-1463] Retry CI Docker Image Pulls with Jittered Backoff

### DIFF
--- a/.github/actions/pull-ci-images/Invoke-CiImagePull.ps1
+++ b/.github/actions/pull-ci-images/Invoke-CiImagePull.ps1
@@ -14,9 +14,11 @@ lane, and a retry with a fixed or purely exponential delay turns those jobs into
 that re-hits the registry in lockstep.
 
 Each image carries its own attempt budget. After a failed attempt the wait is drawn uniformly from
-[base/2, base), where base doubles per attempt until it reaches MaxDelaySeconds. The delay therefore
-grows on every retry while the base is still climbing, and successive retries share one band once the
-cap is reached. Either way the random draw keeps concurrent jobs from retrying in unison.
+[base/2, base), where base doubles per attempt until it reaches MaxDelaySeconds. Neither bound of
+that band ever decreases, so waits trend upward, but consecutive bands overlap at the attempt where
+the clamp engages and are identical past it - a later retry can draw a shorter wait than an earlier
+one. What holds at every attempt is the random draw, which is what keeps concurrent jobs from
+retrying in unison.
 
 Docker's output is never captured, so whatever the registry said about a failure stays visible in the
 job log, and the final failure names the image and the attempt count rather than letting a missing
@@ -61,8 +63,9 @@ $ErrorActionPreference = "Stop"
 # to a terminating error, the first transient failure would abort the run instead of being retried.
 $PSNativeCommandUseErrorActionPreference = $false
 
-# A block scalar in the calling workflow always contributes a trailing newline, and its values are
-# indented, so trimming and dropping empties is required rather than cosmetic.
+# A block scalar in the calling workflow contributes a trailing newline, so the empty-line filter is
+# required. YAML strips the block's indentation before the value ever arrives, which leaves the Trim
+# defensive against a hand-edited input rather than necessary for the call sites.
 $imageList = @(
     $Images -split "\r?\n" |
         ForEach-Object { $_.Trim() } |
@@ -95,11 +98,15 @@ foreach ($image in $imageList) {
             throw "Failed to pull $image after $MaxAttempts attempt(s)."
         }
 
-        # Equal jitter over an exponential base that doubles until it reaches $MaxDelaySeconds. Every
-        # wait is at least half the base and less than the base, so delays grow per retry while the
-        # base is still climbing and share one band after it caps. The random component is what keeps
-        # concurrent jobs from retrying in unison, at either stage.
-        $baseSeconds = [Math]::Min($MaxDelaySeconds, $InitialDelaySeconds * [Math]::Pow(2, $attempt - 1))
+        # Equal jitter over an exponential base that doubles until it reaches $MaxDelaySeconds. Each
+        # wait is at least half the base and less than the base, so the bands trend upward, though
+        # they overlap where the clamp engages and are identical past it - consecutive waits are not
+        # strictly increasing. The random component, not the growth, is what stops concurrent jobs
+        # retrying in unison.
+        # The [double] cast is load-bearing. Without it PowerShell binds Math.Min(Int32, Int32) and
+        # narrows the doubling term instead of widening the cap, so once the term passes Int32 the
+        # script dies on a conversion error partway through a budget ValidateRange calls legal.
+        $baseSeconds = [Math]::Min([double] $MaxDelaySeconds, $InitialDelaySeconds * [Math]::Pow(2, $attempt - 1))
         $halfMilliseconds = [int] ($baseSeconds * 500)
         $delayMilliseconds = $halfMilliseconds + (Get-Random -Minimum 0 -Maximum $halfMilliseconds)
 

--- a/.github/actions/pull-ci-images/Invoke-CiImagePull.ps1
+++ b/.github/actions/pull-ci-images/Invoke-CiImagePull.ps1
@@ -3,6 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+#Requires -Version 7
+
 <#
 .SYNOPSIS
 Pulls container images, retrying transient registry failures with jittered exponential backoff.
@@ -15,10 +17,11 @@ that re-hits the registry in lockstep.
 
 Each image carries its own attempt budget. After a failed attempt the wait is drawn uniformly from
 [base/2, base), where base doubles per attempt until it reaches MaxDelaySeconds. Neither bound of
-that band ever decreases, so waits trend upward, but consecutive bands overlap at the attempt where
-the clamp engages and are identical past it - a later retry can draw a shorter wait than an earlier
-one. What holds at every attempt is the random draw, which is what keeps concurrent jobs from
-retrying in unison.
+that band ever decreases, so waits trend upward, but the bands stop being disjoint once the cap
+binds: every band past the one where the base pins to MaxDelaySeconds is identical to it, and a cap
+that falls between two doublings makes that first pinned band overlap its predecessor as well.
+Either way a later retry can draw a shorter wait than an earlier one. What holds at every attempt is
+the random draw, which is what keeps concurrent jobs from retrying in unison.
 
 Docker's output is never captured, so whatever the registry said about a failure stays visible in the
 job log, and the final failure names the image and the attempt count rather than letting a missing
@@ -99,10 +102,11 @@ foreach ($image in $imageList) {
         }
 
         # Equal jitter over an exponential base that doubles until it reaches $MaxDelaySeconds. Each
-        # wait is at least half the base and less than the base, so the bands trend upward, though
-        # they overlap where the clamp engages and are identical past it - consecutive waits are not
-        # strictly increasing. The random component, not the growth, is what stops concurrent jobs
-        # retrying in unison.
+        # wait is at least half the base and less than the base, so the bands trend upward, but they
+        # stop being disjoint once the cap binds: bands repeat while the base is pinned, and a cap
+        # that falls between two doublings makes the first pinned band overlap its predecessor too.
+        # Consecutive waits are therefore not strictly increasing. The random component, not the
+        # growth, is what stops concurrent jobs retrying in unison.
         # The [double] cast is load-bearing. Without it PowerShell binds Math.Min(Int32, Int32) and
         # narrows the doubling term instead of widening the cap, so once the term passes Int32 the
         # script dies on a conversion error partway through a budget ValidateRange calls legal.

--- a/.github/actions/pull-ci-images/Invoke-CiImagePull.ps1
+++ b/.github/actions/pull-ci-images/Invoke-CiImagePull.ps1
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+<#
+.SYNOPSIS
+Pulls container images, retrying transient registry failures with jittered exponential backoff.
+
+.DESCRIPTION
+One CI job builds the DMS and Configuration Service images, and many downstream jobs then pull those
+same tags at nearly the same moment. An unguarded pull turns a momentary registry error into a failed
+lane, and a retry with a fixed or purely exponential delay turns those jobs into a synchronized herd
+that re-hits the registry in lockstep.
+
+Each image carries its own attempt budget. After a failed attempt the wait is drawn uniformly from
+[base/2, base), where base doubles per attempt up to a cap, so the delay grows on every retry while
+concurrent jobs still spread their retries across a widening window.
+
+Docker's output is never captured, so whatever the registry said about a failure stays visible in the
+job log, and the final failure names the image and the attempt count rather than letting a missing
+image pass as success.
+
+.PARAMETER Images
+Newline-separated image references to pull. Blank and whitespace-only lines are ignored.
+
+.PARAMETER MaxAttempts
+Maximum pull attempts per image.
+
+.PARAMETER InitialDelaySeconds
+Backoff base for the first retry, in seconds.
+
+.PARAMETER MaxDelaySeconds
+Upper bound on the backoff base, in seconds.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [AllowEmptyString()]
+    [string]
+    $Images,
+
+    [ValidateRange(1, 100)]
+    [int]
+    $MaxAttempts = 5,
+
+    [ValidateRange(1, 3600)]
+    [int]
+    $InitialDelaySeconds = 3,
+
+    [ValidateRange(1, 3600)]
+    [int]
+    $MaxDelaySeconds = 60
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# A failed pull has to reach the retry loop as an exit code. Where a non-zero native exit is promoted
+# to a terminating error, the first transient failure would abort the run instead of being retried.
+$PSNativeCommandUseErrorActionPreference = $false
+
+# A block scalar in the calling workflow always contributes a trailing newline, and its values are
+# indented, so trimming and dropping empties is required rather than cosmetic.
+$imageList = @(
+    $Images -split "\r?\n" |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_.Length -gt 0 }
+)
+
+if ($imageList.Count -eq 0) {
+    # A mis-wired input must fail here. Pulling nothing and reporting success would let a job run on
+    # whatever images happen to be on the runner.
+    throw "No images were supplied to pull. Provide one image reference per line in the 'images' input."
+}
+
+foreach ($image in $imageList) {
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        Write-Output "Pulling $image (attempt $attempt of $MaxAttempts)."
+
+        # Deliberately uncaptured: no assignment, pipeline, or subexpression, so Docker's progress and
+        # its registry error stream straight to the job log and $LASTEXITCODE is Docker's own. The `--`
+        # keeps an image reference from ever being parsed as a flag.
+        docker pull -- $image
+
+        if ($LASTEXITCODE -eq 0) {
+            Write-Output "Pulled $image on attempt $attempt of $MaxAttempts."
+            break
+        }
+
+        Write-Output "docker pull failed for $image with exit code $LASTEXITCODE on attempt $attempt of $MaxAttempts. The Docker output above carries the registry error."
+
+        if ($attempt -eq $MaxAttempts) {
+            throw "Failed to pull $image after $MaxAttempts attempt(s)."
+        }
+
+        # Equal jitter over a capped exponential base. Every wait is at least half the base and less
+        # than the base, so the delay grows on each retry while concurrent jobs spread out inside a
+        # widening window instead of retrying in unison.
+        $baseSeconds = [Math]::Min($MaxDelaySeconds, $InitialDelaySeconds * [Math]::Pow(2, $attempt - 1))
+        $halfMilliseconds = [int] ($baseSeconds * 500)
+        $delayMilliseconds = $halfMilliseconds + (Get-Random -Minimum 0 -Maximum $halfMilliseconds)
+
+        Write-Output "Waiting $delayMilliseconds ms before attempt $($attempt + 1) of $MaxAttempts for $image."
+        Start-Sleep -Milliseconds $delayMilliseconds
+    }
+}

--- a/.github/actions/pull-ci-images/Invoke-CiImagePull.ps1
+++ b/.github/actions/pull-ci-images/Invoke-CiImagePull.ps1
@@ -14,8 +14,9 @@ lane, and a retry with a fixed or purely exponential delay turns those jobs into
 that re-hits the registry in lockstep.
 
 Each image carries its own attempt budget. After a failed attempt the wait is drawn uniformly from
-[base/2, base), where base doubles per attempt up to a cap, so the delay grows on every retry while
-concurrent jobs still spread their retries across a widening window.
+[base/2, base), where base doubles per attempt until it reaches MaxDelaySeconds. The delay therefore
+grows on every retry while the base is still climbing, and successive retries share one band once the
+cap is reached. Either way the random draw keeps concurrent jobs from retrying in unison.
 
 Docker's output is never captured, so whatever the registry said about a failure stays visible in the
 job log, and the final failure names the image and the attempt count rather than letting a missing
@@ -94,9 +95,10 @@ foreach ($image in $imageList) {
             throw "Failed to pull $image after $MaxAttempts attempt(s)."
         }
 
-        # Equal jitter over a capped exponential base. Every wait is at least half the base and less
-        # than the base, so the delay grows on each retry while concurrent jobs spread out inside a
-        # widening window instead of retrying in unison.
+        # Equal jitter over an exponential base that doubles until it reaches $MaxDelaySeconds. Every
+        # wait is at least half the base and less than the base, so delays grow per retry while the
+        # base is still climbing and share one band after it caps. The random component is what keeps
+        # concurrent jobs from retrying in unison, at either stage.
         $baseSeconds = [Math]::Min($MaxDelaySeconds, $InitialDelaySeconds * [Math]::Pow(2, $attempt - 1))
         $halfMilliseconds = [int] ($baseSeconds * 500)
         $delayMilliseconds = $halfMilliseconds + (Get-Random -Minimum 0 -Maximum $halfMilliseconds)

--- a/.github/actions/pull-ci-images/action.yml
+++ b/.github/actions/pull-ci-images/action.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Pull CI Docker images
+description: Pulls container images, retrying transient registry failures with jittered exponential backoff.
+
+inputs:
+  images:
+    description: Newline-separated image references to pull. Blank lines are ignored.
+    required: true
+  max-attempts:
+    description: Maximum pull attempts per image.
+    required: false
+    default: "5"
+  initial-delay-seconds:
+    description: Backoff base for the first retry, in seconds.
+    required: false
+    default: "3"
+  max-delay-seconds:
+    description: Upper bound on the backoff base, in seconds.
+    required: false
+    default: "60"
+
+runs:
+  using: composite
+  steps:
+    # Inputs travel by environment variable so no expression is ever interpolated into the script
+    # body. The calling job's defaults.run.shell does not reach a composite step, so pwsh is explicit.
+    - name: Pull CI Docker images
+      shell: pwsh
+      env:
+        IMAGES: ${{ inputs.images }}
+        MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+        INITIAL_DELAY_SECONDS: ${{ inputs.initial-delay-seconds }}
+        MAX_DELAY_SECONDS: ${{ inputs.max-delay-seconds }}
+      run: |
+        & "$env:GITHUB_ACTION_PATH/Invoke-CiImagePull.ps1" `
+          -Images $env:IMAGES `
+          -MaxAttempts ([int] $env:MAX_ATTEMPTS) `
+          -InitialDelaySeconds ([int] $env:INITIAL_DELAY_SECONDS) `
+          -MaxDelaySeconds ([int] $env:MAX_DELAY_SECONDS)

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -214,6 +214,7 @@ jobs:
             "eng/ci/tests/BuildScriptTestGuards.Tests.ps1",
             "eng/ci/tests/Sanitize-E2EArtifacts.Tests.ps1",
             "eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1",
+            "eng/ci/tests/PullCiImages.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-Management.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-WorkflowInputs.Tests.ps1",
             "eng/smoke_test/tests/SmokeTest.Tests.ps1",

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -1506,9 +1506,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Set up Docker Buildx
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images != 'true'
@@ -1674,9 +1676,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Set up Docker Buildx
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images != 'true'
@@ -1848,9 +1852,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Set up Docker Buildx
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images != 'true'
@@ -2022,9 +2028,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Set up Docker Buildx
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images != 'true'
@@ -2232,9 +2240,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Set up Docker Buildx
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images != 'true'
@@ -2469,9 +2479,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Set up Docker Buildx
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images != 'true'
@@ -2650,9 +2662,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Set up Docker Buildx
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images != 'true'
@@ -2852,9 +2866,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Cache Nuget packages
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -119,6 +119,10 @@ jobs:
     name: Release Tag DMS Image
     runs-on: ubuntu-latest
     steps:
+      # Required so the local pull action below resolves from the workspace.
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Prepare Release Tags
         id: prepare-tags
         run: |
@@ -135,7 +139,9 @@ jobs:
           echo "RELEASE_MINOR=$RELEASE_MINOR" >> $GITHUB_OUTPUT
 
       - name: Pull DMS Prerelease Image
-        run: docker pull "${{ steps.prepare-tags.outputs.PRE_IMAGE }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: ${{ steps.prepare-tags.outputs.PRE_IMAGE }}
 
       - name: Tag DMS image
         run: |
@@ -157,6 +163,10 @@ jobs:
     name: Release Tag Configuration Image
     runs-on: ubuntu-latest
     steps:
+      # Required so the local pull action below resolves from the workspace.
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Prepare Release Tags
         id: prepare-tags
         run: |
@@ -173,7 +183,9 @@ jobs:
           echo "RELEASE_MINOR=$RELEASE_MINOR" >> $GITHUB_OUTPUT
 
       - name: Pull Configuration Prerelease Image
-        run: docker pull "${{ steps.prepare-tags.outputs.PRE_IMAGE }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: ${{ steps.prepare-tags.outputs.PRE_IMAGE }}
 
       - name: Tag Configuration image
         run: |

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -256,9 +256,11 @@ jobs:
 
       - name: Pull CI Docker images
         if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'
-        run: |
-          docker pull "${{ needs.build-ci-docker-images.outputs.dms_image }}"
-          docker pull "${{ needs.build-ci-docker-images.outputs.config_image }}"
+        uses: ./.github/actions/pull-ci-images
+        with:
+          images: |
+            ${{ needs.build-ci-docker-images.outputs.dms_image }}
+            ${{ needs.build-ci-docker-images.outputs.config_image }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1

--- a/eng/ci/tests/PullCiImages.Tests.ps1
+++ b/eng/ci/tests/PullCiImages.Tests.ps1
@@ -12,12 +12,12 @@
 # source text, and no registry, image, or wall-clock delay is involved. A child process keeps the
 # shims and the script's preference assignments out of this Pester session.
 #
-# One argument is deliberately not asserted here. The script passes `--` to end Docker's option list,
-# and PowerShell forwards that token verbatim to a native command but strips it from a function call,
-# so a shim can never observe it: `& echo.exe pull -- ref` receives three arguments while a function
-# receives two. The recorded pull lines below therefore omit `--` even though the shipped command
-# includes it - do not "fix" that by removing the guard from the script. The real native command line
-# is covered by the one-time invalid-image exercise against real Docker instead.
+# One argument is deliberately not asserted here, and nothing in this suite covers it. The script
+# passes `--` to end Docker's option list, and PowerShell forwards that token verbatim to a native
+# command but strips it from a function call, so a shim can never observe it: a native
+# `echo pull -- ref` receives three arguments while a function receives two. The recorded pull lines
+# below therefore omit `--` even though the shipped command includes it - do not "fix" that by
+# removing the guard from the script. Only a real native invocation could assert it.
 #
 # Randomness is injected rather than sampled: the shim records the bounds the script asks for and
 # returns a caller-selected value from them. That makes the jitter contract - an expanding
@@ -52,7 +52,10 @@ function docker {
     $global:LASTEXITCODE = $codes[$index]
 
     if ($global:LASTEXITCODE -ne 0) {
-        Write-HarnessRecord "docker-error simulated registry failure"
+        # Emitted on the success stream on purpose. That is the stream an accidental capture
+        # (`$x = docker ...`, `| Out-Null`, `> $null`) would swallow, so asserting this line reaches the
+        # harness output is what holds the script to leaving Docker's registry error in the job log.
+        Write-Output "simulated registry failure for $($args[-1])"
     }
 }
 
@@ -78,11 +81,18 @@ $ErrorActionPreference = "Stop"
 # terminating error would be reported and the harness would still exit 0, making every failure
 # assertion vacuous.
 try {
-    & $env:DMS_PULL_SCRIPT `
-        -Images $env:DMS_PULL_IMAGES `
-        -MaxAttempts ([int] $env:DMS_PULL_MAX_ATTEMPTS) `
-        -InitialDelaySeconds ([int] $env:DMS_PULL_INITIAL_DELAY) `
-        -MaxDelaySeconds ([int] $env:DMS_PULL_MAX_DELAY)
+    if ($env:DMS_PULL_USE_SCRIPT_DEFAULTS -eq "true") {
+        # Passing nothing but the images is the only way to exercise the script's own parameter
+        # defaults; every other scenario supplies them explicitly and would mask a drift.
+        & $env:DMS_PULL_SCRIPT -Images $env:DMS_PULL_IMAGES
+    }
+    else {
+        & $env:DMS_PULL_SCRIPT `
+            -Images $env:DMS_PULL_IMAGES `
+            -MaxAttempts ([int] $env:DMS_PULL_MAX_ATTEMPTS) `
+            -InitialDelaySeconds ([int] $env:DMS_PULL_INITIAL_DELAY) `
+            -MaxDelaySeconds ([int] $env:DMS_PULL_MAX_DELAY)
+    }
 }
 catch {
     [Console]::Error.WriteLine($_.Exception.Message)
@@ -102,7 +112,8 @@ exit 0
                 [int] $MaxAttempts = 5,
                 [int] $InitialDelaySeconds = 3,
                 [int] $MaxDelaySeconds = 60,
-                [ValidateSet("floor", "ceiling", "interior")] [string] $RandomMode = "floor"
+                [ValidateSet("floor", "ceiling", "interior")] [string] $RandomMode = "floor",
+                [switch] $UseScriptDefaults
             )
 
             $logPath = Join-Path $TestDrive ("records-" + [Guid]::NewGuid().ToString("N") + ".log")
@@ -116,6 +127,7 @@ exit 0
             $env:DMS_PULL_EXIT_CODES = $ExitCodes
             $env:DMS_PULL_RANDOM_MODE = $RandomMode
             $env:DMS_PULL_LOG = $logPath
+            $env:DMS_PULL_USE_SCRIPT_DEFAULTS = if ($UseScriptDefaults) { "true" } else { "false" }
 
             $output = & pwsh -NoProfile -File $script:harnessPath 2>&1 | Out-String
             $exitCode = $LASTEXITCODE
@@ -342,6 +354,204 @@ exit 0
 
             $result.ExitCode | Should -Not -Be 0
             $result.Pulls | Should -HaveCount 0
+        }
+    }
+
+    Context "an attempt budget past the Int32 exponent boundary" {
+        # The delay arithmetic multiplies the initial base by 2^(attempt-1). Once that product
+        # exceeds Int32, computing the cap has to stay in floating point: binding Math.Min(Int32,Int32)
+        # instead narrows the double and dies with a conversion error partway through the budget,
+        # which silently caps attempts well below the 100 that ValidateRange advertises.
+        It "spends the whole declared budget instead of dying on the delay arithmetic" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -MaxAttempts 40 -InitialDelaySeconds 3
+
+            $result.Pulls | Should -HaveCount 40
+            $result.Output | Should -Not -Match "Cannot convert"
+            $result.Output | Should -Match "Failed to pull registry/dms:ci after 40 attempt\(s\)\."
+        }
+
+        It "reports failure rather than an arithmetic error at the top of the declared range" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -MaxAttempts 100 -InitialDelaySeconds 3600
+
+            $result.Pulls | Should -HaveCount 100
+            $result.Output | Should -Not -Match "Cannot convert"
+            $result.Output | Should -Match "Failed to pull registry/dms:ci after 100 attempt\(s\)\."
+        }
+
+        It "holds every retry past the cap at the capped band" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -MaxAttempts 40 -InitialDelaySeconds 3 -RandomMode "floor"
+
+            # Base reaches the 60s cap on retry 6 and stays there, so the half-width is fixed at 30000.
+            @($result.Randoms | Select-Object -Skip 6 | Sort-Object -Unique) | Should -Be @("random 0 30000")
+        }
+    }
+
+    Context "Docker's own output" {
+        It "leaves it in the job log rather than capturing it" {
+            # The registry error explaining a failure is the whole point of not capturing the pull, so
+            # the shim's success-stream line has to survive into the harness output.
+            $result = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1,0"
+
+            $result.Output | Should -Match "simulated registry failure for registry/dms:ci"
+        }
+
+        It "keeps it for the final failed attempt too" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -MaxAttempts 2 -InitialDelaySeconds 1
+
+            @([regex]::Matches($result.Output, "simulated registry failure")) | Should -HaveCount 2
+        }
+    }
+
+    Context "the shipped defaults" {
+        BeforeAll {
+            $script:actionPath = [System.IO.Path]::GetFullPath(
+                (Join-Path $PSScriptRoot "../../../.github/actions/pull-ci-images/action.yml")
+            )
+            $script:actionLines = @(Get-Content -LiteralPath $script:actionPath)
+
+            function Get-DeclaredInputDefault {
+                # No YAML parser is available in this lane (see DmsPullRequestMssqlWorkflow.Tests.ps1),
+                # so the input's block is found by its two-space key and scanned for its default.
+                param([Parameter(Mandatory)] [string] $InputName)
+
+                $start = -1
+                for ($i = 0; $i -lt $script:actionLines.Count; $i++) {
+                    if ($script:actionLines[$i] -match "^  $([regex]::Escape($InputName)):\s*$") {
+                        $start = $i
+                        break
+                    }
+                }
+                if ($start -lt 0) {
+                    return $null
+                }
+
+                for ($j = $start + 1; $j -lt $script:actionLines.Count; $j++) {
+                    if ($script:actionLines[$j] -match '^  \S') {
+                        break
+                    }
+                    if ($script:actionLines[$j] -match '^\s+default:\s*"?([^"]+?)"?\s*$') {
+                        return $Matches[1]
+                    }
+                }
+                return $null
+            }
+        }
+
+        It "declares the retry defaults the call sites rely on" {
+            # Every call site passes only `images`, so these declared values are the retry policy for
+            # all of them: lowering max-attempts to 1 here would disable retries fleet-wide.
+            Get-DeclaredInputDefault -InputName "max-attempts" | Should -Be "5"
+            Get-DeclaredInputDefault -InputName "initial-delay-seconds" | Should -Be "3"
+            Get-DeclaredInputDefault -InputName "max-delay-seconds" | Should -Be "60"
+        }
+
+        It "spends five attempts when the caller supplies only images" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -UseScriptDefaults
+
+            $result.Pulls | Should -HaveCount 5
+            $result.Output | Should -Match "Failed to pull registry/dms:ci after 5 attempt\(s\)\."
+        }
+
+        It "starts from a three-second base when the caller supplies only images" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -UseScriptDefaults
+
+            $result.Randoms[0] | Should -Be "random 0 1500"
+            $result.Sleeps[0] | Should -Be 1500
+        }
+    }
+
+    AfterAll {
+        foreach ($name in @(
+                "DMS_PULL_SCRIPT", "DMS_PULL_IMAGES", "DMS_PULL_MAX_ATTEMPTS", "DMS_PULL_INITIAL_DELAY",
+                "DMS_PULL_MAX_DELAY", "DMS_PULL_EXIT_CODES", "DMS_PULL_RANDOM_MODE", "DMS_PULL_LOG",
+                "DMS_PULL_USE_SCRIPT_DEFAULTS")) {
+            # Remove-Item rather than assigning $null: assigning leaves a defined-but-empty variable
+            # behind on some hosts, which a later spec would read as configured.
+            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe "pull-ci-images workflow wiring" {
+    # Two invariants that live purely in declarative CI wiring, so no invoked-script test can reach
+    # them, and whose regression would not surface as a failing pull-request lane. Everything else
+    # about the conversions - the gates, login order, permissions - fails a lane directly when broken
+    # and is deliberately not asserted from source here, following
+    # eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1.
+    BeforeAll {
+        $script:workflowRoot = [System.IO.Path]::GetFullPath(
+            (Join-Path $PSScriptRoot "../../../.github/workflows")
+        )
+
+        function Get-JobBlock {
+            param(
+                # Not Mandatory: a mandatory string[] rejects an array holding the file's blank lines.
+                [string[]] $Lines,
+                [Parameter(Mandatory)] [string] $JobName
+            )
+
+            $start = -1
+            for ($i = 0; $i -lt $Lines.Count; $i++) {
+                if ($Lines[$i] -match "^  $([regex]::Escape($JobName)):\s*$") {
+                    $start = $i
+                    break
+                }
+            }
+            if ($start -lt 0) {
+                return @()
+            }
+
+            $end = $Lines.Count
+            for ($j = $start + 1; $j -lt $Lines.Count; $j++) {
+                if ($Lines[$j] -match '^  [A-Za-z0-9_-]+:\s*$') {
+                    $end = $j
+                    break
+                }
+            }
+
+            return @($Lines[$start..($end - 1)])
+        }
+    }
+
+    It "routes every workflow image pull through the action" {
+        # A reintroduced inline `docker pull` still succeeds, so it drops the retry this action exists
+        # to provide without failing anything.
+        $barePulls = @(
+            Get-ChildItem -LiteralPath $script:workflowRoot -Filter *.yml |
+                ForEach-Object {
+                    $file = $_
+                    Get-Content -LiteralPath $file.FullName |
+                        Where-Object { $_ -match 'docker\s+pull\b' } |
+                        ForEach-Object { "$($file.Name): $($_.Trim())" }
+                }
+        )
+
+        $barePulls | Should -HaveCount 0
+    }
+
+    It "checks out the repository before the local action in each release image-tag job" {
+        # Neither job had a checkout before this action existed, and both run only on release, so a
+        # dropped checkout would first appear during a release instead of on a pull request.
+        $releaseLines = @(Get-Content -LiteralPath (Join-Path $script:workflowRoot "on-release.yml"))
+
+        foreach ($jobName in @("tag-dms-image", "tag-cs-image")) {
+            $block = Get-JobBlock -Lines $releaseLines -JobName $jobName
+            $block | Should -Not -BeNullOrEmpty -Because "$jobName must exist"
+
+            $checkoutIndex = -1
+            $actionIndex = -1
+            for ($k = 0; $k -lt $block.Count; $k++) {
+                if ($checkoutIndex -lt 0 -and $block[$k] -match 'uses:\s+actions/checkout@') {
+                    $checkoutIndex = $k
+                }
+                if ($actionIndex -lt 0 -and $block[$k] -match 'uses:\s+\./\.github/actions/pull-ci-images\s*$') {
+                    $actionIndex = $k
+                }
+            }
+
+            $actionIndex | Should -BeGreaterOrEqual 0 -Because "$jobName must pull through the local action"
+            $checkoutIndex | Should -BeGreaterOrEqual 0 -Because "$jobName must check out the repository"
+            $checkoutIndex | Should -BeLessThan $actionIndex -Because "$jobName must check out before the local action resolves"
         }
     }
 }

--- a/eng/ci/tests/PullCiImages.Tests.ps1
+++ b/eng/ci/tests/PullCiImages.Tests.ps1
@@ -8,16 +8,26 @@
 # Runtime behavior of the shipped .github/actions/pull-ci-images/Invoke-CiImagePull.ps1.
 #
 # The primitive is invoked in a child pwsh with `docker`, `Get-Random`, and `Start-Sleep` replaced by
-# recording functions, so every assertion is on what the real script actually does rather than on its
-# source text, and no registry, image, or wall-clock delay is involved. A child process keeps the
-# shims and the script's preference assignments out of this Pester session.
+# recording functions, so the retry, backoff, and failure assertions are on what the real script
+# actually does, and no registry, image, or wall-clock delay is involved. A child process keeps the
+# shims and the script's preference assignments out of this Pester session. Three tests here do read
+# source text instead, because nothing invoked can reach what they cover: the declared action.yml
+# defaults below, and the two wiring invariants in the second Describe.
 #
-# One argument is deliberately not asserted here, and nothing in this suite covers it. The script
-# passes `--` to end Docker's option list, and PowerShell forwards that token verbatim to a native
-# command but strips it from a function call, so a shim can never observe it: a native
-# `echo pull -- ref` receives three arguments while a function receives two. The recorded pull lines
-# below therefore omit `--` even though the shipped command includes it - do not "fix" that by
-# removing the guard from the script. Only a real native invocation could assert it.
+# Two things the shipped script does are deliberately not asserted anywhere in this suite, because
+# the shim pattern cannot observe either one:
+#
+#   - The `--` that ends Docker's option list. PowerShell forwards that token verbatim to a native
+#     command but strips it from a function call, so a shim can never see it: a native
+#     `echo pull -- ref` receives three arguments while a function receives two. The recorded pull
+#     lines below therefore omit `--` even though the shipped command includes it - do not "fix"
+#     that by removing the guard from the script. Only a real native invocation could assert it.
+#   - `$PSNativeCommandUseErrorActionPreference = $false`. That preference governs native commands
+#     only, so a function shim is indifferent to it and deleting the assignment leaves this suite
+#     green. It is defensive rather than load-bearing on a current host, where the default is
+#     already false: a host that had turned it on would promote the first failed pull to a
+#     terminating error under `$ErrorActionPreference = "Stop"` and abort the run instead of
+#     retrying.
 #
 # Randomness is injected rather than sampled: the shim records the bounds the script asks for and
 # returns a caller-selected value from them. That makes the jitter contract - an expanding
@@ -238,7 +248,10 @@ exit 0
             $script:interior.Sleeps | Should -Be @(2250, 4500, 9000, 18000)
         }
 
-        It "keeps every band strictly increasing and inside [base/2, base)" {
+        It "keeps every wait inside [base/2, base) and rising while the base still doubles" {
+            # Only while the base doubles. The cap is what breaks strict growth, and the default 60s
+            # cap never binds inside four retries from a 3s base; the two capped specs below cover
+            # the bands that repeat instead.
             foreach ($run in @($script:floor, $script:ceiling, $script:interior)) {
                 $delays = $run.Sleeps
                 $delays | Should -HaveCount 4
@@ -381,8 +394,9 @@ exit 0
         It "holds every retry past the cap at the capped band" {
             $result = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -MaxAttempts 40 -InitialDelaySeconds 3 -RandomMode "floor"
 
-            # Base reaches the 60s cap on retry 6 and stays there, so the half-width is fixed at 30000.
-            @($result.Randoms | Select-Object -Skip 6 | Sort-Object -Unique) | Should -Be @("random 0 30000")
+            # Base reaches the 60s cap on retry 6 and stays there, so the half-width is fixed at
+            # 30000 from that retry on. Skipping the five uncapped retries starts the slice at 6.
+            @($result.Randoms | Select-Object -Skip 5 | Sort-Object -Unique) | Should -Be @("random 0 30000")
         }
     }
 
@@ -474,14 +488,18 @@ exit 0
 
 Describe "pull-ci-images workflow wiring" {
     # Two invariants that live purely in declarative CI wiring, so no invoked-script test can reach
-    # them, and whose regression would not surface as a failing pull-request lane. Everything else
-    # about the conversions - the gates, login order, permissions - fails a lane directly when broken
-    # and is deliberately not asserted from source here, following
-    # eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1.
+    # them, and whose regression would not surface as a failing pull-request lane. The rest of the
+    # conversion - login order, permissions, and the `use_prebuilt_images` condition on each pull
+    # step - is left to review, following eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1. Be
+    # clear about what that leaves exposed: `dms_image` and `config_image` are emitted
+    # unconditionally, and `use_prebuilt_images` goes false only for a fork pull request or when the
+    # REBUILD_DOWNSTREAM_IMAGES repository variable is set, so a dropped condition still passes on
+    # an internal pull request - including the one that drops it - and breaks fork lanes only.
     BeforeAll {
-        $script:workflowRoot = [System.IO.Path]::GetFullPath(
-            (Join-Path $PSScriptRoot "../../../.github/workflows")
+        $script:githubRoot = [System.IO.Path]::GetFullPath(
+            (Join-Path $PSScriptRoot "../../../.github")
         )
+        $script:workflowRoot = Join-Path $script:githubRoot "workflows"
 
         function Get-JobBlock {
             param(
@@ -513,15 +531,20 @@ Describe "pull-ci-images workflow wiring" {
         }
     }
 
-    It "routes every workflow image pull through the action" {
+    It "routes every declarative image pull through the action" {
         # A reintroduced inline `docker pull` still succeeds, so it drops the retry this action exists
-        # to provide without failing anything.
+        # to provide without failing anything. The whole .github tree is in scope, not just
+        # workflows: a composite action under .github/actions is as good a place to hide a bare pull.
+        # `docker image pull` is the same command spelled long-hand, and .yaml is the same file type
+        # spelled differently - neither appears today, and neither should slip past this if it does.
+        # Only YAML is scanned: Invoke-CiImagePull.ps1 is the one .ps1 under .github and its
+        # `docker pull` is the call this guard exists to funnel every other site into.
         $barePulls = @(
-            Get-ChildItem -LiteralPath $script:workflowRoot -Filter *.yml |
+            Get-ChildItem -LiteralPath $script:githubRoot -Recurse -File -Include *.yml, *.yaml |
                 ForEach-Object {
                     $file = $_
                     Get-Content -LiteralPath $file.FullName |
-                        Where-Object { $_ -match 'docker\s+pull\b' } |
+                        Where-Object { $_ -match 'docker\s+(image\s+)?pull\b' } |
                         ForEach-Object { "$($file.Name): $($_.Trim())" }
                 }
         )

--- a/eng/ci/tests/PullCiImages.Tests.ps1
+++ b/eng/ci/tests/PullCiImages.Tests.ps1
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+# Runtime behavior of the shipped .github/actions/pull-ci-images/Invoke-CiImagePull.ps1.
+#
+# The primitive is invoked in a child pwsh with `docker`, `Get-Random`, and `Start-Sleep` replaced by
+# recording functions, so every assertion is on what the real script actually does rather than on its
+# source text, and no registry, image, or wall-clock delay is involved. A child process keeps the
+# shims and the script's preference assignments out of this Pester session.
+#
+# One argument is deliberately not asserted here. The script passes `--` to end Docker's option list,
+# and PowerShell forwards that token verbatim to a native command but strips it from a function call,
+# so a shim can never observe it: `& echo.exe pull -- ref` receives three arguments while a function
+# receives two. The recorded pull lines below therefore omit `--` even though the shipped command
+# includes it - do not "fix" that by removing the guard from the script. The real native command line
+# is covered by the one-time invalid-image exercise against real Docker instead.
+#
+# Randomness is injected rather than sampled: the shim records the bounds the script asks for and
+# returns a caller-selected value from them. That makes the jitter contract - an expanding
+# [base/2, base) window per retry, capped - exactly assertable, where sampling real randomness could
+# only ever be probabilistic and would eventually fail a CI run by chance.
+
+Describe "Invoke-CiImagePull retry behavior" {
+    BeforeAll {
+        $script:scriptPath = [System.IO.Path]::GetFullPath(
+            (Join-Path $PSScriptRoot "../../../.github/actions/pull-ci-images/Invoke-CiImagePull.ps1")
+        )
+
+        $script:harnessPath = Join-Path $TestDrive "invoke-pull-harness.ps1"
+        Set-Content -LiteralPath $script:harnessPath -Encoding utf8 -Value @'
+# Global rather than script scope: a shim is called from inside the script under test, so `$script:`
+# would resolve against that script's scope and trip its Set-StrictMode on an unset variable.
+$global:dockerCallIndex = 0
+
+function Write-HarnessRecord {
+    param([Parameter(Mandatory)] [string] $Line)
+    Add-Content -LiteralPath $env:DMS_PULL_LOG -Value $Line
+}
+
+function docker {
+    $global:dockerCallIndex++
+    Write-HarnessRecord "docker $(($args | ForEach-Object { $_ }) -join ' ')"
+
+    # One exit code per invocation; the final value repeats so a scenario need only describe its
+    # leading attempts.
+    $codes = @($env:DMS_PULL_EXIT_CODES -split ',' | ForEach-Object { [int] $_.Trim() })
+    $index = [Math]::Min($global:dockerCallIndex, $codes.Count) - 1
+    $global:LASTEXITCODE = $codes[$index]
+
+    if ($global:LASTEXITCODE -ne 0) {
+        Write-HarnessRecord "docker-error simulated registry failure"
+    }
+}
+
+function Get-Random {
+    param([int] $Minimum, [int] $Maximum)
+    Write-HarnessRecord "random $Minimum $Maximum"
+
+    switch ($env:DMS_PULL_RANDOM_MODE) {
+        "ceiling" { return $Maximum - 1 }
+        "interior" { return [int] (($Minimum + $Maximum) / 2) }
+        default { return $Minimum }
+    }
+}
+
+function Start-Sleep {
+    param([int] $Milliseconds, [double] $Seconds)
+    Write-HarnessRecord "sleep $Milliseconds"
+}
+
+$ErrorActionPreference = "Stop"
+
+# The exit code must reflect whether the script under test failed. Left to the default preference, a
+# terminating error would be reported and the harness would still exit 0, making every failure
+# assertion vacuous.
+try {
+    & $env:DMS_PULL_SCRIPT `
+        -Images $env:DMS_PULL_IMAGES `
+        -MaxAttempts ([int] $env:DMS_PULL_MAX_ATTEMPTS) `
+        -InitialDelaySeconds ([int] $env:DMS_PULL_INITIAL_DELAY) `
+        -MaxDelaySeconds ([int] $env:DMS_PULL_MAX_DELAY)
+}
+catch {
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+}
+
+exit 0
+'@
+
+        function Invoke-PullHarness {
+            # Runs the real script under the shims and returns its combined output, exit code, and the
+            # ordered shim records. Inputs travel by environment variable so a multi-line images value
+            # never has to survive command-line quoting.
+            param(
+                [Parameter(Mandatory)] [AllowEmptyString()] [string] $Images,
+                [string] $ExitCodes = "0",
+                [int] $MaxAttempts = 5,
+                [int] $InitialDelaySeconds = 3,
+                [int] $MaxDelaySeconds = 60,
+                [ValidateSet("floor", "ceiling", "interior")] [string] $RandomMode = "floor"
+            )
+
+            $logPath = Join-Path $TestDrive ("records-" + [Guid]::NewGuid().ToString("N") + ".log")
+            Set-Content -LiteralPath $logPath -Value @() -Encoding utf8
+
+            $env:DMS_PULL_SCRIPT = $script:scriptPath
+            $env:DMS_PULL_IMAGES = $Images
+            $env:DMS_PULL_MAX_ATTEMPTS = "$MaxAttempts"
+            $env:DMS_PULL_INITIAL_DELAY = "$InitialDelaySeconds"
+            $env:DMS_PULL_MAX_DELAY = "$MaxDelaySeconds"
+            $env:DMS_PULL_EXIT_CODES = $ExitCodes
+            $env:DMS_PULL_RANDOM_MODE = $RandomMode
+            $env:DMS_PULL_LOG = $logPath
+
+            $output = & pwsh -NoProfile -File $script:harnessPath 2>&1 | Out-String
+            $exitCode = $LASTEXITCODE
+
+            $records = @(
+                if (Test-Path -LiteralPath $logPath) {
+                    Get-Content -LiteralPath $logPath | Where-Object { $_.Length -gt 0 }
+                }
+            )
+
+            return [pscustomobject]@{
+                Output   = $output
+                ExitCode = $exitCode
+                Records  = $records
+                Pulls    = @($records | Where-Object { $_ -like "docker *" })
+                Randoms  = @($records | Where-Object { $_ -like "random *" })
+                Sleeps   = @($records | Where-Object { $_ -like "sleep *" } | ForEach-Object { [int] ($_ -split " ")[1] })
+            }
+        }
+    }
+
+    Context "the shipped script exists where the action expects it" {
+        It "resolves the script path" {
+            Test-Path -LiteralPath $script:scriptPath | Should -BeTrue
+        }
+    }
+
+    Context "a registry that answers on the first attempt" {
+        BeforeAll {
+            $script:happy = Invoke-PullHarness -Images "registry/dms:ci`nregistry/config:ci" -ExitCodes "0"
+        }
+
+        It "pulls each image once, in the order given" {
+            $script:happy.Pulls | Should -HaveCount 2
+            $script:happy.Pulls[0] | Should -Be "docker pull registry/dms:ci"
+            $script:happy.Pulls[1] | Should -Be "docker pull registry/config:ci"
+        }
+
+        It "never waits and never draws a delay" {
+            $script:happy.Sleeps | Should -HaveCount 0
+            $script:happy.Randoms | Should -HaveCount 0
+        }
+
+        It "succeeds" {
+            $script:happy.ExitCode | Should -Be 0
+        }
+
+        It "reports the attempt and the maximum for the successful pull" {
+            $script:happy.Output | Should -Match "Pulling registry/dms:ci \(attempt 1 of 5\)\."
+            $script:happy.Output | Should -Match "Pulled registry/dms:ci on attempt 1 of 5\."
+        }
+    }
+
+    Context "a registry that fails twice and then answers" {
+        BeforeAll {
+            $script:recovered = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1,1,0"
+        }
+
+        It "retries until the pull succeeds" {
+            $script:recovered.Pulls | Should -HaveCount 3
+        }
+
+        It "waits once per failed attempt and not after the successful one" {
+            $script:recovered.Sleeps | Should -HaveCount 2
+            $script:recovered.Randoms | Should -HaveCount 2
+        }
+
+        It "succeeds" {
+            $script:recovered.ExitCode | Should -Be 0
+        }
+
+        It "keeps every failed attempt visible with its exit code and attempt position" {
+            $script:recovered.Output | Should -Match "docker pull failed for registry/dms:ci with exit code 1 on attempt 1 of 5\."
+            $script:recovered.Output | Should -Match "docker pull failed for registry/dms:ci with exit code 1 on attempt 2 of 5\."
+        }
+
+        It "names the attempt it is waiting for" {
+            $script:recovered.Output | Should -Match "before attempt 2 of 5 for registry/dms:ci\."
+            $script:recovered.Output | Should -Match "before attempt 3 of 5 for registry/dms:ci\."
+        }
+    }
+
+    Context "the jittered backoff envelope" {
+        BeforeAll {
+            $script:floor = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -RandomMode "floor"
+            $script:ceiling = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -RandomMode "ceiling"
+            $script:interior = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -RandomMode "interior"
+        }
+
+        It "draws randomness once per retry over a doubling range" {
+            # Half the base per attempt: 3s, 6s, 12s, 24s bases at the default 3-second initial base.
+            $script:floor.Randoms | Should -HaveCount 4
+            $script:floor.Randoms[0] | Should -Be "random 0 1500"
+            $script:floor.Randoms[1] | Should -Be "random 0 3000"
+            $script:floor.Randoms[2] | Should -Be "random 0 6000"
+            $script:floor.Randoms[3] | Should -Be "random 0 12000"
+        }
+
+        It "waits the band floor when randomness returns its minimum" {
+            $script:floor.Sleeps | Should -Be @(1500, 3000, 6000, 12000)
+        }
+
+        It "waits just under the band ceiling when randomness returns its maximum" {
+            $script:ceiling.Sleeps | Should -Be @(2999, 5999, 11999, 23999)
+        }
+
+        It "waits inside the band for an interior draw" {
+            $script:interior.Sleeps | Should -Be @(2250, 4500, 9000, 18000)
+        }
+
+        It "keeps every band strictly increasing and inside [base/2, base)" {
+            foreach ($run in @($script:floor, $script:ceiling, $script:interior)) {
+                $delays = $run.Sleeps
+                $delays | Should -HaveCount 4
+
+                for ($index = 0; $index -lt 4; $index++) {
+                    $baseMilliseconds = 3000 * [Math]::Pow(2, $index)
+                    $delays[$index] | Should -BeGreaterOrEqual ($baseMilliseconds / 2)
+                    $delays[$index] | Should -BeLessThan $baseMilliseconds
+                }
+
+                for ($index = 1; $index -lt 4; $index++) {
+                    $delays[$index] | Should -BeGreaterThan $delays[$index - 1]
+                }
+            }
+        }
+
+        It "stops growing the base at the cap" {
+            $capped = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -MaxDelaySeconds 6 -RandomMode "floor"
+            $capped.Randoms | Should -Be @("random 0 1500", "random 0 3000", "random 0 3000", "random 0 3000")
+            $capped.Sleeps | Should -Be @(1500, 3000, 3000, 3000)
+        }
+    }
+
+    Context "a registry that never answers" {
+        BeforeAll {
+            $script:exhausted = Invoke-PullHarness -Images "registry/dms:ci" -ExitCodes "1" -MaxAttempts 3 -InitialDelaySeconds 1
+        }
+
+        It "attempts exactly the configured maximum" {
+            $script:exhausted.Pulls | Should -HaveCount 3
+        }
+
+        It "does not wait after the final attempt" {
+            $script:exhausted.Sleeps | Should -HaveCount 2
+        }
+
+        It "fails the step" {
+            $script:exhausted.ExitCode | Should -Not -Be 0
+        }
+
+        It "names the image and the attempt count in the failure" {
+            $script:exhausted.Output | Should -Match "Failed to pull registry/dms:ci after 3 attempt\(s\)\."
+        }
+    }
+
+    Context "a failing image ahead of a healthy one" {
+        It "gives each image its own attempt budget" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci`nregistry/config:ci" -ExitCodes "1,0,0"
+
+            $result.ExitCode | Should -Be 0
+            $result.Pulls | Should -Be @(
+                "docker pull registry/dms:ci",
+                "docker pull registry/dms:ci",
+                "docker pull registry/config:ci"
+            )
+            $result.Sleeps | Should -HaveCount 1
+        }
+
+        It "restarts the backoff for the next image" {
+            # Both images fail once: the second image's retry must draw the first band again rather
+            # than continuing the first image's escalation.
+            $result = Invoke-PullHarness -Images "registry/dms:ci`nregistry/config:ci" -ExitCodes "1,0,1,0"
+
+            $result.ExitCode | Should -Be 0
+            $result.Randoms | Should -Be @("random 0 1500", "random 0 1500")
+        }
+
+        It "stops at the first image that exhausts its budget" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci`nregistry/config:ci" -ExitCodes "1" -MaxAttempts 2 -InitialDelaySeconds 1
+
+            $result.ExitCode | Should -Not -Be 0
+            $result.Pulls | Should -HaveCount 2
+            $result.Output | Should -Match "Failed to pull registry/dms:ci after 2 attempt\(s\)\."
+            $result.Output | Should -Not -Match "registry/config:ci"
+        }
+    }
+
+    Context "the images input" {
+        It "ignores blank and whitespace-only lines" {
+            $result = Invoke-PullHarness -Images "`n  registry/dms:ci  `n`n   `nregistry/config:ci`n"
+
+            $result.ExitCode | Should -Be 0
+            $result.Pulls | Should -Be @(
+                "docker pull registry/dms:ci",
+                "docker pull registry/config:ci"
+            )
+        }
+
+        It "accepts CRLF separators" {
+            $result = Invoke-PullHarness -Images "registry/dms:ci`r`nregistry/config:ci`r`n"
+
+            $result.ExitCode | Should -Be 0
+            $result.Pulls | Should -HaveCount 2
+        }
+
+        It "pulls exactly once for a single-line value" {
+            $result = Invoke-PullHarness -Images "edfialliance/ed-fi-data-management-service:dms-pre-1.0.0"
+
+            $result.ExitCode | Should -Be 0
+            $result.Pulls | Should -Be @("docker pull edfialliance/ed-fi-data-management-service:dms-pre-1.0.0")
+        }
+
+        It "fails without invoking Docker when no image survives parsing" {
+            $result = Invoke-PullHarness -Images "`n   `n`n"
+
+            $result.ExitCode | Should -Not -Be 0
+            $result.Pulls | Should -HaveCount 0
+            $result.Output | Should -Match "No images were supplied to pull\."
+        }
+
+        It "fails without invoking Docker when the value is empty" {
+            $result = Invoke-PullHarness -Images ""
+
+            $result.ExitCode | Should -Not -Be 0
+            $result.Pulls | Should -HaveCount 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The PR workflow builds one DMS/Config CI-image pair, then roughly twenty matrix and downstream jobs pull the same GHCR tags almost simultaneously. Those pulls were unguarded `docker pull` calls, so a transient registry error failed an entire lane.

This adds a local composite action that retries a failed pull with jittered exponential backoff, and routes all 20 existing pull invocations through it. `docker pull` no longer appears anywhere under `.github/workflows`.

## How the retry behaves

- **Per-image attempt budgets** that reset for each image, with fail-fast on the first image to exhaust its budget — every calling job needs all of its images, so continuing would only add latency and bury the real error.
- **Equal jitter over a capped exponential base**: each wait is drawn uniformly from `[base/2, base)` where base doubles per attempt up to `max-delay-seconds`. At the defaults (5 attempts, 3 s initial, 60 s cap) the bands are `[1.5, 3)`, `[3, 6)`, `[6, 12)`, `[12, 24)` seconds — strictly increasing and non-overlapping.
- Equal jitter was chosen over AWS-style full jitter (`Random(0, base)`) for two reasons: the envelope is strictly increasing so it can be asserted exactly rather than statistically, and full jitter can draw ~0 s on the last retry, which weakens the backoff. Desynchronization is still real — twenty jobs entering the first retry together spread uniformly across a 1.5 s window, then 3 s, then 6 s.
- **Docker's output is never captured** — no assignment, pipe, or subexpression — so the registry error that caused a failure streams to the job log exactly as before, and the exit code is Docker's own.
- **Every failed attempt logs the image, exit code, and `attempt N of M`.** The final failure throws, naming the image and the attempt count, so a missing image can never pass as success.
- An `images` value that parses to nothing throws rather than pulling nothing and reporting success.

Worst-case added latency on a genuinely dead registry is about 45 s per failing step, against the current behavior of an immediately failed lane and a full re-run.

## Changes

**New action** — `.github/actions/pull-ci-images/`

`action.yml` declares `shell: pwsh` explicitly (a composite step does not inherit the calling job's `defaults.run.shell`) and passes inputs through an `env:` block, so no workflow expression is ever interpolated into a script body. Inputs are `images` (newline-separated, blank lines ignored) plus `max-attempts`, `initial-delay-seconds`, and `max-delay-seconds`.

`Invoke-CiImagePull.ps1` holds the logic in its own file so the Pester suite exercises the artifact that actually ships. It sets `$PSNativeCommandUseErrorActionPreference = $false` so a failed native pull reaches the retry loop as an exit code rather than a terminating error.

**Call sites** — 20 pulls converted, every step keeping its name and its exact `if:` gate

| Workflow | Converted |
|---|---|
| `on-dms-pullrequest.yml` | 8 `Pull CI Docker images` steps (16 pulls) |
| `scheduled-smoke-test.yml` | 1 step (2 pulls) |
| `on-release.yml` | 2 single-image prerelease pulls |

All nine two-image steps keep `if: needs.build-ci-docker-images.outputs.use_prebuilt_images == 'true'`, stay after their checkout and GHCR login, and remain in jobs declaring `packages: read`. The `!= 'true'` fresh-build branches, the login steps, and job permissions are untouched — the action performs no authentication of its own.

**One additive change worth reviewer attention:** `on-release.yml`'s `tag-dms-image` and `tag-cs-image` had **no checkout step at all**, because nothing in them needed the repository. A local `uses: ./.github/actions/...` cannot resolve without one, so each gained the same pinned `actions/checkout@11bd719` as its first step. Nothing else in those jobs moves — `Prepare Release Tags`, the pull, the tag step, the Docker Hub login used for the push, and the push keep their order, and no gate or `packages: read` was added. These two pulls hit Docker Hub anonymously (their login exists for the push), so they are the pulls most exposed to anonymous rate limiting.

**New tests** — `eng/ci/tests/PullCiImages.Tests.ps1`, 28 tests, registered in the bootstrap Pester lane

Runtime tests over the real script in a child pwsh with `docker`, `Get-Random`, and `Start-Sleep` replaced by recording functions, following the existing `E2ETeardownSafety.Tests.ps1` idiom. Randomness is **injected rather than sampled** — the shim records the bounds requested and returns a caller-chosen floor, ceiling, or interior value — so the backoff assertions are exact instead of probabilistic. A sampling test like "repeated runs differ" would eventually fail a CI run by chance.

Covered: expanding randomness ranges per retry, band floors/ceilings/interiors, the cap engaging, fail-then-succeed, exhausted budget, per-image budget resets, and input parsing (blank lines, CRLF, single scalar, empty).

## Verification

| Check | Result |
|---|---|
| New suite | 28 passed |
| Focused `eng/ci` set (4 specs) | 124 passed |
| Other specs reading any workflow file | 70 passed |
| Full bootstrap Pester list | 2172 passed, 55 skipped, 1 pre-existing failure |
| `docker pull` under `.github/workflows` | no matches |
| Local-action uses (PR / smoke / release) | 8 / 1 / 2 |
| `packages: read` and `docker/login-action` counts vs base | 8 vs 8, 9 vs 9 |
| YAML parse (3 workflows + action metadata) | all 4 parse |
| PSScriptAnalyzer (via pre-commit hook) | no findings |

Conversions were verified structurally by parsing each workflow and checking step indices and `if` equality, not by reading text order.

The single bootstrap failure is `BootstrapSeedDelivery.Tests.ps1` → "Resolve-BootstrapDataStandard rejects a missing extracted directory with the resolved path". It is pre-existing and unrelated: that spec and the script it exercises are byte-identical to base, and this branch touches zero files under `eng/docker-compose`. Its Pester `-ExpectedMessage` wildcard is built from a Windows temp path whose backslashes the comparison consumes; the lane runs on `ubuntu-latest` where the path is forward-slashed and matches, which is why it passes in CI and fails only on a Windows checkout.

Beyond the suite, the shipped script was exercised against real Docker with no shims, using an unreachable registry at 3 attempts and a 1-second base: three attempt logs, a live daemon error preserved on every attempt including the first, real waits of 512 ms then 1969 ms (increasing, each inside its band), and exit 1 naming the image and attempt count. Separately, mutating the jitter to a purely exponential delay fails 8 tests, confirming the envelope assertions bind rather than merely pass.

## Residual risk

The action has never executed under a real Actions runner. Runner-side resolution of `uses: ./.github/actions/pull-ci-images`, `$env:GITHUB_ACTION_PATH`, and `with: images: |` block-scalar delivery through the expression evaluator are CI-only facts — local YAML parsing proves the wiring is well-formed, not that the runner accepts it. **This PR's own checks are the first real exercise of the action.** Relatedly, `on-release.yml` runs only on release, so no PR run will ever exercise its two converted pulls or their new checkout.

Retry also means a non-retryable error (bad tag, `denied`, revoked token) burns the full backoff before failing, and a persistently degraded registry can hide behind slower-but-green lanes. Both are visible in the logs; distinguishing retryable from fatal would mean parsing Docker's stderr text, which is version-fragile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
