### PR TITLE
[DMS-1278] Accept the raw claims document on POST /management/upload-claims

### DIFF
--- a/docs/CLAIMS-LOADING-GUIDE.md
+++ b/docs/CLAIMS-LOADING-GUIDE.md
@@ -316,13 +316,14 @@ curl -X POST -H "Content-Type: application/json" \
 ```
 
 **Important Notes:**
-- The uploaded structure completely replaces the current claims
+- The uploaded document replaces the claims hierarchy and every non-system-reserved claim set;
+  system-reserved claim sets are preserved whether or not the document repeats them
 - Must include both `claimSets` and `claimsHierarchy` sections
 - The request body is the claims document itself. It is not nested under a `claims` property; a body
   shaped that way is rejected with HTTP 400 naming the missing `claimSets` and `claimsHierarchy`
   properties.
 - Subject to JSON Schema validation
-- Returns a reload ID header for tracking
+- Returns the new reload ID in the response body: `{ "success": true, "reloadId": "<guid>" }`
 
 ### Reload Claims from Fragments
 
@@ -333,10 +334,14 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
   http://localhost:8081/management/reload-claims
 ```
 
-Response includes:
-- X-Reload-Id header with unique identifier
-- Status of reload operation
-- Any validation errors encountered
+On success the response body carries the status and the new reload ID:
+
+```json
+{ "success": true, "reloadId": "<guid>" }
+```
+
+A failed reload is returned as an Ed-Fi problem-details error response, not as an error list on a
+success body.
 
 ### Get Current Claims
 
@@ -347,8 +352,10 @@ curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:8081/management/current-claims
 ```
 
-Returns the full Claims.json structure currently in use. This is exactly the document the upload
-endpoint accepts, so the response can be uploaded again without modification.
+Returns the full Claims.json structure currently in use, along with an `X-Reload-Id` response header
+identifying the loaded claims. This is the only endpoint that sets that header, and the body is
+exactly the document the upload endpoint accepts, so the response can be uploaded again without
+modification.
 
 ### Round-Trip: Download and Re-Upload
 

--- a/docs/CLAIMS-LOADING-GUIDE.md
+++ b/docs/CLAIMS-LOADING-GUIDE.md
@@ -63,39 +63,44 @@ The Claims.json file contains two main sections and is used as:
           }
         ]
       },
-      "resources": [
+      "claims": [
         {
-          "name": "ed-fi/academicWeeks",
-          "actions": [
+          "name": "http://ed-fi.org/identity/claims/ed-fi/academicWeeks",
+          "claimSets": [
             {
-              "name": "Create",
-              "authorizationStrategies": [
+              "name": "CustomClaimSet",
+              "actions": [
                 {
-                  "name": "NamespaceBased"
-                }
-              ]
-            },
-            {
-              "name": "Read",
-              "authorizationStrategies": [
+                  "name": "Create",
+                  "authorizationStrategyOverrides": [
+                    {
+                      "name": "NamespaceBased"
+                    }
+                  ]
+                },
                 {
-                  "name": "NoFurtherAuthorizationRequired"
-                }
-              ]
-            },
-            {
-              "name": "Update",
-              "authorizationStrategies": [
+                  "name": "Read",
+                  "authorizationStrategyOverrides": [
+                    {
+                      "name": "NoFurtherAuthorizationRequired"
+                    }
+                  ]
+                },
                 {
-                  "name": "NamespaceBased"
-                }
-              ]
-            },
-            {
-              "name": "Delete",
-              "authorizationStrategies": [
+                  "name": "Update",
+                  "authorizationStrategyOverrides": [
+                    {
+                      "name": "NamespaceBased"
+                    }
+                  ]
+                },
                 {
-                  "name": "NamespaceBased"
+                  "name": "Delete",
+                  "authorizationStrategyOverrides": [
+                    {
+                      "name": "NamespaceBased"
+                    }
+                  ]
                 }
               ]
             }
@@ -114,11 +119,13 @@ The Claims.json file contains two main sections and is used as:
 - **isSystemReserved**: Boolean indicating if the claim set is protected from modification
 
 #### Claims Hierarchy Section
-- **name**: Domain or resource identifier
-- **defaultAuthorization**: Default authorization strategies for all resources in the domain
-- **resources**: Specific resource claims with their authorization strategies
+- **name**: Domain or resource claim identifier
+- **defaultAuthorization**: Default authorization strategies inherited by the claim and its children
+- **claims**: Nested child claims, such as the resource claims within a domain
+- **claimSets**: Per-claim-set grants on a claim, each naming a claim set and the actions it may perform
 - **actions**: CRUD operations (Create, Read, Update, Delete, ReadChanges)
-- **authorizationStrategies**: Security strategies applied to each action
+- **authorizationStrategies**: Security strategies on a `defaultAuthorization` action
+- **authorizationStrategyOverrides**: Strategies replacing the inherited default for a claim set action
 
 ### Per-Data-Standard Embedded Claims
 
@@ -296,14 +303,19 @@ curl -X POST -H "Content-Type: application/json" \
             }
           ]
         },
-        "resources": [
+        "claims": [
           {
-            "name": "ed-fi/students",
-            "actions": [
+            "name": "http://ed-fi.org/identity/claims/ed-fi/students",
+            "claimSets": [
               {
-                "name": "Create",
-                "authorizationStrategies": [
-                  {"name": "NamespaceBased"}
+                "name": "CustomVendor",
+                "actions": [
+                  {
+                    "name": "Create",
+                    "authorizationStrategyOverrides": [
+                      {"name": "NamespaceBased"}
+                    ]
+                  }
                 ]
               }
             ]
@@ -316,8 +328,9 @@ curl -X POST -H "Content-Type: application/json" \
 ```
 
 **Important Notes:**
-- The uploaded document replaces the claims hierarchy and every non-system-reserved claim set;
-  system-reserved claim sets are preserved whether or not the document repeats them
+- The uploaded document becomes the active claims configuration. Internally, persisted
+  non-system-reserved claim-set rows are replaced while existing system-reserved claim-set rows are
+  not deleted.
 - Must include both `claimSets` and `claimsHierarchy` sections
 - The request body is the claims document itself. It is not nested under a `claims` property; a body
   shaped that way is rejected with HTTP 400 naming the missing `claimSets` and `claimsHierarchy`

--- a/docs/CLAIMS-LOADING-GUIDE.md
+++ b/docs/CLAIMS-LOADING-GUIDE.md
@@ -318,6 +318,9 @@ curl -X POST -H "Content-Type: application/json" \
 **Important Notes:**
 - The uploaded structure completely replaces the current claims
 - Must include both `claimSets` and `claimsHierarchy` sections
+- The request body is the claims document itself. It is not nested under a `claims` property; a body
+  shaped that way is rejected with HTTP 400 naming the missing `claimSets` and `claimsHierarchy`
+  properties.
 - Subject to JSON Schema validation
 - Returns a reload ID header for tracking
 
@@ -344,7 +347,27 @@ curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:8081/management/current-claims
 ```
 
-Returns the full Claims.json structure currently in use.
+Returns the full Claims.json structure currently in use. This is exactly the document the upload
+endpoint accepts, so the response can be uploaded again without modification.
+
+### Round-Trip: Download and Re-Upload
+
+Because both endpoints use the same two-section document, a downloaded file can be uploaded as-is:
+
+```bash
+# Download the active claims
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8081/management/current-claims > claims.json
+
+# Upload it unchanged (or after editing claims.json)
+curl -X POST -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  --data-binary @claims.json \
+  http://localhost:8081/management/upload-claims
+```
+
+No wrapping, re-indenting or property renaming is required in between. The upload responds with HTTP
+200 and a new reload ID.
 
 ## Deployment Steps
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimsManagementModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimsManagementModuleTests.cs
@@ -88,6 +88,17 @@ public abstract class ClaimsManagementModuleTests
     }
 
     /// <summary>
+    /// Configures the shared IClaimsProvider fake with the claims document GetCurrentClaims returns and
+    /// the reload id both claims endpoints report.
+    /// </summary>
+    protected void ArrangeCurrentClaims(JsonNode claimSetsNode, JsonNode claimsHierarchyNode, Guid reloadId)
+    {
+        A.CallTo(() => _claimsProvider.GetClaimsDocumentNodes())
+            .Returns(new ClaimsDocument(claimSetsNode, claimsHierarchyNode));
+        A.CallTo(() => _claimsProvider.ReloadId).Returns(reloadId);
+    }
+
+    /// <summary>
     /// Asserts the full Ed-Fi internal-server-error contract for a 500 response and proves the raw
     /// exception text (<paramref name="secretThatMustNotLeak"/>) is absent from the body, including
     /// the legacy ad-hoc singular <c>error</c>/<c>message</c> members.
@@ -129,8 +140,53 @@ public abstract class ClaimsManagementModuleTests
     protected void ArrangeUploadThrows(Exception exception) =>
         A.CallTo(() => _claimsUploadService.UploadClaimsAsync(A<JsonNode>._)).Throws(exception);
 
+    // A non-empty JSON object in the canonical (unwrapped) upload shape. Fixtures using it stub the
+    // upload service, so only "reaches the handler as a JSON object" matters to them.
     protected static StringContent NonEmptyUploadBody() =>
-        new("{\"claims\":{\"placeholder\":true}}", Encoding.UTF8, "application/json");
+        new("{\"claimSets\":[],\"claimsHierarchy\":[]}", Encoding.UTF8, "application/json");
+
+    /// <summary>
+    /// Builds a real <see cref="ClaimsUploadService"/> whose persistence layer reports success, so a
+    /// fixture exercises the production upload path (structure checks, validation, failure mapping)
+    /// instead of a stubbed status. Pass the real <see cref="ClaimsValidator"/> to additionally prove the
+    /// payload satisfies the canonical claims JSON schema.
+    /// </summary>
+    protected static ClaimsUploadService CreateRealUploadService(IClaimsValidator claimsValidator)
+    {
+        IClaimsDataLoader claimsDataLoader = A.Fake<IClaimsDataLoader>();
+        A.CallTo(() => claimsDataLoader.UpdateClaimsAsync(A<ClaimsDocument>._))
+            .Returns(new ClaimsDataLoadResult.Success(ClaimSetsLoaded: 1, HierarchyLoaded: true));
+
+        return new ClaimsUploadService(
+            A.Fake<ILogger<ClaimsUploadService>>(),
+            A.Fake<IClaimsProvider>(),
+            claimsDataLoader,
+            claimsValidator
+        );
+    }
+
+    /// <summary>
+    /// Asserts the 400 produced by a body that carries neither canonical claims-document property: one
+    /// validation entry per property, keyed by the property name the caller must supply.
+    /// </summary>
+    protected static async Task AssertMissingClaimsDocumentPropertiesContract(HttpResponseMessage response) =>
+        await AssertDataValidationContract(
+            response,
+            validationErrors =>
+            {
+                validationErrors.Count.Should().Be(2);
+                validationErrors["claimSets"]!
+                    .AsArray()
+                    .Select(node => node!.GetValue<string>())
+                    .Should()
+                    .Equal("Missing required 'claimSets' property");
+                validationErrors["claimsHierarchy"]!
+                    .AsArray()
+                    .Select(node => node!.GetValue<string>())
+                    .Should()
+                    .Equal("Missing required 'claimsHierarchy' property");
+            }
+        );
 
     /// <summary>
     /// Asserts the generic Ed-Fi bad-request contract (empty extension members, fixed safe detail) and
@@ -659,27 +715,56 @@ public abstract class ClaimsManagementModuleTests
         }
     }
 
-    /// <summary>A null Claims body becomes data validation keyed by "Claims" (400).</summary>
+    /// <summary>
+    /// An empty JSON object is a well-formed request whose two canonical claims properties are both
+    /// absent, so the response names those properties rather than a request wrapper.
+    /// </summary>
     [TestFixture]
-    public class Given_upload_claims_is_null : ClaimsManagementModuleTests
+    public class Given_upload_claims_receives_an_empty_json_object : ClaimsManagementModuleTests
     {
         [SetUp]
         public void Setup() =>
-            ArrangeAuthenticatedClient(AuthorizationScopes.AdminScope.Name, dangerousFlagEnabled: true);
+            ArrangeAuthenticatedClient(
+                AuthorizationScopes.AdminScope.Name,
+                dangerousFlagEnabled: true,
+                uploadServiceOverride: CreateRealUploadService(A.Fake<IClaimsValidator>())
+            );
 
         [Test]
-        public async Task It_should_return_data_validation_for_the_claims_field()
+        public async Task It_should_report_both_missing_claims_document_properties()
         {
             var response = await Client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
-            await AssertDataValidationContract(
-                response,
-                validationErrors =>
-                {
-                    validationErrors.Count.Should().Be(1);
-                    validationErrors["Claims"]!.AsArray().Count.Should().Be(1);
-                    validationErrors["Claims"]![0]!.GetValue<string>().Should().Be("Claims JSON is required");
-                }
+            await AssertMissingClaimsDocumentPropertiesContract(response);
+        }
+    }
+
+    /// <summary>
+    /// The endpoint accepts only the canonical claims document, so a body nesting that document under a
+    /// "claims" property is rejected with the same actionable 400 that names the two required
+    /// properties. The canonical schema forbids the nested shape (root additionalProperties: false).
+    /// </summary>
+    [TestFixture]
+    public class Given_upload_claims_receives_a_nested_claims_property : ClaimsManagementModuleTests
+    {
+        [SetUp]
+        public void Setup() =>
+            ArrangeAuthenticatedClient(
+                AuthorizationScopes.AdminScope.Name,
+                dangerousFlagEnabled: true,
+                uploadServiceOverride: CreateRealUploadService(A.Fake<IClaimsValidator>())
             );
+
+        [Test]
+        public async Task It_should_report_both_missing_claims_document_properties()
+        {
+            using var nestedBody = new StringContent(
+                """{"claims":{"claimSets":[],"claimsHierarchy":[]}}""",
+                Encoding.UTF8,
+                "application/json"
+            );
+
+            var response = await Client.PostAsync(UploadClaimsRoute, nestedBody);
+            await AssertMissingClaimsDocumentPropertiesContract(response);
         }
     }
 
@@ -894,7 +979,7 @@ public abstract class ClaimsManagementModuleTests
         public async Task It_should_return_the_internal_server_error_contract()
         {
             using var content = new StringContent(
-                """{"claims":{"claimSets":[],"claimsHierarchy":[]}}""",
+                """{"claimSets":[],"claimsHierarchy":[]}""",
                 Encoding.UTF8,
                 "application/json"
             );
@@ -983,7 +1068,7 @@ public abstract class ClaimsManagementModuleTests
         public async Task It_returns_the_data_validation_contract_instead_of_an_empty_body()
         {
             using var malformedBody = new StringContent(
-                "{\"claims\":{\"claimSets\":[],}}",
+                "{\"claimSets\":[],}",
                 Encoding.UTF8,
                 "application/json"
             );
@@ -1029,8 +1114,8 @@ public abstract class ClaimsManagementModuleTests
             );
         }
 
-        [TestCase("""{"claims":[]}""")]
-        [TestCase("""{"claims":"x"}""")]
+        [TestCase("[]")]
+        [TestCase("\"x\"")]
         public async Task It_returns_the_data_validation_contract_at_the_document_root(string requestBody)
         {
             using var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
@@ -1089,5 +1174,158 @@ public abstract class ClaimsManagementModuleTests
             var response = await Client.PostAsync(UploadClaimsRoute, NonEmptyUploadBody());
             await AssertGenericBadRequestContract(response, Sentinel);
         }
+    }
+
+    /// <summary>
+    /// The upload request body stays required: an absent body is rejected by model binding before the
+    /// handler runs, keeping the same missing-body contract every other CMS write endpoint returns.
+    /// </summary>
+    [TestFixture]
+    public class Given_upload_claims_receives_no_request_body : ClaimsManagementModuleTests
+    {
+        [SetUp]
+        public void Setup() =>
+            ArrangeAuthenticatedClient(AuthorizationScopes.AdminScope.Name, dangerousFlagEnabled: true);
+
+        [Test]
+        public async Task It_returns_the_missing_body_bad_request_contract()
+        {
+            var response = await Client.PostAsync(UploadClaimsRoute, content: null);
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+            JsonNode body = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request");
+            body["title"]!.GetValue<string>().Should().Be("Bad Request");
+            body["validationErrors"]!.AsObject().Count.Should().Be(0);
+            body["errors"]!
+                .AsArray()
+                .Select(node => node!.GetValue<string>())
+                .Should()
+                .Equal("A non-empty request body is required.");
+        }
+    }
+
+    /// <summary>
+    /// A literal JSON null body deserializes to no document at all, so it is treated as a missing body
+    /// rather than reaching the upload service.
+    /// </summary>
+    [TestFixture]
+    public class Given_upload_claims_receives_a_literal_null_body : ClaimsManagementModuleTests
+    {
+        [SetUp]
+        public void Setup() =>
+            ArrangeAuthenticatedClient(AuthorizationScopes.AdminScope.Name, dangerousFlagEnabled: true);
+
+        [Test]
+        public async Task It_returns_the_missing_body_bad_request_contract()
+        {
+            using var nullBody = new StringContent("null", Encoding.UTF8, "application/json");
+
+            var response = await Client.PostAsync(UploadClaimsRoute, nullBody);
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+            JsonNode body = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request");
+            body["errors"]!
+                .AsArray()
+                .Select(node => node!.GetValue<string>())
+                .Should()
+                .Equal("A non-empty request body is required.");
+        }
+    }
+
+    /// <summary>
+    /// The uniform-contract guarantee: the exact body returned by GET /management/current-claims is
+    /// accepted by POST /management/upload-claims with no wrapping, editing or reformatting. The real
+    /// ClaimsValidator is used, so this also proves the downloaded document satisfies the canonical
+    /// claims JSON schema.
+    /// </summary>
+    [TestFixture]
+    public class Given_the_current_claims_response_is_uploaded_unchanged : ClaimsManagementModuleTests
+    {
+        private static readonly Guid _currentReloadId = new("11111111-2222-3333-4444-555555555555");
+
+        private HttpResponseMessage _getResponse = null!;
+        private string _downloadedClaims = null!;
+        private HttpResponseMessage _uploadResponse = null!;
+        private JsonObject _uploadResponseBody = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            ArrangeCurrentClaims(
+                JsonNode.Parse("""[{ "claimSetName": "RoundTripClaimSet", "isSystemReserved": false }]""")!,
+                JsonNode.Parse(
+                    """
+                    [
+                      {
+                        "name": "http://ed-fi.org/identity/claims/domains/edFiTypes",
+                        "claimSets": [{ "name": "RoundTripClaimSet", "actions": [{ "name": "Read" }] }]
+                      }
+                    ]
+                    """
+                )!,
+                _currentReloadId
+            );
+            ArrangeAuthenticatedClient(
+                AuthorizationScopes.AdminScope.Name,
+                dangerousFlagEnabled: true,
+                uploadServiceOverride: CreateRealUploadService(
+                    new ClaimsValidator(A.Fake<ILogger<ClaimsValidator>>())
+                )
+            );
+
+            _getResponse = await Client.GetAsync(CurrentClaimsRoute);
+            _downloadedClaims = await _getResponse.Content.ReadAsStringAsync();
+
+            // Posted back exactly as downloaded: no wrapper, no re-serialization.
+            using StringContent uploadBody = new(_downloadedClaims, Encoding.UTF8, "application/json");
+            _uploadResponse = await Client.PostAsync(UploadClaimsRoute, uploadBody);
+            _uploadResponseBody = JsonNode
+                .Parse(await _uploadResponse.Content.ReadAsStringAsync())!
+                .AsObject();
+        }
+
+        [TearDown]
+        public void DisposeResponses()
+        {
+            _getResponse?.Dispose();
+            _uploadResponse?.Dispose();
+        }
+
+        [Test]
+        public void It_returns_the_current_claims_with_the_reload_id_header()
+        {
+            _getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            _getResponse.Headers.GetValues("X-Reload-Id").Should().Equal(_currentReloadId.ToString());
+        }
+
+        [Test]
+        public void It_downloads_the_canonical_claims_document_shape() =>
+            JsonNode
+                .Parse(_downloadedClaims)!
+                .AsObject()
+                .Select(property => property.Key)
+                .Should()
+                .Equal("claimSets", "claimsHierarchy");
+
+        [Test]
+        public void It_accepts_the_downloaded_document_without_modification() =>
+            _uploadResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        [Test]
+        public void It_reports_a_successful_upload_with_a_reload_id()
+        {
+            _uploadResponseBody["success"]!.GetValue<bool>().Should().BeTrue();
+            Guid.TryParse(_uploadResponseBody["reloadId"]!.GetValue<string>(), out _).Should().BeTrue();
+        }
+
+        [Test]
+        public void It_reports_no_validation_errors() =>
+            _uploadResponseBody.ContainsKey("validationErrors").Should().BeFalse();
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimsManagementModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimsManagementModule.cs
@@ -34,7 +34,7 @@ public class ClaimsManagementModule : IEndpointModule
             .MapSecuredPost("/upload-claims", UploadClaims)
             .WithName("UploadClaims")
             .WithSummary("Uploads Claims from request body")
-            .Accepts<UploadClaimsRequest>("application/json")
+            .Accepts<JsonNode>("application/json")
             .Produces<UploadClaimsResponse>(200)
             .Produces(400)
             .Produces(404)
@@ -104,7 +104,7 @@ public class ClaimsManagementModule : IEndpointModule
     }
 
     internal static async Task<IResult> UploadClaims(
-        UploadClaimsRequest request,
+        JsonNode claimsDocument,
         IClaimsUploadService claimsUploadService,
         IClaimsProvider claimsProvider,
         IOptions<ClaimsOptions> claimsOptions,
@@ -126,17 +126,9 @@ public class ClaimsManagementModule : IEndpointModule
 
         logger.LogInformation("Claims upload requested via management endpoint");
 
-        if (request?.Claims == null)
-        {
-            return FailureResults.DataValidation(
-                [new ValidationFailure("Claims", "Claims JSON is required")],
-                httpContext.TraceIdentifier
-            );
-        }
-
         try
         {
-            var status = await claimsUploadService.UploadClaimsAsync(request.Claims);
+            var status = await claimsUploadService.UploadClaimsAsync(claimsDocument);
 
             if (status.Success)
             {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.README.md
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.README.md
@@ -76,9 +76,15 @@ Tests invalid claims upload:
 - Sends malformed claims
 - Verifies 400 response with validation errors
 
+### Scenario 6: Round-Trip Upload
+Tests that a downloaded claims document can be uploaded unmodified:
+- Captures the `GET /management/current-claims` response body verbatim, with its reload ID
+- Posts those exact bytes to `POST /management/upload-claims`
+- Verifies HTTP 200 with a new reload ID, and that the claim sets and hierarchy are unchanged afterward
+
 ## Authorization Coverage
 
-This feature's `Background` obtains a **full-access** CMS token (`Given valid credentials` / `And token received`) and sends it on every request, so scenarios 01–05 exercise only the **authenticated happy path** (including the 400 validation case in scenario 05). The feature does **not** contain a negative-authorization scenario.
+This feature's `Background` obtains a **full-access** CMS token (`Given valid credentials` / `And token received`) and sends it on every request, so scenarios 01–06 exercise only the **authenticated happy path** (including the 400 validation case in scenario 05). The feature does **not** contain a negative-authorization scenario.
 
 The negative authorization behavior of the `/management/*` claims endpoints is covered by the focused in-process unit tests in `ClaimsManagementModuleTests` (project `EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit`), not by this E2E feature:
 

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.feature
@@ -73,3 +73,16 @@ Feature: ClaimsManagement endpoints
                   """
              Then it should respond with 400
               And the response body contains validation errors
+
+        # Covers the download-then-upload round trip: the GET response body is posted back unchanged.
+        # Tagged for the SQL Server representative lane because it re-uploads the whole document over
+        # persisted claim sets, exercising the claim-set re-insert path on that engine too.
+        @MssqlRepresentative
+        Scenario: 06 Current claims can be uploaded unchanged
+            Given the current claims response is captured
+             When the captured claims response is uploaded unchanged
+             Then it should respond with 200
+              And the response body contains a new reload ID
+             When a GET request is made to "/management/current-claims"
+             Then it should respond with 200
+              And the response body matches the captured claims response

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.feature
@@ -24,20 +24,18 @@ Feature: ClaimsManagement endpoints
              When a POST request is made to "/management/upload-claims" with
                   """
                   {
-                      "claims": {
-                          "claimSets": [{"claimSetName": "TestUploadSet", "isSystemReserved": false}],
-                          "claimsHierarchy": [
-                              {
-                                  "name": "http://ed-fi.org/identity/claims/test",
-                                  "claimSets": [
-                                      {
-                                          "name": "TestUploadSet",
-                                          "actions": [{"name": "Read"}]
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
+                      "claimSets": [{"claimSetName": "TestUploadSet", "isSystemReserved": false}],
+                      "claimsHierarchy": [
+                          {
+                              "name": "http://ed-fi.org/identity/claims/test",
+                              "claimSets": [
+                                  {
+                                      "name": "TestUploadSet",
+                                      "actions": [{"name": "Read"}]
+                                  }
+                              ]
+                          }
+                      ]
                   }
                   """
              Then it should respond with 200
@@ -69,10 +67,8 @@ Feature: ClaimsManagement endpoints
              When a POST request is made to "/management/upload-claims" with
                   """
                   {
-                      "claims": {
-                          "claimSets": [{"invalidProperty": "test"}],
-                          "claimsHierarchy": []
-                      }
+                      "claimSets": [{"invalidProperty": "test"}],
+                      "claimsHierarchy": []
                   }
                   """
              Then it should respond with 400

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/ClaimsManagementStepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/ClaimsManagementStepDefinitions.cs
@@ -60,25 +60,23 @@ public class ClaimsManagementStepDefinitions(ScenarioContext scenarioContext)
         // Upload test claims
         var uploadBody = """
             {
-                "claims": {
-                    "claimSets": [{"claimSetName": "TestUploadSet", "isSystemReserved": false}],
-                    "claimsHierarchy": [
-                        {
-                            "name": "http://ed-fi.org/identity/claims/test",
-                            "claimSets": [
-                                {
-                                    "name": "TestUploadSet",
-                                    "actions": [{"name": "Read"}]
-                                }
-                            ]
-                        }
-                    ]
-                }
+                "claimSets": [{"claimSetName": "TestUploadSet", "isSystemReserved": false}],
+                "claimsHierarchy": [
+                    {
+                        "name": "http://ed-fi.org/identity/claims/test",
+                        "claimSets": [
+                            {
+                                "name": "TestUploadSet",
+                                "actions": [{"name": "Read"}]
+                            }
+                        ]
+                    }
+                ]
             }
             """;
 
         await stepDefinitions.WhenSendingAPOSTRequestToWithBody("/management/upload-claims", uploadBody);
-        scenarioContext[UploadedClaimsKey] = JsonNode.Parse(uploadBody)!["claims"];
+        scenarioContext[UploadedClaimsKey] = JsonNode.Parse(uploadBody)!;
     }
 
     [Given("dynamic claims loading is disabled")]

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/ClaimsManagementStepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/ClaimsManagementStepDefinitions.cs
@@ -72,10 +72,11 @@ public class ClaimsManagementStepDefinitions(ScenarioContext scenarioContext)
         // Held as the exact response text, not a reparsed document, so the upload posts it byte for byte.
         scenarioContext[CapturedClaimsKey] = await response.TextAsync();
 
-        if (response.Headers.TryGetValue("x-reload-id", out var reloadId))
-        {
-            scenarioContext[InitialReloadIdKey] = reloadId;
-        }
+        bool hasReloadId = response.Headers.TryGetValue("x-reload-id", out var reloadId);
+        hasReloadId
+            .Should()
+            .BeTrue("the upload can only be proven to change the reload id if the GET reported one");
+        scenarioContext[InitialReloadIdKey] = reloadId!;
     }
 
     /// <summary>

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/ClaimsManagementStepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/ClaimsManagementStepDefinitions.cs
@@ -16,6 +16,7 @@ public class ClaimsManagementStepDefinitions(ScenarioContext scenarioContext)
     private const string InitialReloadIdKey = "InitialReloadId";
     private const string CurrentReloadIdKey = "CurrentReloadId";
     private const string UploadedClaimsKey = "UploadedClaims";
+    private const string CapturedClaimsKey = "CapturedClaims";
 
     private static JsonNode? _authoritativeComposition;
 
@@ -51,6 +52,70 @@ public class ClaimsManagementStepDefinitions(ScenarioContext scenarioContext)
             scenarioContext[InitialReloadIdKey] = reloadId;
         }
     }
+
+    /// <summary>
+    /// Captures the current claims response verbatim, together with its reload id, so a later step can
+    /// upload the exact same bytes and the reload id can be proven to have changed.
+    /// </summary>
+    [Given("the current claims response is captured")]
+    public async Task GivenTheCurrentClaimsResponseIsCaptured()
+    {
+        var stepDefinitions = scenarioContext.ScenarioContainer.Resolve<StepDefinitions>();
+
+        await stepDefinitions.WhenAGETRequestIsMadeTo("/management/current-claims");
+
+        var response = GetLastApiResponse();
+        response
+            .Status.Should()
+            .Be(200, "the current claims must be readable before they can be uploaded unchanged");
+
+        // Held as the exact response text, not a reparsed document, so the upload posts it byte for byte.
+        scenarioContext[CapturedClaimsKey] = await response.TextAsync();
+
+        if (response.Headers.TryGetValue("x-reload-id", out var reloadId))
+        {
+            scenarioContext[InitialReloadIdKey] = reloadId;
+        }
+    }
+
+    /// <summary>
+    /// Uploads the captured current-claims response with no wrapping, editing or reserialization. The
+    /// verbatim POST helper is used deliberately: the shared POST step applies placeholder substitution
+    /// to the body, which would defeat the point of an unchanged upload.
+    /// </summary>
+    [When("the captured claims response is uploaded unchanged")]
+    public async Task WhenTheCapturedClaimsResponseIsUploadedUnchanged()
+    {
+        var stepDefinitions = scenarioContext.ScenarioContainer.Resolve<StepDefinitions>();
+
+        await stepDefinitions.PostVerbatimBodyAsync(
+            "/management/upload-claims",
+            (string)scenarioContext[CapturedClaimsKey]
+        );
+    }
+
+    [Then("the response body matches the captured claims response")]
+    public async Task ThenTheResponseBodyMatchesTheCapturedClaimsResponse()
+    {
+        JsonObject captured = JsonNode.Parse((string)scenarioContext[CapturedClaimsKey])!.AsObject();
+        JsonObject current = JsonNode.Parse(await GetLastApiResponse().TextAsync())!.AsObject();
+
+        // The upload deletes and re-inserts claim sets, so their order is not guaranteed; compare them
+        // as an unordered set of name / system-reserved pairs.
+        ClaimSetSummaries(current).Should().BeEquivalentTo(ClaimSetSummaries(captured));
+
+        // The hierarchy is persisted as a single document, so it must survive the round trip exactly.
+        current["claimsHierarchy"]!.ToJsonString().Should().Be(captured["claimsHierarchy"]!.ToJsonString());
+    }
+
+    private static List<string> ClaimSetSummaries(JsonObject claimsDocument) =>
+        claimsDocument["claimSets"]!
+            .AsArray()
+            .Select(claimSet =>
+                $"{claimSet!["claimSetName"]?.GetValue<string>()}|{claimSet["isSystemReserved"]?.GetValue<bool>()}"
+            )
+            .OrderBy(summary => summary, StringComparer.Ordinal)
+            .ToList();
 
     [Given("claims have been uploaded")]
     public async Task GivenClaimsHaveBeenUploaded()

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -276,6 +276,19 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
         await ExtractIdFromHeader(_apiResponse);
     }
 
+    /// <summary>
+    /// POSTs <paramref name="body"/> exactly as supplied. Unlike
+    /// <see cref="WhenSendingAPOSTRequestToWithBody"/> this applies no placeholder substitution, so a
+    /// scenario can prove a body received from an earlier response is accepted without modification.
+    /// </summary>
+    public async Task PostVerbatimBodyAsync(string url, string body)
+    {
+        _apiResponse = await playwrightContext.ApiRequestContext?.PostAsync(
+            url,
+            new() { Headers = _authHeaders, Data = body }
+        )!;
+    }
+
     [When("an unauthenticated POST request is made to {string} with header {string} value {string} and")]
     public async Task WhenAnUnauthenticatedPostRequestIsMadeToWithHeaderAnd(
         string url,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -1056,13 +1056,10 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
 
             string claimsJson = new JsonObject
             {
-                ["claims"] = new JsonObject
-                {
-                    ["claimSets"] = new JsonArray(
-                        new JsonObject { ["claimSetName"] = claimSetName, ["isSystemReserved"] = false }
-                    ),
-                    ["claimsHierarchy"] = new JsonArray(claimsHierarchyNode),
-                },
+                ["claimSets"] = new JsonArray(
+                    new JsonObject { ["claimSetName"] = claimSetName, ["isSystemReserved"] = false }
+                ),
+                ["claimsHierarchy"] = new JsonArray(claimsHierarchyNode),
             }.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
 
             // Call the CMS endpoint to upload the claim set

--- a/src/dms/tests/RestClient/cms-dms-claimset-sync-demo.http
+++ b/src/dms/tests/RestClient/cms-dms-claimset-sync-demo.http
@@ -99,89 +99,87 @@ Authorization: bearer {{configToken}}
 Content-Type: application/json
 
 {
-    "claims": {
-        "claimSets": [
-            {
-                "claimSetName": "TestMinimalClaimSet",
-                "isSystemReserved": false
-            }
-        ],
-        "claimsHierarchy": [
-            {
-                "name": "http://ed-fi.org/identity/claims/domains/edFiTypes",
-                "claims": [
-                    {
-                        "name": "http://ed-fi.org/identity/claims/ed-fi/school",
-                        "claimSets": [
-                            {
-                                "name": "TestMinimalClaimSet",
-                                "actions": [
-                                    {
-                                        "name": "Create",
-                                        "authorizationStrategyOverrides": [
-                                            { "name": "NoFurtherAuthorizationRequired" }
-                                        ]
-                                    },
-                                    {
-                                        "name": "Read",
-                                        "authorizationStrategyOverrides": [
-                                            { "name": "NoFurtherAuthorizationRequired" }
-                                        ]
-                                    },
-                                    {
-                                        "name": "Update",
-                                        "authorizationStrategyOverrides": [
-                                            { "name": "NoFurtherAuthorizationRequired" }
-                                        ]
-                                    },
-                                    {
-                                        "name": "Delete",
-                                        "authorizationStrategyOverrides": [
-                                            { "name": "NoFurtherAuthorizationRequired" }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "name": "http://ed-fi.org/identity/claims/ed-fi/student",
-                        "claimSets": [
-                            {
-                                "name": "TestMinimalClaimSet",
-                                "actions": [
-                                    {
-                                        "name": "Create",
-                                        "authorizationStrategyOverrides": [
-                                            { "name": "NoFurtherAuthorizationRequired" }
-                                        ]
-                                    },
-                                    {
-                                        "name": "Read",
-                                        "authorizationStrategyOverrides": [
-                                            { "name": "NoFurtherAuthorizationRequired" }
-                                        ]
-                                    },
-                                    {
-                                        "name": "Update",
-                                        "authorizationStrategyOverrides": [
-                                            { "name": "NoFurtherAuthorizationRequired" }
-                                        ]
-                                    },
-                                    {
-                                        "name": "Delete",
-                                        "authorizationStrategyOverrides": [
-                                            { "name": "NoFurtherAuthorizationRequired" }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
+    "claimSets": [
+        {
+            "claimSetName": "TestMinimalClaimSet",
+            "isSystemReserved": false
+        }
+    ],
+    "claimsHierarchy": [
+        {
+            "name": "http://ed-fi.org/identity/claims/domains/edFiTypes",
+            "claims": [
+                {
+                    "name": "http://ed-fi.org/identity/claims/ed-fi/school",
+                    "claimSets": [
+                        {
+                            "name": "TestMinimalClaimSet",
+                            "actions": [
+                                {
+                                    "name": "Create",
+                                    "authorizationStrategyOverrides": [
+                                        { "name": "NoFurtherAuthorizationRequired" }
+                                    ]
+                                },
+                                {
+                                    "name": "Read",
+                                    "authorizationStrategyOverrides": [
+                                        { "name": "NoFurtherAuthorizationRequired" }
+                                    ]
+                                },
+                                {
+                                    "name": "Update",
+                                    "authorizationStrategyOverrides": [
+                                        { "name": "NoFurtherAuthorizationRequired" }
+                                    ]
+                                },
+                                {
+                                    "name": "Delete",
+                                    "authorizationStrategyOverrides": [
+                                        { "name": "NoFurtherAuthorizationRequired" }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "http://ed-fi.org/identity/claims/ed-fi/student",
+                    "claimSets": [
+                        {
+                            "name": "TestMinimalClaimSet",
+                            "actions": [
+                                {
+                                    "name": "Create",
+                                    "authorizationStrategyOverrides": [
+                                        { "name": "NoFurtherAuthorizationRequired" }
+                                    ]
+                                },
+                                {
+                                    "name": "Read",
+                                    "authorizationStrategyOverrides": [
+                                        { "name": "NoFurtherAuthorizationRequired" }
+                                    ]
+                                },
+                                {
+                                    "name": "Update",
+                                    "authorizationStrategyOverrides": [
+                                        { "name": "NoFurtherAuthorizationRequired" }
+                                    ]
+                                },
+                                {
+                                    "name": "Delete",
+                                    "authorizationStrategyOverrides": [
+                                        { "name": "NoFurtherAuthorizationRequired" }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }
 
 ###


### PR DESCRIPTION
## Problem

`GET /management/current-claims` returns the raw claims document:

```json
{ "claimSets": [...], "claimsHierarchy": [...] }
```

but `POST /management/upload-claims` bound a `UploadClaimsRequest(JsonNode Claims)` wrapper, so it
required the document nested under a `claims` property. Downloading the current claims and uploading
the file unchanged — the workflow the two endpoints exist to support — returned HTTP 400
`"Claims JSON is required"`.

The wrapper lived at exactly one place, the minimal-API handler parameter. Everything below it already
consumed the raw document: `IClaimsUploadService.UploadClaimsAsync(JsonNode)`, `ClaimsUploadService`'s
`claimSets`/`claimsHierarchy` structure check, and `JsonSchemaForClaims.json`, whose root requires
those two properties with `additionalProperties: false`.

## Change

Bind the upload request body as `JsonNode` and declare that in the OpenAPI request metadata, making the
two endpoints share one canonical contract. The GET response can now be posted back verbatim.

`JsonNode` rather than `JsonObject` keeps a non-object body on the service's existing
`"Claims JSON must be an object"` path, and the parameter stays non-nullable so an absent or literal
`null` body keeps the framework's missing-body 400.

A body missing both canonical properties — an empty object, or the previously required wrapper — is
reported by the existing structure-failure mapping as missing `claimSets` and `claimsHierarchy`, so a
caller on the old shape is told exactly what the body must contain. No new code path, and no
sniffing branch that would leave two live request shapes.

Authorization, the `DangerouslyEnableUnrestrictedClaimsLoading` gate, `X-Reload-Id`, reload behavior,
and the deny-by-default failure mapping are unchanged.

The in-repo callers that sent the wrapper move to the raw shape: the CMS E2E claims scenarios, the DMS
E2E CMS claim-set upload helper, and the REST Client sync demo.

## Tests

- Focused unit coverage for the round trip (the GET response body posted back byte for byte, validated
  by the real `ClaimsValidator` so the document is also proven schema-valid), for rejection of the
  wrapper shape, and for the empty-object, non-object, malformed, absent, and literal-`null` bodies.
- A new CMS E2E scenario uploads the live `current-claims` response unchanged and verifies the claims
  are unchanged afterward. Tagged `@MssqlRepresentative` so the SQL Server lane also exercises
  re-uploading a whole document over persisted claim sets.
- The DMS E2E `ClaimSetSynchronization` scenarios cover the changed upload helper.

## Documentation

`docs/CLAIMS-LOADING-GUIDE.md` already showed the canonical body, so it needed no correction, but it
never said the `current-claims` response *is* that document. It now does, with a download-then-upload
example. Two adjacent inaccuracies found while editing that section are also fixed: the upload and
reload sections claimed a reload ID *header* (both return it in the response body; only
`GET /management/current-claims` sets `X-Reload-Id`), and the claims examples used a `resources`
collection with claim-level `actions`, neither of which the enforced schema allows — they now use
nested `claims` with `claimSets`/`authorizationStrategyOverrides`, validated against
`JsonSchemaForClaims.json`.

## Notes to consider

- **Public documentation is a separate repo.** The ticket's acceptance criteria name
  `odsApi_versioned_docs/version-8.0/how-to-guides/how-to-create-and-manage-api-security-metadata` and
  `.../platform-dev-guide/utilities/cms-hierarchy-tool.md`. Those files are not in this repository; they
  live in `ed-fi-alliance-oss/ed-fi-alliance-oss.github.io`. Both published pages still instruct the
  wrapper shape, and both need two corrections: the body is the document itself, and the hierarchy
  examples use nested `claims` rather than `resources`. Reviewed replacement text is available for the
  docs team on request — this PR does not touch that repository.
- **Breaking change to an undocumented shape.** The wrapper is no longer accepted. The endpoint is
  gated behind `DangerouslyEnableUnrestrictedClaimsLoading`, and this repository's own guide already
  documented the raw shape, so the raw-only contract is the one the ticket asks for rather than a
  dual-shape compatibility path. Anyone running the updated REST Client demo or DMS E2E helper against
  an older published configuration-service image will get a 400 until that image carries this change.
- `UploadClaimsRequest` is intentionally left in place; it is public backend surface and its removal is
  not needed for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
