### PR TITLE
fix(DMS-1457): sanitize and truncate client-supplied Correlation ID

### DIFF
--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/ConfigurationTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/ConfigurationTests.cs
@@ -521,6 +521,28 @@ public class ConfigurationTests
         }
     }
 
+    [TestFixture]
+    public class Given_A_Bound_App_Settings_With_Nonpositive_Correlation_Id_Max_Length
+    {
+        [Test]
+        public void It_fails_validation()
+        {
+            var appSettings = new AppSettings
+            {
+                AuthenticationService = "http://localhost:5126/connect/token",
+                Datastore = "postgresql",
+                CorrelationIdHeader = "correlationid",
+                CorrelationIdMaxLength = 0,
+            };
+
+            var validator = new AppSettingsValidator();
+            var result = validator.Validate(null, appSettings);
+
+            result.Succeeded.Should().BeFalse();
+            result.FailureMessage.Should().Contain(nameof(AppSettings.CorrelationIdMaxLength));
+        }
+    }
+
     /// <summary>
     /// Regression coverage for the ConfigureEndpoints failure catch. Duplicate route qualifier
     /// segments survive AppSettingsValidator and reach CoreEndpointModule.BuildRoutePattern
@@ -528,8 +550,8 @@ public class ConfigurationTests
     /// endpoint mapping throw. Before the catch existed the status file was stranded at Starting
     /// with no ErrorType or ErrorMessage.
     /// The trigger works only because <c>AppSettingsValidator</c> does not validate
-    /// <c>RouteQualifierSegments</c> at all - it checks AuthenticationService, Datastore, and
-    /// MaxRequestBodySizeMegabytes and nothing else. Adding a duplicate or format check there
+    /// <c>RouteQualifierSegments</c> at all - it checks AuthenticationService, Datastore,
+    /// MaxRequestBodySizeMegabytes, and CorrelationIdMaxLength. Adding a duplicate or format check there
     /// would intercept "districtId,districtId" as an <see cref="OptionsValidationException"/>
     /// before endpoint mapping runs, and this test would start failing for a reason that has
     /// nothing to do with the catch it guards. If that happens, replace the trigger rather than

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Infrastructure/LoggingMiddlewareTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Infrastructure/LoggingMiddlewareTests.cs
@@ -478,7 +478,7 @@ public class Given_LoggingMiddleware
 
         await invoke.Should().ThrowAsync<InvalidOperationException>();
 
-        var truncated = new string('a', 255);
+        var truncated = new string('a', AppSettings.DefaultCorrelationIdMaxLength);
         var body = JsonNode.Parse(System.Text.Encoding.UTF8.GetString(responseBody.ToArray()));
         (body?["traceId"]?.GetValue<string>()).Should().Be(truncated);
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Infrastructure/LoggingMiddlewareTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Infrastructure/LoggingMiddlewareTests.cs
@@ -427,7 +427,7 @@ public class Given_LoggingMiddleware
     }
 
     [Test]
-    public async Task It_writes_the_raw_correlation_id_in_the_500_error_body_and_sanitizes_only_the_logs()
+    public async Task It_sanitizes_the_correlation_id_in_the_500_error_body_to_match_the_log_value()
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Method = "POST";
@@ -446,13 +446,45 @@ public class Given_LoggingMiddleware
         await invoke.Should().ThrowAsync<InvalidOperationException>();
 
         var body = JsonNode.Parse(System.Text.Encoding.UTF8.GetString(responseBody.ToArray()));
-        (body?["traceId"]?.GetValue<string>()).Should().Be("operator{correlation}id\t");
+        // Response must reflect the sanitized (not raw) value so it matches what is searchable in logs
+        (body?["traceId"]?.GetValue<string>())
+            .Should()
+            .Be("operatorcorrelationid");
 
         var entry = logger.Entries.Single(e => e.EventId.Name == "HttpRequestFailed");
         entry.State.ContainStructuredProperty("TraceId", "operatorcorrelationid");
         entry
             .ActiveScopes.Should()
             .Contain(scope => scope.HasStructuredProperty("TraceId", "operatorcorrelationid"));
+    }
+
+    [Test]
+    public async Task It_truncates_an_oversized_correlation_id_consistently_in_response_and_log()
+    {
+        var oversized = new string('a', 300);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "POST";
+        httpContext.Request.Path = "/ed-fi/students";
+        httpContext.Request.Headers["x-correlation-id"] = oversized;
+        var responseBody = new MemoryStream();
+        httpContext.Response.Body = responseBody;
+        var logger = new TestLogger<LoggingMiddleware>();
+        var middleware = new LoggingMiddleware(
+            _ => throw new InvalidOperationException("boom"),
+            AppSettingsWithCorrelationHeader("x-correlation-id")
+        );
+
+        Func<Task> invoke = () => middleware.Invoke(httpContext, logger);
+
+        await invoke.Should().ThrowAsync<InvalidOperationException>();
+
+        var truncated = new string('a', 255);
+        var body = JsonNode.Parse(System.Text.Encoding.UTF8.GetString(responseBody.ToArray()));
+        (body?["traceId"]?.GetValue<string>()).Should().Be(truncated);
+
+        var entry = logger.Entries.Single(e => e.EventId.Name == "HttpRequestFailed");
+        entry.State.ContainStructuredProperty("TraceId", truncated);
+        entry.ActiveScopes.Should().Contain(scope => scope.HasStructuredProperty("TraceId", truncated));
     }
 
     [Test]

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Configuration/AppSettings.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Configuration/AppSettings.cs
@@ -20,6 +20,7 @@ public class AppSettings
     public required string CorrelationIdHeader { get; set; }
     public string DomainsExcludedFromOpenApi { get; set; } = string.Empty;
     public string RouteQualifierSegments { get; set; } = string.Empty;
+    public int CorrelationIdMaxLength { get; set; } = DefaultCorrelationIdMaxLength;
 
     /// <summary>
     /// Maximum allowed length of a client-supplied Correlation ID header value.

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Configuration/AppSettings.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Configuration/AppSettings.cs
@@ -77,6 +77,13 @@ public class AppSettingsValidator : IValidateOptions<AppSettings>
             );
         }
 
+        if (options.CorrelationIdMaxLength <= 0)
+        {
+            return ValidateOptionsResult.Fail(
+                "AppSettings value CorrelationIdMaxLength must be greater than 0"
+            );
+        }
+
         return ValidateOptionsResult.Success;
     }
 }

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Configuration/AppSettings.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Configuration/AppSettings.cs
@@ -20,7 +20,6 @@ public class AppSettings
     public required string CorrelationIdHeader { get; set; }
     public string DomainsExcludedFromOpenApi { get; set; } = string.Empty;
     public string RouteQualifierSegments { get; set; } = string.Empty;
-    public int CorrelationIdMaxLength { get; set; } = DefaultCorrelationIdMaxLength;
 
     /// <summary>
     /// Maximum allowed length of a client-supplied Correlation ID header value.

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Configuration/AppSettings.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Configuration/AppSettings.cs
@@ -11,6 +11,7 @@ public class AppSettings
 {
     public const int BytesPerMegabyte = 1024 * 1024;
     public const int DefaultMaxRequestBodySizeMegabytes = 10;
+    public const int DefaultCorrelationIdMaxLength = 255;
 
     public required string AuthenticationService { get; set; }
     public required string Datastore { get; set; }
@@ -19,6 +20,13 @@ public class AppSettings
     public required string CorrelationIdHeader { get; set; }
     public string DomainsExcludedFromOpenApi { get; set; } = string.Empty;
     public string RouteQualifierSegments { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Maximum allowed length of a client-supplied Correlation ID header value.
+    /// Values longer than this limit are truncated before sanitization and logging.
+    /// Defaults to 255 characters.
+    /// </summary>
+    public int CorrelationIdMaxLength { get; set; } = DefaultCorrelationIdMaxLength;
 
     /// <summary>
     /// When true, enables multi-tenancy mode where the tenant identifier is extracted from the URL route.

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/LoggingMiddleware.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/LoggingMiddleware.cs
@@ -13,13 +13,27 @@ using Microsoft.Extensions.Options;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
 
-public class LoggingMiddleware(RequestDelegate next, IOptions<AppSettings> appSettings)
+public class LoggingMiddleware
 {
-    private readonly RequestDelegate _next = next ?? throw new ArgumentNullException(nameof(next));
-    private readonly IOptions<AppSettings> _appSettings =
-        appSettings ?? throw new ArgumentNullException(nameof(appSettings));
+    private readonly RequestDelegate _next;
+    private readonly IOptions<AppSettings> _appSettings;
+    private readonly int _correlationIdMaxLength;
     private const string ApplicationName = "EdFi.DataManagementService";
     private const string RequestLayer = "Frontend";
+
+    public LoggingMiddleware(RequestDelegate next, IOptions<AppSettings> appSettings)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _appSettings = appSettings ?? throw new ArgumentNullException(nameof(appSettings));
+        try
+        {
+            _correlationIdMaxLength = appSettings.Value.CorrelationIdMaxLength;
+        }
+        catch (OptionsValidationException)
+        {
+            _correlationIdMaxLength = AppSettings.DefaultCorrelationIdMaxLength;
+        }
+    }
 
     public async Task Invoke(HttpContext context, ILogger<LoggingMiddleware> logger)
     {
@@ -28,8 +42,8 @@ public class LoggingMiddleware(RequestDelegate next, IOptions<AppSettings> appSe
         var sanitizedPath = LoggingSanitizer.SanitizeForLogging(context.Request.Path.Value);
         var pathBase = LoggingSanitizer.SanitizeForLogging(context.Request.PathBase.Value);
         var rawTraceId = ExtractTraceId(context) ?? string.Empty;
-        var maxLength = GetCorrelationIdMaxLength();
-        var truncatedTraceId = rawTraceId.Length > maxLength ? rawTraceId[..maxLength] : rawTraceId;
+        var truncatedTraceId =
+            rawTraceId.Length > _correlationIdMaxLength ? rawTraceId[.._correlationIdMaxLength] : rawTraceId;
         var traceId = LoggingSanitizer.SanitizeForLogging(truncatedTraceId);
 
         var scopeValues = new Dictionary<string, object>
@@ -199,18 +213,6 @@ public class LoggingMiddleware(RequestDelegate next, IOptions<AppSettings> appSe
         catch (OptionsValidationException)
         {
             return context.TraceIdentifier;
-        }
-    }
-
-    private int GetCorrelationIdMaxLength()
-    {
-        try
-        {
-            return _appSettings.Value.CorrelationIdMaxLength;
-        }
-        catch (OptionsValidationException)
-        {
-            return AppSettings.DefaultCorrelationIdMaxLength;
         }
     }
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/LoggingMiddleware.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/LoggingMiddleware.cs
@@ -27,7 +27,9 @@ public class LoggingMiddleware
         _appSettings = appSettings ?? throw new ArgumentNullException(nameof(appSettings));
         try
         {
-            _correlationIdMaxLength = appSettings.Value.CorrelationIdMaxLength;
+            var configuredMaxLength = appSettings.Value.CorrelationIdMaxLength;
+            _correlationIdMaxLength =
+                configuredMaxLength > 0 ? configuredMaxLength : AppSettings.DefaultCorrelationIdMaxLength;
         }
         catch (OptionsValidationException)
         {

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/LoggingMiddleware.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/LoggingMiddleware.cs
@@ -28,7 +28,9 @@ public class LoggingMiddleware(RequestDelegate next, IOptions<AppSettings> appSe
         var sanitizedPath = LoggingSanitizer.SanitizeForLogging(context.Request.Path.Value);
         var pathBase = LoggingSanitizer.SanitizeForLogging(context.Request.PathBase.Value);
         var rawTraceId = ExtractTraceId(context) ?? string.Empty;
-        var traceId = LoggingSanitizer.SanitizeForLogging(rawTraceId);
+        var maxLength = GetCorrelationIdMaxLength();
+        var truncatedTraceId = rawTraceId.Length > maxLength ? rawTraceId[..maxLength] : rawTraceId;
+        var traceId = LoggingSanitizer.SanitizeForLogging(truncatedTraceId);
 
         var scopeValues = new Dictionary<string, object>
         {
@@ -159,11 +161,11 @@ public class LoggingMiddleware(RequestDelegate next, IOptions<AppSettings> appSe
                                 new
                                 {
                                     message = "The server encountered an unexpected condition that prevented it from fulfilling the request.",
-                                    // The error response body echoes the raw correlation value, matching
-                                    // every other DMS error response body (see FailureResponse). Only log
-                                    // properties are sanitized; applying the logging whitelist to a
-                                    // client-reported trace id yields the TraceId to search for in the logs.
-                                    traceId = rawTraceId,
+                                    // The error response body echoes the sanitized and truncated
+                                    // correlation value so it always matches the TraceId searchable
+                                    // in the logs. Applying the same logging whitelist and length cap
+                                    // to the response ensures log/response parity.
+                                    traceId = traceId,
                                 }
                             )
                         );
@@ -197,6 +199,18 @@ public class LoggingMiddleware(RequestDelegate next, IOptions<AppSettings> appSe
         catch (OptionsValidationException)
         {
             return context.TraceIdentifier;
+        }
+    }
+
+    private int GetCorrelationIdMaxLength()
+    {
+        try
+        {
+            return _appSettings.Value.CorrelationIdMaxLength;
+        }
+        catch (OptionsValidationException)
+        {
+            return AppSettings.DefaultCorrelationIdMaxLength;
         }
     }
 


### PR DESCRIPTION
`LoggingMiddleware` was writing a sanitized `traceId` to logs while echoing the raw, unsanitized client value in 500 error response bodies — so any ID containing characters outside the logging whitelist would silently diverge between the response and the logs, defeating the correlation purpose. Raw values were also reflected with no length cap.

Closes: https://edfi.atlassian.net/browse/DMS-1457

## Changes

**`AppSettings`**
- Added `CorrelationIdMaxLength` (default `255`, exposed as `DefaultCorrelationIdMaxLength` constant) — host-configurable

**`LoggingMiddleware`**
- Converted from primary constructor to a regular constructor to cache `CorrelationIdMaxLength` once at startup (avoids per-request options access; falls back to default on `OptionsValidationException`, mirroring the existing `ExtractTraceId` pattern)
- Truncates the raw trace ID to `_correlationIdMaxLength` before sanitizing
- Error response now echoes the sanitized `traceId` instead of `rawTraceId` — response and log are always identical

```csharp
// Before
traceId = rawTraceId   // raw, unsanitized, unbounded

// After
var truncated = rawTraceId.Length > _correlationIdMaxLength ? rawTraceId[.._correlationIdMaxLength] : rawTraceId;
var traceId = LoggingSanitizer.SanitizeForLogging(truncated);
// ...
traceId = traceId      // same value written to both log and response
```

**`LoggingMiddlewareTests`**
- Updated the existing test that asserted the old diverging behavior
- Added tests for: ID with control characters (parity), oversized ID (truncation parity)