### PR TITLE
[DMS-1373] Load and Cache API-client Ownership Tokens from CMS in DMS

### DIFF
--- a/docs/CACHING-STRATEGY.md
+++ b/docs/CACHING-STRATEGY.md
@@ -76,6 +76,14 @@ built-in stampede protection
 same API client resolves and caches an independent context per tenant. Each
 client's `DataStoreIds` determine which data they can access.
 
+**Dependency Scope:** Every authenticated resource request path that runs
+`ProfileResolutionMiddleware` requires a resolvable application context, because
+profile resolution needs the `ApplicationId`. This is broader than the
+ownership-gated operations alone. With a cold or missing cache entry, a CMS
+outage or a malformed CMS response makes those requests fail closed with
+`503 Service Unavailable`. A `NotFound` context still maps to
+`401 Unauthorized` as an invalid token.
+
 **TTL:** 10 minutes (configurable via `CacheSettings:ApplicationContextCacheExpirationSeconds`)
 
 **Cache Operations:**

--- a/docs/CACHING-STRATEGY.md
+++ b/docs/CACHING-STRATEGY.md
@@ -445,7 +445,7 @@ Default values: ClaimSets, AppContext, and data store = 10 minutes; Token = 25 m
 
 | Cache        | Mechanism    | Scope | TTL    | Tenant | Stampede | Invalidation |
 | ------------ | ------------ | ----- | ------ | ------ | -------- | ------------ |
-| App Context  | HybridCache  | Sing. | 10 min | No     | Yes      | Manual + TTL |
+| App Context  | HybridCache  | Sing. | 10 min | Yes    | Yes      | Manual + TTL |
 | ClaimSets    | HybridCache  | Sing. | 10 min | Yes    | Yes      | Manual + TTL |
 | Comp. Schema | ConcurDict   | Sing. | None   | No     | No       | Reload ID    |
 | CMS Token    | HybridCache  | Sing. | 25 min | No     | Yes      | TTL only     |

--- a/docs/CACHING-STRATEGY.md
+++ b/docs/CACHING-STRATEGY.md
@@ -57,16 +57,24 @@ built-in stampede protection
 
 **Cache Structure:**
 
-- **Key:** `ApplicationContext_{clientId}` (e.g., `ApplicationContext_my-api-client`)
+- **Key:** scoped to the requesting tenant:
+  - Single tenant: `ApplicationContext:single:{clientId}`
+    (e.g., `ApplicationContext:single:my-api-client`)
+  - Multi-tenant: `ApplicationContext:tenant:{tenant.ToLowerInvariant()}:{clientId}`
+    (e.g., `ApplicationContext:tenant:tenant-a:my-api-client`)
 - **Value:** Single `ApplicationContext` record containing:
   - `Id` - API client database ID
   - `ApplicationId` - Parent application ID
   - `ClientId` - Client identifier string
   - `ClientUuid` - Client UUID
   - `DataStoreIds` - List of authorized data store IDs
+  - `CreatorOwnershipTokenId` - Ownership token assigned to documents this
+    client creates, or null when the client has none
+  - `OwnershipTokenIds` - Ownership tokens this client is authorized against
 
-**Multi-Tenancy Support:** No - one cache entry per API client, not per tenant.
-Each client's `DataStoreIds` determine which data they can access.
+**Multi-Tenancy Support:** Yes - the tenant is part of the cache key, so the
+same API client resolves and caches an independent context per tenant. Each
+client's `DataStoreIds` determine which data they can access.
 
 **TTL:** 10 minutes (configurable via `CacheSettings:ApplicationContextCacheExpirationSeconds`)
 

--- a/reference/design/backend-redesign/design-docs/auth.md
+++ b/reference/design/backend-redesign/design-docs/auth.md
@@ -1617,8 +1617,10 @@ DMS uses JWT Bearer tokens validated against an OpenID Connect (OIDC) identity p
 The following auth metadata is stored in the Configuration Service (CMS):
 - Claim Sets (i.e., what strategies apply for a given endpoint, and the order in which `AND` strategies execute).
   - Cached during DMS startup, TTL is 600s by default, configurable in appsettings.json: `CacheSettings.ClaimSetsCacheExpirationSeconds`
-- Granted EducationOrganizationIds, Namespace prefixes, and Ownership tokens.
+- Granted EducationOrganizationIds and Namespace prefixes.
   - These get encoded in the JWT during token generation, token TTL is 30m by default, configurable in CMS appsettings.json `IdentitySettings.TokenExpirationMinutes`
+- API-client creator and read/modify ownership tokens.
+  - DMS retrieves these from the CMS application-context contract (`GET /v3/apiClients/{clientId}`) and caches successful contexts according to `CacheSettings.ApplicationContextCacheExpirationSeconds`.
 
 DMS's current authentication implementation is mostly unaffected by this redesign.
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/RelationalQueryRequestContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/RelationalQueryRequestContracts.cs
@@ -62,7 +62,8 @@ public sealed record RelationalAuthorizationContext
 
     /// <summary>
     /// CMS application ownership tokens available for reading and modifying data.
-    /// Preserves the CMS-provided order and duplicates.
+    /// Snapshotted as supplied; the application context provider normalizes CMS values to
+    /// sorted-distinct before they reach here.
     /// </summary>
     public IReadOnlyList<short> OwnershipTokenIds { get; }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/RelationalQueryRequestContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/RelationalQueryRequestContracts.cs
@@ -20,18 +20,29 @@ public static class RelationalAuthorizationParameterNameConstants
 public sealed record RelationalAuthorizationContext
 {
     public RelationalAuthorizationContext(IReadOnlyList<long> claimEducationOrganizationIds)
-        : this(claimEducationOrganizationIds, []) { }
+        : this(claimEducationOrganizationIds, [], null, []) { }
 
     public RelationalAuthorizationContext(
         IReadOnlyList<long> claimEducationOrganizationIds,
         IReadOnlyList<string> namespacePrefixes
     )
+        : this(claimEducationOrganizationIds, namespacePrefixes, null, []) { }
+
+    public RelationalAuthorizationContext(
+        IReadOnlyList<long> claimEducationOrganizationIds,
+        IReadOnlyList<string> namespacePrefixes,
+        short? creatorOwnershipTokenId,
+        IReadOnlyList<short> ownershipTokenIds
+    )
     {
         ArgumentNullException.ThrowIfNull(claimEducationOrganizationIds);
         ArgumentNullException.ThrowIfNull(namespacePrefixes);
+        ArgumentNullException.ThrowIfNull(ownershipTokenIds);
 
         ClaimEducationOrganizationIds = NormalizeClaimEducationOrganizationIds(claimEducationOrganizationIds);
         NamespacePrefixes = NormalizeNamespacePrefixes(namespacePrefixes);
+        CreatorOwnershipTokenId = creatorOwnershipTokenId;
+        OwnershipTokenIds = [.. ownershipTokenIds];
     }
 
     /// <summary>
@@ -44,7 +55,22 @@ public sealed record RelationalAuthorizationContext
     /// </summary>
     public IReadOnlyList<string> NamespacePrefixes { get; }
 
-    public static RelationalAuthorizationContext Create(ClientAuthorizations clientAuthorizations)
+    /// <summary>
+    /// CMS application ownership token that created the API client, when configured.
+    /// </summary>
+    public short? CreatorOwnershipTokenId { get; }
+
+    /// <summary>
+    /// CMS application ownership tokens available for reading and modifying data.
+    /// Preserves the CMS-provided order and duplicates.
+    /// </summary>
+    public IReadOnlyList<short> OwnershipTokenIds { get; }
+
+    public static RelationalAuthorizationContext Create(
+        ClientAuthorizations clientAuthorizations,
+        short? creatorOwnershipTokenId = null,
+        IReadOnlyList<short>? ownershipTokenIds = null
+    )
     {
         ArgumentNullException.ThrowIfNull(clientAuthorizations);
 
@@ -58,7 +84,9 @@ public sealed record RelationalAuthorizationContext
                 .. clientAuthorizations.NamespacePrefixes.Select(static namespacePrefix =>
                     namespacePrefix.Value
                 ),
-            ]
+            ],
+            creatorOwnershipTokenId,
+            ownershipTokenIds ?? []
         );
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ApiSchema/InvalidResourceSchemasTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ApiSchema/InvalidResourceSchemasTests.cs
@@ -100,15 +100,21 @@ public class InvalidResourceSchemasTests
             services.AddTransient<ResolveDataStoreMiddleware>();
 
             var fakeApplicationContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => fakeApplicationContextProvider.GetApplicationByClientIdAsync(A<string>._))
+            A.CallTo(() =>
+                    fakeApplicationContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null)
+                )
                 .Returns(
-                    Task.FromResult<ApplicationContext?>(
-                        new ApplicationContext(
-                            Id: 1,
-                            ApplicationId: 1,
-                            ClientId: "test-client",
-                            ClientUuid: Guid.NewGuid(),
-                            DataStoreIds: [1]
+                    Task.FromResult<ApplicationContextResult>(
+                        new ApplicationContextResult.Success(
+                            new ApplicationContext(
+                                Id: 1,
+                                ApplicationId: 1,
+                                ClientId: "test-client",
+                                ClientUuid: Guid.NewGuid(),
+                                DataStoreIds: [1],
+                                CreatorOwnershipTokenId: null,
+                                OwnershipTokenIds: []
+                            )
                         )
                     )
                 );

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ApiServiceJwtAuthenticationTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ApiServiceJwtAuthenticationTests.cs
@@ -48,15 +48,21 @@ public class ApiServiceJwtAuthenticationTests
         services.AddTransient<ResolveDataStoreMiddleware>();
 
         var fakeApplicationContextProvider = A.Fake<IApplicationContextProvider>();
-        A.CallTo(() => fakeApplicationContextProvider.GetApplicationByClientIdAsync(A<string>._))
+        A.CallTo(() =>
+                fakeApplicationContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null)
+            )
             .Returns(
-                Task.FromResult<ApplicationContext?>(
-                    new ApplicationContext(
-                        Id: 1,
-                        ApplicationId: 1,
-                        ClientId: "test-client",
-                        ClientUuid: Guid.NewGuid(),
-                        DataStoreIds: [1]
+                Task.FromResult<ApplicationContextResult>(
+                    new ApplicationContextResult.Success(
+                        new ApplicationContext(
+                            Id: 1,
+                            ApplicationId: 1,
+                            ClientId: "test-client",
+                            ClientUuid: Guid.NewGuid(),
+                            DataStoreIds: [1],
+                            CreatorOwnershipTokenId: null,
+                            OwnershipTokenIds: []
+                        )
                     )
                 )
             );

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ApplicationContextResultTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ApplicationContextResultTests.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Configuration;
+
+[TestFixture]
+public class Given_ApplicationContextResult
+{
+    [Test]
+    public void It_Should_Expose_The_Successful_Application_Context_Payload()
+    {
+        var applicationContext = new ApplicationContext(1, 2, "client-id", Guid.NewGuid(), [3], 4, [5, 6]);
+
+        ApplicationContextResult result = new ApplicationContextResult.Success(applicationContext);
+
+        result.Should().BeOfType<ApplicationContextResult.Success>();
+        ((ApplicationContextResult.Success)result).ApplicationContext.Should().Be(applicationContext);
+    }
+
+    [Test]
+    public void It_Should_Accept_A_Null_Creator_And_Empty_Ownership_Tokens()
+    {
+        var applicationContext = new ApplicationContext(1, 2, "client-id", Guid.NewGuid(), [3], null, []);
+
+        applicationContext.CreatorOwnershipTokenId.Should().BeNull();
+        applicationContext.OwnershipTokenIds.Should().BeEmpty();
+    }
+
+    [TestCase(ApplicationContextResultKind.Success)]
+    [TestCase(ApplicationContextResultKind.NotFound)]
+    [TestCase(ApplicationContextResultKind.Unavailable)]
+    public void It_Should_Support_Exhaustive_Typed_Outcome_Matching(ApplicationContextResultKind kind)
+    {
+        ApplicationContextResult result = kind switch
+        {
+            ApplicationContextResultKind.Success => new ApplicationContextResult.Success(
+                new ApplicationContext(1, 2, "client-id", Guid.NewGuid(), [3], null, [])
+            ),
+            ApplicationContextResultKind.NotFound => new ApplicationContextResult.NotFound(),
+            ApplicationContextResultKind.Unavailable => new ApplicationContextResult.Unavailable(),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        var outcome = result switch
+        {
+            ApplicationContextResult.Success => ApplicationContextResultKind.Success,
+            ApplicationContextResult.NotFound => ApplicationContextResultKind.NotFound,
+            ApplicationContextResult.Unavailable => ApplicationContextResultKind.Unavailable,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        outcome.Should().Be(kind);
+    }
+
+    public enum ApplicationContextResultKind
+    {
+        Success,
+        NotFound,
+        Unavailable,
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/CacheSettingsTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/CacheSettingsTests.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core;
+using EdFi.DataManagementService.Core.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Configuration;
+
+[TestFixture]
+public class Given_ApplicationContext_Cache_Expiration_Configuration
+{
+    [Test]
+    public void It_uses_the_default_expiration_of_600_seconds()
+    {
+        using ServiceProvider serviceProvider = CreateServiceProvider();
+
+        serviceProvider.GetRequiredService<IStartupValidator>().Validate();
+
+        serviceProvider
+            .GetRequiredService<CacheSettings>()
+            .ApplicationContextCacheExpirationSeconds.Should()
+            .Be(600);
+    }
+
+    [TestCase("0")]
+    [TestCase("-1")]
+    public void It_rejects_nonpositive_expiration_values(string configuredValue)
+    {
+        using ServiceProvider serviceProvider = CreateServiceProvider(configuredValue);
+
+        Action validate = () => serviceProvider.GetRequiredService<IStartupValidator>().Validate();
+
+        validate
+            .Should()
+            .Throw<OptionsValidationException>()
+            .Which.Failures.Should()
+            .Contain("ApplicationContextCacheExpirationSeconds must be positive.");
+    }
+
+    [Test]
+    public void It_accepts_an_arbitrary_positive_expiration_above_600_seconds()
+    {
+        using ServiceProvider serviceProvider = CreateServiceProvider("86400");
+
+        serviceProvider.GetRequiredService<IStartupValidator>().Validate();
+
+        serviceProvider
+            .GetRequiredService<CacheSettings>()
+            .ApplicationContextCacheExpirationSeconds.Should()
+            .Be(86400);
+    }
+
+    private static ServiceProvider CreateServiceProvider(string? expirationSeconds = null)
+    {
+        Dictionary<string, string?> settings = new()
+        {
+            ["ConfigurationServiceSettings:BaseUrl"] = "https://cms.example.com",
+        };
+
+        if (expirationSeconds is not null)
+        {
+            settings["CacheSettings:ApplicationContextCacheExpirationSeconds"] = expirationSeconds;
+        }
+
+        IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        var services = new ServiceCollection();
+        services.AddDmsConfigurationServiceDataStoreProvider(configuration);
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/CachedApplicationContextProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/CachedApplicationContextProviderTests.cs
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Configuration;
+
+[TestFixture]
+public class Given_A_CachedApplicationContextProvider
+{
+    private IConfigurationServiceApplicationProvider _configurationServiceApplicationProvider = null!;
+    private HybridCache _hybridCache = null!;
+    private CachedApplicationContextProvider _provider = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _configurationServiceApplicationProvider = A.Fake<IConfigurationServiceApplicationProvider>();
+        _hybridCache = CreateHybridCache();
+        _provider = CreateProvider();
+    }
+
+    [Test]
+    public async Task It_Uses_The_Exact_Single_Tenant_Cache_Key()
+    {
+        var expectedContext = CreateApplicationContext("client-id", 1);
+        await _hybridCache.SetAsync("ApplicationContext:single:client-id", expectedContext);
+
+        ApplicationContextResult result = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeEquivalentTo(new ApplicationContextResult.Success(expectedContext));
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    A<string>.Ignored,
+                    A<string?>.Ignored
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_Uses_The_Exact_Normalized_Tenant_Cache_Key()
+    {
+        var expectedContext = CreateApplicationContext("client-id", 2);
+        await _hybridCache.SetAsync("ApplicationContext:tenant:districta:client-id", expectedContext);
+
+        ApplicationContextResult result = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            "DistrictA"
+        );
+
+        result.Should().BeEquivalentTo(new ApplicationContextResult.Success(expectedContext));
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    A<string>.Ignored,
+                    A<string?>.Ignored
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_Keeps_The_Same_Client_Isolated_Between_Tenants()
+    {
+        var northContext = CreateApplicationContext("client-id", 1);
+        var southContext = CreateApplicationContext("client-id", 2);
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync("client-id", "north")
+            )
+            .Returns(new ApplicationContextResult.Success(northContext));
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync("client-id", "south")
+            )
+            .Returns(new ApplicationContextResult.Success(southContext));
+
+        ApplicationContextResult north = await _provider.GetApplicationByClientIdAsync("client-id", "north");
+        ApplicationContextResult south = await CreateProvider()
+            .GetApplicationByClientIdAsync("client-id", "south");
+
+        north.Should().BeEquivalentTo(new ApplicationContextResult.Success(northContext));
+        south.Should().BeEquivalentTo(new ApplicationContextResult.Success(southContext));
+    }
+
+    [Test]
+    public async Task It_Normalizes_Tenant_Case_While_Preserving_The_Original_Tenant_For_Cms()
+    {
+        var expectedContext = CreateApplicationContext("client-id", 1);
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    "DistrictA"
+                )
+            )
+            .Returns(new ApplicationContextResult.Success(expectedContext));
+
+        await _provider.GetApplicationByClientIdAsync("client-id", "DistrictA");
+        var secondScopeProvider = CreateProvider();
+        ApplicationContextResult result = await secondScopeProvider.GetApplicationByClientIdAsync(
+            "client-id",
+            "districta"
+        );
+
+        result.Should().BeEquivalentTo(new ApplicationContextResult.Success(expectedContext));
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    A<string?>.Ignored
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task It_Performs_One_Normal_Lookup_On_A_Cold_NotFound_Without_Reloading()
+    {
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .Returns(new ApplicationContextResult.NotFound());
+
+        ApplicationContextResult result = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.NotFound>();
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.ReloadApplicationByClientIdAsync(
+                    A<string>.Ignored,
+                    A<string?>.Ignored
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [TestCase(ApplicationContextOutcome.Success)]
+    [TestCase(ApplicationContextOutcome.NotFound)]
+    [TestCase(ApplicationContextOutcome.Unavailable)]
+    public async Task It_Memoizes_The_First_Outcome_For_The_Request(ApplicationContextOutcome outcome)
+    {
+        ApplicationContextResult expectedResult = CreateResult(outcome);
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .Returns(expectedResult);
+
+        ApplicationContextResult first = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+        ApplicationContextResult second = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        second.Should().BeSameAs(first);
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [TestCase(ApplicationContextOutcome.NotFound)]
+    [TestCase(ApplicationContextOutcome.Unavailable)]
+    public async Task It_Does_Not_Admit_Failed_Results_To_The_Shared_Cache(ApplicationContextOutcome outcome)
+    {
+        var expectedContext = CreateApplicationContext("client-id", 1);
+        var lookupCount = 0;
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .ReturnsLazily(_ =>
+            {
+                lookupCount++;
+                return Task.FromResult<ApplicationContextResult>(
+                    lookupCount == 1
+                        ? CreateResult(outcome)
+                        : new ApplicationContextResult.Success(expectedContext)
+                );
+            });
+
+        ApplicationContextResult failed = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+        ApplicationContextResult recovered = await CreateProvider()
+            .GetApplicationByClientIdAsync("client-id", tenant: null);
+
+        failed
+            .GetType()
+            .Should()
+            .Be(
+                outcome switch
+                {
+                    ApplicationContextOutcome.NotFound => typeof(ApplicationContextResult.NotFound),
+                    ApplicationContextOutcome.Unavailable => typeof(ApplicationContextResult.Unavailable),
+                    _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
+                }
+            );
+        recovered.Should().BeEquivalentTo(new ApplicationContextResult.Success(expectedContext));
+        lookupCount.Should().Be(2);
+    }
+
+    [Test]
+    public async Task It_Serves_A_Warm_Success_Cache_When_Cms_Is_Unavailable()
+    {
+        var expectedContext = CreateApplicationContext("client-id", 1);
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .Returns(new ApplicationContextResult.Success(expectedContext));
+
+        await _provider.GetApplicationByClientIdAsync("client-id", tenant: null);
+        var outageScopeProvider = CreateProvider();
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .Returns(new ApplicationContextResult.Unavailable());
+
+        ApplicationContextResult result = await outageScopeProvider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeEquivalentTo(new ApplicationContextResult.Success(expectedContext));
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task It_Reloads_Only_The_Matching_Normalized_Tenant_Key()
+    {
+        var staleNorthContext = CreateApplicationContext("client-id", 1);
+        var southContext = CreateApplicationContext("client-id", 2);
+        var refreshedNorthContext = CreateApplicationContext("client-id", 3);
+        await _hybridCache.SetAsync("ApplicationContext:tenant:north:client-id", staleNorthContext);
+        await _hybridCache.SetAsync("ApplicationContext:tenant:south:client-id", southContext);
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.ReloadApplicationByClientIdAsync(
+                    "client-id",
+                    "North"
+                )
+            )
+            .Returns(new ApplicationContextResult.Success(refreshedNorthContext));
+
+        ApplicationContextResult reloadResult = await _provider.ReloadApplicationByClientIdAsync(
+            "client-id",
+            "North"
+        );
+        ApplicationContextResult north = await CreateProvider()
+            .GetApplicationByClientIdAsync("client-id", "north");
+        ApplicationContextResult south = await CreateProvider()
+            .GetApplicationByClientIdAsync("client-id", "south");
+
+        reloadResult.Should().BeEquivalentTo(new ApplicationContextResult.Success(refreshedNorthContext));
+        north.Should().BeEquivalentTo(new ApplicationContextResult.Success(refreshedNorthContext));
+        south.Should().BeEquivalentTo(new ApplicationContextResult.Success(southContext));
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.ReloadApplicationByClientIdAsync(
+                    "client-id",
+                    "North"
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    A<string>.Ignored,
+                    A<string?>.Ignored
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_Returns_A_Typed_Unavailable_Result_For_A_Blank_Client_Without_Caching()
+    {
+        ApplicationContextResult result = await _provider.GetApplicationByClientIdAsync(" ", tenant: null);
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    A<string>.Ignored,
+                    A<string?>.Ignored
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    private CachedApplicationContextProvider CreateProvider() =>
+        new(
+            _configurationServiceApplicationProvider,
+            _hybridCache,
+            new CacheSettings { ApplicationContextCacheExpirationSeconds = 123 },
+            NullLogger<CachedApplicationContextProvider>.Instance
+        );
+
+    private static HybridCache CreateHybridCache()
+    {
+        var services = new ServiceCollection();
+        services.AddMemoryCache();
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+
+    private static ApplicationContextResult CreateResult(ApplicationContextOutcome outcome) =>
+        outcome switch
+        {
+            ApplicationContextOutcome.Success => new ApplicationContextResult.Success(
+                CreateApplicationContext("client-id", 1)
+            ),
+            ApplicationContextOutcome.NotFound => new ApplicationContextResult.NotFound(),
+            ApplicationContextOutcome.Unavailable => new ApplicationContextResult.Unavailable(),
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
+        };
+
+    private static ApplicationContext CreateApplicationContext(string clientId, long applicationId) =>
+        new(applicationId, 100, clientId, Guid.NewGuid(), [1, 2, 3], null, []);
+
+    public enum ApplicationContextOutcome
+    {
+        Success,
+        NotFound,
+        Unavailable,
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/CachedApplicationContextProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/CachedApplicationContextProviderTests.cs
@@ -313,11 +313,11 @@ public class Given_A_CachedApplicationContextProvider
     }
 
     [Test]
-    public async Task It_Returns_A_Typed_Unavailable_Result_For_A_Blank_Client_Without_Caching()
+    public async Task It_Returns_A_Typed_NotFound_Result_For_A_Blank_Client_Without_Caching()
     {
         ApplicationContextResult result = await _provider.GetApplicationByClientIdAsync(" ", tenant: null);
 
-        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+        result.Should().BeOfType<ApplicationContextResult.NotFound>();
         A.CallTo(() =>
                 _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
                     A<string>.Ignored,
@@ -325,6 +325,63 @@ public class Given_A_CachedApplicationContextProvider
                 )
             )
             .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_Invalidates_The_Request_Scoped_Memo_On_Reload()
+    {
+        var reloadedContext = CreateApplicationContext("client-id", 9);
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .Returns(new ApplicationContextResult.NotFound());
+        A.CallTo(() =>
+                _configurationServiceApplicationProvider.ReloadApplicationByClientIdAsync(
+                    "client-id",
+                    tenant: null
+                )
+            )
+            .Returns(new ApplicationContextResult.Success(reloadedContext));
+
+        ApplicationContextResult beforeReload = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+        ApplicationContextResult reloadResult = await _provider.ReloadApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+        ApplicationContextResult afterReload = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        beforeReload.Should().BeOfType<ApplicationContextResult.NotFound>();
+        reloadResult.Should().BeEquivalentTo(new ApplicationContextResult.Success(reloadedContext));
+        afterReload.Should().BeEquivalentTo(new ApplicationContextResult.Success(reloadedContext));
+    }
+
+    [Test]
+    public async Task It_Preserves_Ownership_Tokens_Through_The_Cache()
+    {
+        ApplicationContext expectedContext = CreateApplicationContext("client-id", 1) with
+        {
+            CreatorOwnershipTokenId = 303,
+            OwnershipTokenIds = [202, 404],
+        };
+        await _hybridCache.SetAsync("ApplicationContext:single:client-id", expectedContext);
+
+        ApplicationContextResult result = await _provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        var success = result.Should().BeOfType<ApplicationContextResult.Success>().Subject;
+        success.ApplicationContext.CreatorOwnershipTokenId.Should().Be(303);
+        success.ApplicationContext.OwnershipTokenIds.Should().Equal((short)202, (short)404);
     }
 
     private CachedApplicationContextProvider CreateProvider() =>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -178,6 +178,9 @@ public class Given_ConfigurationServiceApplicationProvider
     [TestCase(
         "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[7,7]}"
     )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[7,6]}"
+    )]
     public async Task It_Should_Return_Unavailable_For_OutOfRange_Ownership_Token_Ids(string responseBody)
     {
         using var fixture = new ProviderFixture(HttpStatusCode.OK, responseBody);
@@ -329,8 +332,7 @@ public class Given_ConfigurationServiceApplicationProvider
                     Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
                 },
                 useResponseHandler
-            )
-        { }
+            ) { }
 
         public ProviderFixture(Exception exception)
         {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -55,6 +55,19 @@ public class Given_ConfigurationServiceApplicationProvider
         result.Should().BeOfType<ApplicationContextResult.NotFound>();
     }
 
+    [Test]
+    public async Task It_Should_Return_NotFound_For_A_404_Response_Through_The_Production_Response_Handler()
+    {
+        using var fixture = new ProviderFixture(HttpStatusCode.NotFound, "", useResponseHandler: true);
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.NotFound>();
+    }
+
     [TestCase(HttpStatusCode.InternalServerError)]
     [TestCase(HttpStatusCode.Unauthorized)]
     public async Task It_Should_Return_Unavailable_For_A_NonSuccess_Response(HttpStatusCode statusCode)
@@ -205,7 +218,7 @@ public class Given_ConfigurationServiceApplicationProvider
     }
 
     [Test]
-    public async Task It_Should_Accept_A_Response_That_Omits_The_Null_Creator_Token()
+    public async Task It_Should_Return_Unavailable_When_Response_Omits_The_Nullable_Creator_Token()
     {
         using var fixture = new ProviderFixture(
             HttpStatusCode.OK,
@@ -226,7 +239,7 @@ public class Given_ConfigurationServiceApplicationProvider
             tenant: null
         );
 
-        result.Should().BeOfType<ApplicationContextResult.Success>();
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
     }
 
     [Test]
@@ -305,14 +318,18 @@ public class Given_ConfigurationServiceApplicationProvider
 
     private sealed class ProviderFixture : IDisposable
     {
-        public ProviderFixture(HttpStatusCode statusCode, string responseBody)
+        public ProviderFixture(
+            HttpStatusCode statusCode,
+            string responseBody,
+            bool useResponseHandler = false
+        )
             : this(
                 new HttpResponseMessage(statusCode)
                 {
                     Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
-                }
-            )
-        { }
+                },
+                useResponseHandler
+            ) { }
 
         public ProviderFixture(Exception exception)
         {
@@ -321,10 +338,18 @@ public class Given_ConfigurationServiceApplicationProvider
             Provider = CreateProvider(Client);
         }
 
-        private ProviderFixture(HttpResponseMessage response)
+        private ProviderFixture(HttpResponseMessage response, bool useResponseHandler = false)
         {
             Handler = new CapturingHttpMessageHandler(response);
-            Client = new HttpClient(Handler) { BaseAddress = new Uri("https://cms.example/") };
+            HttpMessageHandler messageHandler = useResponseHandler
+                ? new ConfigurationServiceResponseHandler(
+                    NullLogger<ConfigurationServiceResponseHandler>.Instance
+                )
+                {
+                    InnerHandler = Handler,
+                }
+                : Handler;
+            Client = new HttpClient(messageHandler) { BaseAddress = new Uri("https://cms.example/") };
             Provider = CreateProvider(Client);
         }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -332,7 +332,8 @@ public class Given_ConfigurationServiceApplicationProvider
                     Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
                 },
                 useResponseHandler
-            ) { }
+            )
+        { }
 
         public ProviderFixture(Exception exception)
         {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -150,6 +150,21 @@ public class Given_ConfigurationServiceApplicationProvider
     [TestCase(
         "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[32768]}"
     )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":0,\"ownershipTokenIds\":[]}"
+    )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":-1,\"ownershipTokenIds\":[]}"
+    )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[0]}"
+    )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[-1]}"
+    )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[7,7]}"
+    )]
     public async Task It_Should_Return_Unavailable_For_OutOfRange_Ownership_Token_Ids(string responseBody)
     {
         using var fixture = new ProviderFixture(HttpStatusCode.OK, responseBody);
@@ -160,6 +175,58 @@ public class Given_ConfigurationServiceApplicationProvider
         );
 
         result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [Test]
+    public async Task It_Should_Return_Unavailable_When_Ownership_Token_List_Is_Too_Large()
+    {
+        string ownershipTokenIds = string.Join(",", Enumerable.Repeat("7", 2000));
+        using var fixture = new ProviderFixture(
+            HttpStatusCode.OK,
+            $$"""
+            {
+              "id": 1,
+              "applicationId": 2,
+              "clientId": "client-id",
+              "clientUuid": "8c58fef1-7d9b-4423-bb3c-f1581e77e922",
+              "dataStoreIds": [3],
+              "creatorOwnershipTokenId": null,
+              "ownershipTokenIds": [{{ownershipTokenIds}}]
+            }
+            """
+        );
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [Test]
+    public async Task It_Should_Accept_A_Response_That_Omits_The_Null_Creator_Token()
+    {
+        using var fixture = new ProviderFixture(
+            HttpStatusCode.OK,
+            """
+            {
+              "id": 1,
+              "applicationId": 2,
+              "clientId": "client-id",
+              "clientUuid": "8c58fef1-7d9b-4423-bb3c-f1581e77e922",
+              "dataStoreIds": [3],
+              "ownershipTokenIds": []
+            }
+            """
+        );
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Success>();
     }
 
     [Test]
@@ -244,9 +311,7 @@ public class Given_ConfigurationServiceApplicationProvider
                 {
                     Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
                 }
-            )
-        {
-        }
+            ) { }
 
         public ProviderFixture(Exception exception)
         {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -8,8 +8,10 @@ using System.Net.Http.Headers;
 using System.Text;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Core.Tests.Unit.TestSupport;
 using FakeItEasy;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
@@ -139,6 +141,37 @@ public class Given_ConfigurationServiceApplicationProvider
         );
 
         result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [Test]
+    public async Task It_Should_Log_A_Distinct_Error_When_Response_Client_Id_Is_A_Different_Client()
+    {
+        RecordingLogger<ConfigurationServiceApplicationProvider> logger = new();
+        using var fixture = new ProviderFixture(
+            HttpStatusCode.OK,
+            ValidApplicationContextJson(clientId: "other-client"),
+            logger: logger
+        );
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+
+        LogRecord rejection = logger
+            .Records.Should()
+            .ContainSingle(record => record.Level == LogLevel.Error)
+            .Subject;
+        rejection.Message.Should().NotContain("Failed to deserialize application context");
+        rejection
+            .Message.Should()
+            .Be(
+                "Configuration Service returned an application context for a different clientId. Requested clientId: client-id, returned clientId: other-client"
+            );
+        rejection.Properties.Should().Contain("RequestedClientId", "client-id");
+        rejection.Properties.Should().Contain("ResponseClientId", "other-client");
     }
 
     [Test]
@@ -351,14 +384,16 @@ public class Given_ConfigurationServiceApplicationProvider
         public ProviderFixture(
             HttpStatusCode statusCode,
             string responseBody,
-            bool useResponseHandler = false
+            bool useResponseHandler = false,
+            ILogger<ConfigurationServiceApplicationProvider>? logger = null
         )
             : this(
                 new HttpResponseMessage(statusCode)
                 {
                     Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
                 },
-                useResponseHandler
+                useResponseHandler,
+                logger
             )
         { }
 
@@ -369,7 +404,11 @@ public class Given_ConfigurationServiceApplicationProvider
             Provider = CreateProvider(Client);
         }
 
-        private ProviderFixture(HttpResponseMessage response, bool useResponseHandler = false)
+        private ProviderFixture(
+            HttpResponseMessage response,
+            bool useResponseHandler = false,
+            ILogger<ConfigurationServiceApplicationProvider>? logger = null
+        )
         {
             Handler = new CapturingHttpMessageHandler(response);
             HttpMessageHandler messageHandler = useResponseHandler
@@ -381,7 +420,7 @@ public class Given_ConfigurationServiceApplicationProvider
                 }
                 : Handler;
             Client = new HttpClient(messageHandler) { BaseAddress = new Uri("https://cms.example/") };
-            Provider = CreateProvider(Client);
+            Provider = CreateProvider(Client, logger);
         }
 
         public HttpClient Client { get; }
@@ -396,7 +435,10 @@ public class Given_ConfigurationServiceApplicationProvider
             Handler.Dispose();
         }
 
-        private static ConfigurationServiceApplicationProvider CreateProvider(HttpClient httpClient)
+        private static ConfigurationServiceApplicationProvider CreateProvider(
+            HttpClient httpClient,
+            ILogger<ConfigurationServiceApplicationProvider>? logger = null
+        )
         {
             var tokenHandler = A.Fake<IConfigurationServiceTokenHandler>();
             A.CallTo(() =>
@@ -413,7 +455,7 @@ public class Given_ConfigurationServiceApplicationProvider
                 new ConfigurationServiceApiClient(httpClient),
                 tokenHandler,
                 new ConfigurationServiceContext("cms-client", "cms-secret", "cms-scope"),
-                NullLogger<ConfigurationServiceApplicationProvider>.Instance
+                logger ?? NullLogger<ConfigurationServiceApplicationProvider>.Instance
             );
         }
     }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -158,6 +158,32 @@ public class Given_ConfigurationServiceApplicationProvider
     }
 
     [TestCase(
+        "{\"id\":0,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[]}"
+    )]
+    [TestCase(
+        "{\"id\":-1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[]}"
+    )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":0,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[]}"
+    )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":-1,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[]}"
+    )]
+    public async Task It_Should_Return_Unavailable_For_NonPositive_Application_Identifiers(
+        string responseBody
+    )
+    {
+        using var fixture = new ProviderFixture(HttpStatusCode.OK, responseBody);
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [TestCase(
         "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":32768,\"ownershipTokenIds\":[]}"
     )]
     [TestCase(
@@ -321,6 +347,7 @@ public class Given_ConfigurationServiceApplicationProvider
 
     private sealed class ProviderFixture : IDisposable
     {
+        // csharpier-ignore - IDE0055 requires this empty delegating constructor body shape.
         public ProviderFixture(
             HttpStatusCode statusCode,
             string responseBody,

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -234,12 +234,6 @@ public class Given_ConfigurationServiceApplicationProvider
     [TestCase(
         "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[-1]}"
     )]
-    [TestCase(
-        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[7,7]}"
-    )]
-    [TestCase(
-        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[7,6]}"
-    )]
     public async Task It_Should_Return_Unavailable_For_OutOfRange_Ownership_Token_Ids(string responseBody)
     {
         using var fixture = new ProviderFixture(HttpStatusCode.OK, responseBody);
@@ -250,6 +244,38 @@ public class Given_ConfigurationServiceApplicationProvider
         );
 
         result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [TestCase("7,7", new short[] { 7 })]
+    [TestCase("7,6", new short[] { 6, 7 })]
+    [TestCase("7,6,7", new short[] { 6, 7 })]
+    public async Task It_Should_Normalize_Ownership_Token_Ids_To_Sorted_Distinct(
+        string responseOwnershipTokenIds,
+        short[] expectedOwnershipTokenIds
+    )
+    {
+        using var fixture = new ProviderFixture(
+            HttpStatusCode.OK,
+            $$"""
+            {
+              "id": 1,
+              "applicationId": 2,
+              "clientId": "client-id",
+              "clientUuid": "8c58fef1-7d9b-4423-bb3c-f1581e77e922",
+              "dataStoreIds": [3],
+              "creatorOwnershipTokenId": null,
+              "ownershipTokenIds": [{{responseOwnershipTokenIds}}]
+            }
+            """
+        );
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        var success = result.Should().BeOfType<ApplicationContextResult.Success>().Subject;
+        success.ApplicationContext.OwnershipTokenIds.Should().Equal(expectedOwnershipTokenIds);
     }
 
     [Test]
@@ -280,7 +306,7 @@ public class Given_ConfigurationServiceApplicationProvider
     }
 
     [Test]
-    public async Task It_Should_Return_Unavailable_When_Response_Omits_The_Nullable_Creator_Token()
+    public async Task It_Should_Accept_A_Response_That_Omits_The_Nullable_Creator_Token()
     {
         using var fixture = new ProviderFixture(
             HttpStatusCode.OK,
@@ -291,7 +317,7 @@ public class Given_ConfigurationServiceApplicationProvider
               "clientId": "client-id",
               "clientUuid": "8c58fef1-7d9b-4423-bb3c-f1581e77e922",
               "dataStoreIds": [3],
-              "ownershipTokenIds": []
+              "ownershipTokenIds": [7, 6]
             }
             """
         );
@@ -301,7 +327,9 @@ public class Given_ConfigurationServiceApplicationProvider
             tenant: null
         );
 
-        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+        var success = result.Should().BeOfType<ApplicationContextResult.Success>().Subject;
+        success.ApplicationContext.CreatorOwnershipTokenId.Should().BeNull();
+        success.ApplicationContext.OwnershipTokenIds.Should().Equal((short)6, (short)7);
     }
 
     [Test]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -311,7 +311,8 @@ public class Given_ConfigurationServiceApplicationProvider
                 {
                     Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
                 }
-            ) { }
+            )
+        { }
 
         public ProviderFixture(Exception exception)
         {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -329,7 +329,8 @@ public class Given_ConfigurationServiceApplicationProvider
                     Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
                 },
                 useResponseHandler
-            ) { }
+            )
+        { }
 
         public ProviderFixture(Exception exception)
         {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/ConfigurationServiceApplicationProviderTests.cs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Security;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Configuration;
+
+[TestFixture]
+public class Given_ConfigurationServiceApplicationProvider
+{
+    [Test]
+    public async Task It_Should_Return_A_Successful_Application_Context_From_A_Valid_Response()
+    {
+        using var fixture = new ProviderFixture(HttpStatusCode.OK, ValidApplicationContextJson());
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        var success = result.Should().BeOfType<ApplicationContextResult.Success>().Subject;
+        success.ApplicationContext.Id.Should().Be(1);
+        success.ApplicationContext.ApplicationId.Should().Be(2);
+        success.ApplicationContext.ClientId.Should().Be("client-id");
+        success.ApplicationContext.DataStoreIds.Should().Equal(3L, 4L);
+        success.ApplicationContext.CreatorOwnershipTokenId.Should().Be(5);
+        success.ApplicationContext.OwnershipTokenIds.Should().Equal((short)6, (short)7);
+        fixture.Handler.Request!.Method.Should().Be(HttpMethod.Get);
+        fixture.Handler.Request.RequestUri!.PathAndQuery.Should().Be("/v3/apiClients/client-id");
+        fixture
+            .Handler.Request.Headers.Authorization.Should()
+            .BeEquivalentTo(new AuthenticationHeaderValue("Bearer", "cms-token"));
+    }
+
+    [Test]
+    public async Task It_Should_Return_NotFound_For_A_404_Response()
+    {
+        using var fixture = new ProviderFixture(HttpStatusCode.NotFound, "");
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.NotFound>();
+    }
+
+    [TestCase(HttpStatusCode.InternalServerError)]
+    [TestCase(HttpStatusCode.Unauthorized)]
+    public async Task It_Should_Return_Unavailable_For_A_NonSuccess_Response(HttpStatusCode statusCode)
+    {
+        using var fixture = new ProviderFixture(statusCode, "");
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [Test]
+    public async Task It_Should_Return_Unavailable_For_A_Transport_Failure()
+    {
+        using var fixture = new ProviderFixture(new HttpRequestException("transport failure"));
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [Test]
+    public async Task It_Should_Return_Unavailable_For_Malformed_Json()
+    {
+        using var fixture = new ProviderFixture(HttpStatusCode.OK, "not-json");
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [Test]
+    public async Task It_Should_Return_Unavailable_When_Required_Application_Context_Structure_Is_Missing()
+    {
+        using var fixture = new ProviderFixture(HttpStatusCode.OK, "{\"id\":1}");
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [TestCase("other-client")]
+    [TestCase("")]
+    [TestCase("   ")]
+    public async Task It_Should_Return_Unavailable_When_Response_Client_Id_Is_Not_The_Requested_Client(
+        string responseClientId
+    )
+    {
+        using var fixture = new ProviderFixture(
+            HttpStatusCode.OK,
+            ValidApplicationContextJson(clientId: responseClientId)
+        );
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [Test]
+    public async Task It_Should_Return_Unavailable_When_Response_Client_Uuid_Is_Empty()
+    {
+        using var fixture = new ProviderFixture(
+            HttpStatusCode.OK,
+            ValidApplicationContextJson(clientUuid: Guid.Empty)
+        );
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [TestCase(
+        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":32768,\"ownershipTokenIds\":[]}"
+    )]
+    [TestCase(
+        "{\"id\":1,\"applicationId\":2,\"clientId\":\"client-id\",\"clientUuid\":\"8c58fef1-7d9b-4423-bb3c-f1581e77e922\",\"dataStoreIds\":[3],\"creatorOwnershipTokenId\":null,\"ownershipTokenIds\":[32768]}"
+    )]
+    public async Task It_Should_Return_Unavailable_For_OutOfRange_Ownership_Token_Ids(string responseBody)
+    {
+        using var fixture = new ProviderFixture(HttpStatusCode.OK, responseBody);
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        result.Should().BeOfType<ApplicationContextResult.Unavailable>();
+    }
+
+    [Test]
+    public async Task It_Should_Accept_A_Null_Creator_And_Empty_Ownership_Tokens()
+    {
+        using var fixture = new ProviderFixture(
+            HttpStatusCode.OK,
+            ValidApplicationContextJson(creatorOwnershipTokenId: null, ownershipTokenIds: [])
+        );
+
+        ApplicationContextResult result = await fixture.Provider.GetApplicationByClientIdAsync(
+            "client-id",
+            tenant: null
+        );
+
+        var success = result.Should().BeOfType<ApplicationContextResult.Success>().Subject;
+        success.ApplicationContext.CreatorOwnershipTokenId.Should().BeNull();
+        success.ApplicationContext.OwnershipTokenIds.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_Should_Send_The_Original_Case_Tenant_Header_Only_When_A_Tenant_Is_Supplied()
+    {
+        using var tenantFixture = new ProviderFixture(HttpStatusCode.OK, ValidApplicationContextJson());
+        await tenantFixture.Provider.GetApplicationByClientIdAsync("client-id", "Tenant-MixedCase");
+
+        tenantFixture
+            .Handler.Request!.Headers.Should()
+            .Contain(header => header.Key == "Tenant" && header.Value.Single() == "Tenant-MixedCase");
+        tenantFixture.Handler.Request!.Headers.GetValues("Tenant").Should().ContainSingle("Tenant-MixedCase");
+
+        using var singleTenantFixture = new ProviderFixture(HttpStatusCode.OK, ValidApplicationContextJson());
+        await singleTenantFixture.Provider.GetApplicationByClientIdAsync("client-id", tenant: null);
+
+        singleTenantFixture.Handler.Request!.Headers.Contains("Tenant").Should().BeFalse();
+    }
+
+    [Test]
+    public async Task It_Should_Not_Mutate_HttpClient_Default_Request_Headers()
+    {
+        using var fixture = new ProviderFixture(HttpStatusCode.OK, ValidApplicationContextJson());
+        fixture.Client.DefaultRequestHeaders.Add("Existing-Header", "existing-value");
+
+        await fixture.Provider.GetApplicationByClientIdAsync("client-id", "Tenant-A");
+
+        fixture.Client.DefaultRequestHeaders.Authorization.Should().BeNull();
+        fixture.Client.DefaultRequestHeaders.Contains("Tenant").Should().BeFalse();
+        fixture
+            .Client.DefaultRequestHeaders.GetValues("Existing-Header")
+            .Should()
+            .ContainSingle("existing-value");
+    }
+
+    private static string ValidApplicationContextJson(
+        string clientId = "client-id",
+        Guid? clientUuid = null,
+        short? creatorOwnershipTokenId = 5,
+        short[]? ownershipTokenIds = null
+    )
+    {
+        var creator = creatorOwnershipTokenId.HasValue ? creatorOwnershipTokenId.Value.ToString() : "null";
+        var ownershipTokens = ownershipTokenIds is null ? "6,7" : string.Join(",", ownershipTokenIds);
+
+        return $$"""
+            {
+              "id": 1,
+              "applicationId": 2,
+              "clientId": "{{clientId}}",
+              "clientUuid": "{{clientUuid ?? Guid.Parse("8c58fef1-7d9b-4423-bb3c-f1581e77e922")}}",
+              "dataStoreIds": [3, 4],
+              "creatorOwnershipTokenId": {{creator}},
+              "ownershipTokenIds": [{{ownershipTokens}}]
+            }
+            """;
+    }
+
+    private sealed class ProviderFixture : IDisposable
+    {
+        public ProviderFixture(HttpStatusCode statusCode, string responseBody)
+            : this(
+                new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+                }
+            )
+        {
+        }
+
+        public ProviderFixture(Exception exception)
+        {
+            Handler = new CapturingHttpMessageHandler(exception);
+            Client = new HttpClient(Handler) { BaseAddress = new Uri("https://cms.example/") };
+            Provider = CreateProvider(Client);
+        }
+
+        private ProviderFixture(HttpResponseMessage response)
+        {
+            Handler = new CapturingHttpMessageHandler(response);
+            Client = new HttpClient(Handler) { BaseAddress = new Uri("https://cms.example/") };
+            Provider = CreateProvider(Client);
+        }
+
+        public HttpClient Client { get; }
+
+        public CapturingHttpMessageHandler Handler { get; }
+
+        public ConfigurationServiceApplicationProvider Provider { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            Handler.Dispose();
+        }
+
+        private static ConfigurationServiceApplicationProvider CreateProvider(HttpClient httpClient)
+        {
+            var tokenHandler = A.Fake<IConfigurationServiceTokenHandler>();
+            A.CallTo(() =>
+                    tokenHandler.GetTokenAsync(
+                        "cms-client",
+                        "cms-secret",
+                        "cms-scope",
+                        A<CancellationToken>._
+                    )
+                )
+                .Returns("cms-token");
+
+            return new ConfigurationServiceApplicationProvider(
+                new ConfigurationServiceApiClient(httpClient),
+                tokenHandler,
+                new ConfigurationServiceContext("cms-client", "cms-secret", "cms-scope"),
+                NullLogger<ConfigurationServiceApplicationProvider>.Instance
+            );
+        }
+    }
+
+    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception? _exception;
+        private readonly HttpResponseMessage? _response;
+
+        public CapturingHttpMessageHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        public CapturingHttpMessageHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Request = request;
+
+            if (_exception is not null)
+            {
+                return Task.FromException<HttpResponseMessage>(_exception);
+            }
+
+            return Task.FromResult(_response!);
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
@@ -844,7 +844,7 @@ actual: {_requestInfo.FrontendResponse.Body}
                 ClientUuid: Guid.Parse("55555555-5555-5555-5555-555555555555"),
                 DataStoreIds: [],
                 CreatorOwnershipTokenId: 303,
-                OwnershipTokenIds: [404, 202, 404]
+                OwnershipTokenIds: [202, 404]
             );
 
             var (deleteByIdHandler, serviceProvider) = Handler(_repository);
@@ -879,7 +879,7 @@ actual: {_requestInfo.FrontendResponse.Body}
                 .AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://sample-a.org", "uri://sample-b.org");
             relationalRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
-            relationalRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            relationalRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(202, 404);
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
@@ -837,6 +837,15 @@ actual: {_requestInfo.FrontendResponse.Body}
                 ],
                 DataStoreIds: []
             );
+            _requestInfo.ApplicationContext = new(
+                Id: 1,
+                ApplicationId: 2,
+                ClientId: "client-id",
+                ClientUuid: Guid.Parse("55555555-5555-5555-5555-555555555555"),
+                DataStoreIds: [],
+                CreatorOwnershipTokenId: 303,
+                OwnershipTokenIds: [404, 202, 404]
+            );
 
             var (deleteByIdHandler, serviceProvider) = Handler(_repository);
             _requestInfo.ScopedServiceProvider = serviceProvider;
@@ -869,6 +878,8 @@ actual: {_requestInfo.FrontendResponse.Body}
             relationalRequest
                 .AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://sample-a.org", "uri://sample-b.org");
+            relationalRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
+            relationalRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
@@ -953,7 +953,7 @@ actual: {requestInfo.FrontendResponse.Body}
                 ClientUuid: Guid.Parse("22222222-2222-2222-2222-222222222222"),
                 DataStoreIds: [],
                 CreatorOwnershipTokenId: 303,
-                OwnershipTokenIds: [404, 202, 404]
+                OwnershipTokenIds: [202, 404]
             );
             _requestInfo.ProfileContext = new ProfileContext(
                 ProfileName: "ReadableProfile",
@@ -1002,7 +1002,7 @@ actual: {requestInfo.FrontendResponse.Body}
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://sample-a.org", "uri://sample-b.org");
             _repository.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
-            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(202, 404);
             _repository.CapturedRequest.ReadableProfileProjectionContext.Should().NotBeNull();
             _repository
                 .CapturedRequest.ReadableProfileProjectionContext!.ContentTypeDefinition.Should()

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
@@ -946,6 +946,15 @@ actual: {requestInfo.FrontendResponse.Body}
                 ],
                 DataStoreIds: []
             );
+            _requestInfo.ApplicationContext = new(
+                Id: 1,
+                ApplicationId: 2,
+                ClientId: "client-id",
+                ClientUuid: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+                DataStoreIds: [],
+                CreatorOwnershipTokenId: 303,
+                OwnershipTokenIds: [404, 202, 404]
+            );
             _requestInfo.ProfileContext = new ProfileContext(
                 ProfileName: "ReadableProfile",
                 ContentType: ProfileContentType.Read,
@@ -992,6 +1001,8 @@ actual: {requestInfo.FrontendResponse.Body}
             _repository
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://sample-a.org", "uri://sample-b.org");
+            _repository.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
+            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
             _repository.CapturedRequest.ReadableProfileProjectionContext.Should().NotBeNull();
             _repository
                 .CapturedRequest.ReadableProfileProjectionContext!.ContentTypeDefinition.Should()

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetTokenInfoHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetTokenInfoHandlerTests.cs
@@ -454,6 +454,36 @@ public class Given_GetTokenInfoHandler
         await action.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    [Test]
+    public async Task It_returns_401_when_application_context_is_not_found()
+    {
+        var clientAuthorizations = CreateClientAuthorizations([]);
+        ConfigureJwtValidation(clientAuthorizations);
+        RequestInfo requestInfo = CreateRequestInfo(
+            clientAuthorizations,
+            CreateScopedServiceProvider(null, new ApplicationContextResult.NotFound())
+        );
+
+        await Execute(requestInfo);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(401);
+    }
+
+    [Test]
+    public async Task It_returns_503_when_application_context_is_unavailable()
+    {
+        var clientAuthorizations = CreateClientAuthorizations([]);
+        ConfigureJwtValidation(clientAuthorizations);
+        RequestInfo requestInfo = CreateRequestInfo(
+            clientAuthorizations,
+            CreateScopedServiceProvider(null, new ApplicationContextResult.Unavailable())
+        );
+
+        await Execute(requestInfo);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(503);
+    }
+
     private void ConfigureJwtValidation(ClientAuthorizations clientAuthorizations)
     {
         A.CallTo(() =>
@@ -556,21 +586,27 @@ public class Given_GetTokenInfoHandler
     }
 
     private static ServiceProvider CreateScopedServiceProvider(
-        IRelationalTokenInfoEducationOrganizationLookup? relationalLookup
+        IRelationalTokenInfoEducationOrganizationLookup? relationalLookup,
+        ApplicationContextResult? applicationContextResult = null
     )
     {
         var services = new ServiceCollection();
         var applicationContextProvider = A.Fake<IApplicationContextProvider>();
-        A.CallTo(() => applicationContextProvider.GetApplicationByClientIdAsync(ClientId))
+        A.CallTo(() => applicationContextProvider.GetApplicationByClientIdAsync(ClientId, tenant: null))
             .Returns(
-                Task.FromResult<ApplicationContext?>(
-                    new ApplicationContext(
-                        Id: 1,
-                        ApplicationId: 7,
-                        ClientId: ClientId,
-                        ClientUuid: Guid.Parse("a650c029-1fc0-4d9a-8844-f9386e35103f"),
-                        DataStoreIds: [1]
-                    )
+                Task.FromResult(
+                    applicationContextResult
+                        ?? new ApplicationContextResult.Success(
+                            new ApplicationContext(
+                                Id: 1,
+                                ApplicationId: 7,
+                                ClientId: ClientId,
+                                ClientUuid: Guid.Parse("a650c029-1fc0-4d9a-8844-f9386e35103f"),
+                                DataStoreIds: [1],
+                                CreatorOwnershipTokenId: null,
+                                OwnershipTokenIds: []
+                            )
+                        )
                 )
             );
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
@@ -104,7 +104,7 @@ public class PartitionRequestHandlerTests
             ClientUuid: Guid.Parse("66666666-6666-6666-6666-666666666666"),
             DataStoreIds: [],
             CreatorOwnershipTokenId: 303,
-            OwnershipTokenIds: [404, 202, 404]
+            OwnershipTokenIds: [202, 404]
         );
 
         await new PartitionRequestHandler(
@@ -301,7 +301,7 @@ public class PartitionRequestHandlerTests
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://sample.org");
             _handler.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
-            _handler.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            _handler.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(202, 404);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/PartitionRequestHandlerTests.cs
@@ -89,6 +89,23 @@ public class PartitionRequestHandlerTests
         // that it crosses the seam has to be able to fail: DocumentId is the enum's zero value.
         requestInfo.PageOrderingMode = orderingMode;
         requestInfo.FrontendRequest = requestInfo.FrontendRequest with { Tenant = TenantKey };
+        requestInfo.ClientAuthorizations = new ClientAuthorizations(
+            TokenId: "token-id",
+            ClientId: "client-id",
+            ClaimSetName: "claim-set",
+            EducationOrganizationIds: [new EducationOrganizationId(255902), new(255901)],
+            NamespacePrefixes: [new NamespacePrefix("uri://sample.org")],
+            DataStoreIds: []
+        );
+        requestInfo.ApplicationContext = new(
+            Id: 1,
+            ApplicationId: 2,
+            ClientId: "client-id",
+            ClientUuid: Guid.Parse("66666666-6666-6666-6666-666666666666"),
+            DataStoreIds: [],
+            CreatorOwnershipTokenId: 303,
+            OwnershipTokenIds: [404, 202, 404]
+        );
 
         await new PartitionRequestHandler(
             NullLogger.Instance,
@@ -272,6 +289,19 @@ public class PartitionRequestHandlerTests
         public void It_hands_the_tenant_to_the_backend()
         {
             _handler.CapturedRequest!.TenantKey.Should().Be(TenantKey);
+        }
+
+        [Test]
+        public void It_hands_JWT_and_ownership_authorization_inputs_to_the_backend()
+        {
+            _handler
+                .CapturedRequest!.AuthorizationContext.ClaimEducationOrganizationIds.Should()
+                .Equal(255901L, 255902L);
+            _handler
+                .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
+                .Equal("uri://sample.org");
+            _handler.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
+            _handler.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -1135,6 +1135,15 @@ public class QueryRequestHandlerTests
                 ],
                 DataStoreIds: []
             );
+            _requestInfo.ApplicationContext = new(
+                Id: 1,
+                ApplicationId: 2,
+                ClientId: "client-id",
+                ClientUuid: Guid.Parse("33333333-3333-3333-3333-333333333333"),
+                DataStoreIds: [],
+                CreatorOwnershipTokenId: 303,
+                OwnershipTokenIds: [404, 202, 404]
+            );
 
             var (queryHandler, serviceProvider) = Handler(_repository);
             _requestInfo.ScopedServiceProvider = serviceProvider;
@@ -1152,6 +1161,8 @@ public class QueryRequestHandlerTests
             _repository
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://sample-a.org", "uri://sample-b.org");
+            _repository.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
+            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
             _repository.CapturedRequest.ResourceInfo.Should().BeSameAs(_requestInfo.ResourceInfo);
             _repository.CapturedRequest.QueryElements.Should().BeSameAs(_queryElements);
             _repository
@@ -1242,6 +1253,24 @@ public class QueryRequestHandlerTests
             _repository
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal(directlyConstructedContext.NamespacePrefixes);
+        }
+
+        [Test]
+        public void It_snapshots_the_optional_ownership_projection_without_normalizing_CMS_order()
+        {
+            short[] ownershipTokenIds = [404, 202, 404];
+
+            RelationalAuthorizationContext context = RelationalAuthorizationContext.Create(
+                _requestInfo.ClientAuthorizations,
+                creatorOwnershipTokenId: 303,
+                ownershipTokenIds
+            );
+            ownershipTokenIds[0] = 999;
+
+            context.CreatorOwnershipTokenId.Should().Be(303);
+            context.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            context.ClaimEducationOrganizationIds.Should().Equal(255900L, 255901L, 255902L);
+            context.NamespacePrefixes.Should().Equal("uri://sample-a.org", "uri://sample-b.org");
         }
 
         [Test]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -1142,7 +1142,7 @@ public class QueryRequestHandlerTests
                 ClientUuid: Guid.Parse("33333333-3333-3333-3333-333333333333"),
                 DataStoreIds: [],
                 CreatorOwnershipTokenId: 303,
-                OwnershipTokenIds: [404, 202, 404]
+                OwnershipTokenIds: [202, 404]
             );
 
             var (queryHandler, serviceProvider) = Handler(_repository);
@@ -1162,7 +1162,7 @@ public class QueryRequestHandlerTests
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://sample-a.org", "uri://sample-b.org");
             _repository.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
-            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(202, 404);
             _repository.CapturedRequest.ResourceInfo.Should().BeSameAs(_requestInfo.ResourceInfo);
             _repository.CapturedRequest.QueryElements.Should().BeSameAs(_queryElements);
             _repository
@@ -1256,9 +1256,9 @@ public class QueryRequestHandlerTests
         }
 
         [Test]
-        public void It_snapshots_the_optional_ownership_projection_without_normalizing_CMS_order()
+        public void It_snapshots_the_optional_ownership_projection_defensively()
         {
-            short[] ownershipTokenIds = [404, 202, 404];
+            short[] ownershipTokenIds = [202, 404];
 
             RelationalAuthorizationContext context = RelationalAuthorizationContext.Create(
                 _requestInfo.ClientAuthorizations,
@@ -1268,7 +1268,7 @@ public class QueryRequestHandlerTests
             ownershipTokenIds[0] = 999;
 
             context.CreatorOwnershipTokenId.Should().Be(303);
-            context.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            context.OwnershipTokenIds.Should().Equal(202, 404);
             context.ClaimEducationOrganizationIds.Should().Equal(255900L, 255901L, 255902L);
             context.NamespacePrefixes.Should().Equal("uri://sample-a.org", "uri://sample-b.org");
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/TrackedChangeQueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/TrackedChangeQueryRequestHandlerTests.cs
@@ -143,7 +143,7 @@ public class TrackedChangeQueryRequestHandlerTests
                 .AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://ed-fi.org", "uri://sample.org");
             relationalRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
-            relationalRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            relationalRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(202, 404);
         }
     }
 
@@ -417,7 +417,7 @@ public class TrackedChangeQueryRequestHandlerTests
             ClientUuid: Guid.Parse("77777777-7777-7777-7777-777777777777"),
             DataStoreIds: [],
             CreatorOwnershipTokenId: 303,
-            OwnershipTokenIds: [404, 202, 404]
+            OwnershipTokenIds: [202, 404]
         );
         return requestInfo;
     }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/TrackedChangeQueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/TrackedChangeQueryRequestHandlerTests.cs
@@ -142,6 +142,8 @@ public class TrackedChangeQueryRequestHandlerTests
             relationalRequest
                 .AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://ed-fi.org", "uri://sample.org");
+            relationalRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
+            relationalRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
         }
     }
 
@@ -407,6 +409,15 @@ public class TrackedChangeQueryRequestHandlerTests
                 new NamespacePrefix("uri://sample.org"),
             ],
             DataStoreIds: []
+        );
+        requestInfo.ApplicationContext = new(
+            Id: 1,
+            ApplicationId: 2,
+            ClientId: "client-id",
+            ClientUuid: Guid.Parse("77777777-7777-7777-7777-777777777777"),
+            DataStoreIds: [],
+            CreatorOwnershipTokenId: 303,
+            OwnershipTokenIds: [404, 202, 404]
         );
         return requestInfo;
     }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
@@ -414,6 +414,23 @@ public class UpdateByIdHandlerTests
             _requestInfo.ProfileContext = CreateWriteProfileContext(_readContentType);
             _requestInfo.BackendProfileWriteContext = CreateBackendProfileWriteContext(_writableRequestBody);
             _requestInfo.ParsedBody = JsonNode.Parse("""{"studentUniqueId":"1000","firstName":"Lincoln"}""")!;
+            _requestInfo.ClientAuthorizations = new ClientAuthorizations(
+                TokenId: "token-id",
+                ClientId: "client-id",
+                ClaimSetName: "claim-set",
+                EducationOrganizationIds: [new EducationOrganizationId(255902), new(255901)],
+                NamespacePrefixes: [new NamespacePrefix("uri://sample.org")],
+                DataStoreIds: []
+            );
+            _requestInfo.ApplicationContext = new(
+                Id: 1,
+                ApplicationId: 2,
+                ClientId: "client-id",
+                ClientUuid: Guid.Parse("44444444-4444-4444-4444-444444444444"),
+                DataStoreIds: [],
+                CreatorOwnershipTokenId: 303,
+                OwnershipTokenIds: [404, 202, 404]
+            );
 
             var (updateByIdHandler, serviceProvider) = Handler(_repository);
             _requestInfo.ScopedServiceProvider = serviceProvider;
@@ -429,6 +446,19 @@ public class UpdateByIdHandlerTests
             _repository
                 .CapturedRequest.BackendProfileWriteContext!.Request.WritableRequestBody.Should()
                 .BeSameAs(_writableRequestBody);
+        }
+
+        [Test]
+        public void It_carries_JWT_and_ownership_authorization_inputs()
+        {
+            _repository
+                .CapturedRequest.AuthorizationContext.ClaimEducationOrganizationIds.Should()
+                .Equal(255901L, 255902L);
+            _repository
+                .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
+                .Equal("uri://sample.org");
+            _repository.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
+            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
@@ -429,7 +429,7 @@ public class UpdateByIdHandlerTests
                 ClientUuid: Guid.Parse("44444444-4444-4444-4444-444444444444"),
                 DataStoreIds: [],
                 CreatorOwnershipTokenId: 303,
-                OwnershipTokenIds: [404, 202, 404]
+                OwnershipTokenIds: [202, 404]
             );
 
             var (updateByIdHandler, serviceProvider) = Handler(_repository);
@@ -458,7 +458,7 @@ public class UpdateByIdHandlerTests
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://sample.org");
             _repository.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
-            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(202, 404);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
@@ -285,6 +285,15 @@ public class UpsertHandlerTests
                 ],
                 DataStoreIds: []
             );
+            _requestInfo.ApplicationContext = new(
+                Id: 1,
+                ApplicationId: 2,
+                ClientId: "client",
+                ClientUuid: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                DataStoreIds: [],
+                CreatorOwnershipTokenId: 303,
+                OwnershipTokenIds: [404, 202, 404]
+            );
 
             var (upsertHandler, serviceProvider) = Handler(_repository);
             _requestInfo.ScopedServiceProvider = serviceProvider;
@@ -309,6 +318,8 @@ public class UpsertHandlerTests
             _repository
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://ed-fi.org", "uri://sample.org");
+            _repository.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
+            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
@@ -292,7 +292,7 @@ public class UpsertHandlerTests
                 ClientUuid: Guid.Parse("11111111-1111-1111-1111-111111111111"),
                 DataStoreIds: [],
                 CreatorOwnershipTokenId: 303,
-                OwnershipTokenIds: [404, 202, 404]
+                OwnershipTokenIds: [202, 404]
             );
 
             var (upsertHandler, serviceProvider) = Handler(_repository);
@@ -319,7 +319,7 @@ public class UpsertHandlerTests
                 .CapturedRequest.AuthorizationContext.NamespacePrefixes.Should()
                 .Equal("uri://ed-fi.org", "uri://sample.org");
             _repository.CapturedRequest.AuthorizationContext.CreatorOwnershipTokenId.Should().Be(303);
-            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(404, 202, 404);
+            _repository.CapturedRequest.AuthorizationContext.OwnershipTokenIds.Should().Equal(202, 404);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ApplicationContextRequirementMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ApplicationContextRequirementMiddlewareTests.cs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Frontend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Middleware;
+using EdFi.DataManagementService.Core.Model;
+using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Profile;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Middleware;
+
+[TestFixture]
+public class ApplicationContextRequirementMiddlewareTests
+{
+    private const string ClientId = "client-123";
+    private const string Tenant = "Tenant-A";
+    private static readonly ApplicationContext _applicationContext = new(
+        Id: 1,
+        ApplicationId: 2,
+        ClientId,
+        ClientUuid: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+        DataStoreIds: [3],
+        CreatorOwnershipTokenId: 31415,
+        OwnershipTokenIds: [2718]
+    );
+
+    [Test]
+    public async Task It_requires_application_context_for_POST_regardless_of_strategies()
+    {
+        var provider = CreateProvider(new ApplicationContextResult.Success(_applicationContext));
+        RequestInfo requestInfo = CreateRequestInfo(RequestMethod.POST, provider);
+        var nextCalled = false;
+
+        await CreateMiddleware()
+            .Execute(
+                requestInfo,
+                () =>
+                {
+                    nextCalled = true;
+                    return Task.CompletedTask;
+                }
+            );
+
+        nextCalled.Should().BeTrue();
+        requestInfo.ApplicationContext.Should().BeSameAs(_applicationContext);
+        A.CallTo(() => provider.GetApplicationByClientIdAsync(ClientId, Tenant))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [TestCase("GET")]
+    [TestCase("PUT")]
+    [TestCase("DELETE")]
+    public async Task It_requires_application_context_for_OwnershipBased_resource_actions(string methodName)
+    {
+        var provider = CreateProvider(new ApplicationContextResult.Success(_applicationContext));
+        RequestMethod method = Enum.Parse<RequestMethod>(methodName);
+        RequestInfo requestInfo = CreateRequestInfo(method, provider);
+        requestInfo.ResourceActionAuthStrategies = ["NoFurtherAuthorizationRequired", "OwnershipBased"];
+        var nextCalled = false;
+
+        await CreateMiddleware()
+            .Execute(
+                requestInfo,
+                () =>
+                {
+                    nextCalled = true;
+                    return Task.CompletedTask;
+                }
+            );
+
+        nextCalled.Should().BeTrue();
+        requestInfo.ApplicationContext.Should().BeSameAs(_applicationContext);
+        A.CallTo(() => provider.GetApplicationByClientIdAsync(ClientId, Tenant))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task It_does_not_resolve_application_context_for_an_unrelated_operation()
+    {
+        var provider = CreateProvider(new ApplicationContextResult.Success(_applicationContext));
+        RequestInfo requestInfo = CreateRequestInfo(RequestMethod.GET, provider);
+        requestInfo.ResourceActionAuthStrategies = ["NoFurtherAuthorizationRequired"];
+        var nextCalled = false;
+
+        await CreateMiddleware()
+            .Execute(
+                requestInfo,
+                () =>
+                {
+                    nextCalled = true;
+                    return Task.CompletedTask;
+                }
+            );
+
+        nextCalled.Should().BeTrue();
+        requestInfo.ApplicationContext.Should().BeNull();
+        A.CallTo(() => provider.GetApplicationByClientIdAsync(A<string>._, A<string?>._))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_the_deferred_profile_failure_when_context_is_not_required()
+    {
+        var provider = CreateProvider(new ApplicationContextResult.Success(_applicationContext));
+        RequestInfo requestInfo = CreateRequestInfo(RequestMethod.GET, provider);
+        var deferredResponse = new FrontendResponse(
+            StatusCode: 406,
+            Body: new JsonObject { ["status"] = 406 },
+            Headers: [],
+            ContentType: "application/problem+json"
+        );
+        requestInfo.DeferredProfileContextFailureResponse = deferredResponse;
+
+        await CreateMiddleware().Execute(requestInfo, TestHelper.NullNext);
+
+        requestInfo.FrontendResponse.Should().BeSameAs(deferredResponse);
+        A.CallTo(() => provider.GetApplicationByClientIdAsync(A<string>._, A<string?>._))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_maps_required_NotFound_to_generic_401_before_a_profile_fallback()
+    {
+        var provider = CreateProvider(new ApplicationContextResult.NotFound());
+        RequestInfo requestInfo = CreateRequestInfo(RequestMethod.GET, provider);
+        requestInfo.ResourceActionAuthStrategies = ["OwnershipBased"];
+        requestInfo.DeferredProfileContextFailureResponse = new FrontendResponse(
+            StatusCode: 406,
+            Body: new JsonObject { ["ownershipTokenId"] = 31415 },
+            Headers: []
+        );
+
+        await CreateMiddleware().Execute(requestInfo, TestHelper.NullNext);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(401);
+        TestHelper.AssertUnauthorizedProblemDetails(
+            requestInfo.FrontendResponse,
+            "Unable to resolve application context for the authenticated client."
+        );
+        requestInfo.FrontendResponse.Body!.ToJsonString().Should().NotContain("31415");
+        requestInfo.FrontendResponse.Body!.ToJsonString().Should().NotContain("ownershipTokenId");
+    }
+
+    [Test]
+    public async Task It_maps_required_Unavailable_to_generic_503_without_ownership_values()
+    {
+        var provider = CreateProvider(new ApplicationContextResult.Unavailable());
+        RequestInfo requestInfo = CreateRequestInfo(RequestMethod.DELETE, provider);
+        requestInfo.ResourceActionAuthStrategies = ["OwnershipBased"];
+
+        await CreateMiddleware().Execute(requestInfo, TestHelper.NullNext);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(503);
+        requestInfo.FrontendResponse.Body!["type"]!
+            .GetValue<string>()
+            .Should()
+            .Be("urn:ed-fi:api:service-unavailable");
+        requestInfo.FrontendResponse.Body!.ToJsonString().Should().NotContain("31415");
+        requestInfo.FrontendResponse.Body!.ToJsonString().Should().NotContain("2718");
+        requestInfo.FrontendResponse.Body!.ToJsonString().Should().NotContain("ownershipTokenId");
+    }
+
+    [Test]
+    public async Task It_reuses_the_scoped_profile_lookup_and_gives_required_401_precedence()
+    {
+        var configurationProvider = A.Fake<IConfigurationServiceApplicationProvider>();
+        A.CallTo(() => configurationProvider.GetApplicationByClientIdAsync(ClientId, Tenant))
+            .Returns(new ApplicationContextResult.NotFound());
+        var cachedProvider = new CachedApplicationContextProvider(
+            configurationProvider,
+            CreateHybridCache(),
+            new CacheSettings { ApplicationContextCacheExpirationSeconds = 600 },
+            NullLogger<CachedApplicationContextProvider>.Instance
+        );
+        RequestInfo requestInfo = CreateRequestInfo(RequestMethod.GET, cachedProvider);
+        requestInfo.FrontendRequest = requestInfo.FrontendRequest with
+        {
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Accept"] = "application/vnd.ed-fi.student.testprofile.readable+json",
+            },
+        };
+        var handlerCalled = false;
+        var profileMiddleware = new ProfileResolutionMiddleware(
+            A.Fake<IProfileService>(),
+            NullLogger<ProfileResolutionMiddleware>.Instance
+        );
+
+        await profileMiddleware.Execute(
+            requestInfo,
+            async () =>
+            {
+                requestInfo.ResourceActionAuthStrategies = ["OwnershipBased"];
+                await CreateMiddleware()
+                    .Execute(
+                        requestInfo,
+                        () =>
+                        {
+                            handlerCalled = true;
+                            return Task.CompletedTask;
+                        }
+                    );
+            }
+        );
+
+        handlerCalled.Should().BeFalse();
+        requestInfo.DeferredProfileContextFailureResponse!.StatusCode.Should().Be(406);
+        requestInfo.FrontendResponse.StatusCode.Should().Be(401);
+        A.CallTo(() => configurationProvider.GetApplicationByClientIdAsync(ClientId, Tenant))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    private static ApplicationContextRequirementMiddleware CreateMiddleware() =>
+        new(NullLogger<ApplicationContextRequirementMiddleware>.Instance);
+
+    private static IApplicationContextProvider CreateProvider(ApplicationContextResult result)
+    {
+        var provider = A.Fake<IApplicationContextProvider>();
+        A.CallTo(() => provider.GetApplicationByClientIdAsync(ClientId, Tenant)).Returns(result);
+        return provider;
+    }
+
+    private static RequestInfo CreateRequestInfo(RequestMethod method, IApplicationContextProvider provider)
+    {
+        IServiceProvider scopedServiceProvider = new ServiceCollection()
+            .AddSingleton(provider)
+            .BuildServiceProvider();
+        var frontendRequest = new FrontendRequest(
+            Path: "/ed-fi/students",
+            Body: null,
+            Form: null,
+            Headers: [],
+            QueryParameters: [],
+            TraceId: new TraceId("application-context-requirement"),
+            RouteQualifiers: [],
+            Tenant: Tenant
+        );
+
+        return new RequestInfo(frontendRequest, method, scopedServiceProvider)
+        {
+            ClientAuthorizations = new ClientAuthorizations(
+                TokenId: "token-id",
+                ClientId,
+                ClaimSetName: "claim-set",
+                EducationOrganizationIds: [],
+                NamespacePrefixes: [],
+                DataStoreIds: []
+            ),
+        };
+    }
+
+    private static HybridCache CreateHybridCache()
+    {
+        var services = new ServiceCollection();
+        services.AddMemoryCache();
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ApplicationContextRequirementMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ApplicationContextRequirementMiddlewareTests.cs
@@ -130,26 +130,6 @@ public class ApplicationContextRequirementMiddlewareTests
             .MustNotHaveHappened();
     }
 
-    [Test]
-    public async Task It_returns_the_deferred_profile_failure_when_context_is_not_required()
-    {
-        var provider = CreateProvider(new ApplicationContextResult.Success(_applicationContext));
-        RequestInfo requestInfo = CreateRequestInfo(RequestMethod.GET, provider);
-        var deferredResponse = new FrontendResponse(
-            StatusCode: 406,
-            Body: new JsonObject { ["status"] = 406 },
-            Headers: [],
-            ContentType: "application/problem+json"
-        );
-        requestInfo.DeferredProfileContextFailureResponse = deferredResponse;
-
-        await CreateMiddleware().Execute(requestInfo, TestHelper.NullNext);
-
-        requestInfo.FrontendResponse.Should().BeSameAs(deferredResponse);
-        A.CallTo(() => provider.GetApplicationByClientIdAsync(A<string>._, A<string?>._))
-            .MustNotHaveHappened();
-    }
-
     [TestCase("GET")]
     [TestCase("PUT")]
     public async Task It_maps_a_profile_required_NotFound_to_generic_401_when_context_is_not_otherwise_required(
@@ -197,16 +177,11 @@ public class ApplicationContextRequirementMiddlewareTests
     }
 
     [Test]
-    public async Task It_maps_required_NotFound_to_generic_401_before_a_profile_fallback()
+    public async Task It_maps_required_NotFound_to_generic_401()
     {
         var provider = CreateProvider(new ApplicationContextResult.NotFound());
         RequestInfo requestInfo = CreateRequestInfo(RequestMethod.GET, provider);
         requestInfo.ResourceActionAuthStrategies = ["OwnershipBased"];
-        requestInfo.DeferredProfileContextFailureResponse = new FrontendResponse(
-            StatusCode: 406,
-            Body: new JsonObject { ["ownershipTokenId"] = 31415 },
-            Headers: []
-        );
 
         await CreateMiddleware().Execute(requestInfo, TestHelper.NullNext);
 
@@ -239,7 +214,7 @@ public class ApplicationContextRequirementMiddlewareTests
     }
 
     [Test]
-    public async Task It_reuses_the_scoped_profile_lookup_and_returns_generic_401()
+    public async Task It_resolves_not_found_for_a_profile_with_one_configuration_lookup()
     {
         var configurationProvider = A.Fake<IConfigurationServiceApplicationProvider>();
         A.CallTo(() => configurationProvider.GetApplicationByClientIdAsync(ClientId, Tenant))
@@ -282,10 +257,6 @@ public class ApplicationContextRequirementMiddlewareTests
         );
 
         handlerCalled.Should().BeFalse();
-        TestHelper.AssertUnauthorizedProblemDetails(
-            requestInfo.DeferredProfileContextFailureResponse!,
-            "Unable to resolve application context for the authenticated client."
-        );
         TestHelper.AssertUnauthorizedProblemDetails(
             requestInfo.FrontendResponse,
             "Unable to resolve application context for the authenticated client."

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ApplicationContextRequirementMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ApplicationContextRequirementMiddlewareTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
 using EdFi.DataManagementService.Core.Middleware;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
@@ -90,7 +91,10 @@ public class ApplicationContextRequirementMiddlewareTests
     {
         var provider = CreateProvider(new ApplicationContextResult.Success(_applicationContext));
         RequestInfo requestInfo = CreateRequestInfo(RequestMethod.GET, provider);
-        requestInfo.ResourceActionAuthStrategies = ["NoFurtherAuthorizationRequired"];
+        requestInfo.ResourceActionAuthStrategies =
+        [
+            AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
+        ];
         var nextCalled = false;
 
         await CreateMiddleware()
@@ -104,6 +108,23 @@ public class ApplicationContextRequirementMiddlewareTests
             );
 
         nextCalled.Should().BeTrue();
+        requestInfo.ApplicationContext.Should().BeNull();
+        A.CallTo(() => provider.GetApplicationByClientIdAsync(A<string>._, A<string?>._))
+            .MustNotHaveHappened();
+    }
+
+    [TestCase("PUT")]
+    [TestCase("DELETE")]
+    public async Task It_does_not_resolve_application_context_for_non_ownership_resource_actions(
+        string methodName
+    )
+    {
+        var provider = CreateProvider(new ApplicationContextResult.Success(_applicationContext));
+        RequestInfo requestInfo = CreateRequestInfo(Enum.Parse<RequestMethod>(methodName), provider);
+        requestInfo.ResourceActionAuthStrategies = ["NoFurtherAuthorizationRequired"];
+
+        await CreateMiddleware().Execute(requestInfo, TestHelper.NullNext);
+
         requestInfo.ApplicationContext.Should().BeNull();
         A.CallTo(() => provider.GetApplicationByClientIdAsync(A<string>._, A<string?>._))
             .MustNotHaveHappened();

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ApplicationContextRequirementMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ApplicationContextRequirementMiddlewareTests.cs
@@ -150,6 +150,52 @@ public class ApplicationContextRequirementMiddlewareTests
             .MustNotHaveHappened();
     }
 
+    [TestCase("GET")]
+    [TestCase("PUT")]
+    public async Task It_maps_a_profile_required_NotFound_to_generic_401_when_context_is_not_otherwise_required(
+        string methodName
+    )
+    {
+        RequestMethod method = Enum.Parse<RequestMethod>(methodName);
+        var provider = CreateProvider(new ApplicationContextResult.NotFound());
+        RequestInfo requestInfo = CreateRequestInfo(method, provider);
+        requestInfo.FrontendRequest = requestInfo.FrontendRequest with
+        {
+            Headers = CreateProfileHeaders(method),
+        };
+
+        await ExecuteProfileAndApplicationContextRequirementMiddlewareAsync(requestInfo);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(401);
+        TestHelper.AssertUnauthorizedProblemDetails(
+            requestInfo.FrontendResponse,
+            "Unable to resolve application context for the authenticated client."
+        );
+    }
+
+    [TestCase("GET")]
+    [TestCase("PUT")]
+    public async Task It_maps_a_profile_required_Unavailable_to_generic_503_when_context_is_not_otherwise_required(
+        string methodName
+    )
+    {
+        RequestMethod method = Enum.Parse<RequestMethod>(methodName);
+        var provider = CreateProvider(new ApplicationContextResult.Unavailable());
+        RequestInfo requestInfo = CreateRequestInfo(method, provider);
+        requestInfo.FrontendRequest = requestInfo.FrontendRequest with
+        {
+            Headers = CreateProfileHeaders(method),
+        };
+
+        await ExecuteProfileAndApplicationContextRequirementMiddlewareAsync(requestInfo);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(503);
+        requestInfo.FrontendResponse.Body!["type"]!
+            .GetValue<string>()
+            .Should()
+            .Be("urn:ed-fi:api:service-unavailable");
+    }
+
     [Test]
     public async Task It_maps_required_NotFound_to_generic_401_before_a_profile_fallback()
     {
@@ -193,7 +239,7 @@ public class ApplicationContextRequirementMiddlewareTests
     }
 
     [Test]
-    public async Task It_reuses_the_scoped_profile_lookup_and_gives_required_401_precedence()
+    public async Task It_reuses_the_scoped_profile_lookup_and_returns_generic_401()
     {
         var configurationProvider = A.Fake<IConfigurationServiceApplicationProvider>();
         A.CallTo(() => configurationProvider.GetApplicationByClientIdAsync(ClientId, Tenant))
@@ -236,14 +282,56 @@ public class ApplicationContextRequirementMiddlewareTests
         );
 
         handlerCalled.Should().BeFalse();
-        requestInfo.DeferredProfileContextFailureResponse!.StatusCode.Should().Be(406);
-        requestInfo.FrontendResponse.StatusCode.Should().Be(401);
+        TestHelper.AssertUnauthorizedProblemDetails(
+            requestInfo.DeferredProfileContextFailureResponse!,
+            "Unable to resolve application context for the authenticated client."
+        );
+        TestHelper.AssertUnauthorizedProblemDetails(
+            requestInfo.FrontendResponse,
+            "Unable to resolve application context for the authenticated client."
+        );
         A.CallTo(() => configurationProvider.GetApplicationByClientIdAsync(ClientId, Tenant))
             .MustHaveHappenedOnceExactly();
     }
 
     private static ApplicationContextRequirementMiddleware CreateMiddleware() =>
         new(NullLogger<ApplicationContextRequirementMiddleware>.Instance);
+
+    private static async Task ExecuteProfileAndApplicationContextRequirementMiddlewareAsync(
+        RequestInfo requestInfo
+    )
+    {
+        var profileMiddleware = new ProfileResolutionMiddleware(
+            A.Fake<IProfileService>(),
+            NullLogger<ProfileResolutionMiddleware>.Instance
+        );
+
+        await profileMiddleware.Execute(
+            requestInfo,
+            async () =>
+            {
+                requestInfo.ResourceActionAuthStrategies =
+                [
+                    AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
+                ];
+                await CreateMiddleware().Execute(requestInfo, TestHelper.NullNext);
+            }
+        );
+    }
+
+    private static Dictionary<string, string> CreateProfileHeaders(RequestMethod method) =>
+        method switch
+        {
+            RequestMethod.GET => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Accept"] = "application/vnd.ed-fi.student.testprofile.readable+json",
+            },
+            RequestMethod.PUT => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = "application/vnd.ed-fi.student.testprofile.writable+json",
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(method), method, null),
+        };
 
     private static IApplicationContextProvider CreateProvider(ApplicationContextResult result)
     {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileResolutionMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileResolutionMiddlewareTests.cs
@@ -224,9 +224,69 @@ public class ProfileResolutionMiddlewareTests
         }
 
         [Test]
-        public void It_calls_next()
+        public void It_does_not_call_next()
         {
-            _nextCalled.Should().BeTrue();
+            _nextCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void It_returns_generic_401()
+        {
+            TestHelper.AssertUnauthorizedProblemDetails(
+                _requestInfo.FrontendResponse,
+                "Unable to resolve application context for the authenticated client."
+            );
+        }
+    }
+
+    [TestFixture]
+    public class Given_Unavailable_Application_Context_And_No_Profile_Header
+        : ProfileResolutionMiddlewareTests
+    {
+        private RequestInfo _requestInfo = null!;
+        private bool _nextCalled;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var appContextProvider = A.Fake<IApplicationContextProvider>();
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(
+                    Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.Unavailable())
+                );
+
+            _requestInfo = CreateRequestInfo(
+                RequestMethod.GET,
+                scopedServiceProvider: BuildScopedServiceProvider(appContextProvider)
+            );
+            _nextCalled = false;
+
+            var middleware = CreateMiddleware();
+
+            await middleware.Execute(
+                _requestInfo,
+                () =>
+                {
+                    _nextCalled = true;
+                    return Task.CompletedTask;
+                }
+            );
+        }
+
+        [Test]
+        public void It_does_not_call_next()
+        {
+            _nextCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void It_returns_generic_503()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(503);
+            _requestInfo.FrontendResponse.Body!["type"]!
+                .GetValue<string>()
+                .Should()
+                .Be("urn:ed-fi:api:service-unavailable");
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileResolutionMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileResolutionMiddlewareTests.cs
@@ -268,16 +268,20 @@ public class ProfileResolutionMiddlewareTests
         }
 
         [Test]
-        public void It_calls_next_to_allow_strategy_selection()
+        public void It_returns_the_fail_closed_response_without_continuing_the_pipeline()
         {
-            _nextCalled.Should().BeTrue();
+            _nextCalled.Should().BeFalse();
+            TestHelper.AssertUnauthorizedProblemDetails(
+                _requestInfo.FrontendResponse!,
+                "Unable to resolve application context for the authenticated client."
+            );
         }
 
         [Test]
-        public void It_defers_generic_401_for_GET()
+        public void It_returns_generic_401_for_GET()
         {
             TestHelper.AssertUnauthorizedProblemDetails(
-                _requestInfo.DeferredProfileContextFailureResponse!,
+                _requestInfo.FrontendResponse,
                 "Unable to resolve application context for the authenticated client."
             );
         }
@@ -286,7 +290,7 @@ public class ProfileResolutionMiddlewareTests
         public void It_returns_the_expected_application_context_failure_payload()
         {
             TestHelper.AssertUnauthorizedProblemDetails(
-                _requestInfo.DeferredProfileContextFailureResponse!,
+                _requestInfo.FrontendResponse,
                 "Unable to resolve application context for the authenticated client."
             );
         }
@@ -321,10 +325,10 @@ public class ProfileResolutionMiddlewareTests
         }
 
         [Test]
-        public void It_defers_generic_401_for_POST()
+        public void It_returns_generic_401_for_POST()
         {
             TestHelper.AssertUnauthorizedProblemDetails(
-                _requestInfo.DeferredProfileContextFailureResponse!,
+                _requestInfo.FrontendResponse,
                 "Unable to resolve application context for the authenticated client."
             );
         }
@@ -333,7 +337,7 @@ public class ProfileResolutionMiddlewareTests
         public void It_returns_the_expected_application_context_failure_payload()
         {
             TestHelper.AssertUnauthorizedProblemDetails(
-                _requestInfo.DeferredProfileContextFailureResponse!,
+                _requestInfo.FrontendResponse,
                 "Unable to resolve application context for the authenticated client."
             );
         }
@@ -368,10 +372,10 @@ public class ProfileResolutionMiddlewareTests
         }
 
         [Test]
-        public void It_defers_generic_401_for_PUT()
+        public void It_returns_generic_401_for_PUT()
         {
             TestHelper.AssertUnauthorizedProblemDetails(
-                _requestInfo.DeferredProfileContextFailureResponse!,
+                _requestInfo.FrontendResponse,
                 "Unable to resolve application context for the authenticated client."
             );
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileResolutionMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileResolutionMiddlewareTests.cs
@@ -66,8 +66,10 @@ public class ProfileResolutionMiddlewareTests
 
         if (appContextProvider is null)
         {
-            A.CallTo(() => applicationContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(Task.FromResult<ApplicationContext?>(null));
+            A.CallTo(() =>
+                    applicationContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null)
+                )
+                .Returns(Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound()));
         }
 
         return new ServiceCollection()
@@ -83,7 +85,9 @@ public class ProfileResolutionMiddlewareTests
             ApplicationId: applicationId,
             ClientId: "client123",
             ClientUuid: Guid.NewGuid(),
-            DataStoreIds: []
+            DataStoreIds: [],
+            CreatorOwnershipTokenId: null,
+            OwnershipTokenIds: []
         );
 
     private static RequestInfo CreateRequestInfo(
@@ -198,8 +202,8 @@ public class ProfileResolutionMiddlewareTests
         public async Task Setup()
         {
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(Task.FromResult<ApplicationContext?>(null));
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.GET,
@@ -241,8 +245,8 @@ public class ProfileResolutionMiddlewareTests
             };
 
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(Task.FromResult<ApplicationContext?>(null));
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.GET,
@@ -264,22 +268,22 @@ public class ProfileResolutionMiddlewareTests
         }
 
         [Test]
-        public void It_does_not_call_next()
+        public void It_calls_next_to_allow_strategy_selection()
         {
-            _nextCalled.Should().BeFalse();
+            _nextCalled.Should().BeTrue();
         }
 
         [Test]
         public void It_returns_406_for_GET()
         {
-            _requestInfo.FrontendResponse!.StatusCode.Should().Be(406);
+            _requestInfo.DeferredProfileContextFailureResponse!.StatusCode.Should().Be(406);
         }
 
         [Test]
         public void It_returns_the_expected_problem_details_payload()
         {
             AssertExpectedProblemDetailsResponse(
-                _requestInfo.FrontendResponse!,
+                _requestInfo.DeferredProfileContextFailureResponse!,
                 expectedStatusCode: 406,
                 expectedType: "urn:ed-fi:api:profile:invalid-profile-usage",
                 expectedTitle: "Invalid Profile Usage",
@@ -304,8 +308,8 @@ public class ProfileResolutionMiddlewareTests
             };
 
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(Task.FromResult<ApplicationContext?>(null));
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.POST,
@@ -321,14 +325,14 @@ public class ProfileResolutionMiddlewareTests
         [Test]
         public void It_returns_415_for_POST()
         {
-            _requestInfo.FrontendResponse!.StatusCode.Should().Be(415);
+            _requestInfo.DeferredProfileContextFailureResponse!.StatusCode.Should().Be(415);
         }
 
         [Test]
         public void It_returns_the_expected_problem_details_payload()
         {
             AssertExpectedProblemDetailsResponse(
-                _requestInfo.FrontendResponse!,
+                _requestInfo.DeferredProfileContextFailureResponse!,
                 expectedStatusCode: 415,
                 expectedType: "urn:ed-fi:api:profile:invalid-profile-usage",
                 expectedTitle: "Invalid Profile Usage",
@@ -353,8 +357,8 @@ public class ProfileResolutionMiddlewareTests
             };
 
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(Task.FromResult<ApplicationContext?>(null));
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.PUT,
@@ -370,7 +374,7 @@ public class ProfileResolutionMiddlewareTests
         [Test]
         public void It_returns_415_for_PUT()
         {
-            _requestInfo.FrontendResponse!.StatusCode.Should().Be(415);
+            _requestInfo.DeferredProfileContextFailureResponse!.StatusCode.Should().Be(415);
         }
     }
 
@@ -389,8 +393,8 @@ public class ProfileResolutionMiddlewareTests
             };
 
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(CreateApplicationContext());
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(new ApplicationContextResult.Success(CreateApplicationContext()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.GET,
@@ -481,8 +485,8 @@ public class ProfileResolutionMiddlewareTests
             };
 
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(CreateApplicationContext());
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(new ApplicationContextResult.Success(CreateApplicationContext()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.GET,
@@ -555,8 +559,8 @@ public class ProfileResolutionMiddlewareTests
         public async Task Setup()
         {
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(CreateApplicationContext());
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(new ApplicationContextResult.Success(CreateApplicationContext()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.GET,
@@ -616,8 +620,8 @@ public class ProfileResolutionMiddlewareTests
             };
 
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(CreateApplicationContext());
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(new ApplicationContextResult.Success(CreateApplicationContext()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.PUT,
@@ -690,8 +694,8 @@ public class ProfileResolutionMiddlewareTests
         public async Task Setup()
         {
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(CreateApplicationContext());
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(new ApplicationContextResult.Success(CreateApplicationContext()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.DELETE,
@@ -761,8 +765,8 @@ public class ProfileResolutionMiddlewareTests
             };
 
             var appContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                .Returns(CreateApplicationContext());
+            A.CallTo(() => appContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null))
+                .Returns(new ApplicationContextResult.Success(CreateApplicationContext()));
 
             _requestInfo = CreateRequestInfo(
                 RequestMethod.GET,
@@ -828,12 +832,16 @@ public class ProfileResolutionMiddlewareTests
         public async Task Setup()
         {
             _firstApplicationContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => _firstApplicationContextProvider.GetApplicationByClientIdAsync("client123"))
-                .Returns(CreateApplicationContext(11));
+            A.CallTo(() =>
+                    _firstApplicationContextProvider.GetApplicationByClientIdAsync("client123", tenant: null)
+                )
+                .Returns(new ApplicationContextResult.Success(CreateApplicationContext(11)));
 
             _secondApplicationContextProvider = A.Fake<IApplicationContextProvider>();
-            A.CallTo(() => _secondApplicationContextProvider.GetApplicationByClientIdAsync("client123"))
-                .Returns(CreateApplicationContext(22));
+            A.CallTo(() =>
+                    _secondApplicationContextProvider.GetApplicationByClientIdAsync("client123", tenant: null)
+                )
+                .Returns(new ApplicationContextResult.Success(CreateApplicationContext(22)));
 
             _profileService = A.Fake<IProfileService>();
             A.CallTo(() =>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileResolutionMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileResolutionMiddlewareTests.cs
@@ -274,22 +274,20 @@ public class ProfileResolutionMiddlewareTests
         }
 
         [Test]
-        public void It_returns_406_for_GET()
+        public void It_defers_generic_401_for_GET()
         {
-            _requestInfo.DeferredProfileContextFailureResponse!.StatusCode.Should().Be(406);
+            TestHelper.AssertUnauthorizedProblemDetails(
+                _requestInfo.DeferredProfileContextFailureResponse!,
+                "Unable to resolve application context for the authenticated client."
+            );
         }
 
         [Test]
-        public void It_returns_the_expected_problem_details_payload()
+        public void It_returns_the_expected_application_context_failure_payload()
         {
-            AssertExpectedProblemDetailsResponse(
+            TestHelper.AssertUnauthorizedProblemDetails(
                 _requestInfo.DeferredProfileContextFailureResponse!,
-                expectedStatusCode: 406,
-                expectedType: "urn:ed-fi:api:profile:invalid-profile-usage",
-                expectedTitle: "Invalid Profile Usage",
-                expectedDetail: "The request construction was invalid with respect to usage of a data policy.",
-                expectedCorrelationId: "test-trace-id",
-                "Unable to resolve application context for profile validation."
+                "Unable to resolve application context for the authenticated client."
             );
         }
     }
@@ -323,22 +321,20 @@ public class ProfileResolutionMiddlewareTests
         }
 
         [Test]
-        public void It_returns_415_for_POST()
+        public void It_defers_generic_401_for_POST()
         {
-            _requestInfo.DeferredProfileContextFailureResponse!.StatusCode.Should().Be(415);
+            TestHelper.AssertUnauthorizedProblemDetails(
+                _requestInfo.DeferredProfileContextFailureResponse!,
+                "Unable to resolve application context for the authenticated client."
+            );
         }
 
         [Test]
-        public void It_returns_the_expected_problem_details_payload()
+        public void It_returns_the_expected_application_context_failure_payload()
         {
-            AssertExpectedProblemDetailsResponse(
+            TestHelper.AssertUnauthorizedProblemDetails(
                 _requestInfo.DeferredProfileContextFailureResponse!,
-                expectedStatusCode: 415,
-                expectedType: "urn:ed-fi:api:profile:invalid-profile-usage",
-                expectedTitle: "Invalid Profile Usage",
-                expectedDetail: "The request construction was invalid with respect to usage of a data policy.",
-                expectedCorrelationId: "test-trace-id",
-                "Unable to resolve application context for profile validation."
+                "Unable to resolve application context for the authenticated client."
             );
         }
     }
@@ -372,9 +368,12 @@ public class ProfileResolutionMiddlewareTests
         }
 
         [Test]
-        public void It_returns_415_for_PUT()
+        public void It_defers_generic_401_for_PUT()
         {
-            _requestInfo.DeferredProfileContextFailureResponse!.StatusCode.Should().Be(415);
+            TestHelper.AssertUnauthorizedProblemDetails(
+                _requestInfo.DeferredProfileContextFailureResponse!,
+                "Unable to resolve application context for the authenticated client."
+            );
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
@@ -647,6 +647,42 @@ public class PipelineOrderingTests
     public class Given_The_Routed_Resource_Pipelines : PipelineOrderingTests
     {
         [TestCase("CreateUpsertPipeline")]
+        [TestCase("CreateGetByIdPipeline")]
+        [TestCase("CreateQueryPipeline")]
+        [TestCase("CreateGetPartitionsPipeline")]
+        [TestCase("CreateUpdatePipeline")]
+        [TestCase("CreateDeleteByIdPipeline")]
+        [TestCase("CreateGetTrackedChangesPipeline")]
+        public void It_places_the_application_context_gate_immediately_after_strategy_selection(
+            string factoryMethodName
+        )
+        {
+            var stepTypes = GetRoutedResourcePipelineStepTypes(factoryMethodName);
+            var authorizationIndex = stepTypes.IndexOf(typeof(ResourceActionAuthorizationMiddleware));
+            var requirementIndex = stepTypes.LastIndexOf(typeof(ApplicationContextRequirementMiddleware));
+
+            authorizationIndex.Should().BeGreaterThanOrEqualTo(0);
+            requirementIndex
+                .Should()
+                .Be(
+                    authorizationIndex + 1,
+                    "the selected strategies must be available before application context is demanded"
+                );
+        }
+
+        [Test]
+        public void It_places_the_POST_demand_after_authentication_and_before_profile_resolution()
+        {
+            var stepTypes = GetRoutedResourcePipelineStepTypes("CreateUpsertPipeline");
+            var authenticationIndex = stepTypes.IndexOf(typeof(JwtAuthenticationMiddleware));
+            var requirementIndex = stepTypes.IndexOf(typeof(ApplicationContextRequirementMiddleware));
+            var profileIndex = stepTypes.IndexOf(typeof(ProfileResolutionMiddleware));
+
+            requirementIndex.Should().BeGreaterThan(authenticationIndex);
+            requirementIndex.Should().BeLessThan(profileIndex);
+        }
+
+        [TestCase("CreateUpsertPipeline")]
         [TestCase("CreateUpdatePipeline")]
         [TestCase("CreateDeleteByIdPipeline")]
         public void It_places_validate_route_semantics_after_validate_endpoint(string factoryMethodName)

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/StampedeProtectionTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/StampedeProtectionTests.cs
@@ -116,7 +116,7 @@ public class StampedeProtectionTests
             _factoryExecutionCount = 0;
             _mockProvider = A.Fake<IConfigurationServiceApplicationProvider>();
 
-            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync(A<string>.Ignored))
+            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync(A<string>.Ignored, tenant: null))
                 .ReturnsLazily(_ => FetchApplicationContextAsync());
 
             _cachedProvider = new CachedApplicationContextProvider(
@@ -127,64 +127,90 @@ public class StampedeProtectionTests
             );
         }
 
-        private async Task<ApplicationContext?> FetchApplicationContextAsync()
+        private async Task<ApplicationContextResult> FetchApplicationContextAsync()
         {
             Interlocked.Increment(ref _factoryExecutionCount);
             await Task.Delay(100);
-            return new ApplicationContext(1, 100, "testClient", Guid.NewGuid(), [1, 2, 3]);
+            return new ApplicationContextResult.Success(
+                new ApplicationContext(1, 100, "testClient", Guid.NewGuid(), [1, 2, 3], null, [])
+            );
         }
 
         [Test]
-        public async Task It_Should_Execute_Factory_Only_Once_For_Same_ClientId()
+        public async Task It_Should_Memoize_The_First_Lookup_Task_For_Concurrent_Calls_In_The_Same_Scope()
         {
-            // Arrange
-            const string clientId = "test-client";
-            var tasks = Enumerable
-                .Range(0, 10)
-                .Select(_ => _cachedProvider.GetApplicationByClientIdAsync(clientId))
-                .ToList();
+            var tasks = new[]
+            {
+                _cachedProvider.GetApplicationByClientIdAsync("first-client", tenant: null),
+                _cachedProvider.GetApplicationByClientIdAsync("second-client", "north"),
+                _cachedProvider.GetApplicationByClientIdAsync("third-client", "south"),
+            };
 
-            // Act
             var results = await Task.WhenAll(tasks);
 
-            // Assert: Factory should execute only once for same clientId
             _factoryExecutionCount.Should().Be(1);
-
-            // All results should be non-null
-            results.Should().AllSatisfy(r => r.Should().NotBeNull());
+            results.Should().AllSatisfy(result => result.Should().BeSameAs(results[0]));
+            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync("first-client", tenant: null))
+                .MustHaveHappenedOnceExactly();
+            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync(A<string>.Ignored, A<string?>.Ignored))
+                .MustHaveHappenedOnceExactly();
         }
 
         [Test]
-        public async Task It_Should_Execute_Factory_Separately_For_Different_ClientIds()
+        public async Task It_Should_Coalesce_The_Same_Key_Across_Independent_Scopes()
         {
-            // Arrange - Reset factory count and reconfigure mock
-            _factoryExecutionCount = 0;
-            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync(A<string>.Ignored))
-                .ReturnsLazily(call =>
-                {
-                    var clientId = call.GetArgument<string>(0) ?? "unknown";
-                    return FetchApplicationContextForClientAsync(clientId);
-                });
+            HybridCache sharedHybridCache = CreateHybridCache();
+            var firstScopeProvider = new CachedApplicationContextProvider(
+                _mockProvider,
+                sharedHybridCache,
+                CreateCacheSettings(),
+                NullLogger<CachedApplicationContextProvider>.Instance
+            );
+            var secondScopeProvider = new CachedApplicationContextProvider(
+                _mockProvider,
+                sharedHybridCache,
+                CreateCacheSettings(),
+                NullLogger<CachedApplicationContextProvider>.Instance
+            );
 
             var tasks = new[]
             {
-                _cachedProvider.GetApplicationByClientIdAsync("client1"),
-                _cachedProvider.GetApplicationByClientIdAsync("client2"),
-                _cachedProvider.GetApplicationByClientIdAsync("client3"),
+                firstScopeProvider.GetApplicationByClientIdAsync("client-id", tenant: null),
+                secondScopeProvider.GetApplicationByClientIdAsync("client-id", tenant: null),
             };
 
-            // Act
-            await Task.WhenAll(tasks);
+            var results = await Task.WhenAll(tasks);
 
-            // Assert: Each unique client should trigger factory once
-            _factoryExecutionCount.Should().Be(3);
+            _factoryExecutionCount.Should().Be(1);
+            var applicationContexts = results
+                .Select(result =>
+                    result.Should().BeOfType<ApplicationContextResult.Success>().Subject.ApplicationContext
+                )
+                .ToArray();
+            applicationContexts.Should().AllBeEquivalentTo(applicationContexts[0]);
         }
 
-        private async Task<ApplicationContext?> FetchApplicationContextForClientAsync(string clientId)
+        [Test]
+        public async Task It_Should_Execute_Factories_Independently_For_Distinct_Keys_Across_Scopes()
         {
-            Interlocked.Increment(ref _factoryExecutionCount);
-            await Task.Delay(50);
-            return new ApplicationContext(1, 100, clientId, Guid.NewGuid(), [1, 2, 3]);
+            HybridCache sharedHybridCache = CreateHybridCache();
+            var providers = Enumerable
+                .Range(0, 3)
+                .Select(_ => new CachedApplicationContextProvider(
+                    _mockProvider,
+                    sharedHybridCache,
+                    CreateCacheSettings(),
+                    NullLogger<CachedApplicationContextProvider>.Instance
+                ))
+                .ToArray();
+
+            await Task.WhenAll(
+                providers[0].GetApplicationByClientIdAsync("client1", tenant: null),
+                providers[1].GetApplicationByClientIdAsync("client2", tenant: null),
+                providers[2].GetApplicationByClientIdAsync("client3", tenant: null)
+            );
+
+            _factoryExecutionCount.Should().Be(3);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/StampedeProtectionTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/StampedeProtectionTests.cs
@@ -116,7 +116,7 @@ public class StampedeProtectionTests
             _factoryExecutionCount = 0;
             _mockProvider = A.Fake<IConfigurationServiceApplicationProvider>();
 
-            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync(A<string>.Ignored, tenant: null))
+            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync(A<string>.Ignored, A<string?>.Ignored))
                 .ReturnsLazily(_ => FetchApplicationContextAsync());
 
             _cachedProvider = new CachedApplicationContextProvider(
@@ -137,7 +137,7 @@ public class StampedeProtectionTests
         }
 
         [Test]
-        public async Task It_Should_Memoize_The_First_Lookup_Task_For_Concurrent_Calls_In_The_Same_Scope()
+        public async Task It_Should_Memoize_Each_Lookup_Task_By_Client_And_Tenant_In_The_Same_Scope()
         {
             var tasks = new[]
             {
@@ -148,11 +148,15 @@ public class StampedeProtectionTests
 
             var results = await Task.WhenAll(tasks);
 
-            _factoryExecutionCount.Should().Be(1);
-            results.Should().AllSatisfy(result => result.Should().BeSameAs(results[0]));
+            _factoryExecutionCount.Should().Be(3);
+            results
+                .Should()
+                .AllSatisfy(result => result.Should().BeOfType<ApplicationContextResult.Success>());
             A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync("first-client", tenant: null))
                 .MustHaveHappenedOnceExactly();
-            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync(A<string>.Ignored, A<string?>.Ignored))
+            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync("second-client", "north"))
+                .MustHaveHappenedOnceExactly();
+            A.CallTo(() => _mockProvider.GetApplicationByClientIdAsync("third-client", "south"))
                 .MustHaveHappenedOnceExactly();
         }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
@@ -41,6 +41,7 @@ internal class ApiService : IApiService
     private readonly IDecimalValidator _decimalValidator;
     private readonly ILogger<ApiService> _logger;
     private readonly ILogger<RequestResponseLoggingMiddleware> _requestResponseLogger;
+    private readonly ILogger<ApplicationContextRequirementMiddleware> _applicationContextRequirementLogger;
     private readonly IOptions<AppSettings> _appSettings;
     private readonly ResiliencePipeline _resiliencePipeline;
     private readonly CircuitBreakerSettings _circuitBreakerSettings;
@@ -157,6 +158,8 @@ internal class ApiService : IApiService
         _decimalValidator = decimalValidator;
         _logger = logger;
         _requestResponseLogger = loggerFactory.CreateLogger<RequestResponseLoggingMiddleware>();
+        _applicationContextRequirementLogger =
+            loggerFactory.CreateLogger<ApplicationContextRequirementMiddleware>();
         _appSettings = appSettings;
         _resiliencePipeline = resiliencePipeline;
         _resourceLoadCalculator = resourceLoadCalculator;
@@ -227,6 +230,7 @@ internal class ApiService : IApiService
             new ParseBodyMiddleware(_logger),
             new RequestInfoBodyLoggingMiddleware(_logger, _appSettings.Value.MaskRequestBodyInLogs),
             new DuplicatePropertiesMiddleware(_logger),
+            new ApplicationContextRequirementMiddleware(_applicationContextRequirementLogger),
             _serviceProvider.GetRequiredService<ProfileResolutionMiddleware>(),
             new RejectResourceIdentifierMiddleware(_logger),
             new CoerceDateFormatMiddleware(_logger),
@@ -257,6 +261,7 @@ internal class ApiService : IApiService
             new ArrayUniquenessValidationMiddleware(_logger),
             new InjectVersionMetadataToEdFiDocumentMiddleware(_logger),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
+            new ApplicationContextRequirementMiddleware(_applicationContextRequirementLogger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
             new UpsertHandler(_logger, _resiliencePipeline),
         ]);
@@ -277,6 +282,7 @@ internal class ApiService : IApiService
                 _appSettings.Value.AllowIdentityUpdateOverrides.Split(',').ToList()
             ),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
+            new ApplicationContextRequirementMiddleware(_applicationContextRequirementLogger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
             new GetByIdHandler(_logger, _resiliencePipeline),
         ]);
@@ -304,6 +310,7 @@ internal class ApiService : IApiService
                 _appSettings.Value.UseLegacyDocumentIdOrderingForChangeQueries
             ),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
+            new ApplicationContextRequirementMiddleware(_applicationContextRequirementLogger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
             new QueryRequestHandler(
                 _logger,
@@ -345,6 +352,7 @@ internal class ApiService : IApiService
                 _appSettings.Value.UseLegacyDocumentIdOrderingForChangeQueries
             ),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
+            new ApplicationContextRequirementMiddleware(_applicationContextRequirementLogger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
             new PartitionRequestHandler(
                 _logger,
@@ -399,6 +407,7 @@ internal class ApiService : IApiService
             new ArrayUniquenessValidationMiddleware(_logger),
             new InjectVersionMetadataToEdFiDocumentMiddleware(_logger),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
+            new ApplicationContextRequirementMiddleware(_applicationContextRequirementLogger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
             new UpdateByIdHandler(_logger, _resiliencePipeline),
         ]);
@@ -418,6 +427,7 @@ internal class ApiService : IApiService
                 _appSettings.Value.AllowIdentityUpdateOverrides.Split(',').ToList()
             ),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
+            new ApplicationContextRequirementMiddleware(_applicationContextRequirementLogger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
             new DeleteByIdHandler(_logger, _resiliencePipeline),
         ]);
@@ -485,6 +495,7 @@ internal class ApiService : IApiService
             ),
             new ValidateTrackedChangeQueryMiddleware(_logger),
             new ResourceActionAuthorizationMiddleware(_claimSetProvider, _logger),
+            new ApplicationContextRequirementMiddleware(_applicationContextRequirementLogger),
             new ProvideAuthorizationFiltersMiddleware(_logger),
             new TrackedChangeQueryRequestHandler(_logger, _resiliencePipeline),
         ]);

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ApplicationContext.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ApplicationContext.cs
@@ -28,5 +28,13 @@ public record ApplicationContext(
     /// <summary>
     /// List of data store IDs this application is authorized to access
     /// </summary>
-    List<long> DataStoreIds
+    List<long> DataStoreIds,
+    /// <summary>
+    /// Ownership token that created the application, when configured
+    /// </summary>
+    short? CreatorOwnershipTokenId,
+    /// <summary>
+    /// Ownership tokens assigned to the application
+    /// </summary>
+    IReadOnlyList<short> OwnershipTokenIds
 );

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ApplicationContextResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ApplicationContextResult.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.Configuration;
+
+/// <summary>
+/// Represents the outcome of resolving an application context.
+/// </summary>
+public abstract record ApplicationContextResult
+{
+    private ApplicationContextResult() { }
+
+    /// <summary>
+    /// An application context was resolved successfully.
+    /// </summary>
+    public sealed record Success(ApplicationContext ApplicationContext) : ApplicationContextResult;
+
+    /// <summary>
+    /// No application context exists for the requested client.
+    /// </summary>
+    public sealed record NotFound : ApplicationContextResult;
+
+    /// <summary>
+    /// The application context could not be resolved.
+    /// </summary>
+    public sealed record Unavailable : ApplicationContextResult;
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/CacheSettings.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/CacheSettings.cs
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using Microsoft.Extensions.Options;
+
 namespace EdFi.DataManagementService.Core.Configuration;
 
 /// <summary>
@@ -26,4 +28,15 @@ public class CacheSettings
     /// Set to 0 or a negative value to keep the cached configuration until the next explicit reload.
     /// </summary>
     public int DataStoreCacheExpirationSeconds { get; set; } = 600; // 10 minutes
+}
+
+public sealed class CacheSettingsValidator : IValidateOptions<CacheSettings>
+{
+    public const string ApplicationContextExpirationValidationError =
+        "ApplicationContextCacheExpirationSeconds must be positive.";
+
+    public ValidateOptionsResult Validate(string? name, CacheSettings options) =>
+        options.ApplicationContextCacheExpirationSeconds > 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(ApplicationContextExpirationValidationError);
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/CachedApplicationContextProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/CachedApplicationContextProvider.cs
@@ -21,92 +21,115 @@ public class CachedApplicationContextProvider(
 ) : IApplicationContextProvider
 {
     private const string CacheKeyPrefix = "ApplicationContext";
+    private readonly HybridCacheEntryOptions _cacheEntryOptions = new()
+    {
+        Expiration = TimeSpan.FromSeconds(cacheSettings.ApplicationContextCacheExpirationSeconds),
+        LocalCacheExpiration = TimeSpan.FromSeconds(cacheSettings.ApplicationContextCacheExpirationSeconds),
+    };
+    private Lazy<Task<ApplicationContextResult>>? _requestResult;
 
     /// <summary>
-    /// Gets the cache key for a client ID.
+    /// Gets the cache key for a client ID and tenant.
     /// </summary>
-    private static string GetCacheKey(string clientId) => $"{CacheKeyPrefix}:{clientId}";
+    private static string GetCacheKey(string clientId, string? tenant) =>
+        tenant is null
+            ? $"{CacheKeyPrefix}:single:{clientId}"
+            : $"{CacheKeyPrefix}:tenant:{tenant.ToLowerInvariant()}:{clientId}";
 
     /// <inheritdoc />
-    public async Task<ApplicationContext?> GetApplicationByClientIdAsync(string clientId)
+    public Task<ApplicationContextResult> GetApplicationByClientIdAsync(string clientId, string? tenant)
+    {
+        var firstLookup = new Lazy<Task<ApplicationContextResult>>(
+            () => GetFirstApplicationContextAsync(clientId, tenant),
+            LazyThreadSafetyMode.ExecutionAndPublication
+        );
+        Lazy<Task<ApplicationContextResult>> requestResult =
+            Interlocked.CompareExchange(ref _requestResult, firstLookup, null) ?? firstLookup;
+
+        return requestResult.Value;
+    }
+
+    private async Task<ApplicationContextResult> GetFirstApplicationContextAsync(
+        string clientId,
+        string? tenant
+    )
     {
         if (string.IsNullOrWhiteSpace(clientId))
         {
             logger.LogWarning("GetApplicationByClientIdAsync called with null or empty clientId");
-            return null;
+            return new ApplicationContextResult.Unavailable();
         }
 
-        var cacheKey = GetCacheKey(clientId);
-
-        // HybridCache.GetOrCreateAsync provides stampede protection:
-        // Only one concurrent caller executes the factory; others wait for the result
-        return await hybridCache.GetOrCreateAsync(
-            cacheKey,
-            async cancel =>
-            {
-                // First attempt
-                var context = await configurationServiceApplicationProvider.GetApplicationByClientIdAsync(
-                    clientId
-                );
-
-                if (context != null)
-                {
-                    return context;
-                }
-
-                // Not found on first try - try reloading (it might be a new client)
-                context = await configurationServiceApplicationProvider.ReloadApplicationByClientIdAsync(
-                    clientId
-                );
-
-                if (context == null)
-                {
-                    logger.LogWarning(
-                        "Application context not found for clientId: {ClientId}",
-                        LoggingSanitizer.SanitizeForLogging(clientId)
-                    );
-                }
-
-                return context;
-            },
-            new HybridCacheEntryOptions
-            {
-                Expiration = TimeSpan.FromSeconds(cacheSettings.ApplicationContextCacheExpirationSeconds),
-                LocalCacheExpiration = TimeSpan.FromSeconds(
-                    cacheSettings.ApplicationContextCacheExpirationSeconds
-                ),
-            }
+        return await GetOrCreateResultAsync(
+            GetCacheKey(clientId, tenant),
+            clientId,
+            () => configurationServiceApplicationProvider.GetApplicationByClientIdAsync(clientId, tenant)
         );
     }
 
     /// <inheritdoc />
-    public async Task<ApplicationContext?> ReloadApplicationByClientIdAsync(string clientId)
+    public async Task<ApplicationContextResult> ReloadApplicationByClientIdAsync(
+        string clientId,
+        string? tenant
+    )
     {
         if (string.IsNullOrWhiteSpace(clientId))
         {
             logger.LogWarning("ReloadApplicationByClientIdAsync called with null or empty clientId");
-            return null;
+            return new ApplicationContextResult.Unavailable();
         }
 
-        // Clear cache first, then fetch fresh
-        var cacheKey = GetCacheKey(clientId);
+        var cacheKey = GetCacheKey(clientId, tenant);
         await hybridCache.RemoveAsync(cacheKey);
 
-        return await hybridCache.GetOrCreateAsync(
+        return await GetOrCreateResultAsync(
             cacheKey,
-            async cancel =>
-            {
-                return await configurationServiceApplicationProvider.ReloadApplicationByClientIdAsync(
-                    clientId
-                );
-            },
-            new HybridCacheEntryOptions
-            {
-                Expiration = TimeSpan.FromSeconds(cacheSettings.ApplicationContextCacheExpirationSeconds),
-                LocalCacheExpiration = TimeSpan.FromSeconds(
-                    cacheSettings.ApplicationContextCacheExpirationSeconds
-                ),
-            }
+            clientId,
+            () => configurationServiceApplicationProvider.ReloadApplicationByClientIdAsync(clientId, tenant)
         );
+    }
+
+    private async Task<ApplicationContextResult> GetOrCreateResultAsync(
+        string cacheKey,
+        string clientId,
+        Func<Task<ApplicationContextResult>> loadApplicationContext
+    )
+    {
+        try
+        {
+            ApplicationContext applicationContext = await hybridCache.GetOrCreateAsync(
+                cacheKey,
+                async _ =>
+                {
+                    ApplicationContextResult result = await loadApplicationContext();
+                    return result switch
+                    {
+                        ApplicationContextResult.Success success => success.ApplicationContext,
+                        _ => throw new ApplicationContextNotCacheableException(result),
+                    };
+                },
+                _cacheEntryOptions
+            );
+
+            return new ApplicationContextResult.Success(applicationContext);
+        }
+        catch (ApplicationContextNotCacheableException exception)
+        {
+            if (exception.Result is ApplicationContextResult.NotFound)
+            {
+                logger.LogWarning(
+                    exception,
+                    "Application context not found for clientId: {ClientId}",
+                    LoggingSanitizer.SanitizeForLogging(clientId)
+                );
+            }
+
+            return exception.Result;
+        }
+    }
+
+    public sealed class ApplicationContextNotCacheableException(ApplicationContextResult result) : Exception
+    {
+        public ApplicationContextResult Result { get; } = result;
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/CachedApplicationContextProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/CachedApplicationContextProvider.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Concurrent;
 using EdFi.DataManagementService.Core.Utilities;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Logging;
@@ -26,7 +27,10 @@ public class CachedApplicationContextProvider(
         Expiration = TimeSpan.FromSeconds(cacheSettings.ApplicationContextCacheExpirationSeconds),
         LocalCacheExpiration = TimeSpan.FromSeconds(cacheSettings.ApplicationContextCacheExpirationSeconds),
     };
-    private Lazy<Task<ApplicationContextResult>>? _requestResult;
+    private readonly ConcurrentDictionary<
+        RequestLookupKey,
+        Lazy<Task<ApplicationContextResult>>
+    > _requestResults = [];
 
     /// <summary>
     /// Gets the cache key for a client ID and tenant.
@@ -39,12 +43,12 @@ public class CachedApplicationContextProvider(
     /// <inheritdoc />
     public Task<ApplicationContextResult> GetApplicationByClientIdAsync(string clientId, string? tenant)
     {
-        var firstLookup = new Lazy<Task<ApplicationContextResult>>(
+        var lookup = new Lazy<Task<ApplicationContextResult>>(
             () => GetFirstApplicationContextAsync(clientId, tenant),
             LazyThreadSafetyMode.ExecutionAndPublication
         );
-        Lazy<Task<ApplicationContextResult>> requestResult =
-            Interlocked.CompareExchange(ref _requestResult, firstLookup, null) ?? firstLookup;
+        RequestLookupKey key = new(clientId, tenant?.ToLowerInvariant());
+        Lazy<Task<ApplicationContextResult>> requestResult = _requestResults.GetOrAdd(key, lookup);
 
         return requestResult.Value;
     }
@@ -132,4 +136,6 @@ public class CachedApplicationContextProvider(
     {
         public ApplicationContextResult Result { get; } = result;
     }
+
+    private readonly record struct RequestLookupKey(string ClientId, string? Tenant);
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/CachedApplicationContextProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/CachedApplicationContextProvider.cs
@@ -33,6 +33,12 @@ public class CachedApplicationContextProvider(
     > _requestResults = [];
 
     /// <summary>
+    /// Gets the request-scoped memoization key for a client ID and tenant.
+    /// </summary>
+    private static RequestLookupKey GetRequestLookupKey(string clientId, string? tenant) =>
+        new(clientId, tenant?.ToLowerInvariant());
+
+    /// <summary>
     /// Gets the cache key for a client ID and tenant.
     /// </summary>
     private static string GetCacheKey(string clientId, string? tenant) =>
@@ -47,7 +53,7 @@ public class CachedApplicationContextProvider(
             () => GetFirstApplicationContextAsync(clientId, tenant),
             LazyThreadSafetyMode.ExecutionAndPublication
         );
-        RequestLookupKey key = new(clientId, tenant?.ToLowerInvariant());
+        RequestLookupKey key = GetRequestLookupKey(clientId, tenant);
         Lazy<Task<ApplicationContextResult>> requestResult = _requestResults.GetOrAdd(key, lookup);
 
         return requestResult.Value;
@@ -61,7 +67,7 @@ public class CachedApplicationContextProvider(
         if (string.IsNullOrWhiteSpace(clientId))
         {
             logger.LogWarning("GetApplicationByClientIdAsync called with null or empty clientId");
-            return new ApplicationContextResult.Unavailable();
+            return new ApplicationContextResult.NotFound();
         }
 
         return await GetOrCreateResultAsync(
@@ -80,8 +86,11 @@ public class CachedApplicationContextProvider(
         if (string.IsNullOrWhiteSpace(clientId))
         {
             logger.LogWarning("ReloadApplicationByClientIdAsync called with null or empty clientId");
-            return new ApplicationContextResult.Unavailable();
+            return new ApplicationContextResult.NotFound();
         }
+
+        // Drop the request-scoped memo so a reload is not shadowed by an earlier lookup in this scope.
+        _requestResults.TryRemove(GetRequestLookupKey(clientId, tenant), out _);
 
         var cacheKey = GetCacheKey(clientId, tenant);
         await hybridCache.RemoveAsync(cacheKey);

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
@@ -189,7 +189,21 @@ public class ConfigurationServiceApplicationProvider(
             && applicationContext.OwnershipTokenIds.Count <= MaximumOwnershipTokenCount
             && applicationContext.OwnershipTokenIds.Distinct().Count()
                 == applicationContext.OwnershipTokenIds.Count
-            && applicationContext.OwnershipTokenIds.All(IsValidOwnershipTokenId);
+            && applicationContext.OwnershipTokenIds.All(IsValidOwnershipTokenId)
+            && IsAscending(applicationContext.OwnershipTokenIds);
+    }
+
+    private static bool IsAscending(IReadOnlyList<short> ownershipTokenIds)
+    {
+        for (int i = 1; i < ownershipTokenIds.Count; i++)
+        {
+            if (ownershipTokenIds[i] <= ownershipTokenIds[i - 1])
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool IsValidOwnershipTokenId(short tokenId) =>

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
@@ -67,6 +67,7 @@ public class ConfigurationServiceApplicationProvider(
                 request.Headers.Add("Tenant", tenant);
             }
 
+            request.Options.Set(ConfigurationServiceResponseHandler.AllowNotFoundResponse, true);
             using HttpResponseMessage response = await configurationServiceApiClient.Client.SendAsync(
                 request
             );
@@ -174,6 +175,7 @@ public class ConfigurationServiceApplicationProvider(
             && HasProperty(applicationContext, "clientId")
             && HasProperty(applicationContext, "clientUuid")
             && HasProperty(applicationContext, "dataStoreIds")
+            && HasProperty(applicationContext, "creatorOwnershipTokenId")
             && HasProperty(applicationContext, "ownershipTokenIds");
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
@@ -20,6 +20,9 @@ public class ConfigurationServiceApplicationProvider(
     ILogger<ConfigurationServiceApplicationProvider> logger
 ) : IApplicationContextProvider, IConfigurationServiceApplicationProvider
 {
+    private const short MinimumOwnershipTokenId = 1;
+    private const short MaximumOwnershipTokenId = 32767;
+    private const int MaximumOwnershipTokenCount = 1999;
     private static readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     /// <inheritdoc />
@@ -91,6 +94,7 @@ public class ConfigurationServiceApplicationProvider(
                 applicationContext is null
                 || !string.Equals(applicationContext.ClientId, clientId, StringComparison.Ordinal)
                 || applicationContext.ClientUuid == Guid.Empty
+                || !HasValidOwnershipConfiguration(applicationContext)
             )
             {
                 logger.LogError(
@@ -170,9 +174,24 @@ public class ConfigurationServiceApplicationProvider(
             && HasProperty(applicationContext, "clientId")
             && HasProperty(applicationContext, "clientUuid")
             && HasProperty(applicationContext, "dataStoreIds")
-            && HasProperty(applicationContext, "creatorOwnershipTokenId")
             && HasProperty(applicationContext, "ownershipTokenIds");
     }
+
+    private static bool HasValidOwnershipConfiguration(ApplicationContext applicationContext)
+    {
+        bool creatorIsValid =
+            applicationContext.CreatorOwnershipTokenId is null
+            || IsValidOwnershipTokenId(applicationContext.CreatorOwnershipTokenId.Value);
+
+        return creatorIsValid
+            && applicationContext.OwnershipTokenIds.Count <= MaximumOwnershipTokenCount
+            && applicationContext.OwnershipTokenIds.Distinct().Count()
+                == applicationContext.OwnershipTokenIds.Count
+            && applicationContext.OwnershipTokenIds.All(IsValidOwnershipTokenId);
+    }
+
+    private static bool IsValidOwnershipTokenId(short tokenId) =>
+        tokenId is >= MinimumOwnershipTokenId and <= MaximumOwnershipTokenId;
 
     private static bool HasProperty(JsonElement element, string propertyName)
     {

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
@@ -118,8 +118,15 @@ public class ConfigurationServiceApplicationProvider(
             )
             {
                 logger.LogError(
-                    "Failed to deserialize application context for clientId: {ClientId}",
-                    clientId
+                    "Configuration Service returned an invalid application context for clientId: {ClientId}. "
+                        + "Id: {Id}, ApplicationId: {ApplicationId}, ClientUuid: {ClientUuid}, "
+                        + "CreatorOwnershipTokenId: {CreatorOwnershipTokenId}, OwnershipTokenCount: {OwnershipTokenCount}",
+                    clientId,
+                    applicationContext.Id,
+                    applicationContext.ApplicationId,
+                    applicationContext.ClientUuid,
+                    applicationContext.CreatorOwnershipTokenId,
+                    applicationContext.OwnershipTokenIds.Count
                 );
                 return new ApplicationContextResult.Unavailable();
             }
@@ -130,7 +137,14 @@ public class ConfigurationServiceApplicationProvider(
                 applicationContext.ApplicationId
             );
 
-            return new ApplicationContextResult.Success(applicationContext);
+            // CMS query ordering is not part of this contract, so ownership tokens are exposed
+            // sorted-distinct to give downstream authorization a deterministic list.
+            return new ApplicationContextResult.Success(
+                applicationContext with
+                {
+                    OwnershipTokenIds = [.. applicationContext.OwnershipTokenIds.Distinct().Order()],
+                }
+            );
         }
         catch (HttpRequestException ex)
         {
@@ -194,7 +208,6 @@ public class ConfigurationServiceApplicationProvider(
             && HasProperty(applicationContext, "clientId")
             && HasProperty(applicationContext, "clientUuid")
             && HasProperty(applicationContext, "dataStoreIds")
-            && HasProperty(applicationContext, "creatorOwnershipTokenId")
             && HasProperty(applicationContext, "ownershipTokenIds");
     }
 
@@ -206,23 +219,7 @@ public class ConfigurationServiceApplicationProvider(
 
         return creatorIsValid
             && applicationContext.OwnershipTokenIds.Count <= MaximumOwnershipTokenCount
-            && applicationContext.OwnershipTokenIds.Distinct().Count()
-                == applicationContext.OwnershipTokenIds.Count
-            && applicationContext.OwnershipTokenIds.All(IsValidOwnershipTokenId)
-            && IsAscending(applicationContext.OwnershipTokenIds);
-    }
-
-    private static bool IsAscending(IReadOnlyList<short> ownershipTokenIds)
-    {
-        for (int i = 1; i < ownershipTokenIds.Count; i++)
-        {
-            if (ownershipTokenIds[i] <= ownershipTokenIds[i - 1])
-            {
-                return false;
-            }
-        }
-
-        return true;
+            && applicationContext.OwnershipTokenIds.All(IsValidOwnershipTokenId);
     }
 
     private static bool IsValidOwnershipTokenId(short tokenId) =>

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
@@ -93,6 +93,8 @@ public class ConfigurationServiceApplicationProvider(
 
             if (
                 applicationContext is null
+                || applicationContext.Id <= 0
+                || applicationContext.ApplicationId <= 0
                 || !string.Equals(applicationContext.ClientId, clientId, StringComparison.Ordinal)
                 || applicationContext.ClientUuid == Guid.Empty
                 || !HasValidOwnershipConfiguration(applicationContext)

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
@@ -23,69 +23,90 @@ public class ConfigurationServiceApplicationProvider(
     private static readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     /// <inheritdoc />
-    public async Task<ApplicationContext?> GetApplicationByClientIdAsync(string clientId)
+    public async Task<ApplicationContextResult> GetApplicationByClientIdAsync(string clientId, string? tenant)
     {
-        return await FetchApplicationByClientIdAsync(clientId);
+        return await FetchApplicationByClientIdAsync(clientId, tenant);
     }
 
     /// <inheritdoc />
-    public async Task<ApplicationContext?> ReloadApplicationByClientIdAsync(string clientId)
+    public async Task<ApplicationContextResult> ReloadApplicationByClientIdAsync(
+        string clientId,
+        string? tenant
+    )
     {
         logger.LogInformation("Force reloading application context for clientId: {ClientId}", clientId);
-        return await FetchApplicationByClientIdAsync(clientId);
+        return await FetchApplicationByClientIdAsync(clientId, tenant);
     }
 
-    private async Task<ApplicationContext?> FetchApplicationByClientIdAsync(string clientId)
+    private async Task<ApplicationContextResult> FetchApplicationByClientIdAsync(
+        string clientId,
+        string? tenant
+    )
     {
         try
         {
-            // Get token for the Configuration Service API
-            string? configurationServiceToken = await configurationServiceTokenHandler.GetTokenAsync(
+            string configurationServiceToken = await configurationServiceTokenHandler.GetTokenAsync(
                 configurationServiceContext.clientId,
                 configurationServiceContext.clientSecret,
                 configurationServiceContext.scope
             );
 
-            configurationServiceApiClient.Client.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Bearer", configurationServiceToken);
-
             logger.LogDebug("Fetching application context for clientId: {ClientId}", clientId);
 
-            HttpResponseMessage response = await configurationServiceApiClient.Client.GetAsync(
-                $"/v3/apiClients/{clientId}"
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/apiClients/{clientId}");
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                "Bearer",
+                configurationServiceToken
+            );
+
+            if (tenant is not null)
+            {
+                request.Headers.Add("Tenant", tenant);
+            }
+
+            using HttpResponseMessage response = await configurationServiceApiClient.Client.SendAsync(
+                request
             );
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 logger.LogWarning("Application not found for clientId: {ClientId}", clientId);
-                return null;
+                return new ApplicationContextResult.NotFound();
             }
 
-            response.EnsureSuccessStatusCode();
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError(
+                    "Configuration Service returned {StatusCode} while fetching application context for clientId: {ClientId}",
+                    response.StatusCode,
+                    clientId
+                );
+                return new ApplicationContextResult.Unavailable();
+            }
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            ApplicationContext? applicationContext = JsonSerializer.Deserialize<ApplicationContext>(
-                responseBody,
-                _jsonOptions
-            );
+            ApplicationContext? applicationContext = DeserializeApplicationContext(responseBody);
 
-            if (applicationContext == null)
+            if (
+                applicationContext is null
+                || !string.Equals(applicationContext.ClientId, clientId, StringComparison.Ordinal)
+                || applicationContext.ClientUuid == Guid.Empty
+            )
             {
                 logger.LogError(
                     "Failed to deserialize application context for clientId: {ClientId}",
                     clientId
                 );
-                return null;
+                return new ApplicationContextResult.Unavailable();
             }
 
             logger.LogDebug(
-                "Successfully fetched application context for clientId: {ClientId}, ApplicationId: {ApplicationId}, DataStoreIds: [{DataStoreIds}]",
+                "Successfully fetched application context for clientId: {ClientId}, ApplicationId: {ApplicationId}",
                 clientId,
-                applicationContext.ApplicationId,
-                string.Join(", ", applicationContext.DataStoreIds)
+                applicationContext.ApplicationId
             );
 
-            return applicationContext;
+            return new ApplicationContextResult.Success(applicationContext);
         }
         catch (HttpRequestException ex)
         {
@@ -94,7 +115,7 @@ public class ConfigurationServiceApplicationProvider(
                 "HTTP request failed while fetching application context for clientId: {ClientId}",
                 clientId
             );
-            return null;
+            return new ApplicationContextResult.Unavailable();
         }
         catch (JsonException ex)
         {
@@ -103,7 +124,7 @@ public class ConfigurationServiceApplicationProvider(
                 "Failed to parse application context response for clientId: {ClientId}",
                 clientId
             );
-            return null;
+            return new ApplicationContextResult.Unavailable();
         }
         catch (Exception ex)
         {
@@ -112,7 +133,51 @@ public class ConfigurationServiceApplicationProvider(
                 "Unexpected error while fetching application context for clientId: {ClientId}",
                 clientId
             );
+            return new ApplicationContextResult.Unavailable();
+        }
+    }
+
+    private static ApplicationContext? DeserializeApplicationContext(string responseBody)
+    {
+        using JsonDocument document = JsonDocument.Parse(responseBody);
+
+        if (
+            document.RootElement.ValueKind != JsonValueKind.Object
+            || !HasRequiredProperties(document.RootElement)
+        )
+        {
             return null;
         }
+
+        ApplicationContext? applicationContext = JsonSerializer.Deserialize<ApplicationContext>(
+            responseBody,
+            _jsonOptions
+        );
+
+        return
+            applicationContext is not null
+            && !string.IsNullOrWhiteSpace(applicationContext.ClientId)
+            && applicationContext.DataStoreIds is not null
+            && applicationContext.OwnershipTokenIds is not null
+            ? applicationContext
+            : null;
+    }
+
+    private static bool HasRequiredProperties(JsonElement applicationContext)
+    {
+        return HasProperty(applicationContext, "id")
+            && HasProperty(applicationContext, "applicationId")
+            && HasProperty(applicationContext, "clientId")
+            && HasProperty(applicationContext, "clientUuid")
+            && HasProperty(applicationContext, "dataStoreIds")
+            && HasProperty(applicationContext, "creatorOwnershipTokenId")
+            && HasProperty(applicationContext, "ownershipTokenIds");
+    }
+
+    private static bool HasProperty(JsonElement element, string propertyName)
+    {
+        return element
+            .EnumerateObject()
+            .Any(property => string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs
@@ -91,11 +91,28 @@ public class ConfigurationServiceApplicationProvider(
             string responseBody = await response.Content.ReadAsStringAsync();
             ApplicationContext? applicationContext = DeserializeApplicationContext(responseBody);
 
+            if (applicationContext is null)
+            {
+                logger.LogError(
+                    "Failed to deserialize application context for clientId: {ClientId}",
+                    clientId
+                );
+                return new ApplicationContextResult.Unavailable();
+            }
+
+            if (!string.Equals(applicationContext.ClientId, clientId, StringComparison.Ordinal))
+            {
+                logger.LogError(
+                    "Configuration Service returned an application context for a different clientId. Requested clientId: {RequestedClientId}, returned clientId: {ResponseClientId}",
+                    clientId,
+                    applicationContext.ClientId
+                );
+                return new ApplicationContextResult.Unavailable();
+            }
+
             if (
-                applicationContext is null
-                || applicationContext.Id <= 0
+                applicationContext.Id <= 0
                 || applicationContext.ApplicationId <= 0
-                || !string.Equals(applicationContext.ClientId, clientId, StringComparison.Ordinal)
                 || applicationContext.ClientUuid == Guid.Empty
                 || !HasValidOwnershipConfiguration(applicationContext)
             )

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/IApplicationContextProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/IApplicationContextProvider.cs
@@ -14,13 +14,15 @@ public interface IApplicationContextProvider
     /// Retrieves application context by client ID
     /// </summary>
     /// <param name="clientId">The client identifier from the JWT token</param>
-    /// <returns>ApplicationContext if found, null otherwise</returns>
-    Task<ApplicationContext?> GetApplicationByClientIdAsync(string clientId);
+    /// <param name="tenant">The optional tenant context for the request</param>
+    /// <returns>The typed application-context lookup outcome</returns>
+    Task<ApplicationContextResult> GetApplicationByClientIdAsync(string clientId, string? tenant);
 
     /// <summary>
     /// Forces a reload of application data from CMS, bypassing cache
     /// </summary>
     /// <param name="clientId">The client identifier to reload</param>
-    /// <returns>ApplicationContext if found, null otherwise</returns>
-    Task<ApplicationContext?> ReloadApplicationByClientIdAsync(string clientId);
+    /// <param name="tenant">The optional tenant context for the request</param>
+    /// <returns>The typed application-context reload outcome</returns>
+    Task<ApplicationContextResult> ReloadApplicationByClientIdAsync(string clientId, string? tenant);
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/IConfigurationServiceApplicationProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/IConfigurationServiceApplicationProvider.cs
@@ -15,14 +15,16 @@ public interface IConfigurationServiceApplicationProvider
     /// Retrieves application context for a client ID from the Configuration Service API.
     /// </summary>
     /// <param name="clientId">The client ID to look up.</param>
-    /// <returns>Application context if found, null otherwise.</returns>
-    Task<ApplicationContext?> GetApplicationByClientIdAsync(string clientId);
+    /// <param name="tenant">The optional tenant context for the request.</param>
+    /// <returns>The typed application-context lookup outcome.</returns>
+    Task<ApplicationContextResult> GetApplicationByClientIdAsync(string clientId, string? tenant);
 
     /// <summary>
     /// Forces a reload of application context from the Configuration Service API.
     /// Use this when the application may have been recently created or modified.
     /// </summary>
     /// <param name="clientId">The client ID to reload.</param>
-    /// <returns>Application context if found, null otherwise.</returns>
-    Task<ApplicationContext?> ReloadApplicationByClientIdAsync(string clientId);
+    /// <param name="tenant">The optional tenant context for the request.</param>
+    /// <returns>The typed application-context reload outcome.</returns>
+    Task<ApplicationContextResult> ReloadApplicationByClientIdAsync(string clientId, string? tenant);
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
@@ -293,12 +293,20 @@ public static class DmsCoreServiceExtensions
         );
 
         services.AddHybridCache();
-        services.TryAddSingleton(_ =>
+        if (!services.Any(descriptor => descriptor.ServiceType == typeof(IConfigureOptions<CacheSettings>)))
         {
-            CacheSettings cacheSettings = new();
-            configuration.GetSection("CacheSettings").Bind(cacheSettings);
-            return cacheSettings;
-        });
+            services
+                .AddOptions<CacheSettings>()
+                .Bind(configuration.GetSection("CacheSettings"))
+                .ValidateOnStart();
+        }
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<CacheSettings>, CacheSettingsValidator>()
+        );
+        services.TryAddSingleton(serviceProvider =>
+            serviceProvider.GetRequiredService<IOptions<CacheSettings>>().Value
+        );
 
         services.AddTransient<ConfigurationServiceResponseHandler>();
         services

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
@@ -48,7 +48,9 @@ internal class DeleteByIdHandler(ILogger _logger, ResiliencePipeline _resilience
                     )
                     {
                         AuthorizationContext = RelationalAuthorizationContext.Create(
-                            requestInfo.ClientAuthorizations
+                            requestInfo.ClientAuthorizations,
+                            requestInfo.ApplicationContext?.CreatorOwnershipTokenId,
+                            requestInfo.ApplicationContext?.OwnershipTokenIds
                         ),
                         AuthorizationStrategyEvaluators = requestInfo.AuthorizationStrategyEvaluators,
                     }

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/GetByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/GetByIdHandler.cs
@@ -235,7 +235,11 @@ internal class GetByIdHandler(ILogger _logger, ResiliencePipeline _resiliencePip
             DocumentUuid: requestInfo.PathComponents.DocumentUuid,
             ResourceInfo: requestInfo.ResourceInfo,
             MappingSet: mappingSet,
-            AuthorizationContext: RelationalAuthorizationContext.Create(requestInfo.ClientAuthorizations),
+            AuthorizationContext: RelationalAuthorizationContext.Create(
+                requestInfo.ClientAuthorizations,
+                requestInfo.ApplicationContext?.CreatorOwnershipTokenId,
+                requestInfo.ApplicationContext?.OwnershipTokenIds
+            ),
             AuthorizationStrategyEvaluators: requestInfo.AuthorizationStrategyEvaluators,
             TraceId: requestInfo.FrontendRequest.TraceId,
             TenantKey: requestInfo.FrontendRequest.Tenant ?? string.Empty,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/GetTokenInfoHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/GetTokenInfoHandler.cs
@@ -145,11 +145,13 @@ internal partial class GetTokenInfoHandler(
         }
 
         // Get application context to find ApplicationId
-        ApplicationContext? appContext = await applicationContextProvider.GetApplicationByClientIdAsync(
-            requestInfo.ClientAuthorizations.ClientId
-        );
+        ApplicationContextResult applicationContextResult =
+            await applicationContextProvider.GetApplicationByClientIdAsync(
+                requestInfo.ClientAuthorizations.ClientId,
+                requestInfo.FrontendRequest.Tenant
+            );
 
-        if (appContext == null)
+        if (applicationContextResult is ApplicationContextResult.NotFound)
         {
             requestInfo.FrontendResponse = new FrontendResponse(
                 StatusCode: 401,
@@ -162,6 +164,21 @@ internal partial class GetTokenInfoHandler(
             );
             return;
         }
+
+        if (applicationContextResult is ApplicationContextResult.Unavailable)
+        {
+            requestInfo.FrontendResponse = new FrontendResponse(
+                StatusCode: 503,
+                Body: FailureResponse.ForServiceUnavailable(requestInfo.FrontendRequest.TraceId),
+                Headers: [],
+                ContentType: "application/problem+json"
+            );
+            return;
+        }
+
+        ApplicationContextResult.Success success = (ApplicationContextResult.Success)applicationContextResult;
+
+        ApplicationContext appContext = success.ApplicationContext;
 
         var educationOrganizations = await GetAuthorizedEducationOrganizations(
             requestInfo,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/PartitionRequestHandler.cs
@@ -323,7 +323,11 @@ internal class PartitionRequestHandler(
 
         return new RelationalPartitionRequest(
             ResourceInfo: requestInfo.ResourceInfo,
-            AuthorizationContext: RelationalAuthorizationContext.Create(requestInfo.ClientAuthorizations),
+            AuthorizationContext: RelationalAuthorizationContext.Create(
+                requestInfo.ClientAuthorizations,
+                requestInfo.ApplicationContext?.CreatorOwnershipTokenId,
+                requestInfo.ApplicationContext?.OwnershipTokenIds
+            ),
             MappingSet: mappingSet,
             QueryElements: requestInfo.QueryElements,
             AuthorizationStrategyEvaluators: requestInfo.AuthorizationStrategyEvaluators,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
@@ -390,7 +390,11 @@ internal class QueryRequestHandler(
 
         return new RelationalQueryRequest(
             ResourceInfo: requestInfo.ResourceInfo,
-            AuthorizationContext: RelationalAuthorizationContext.Create(requestInfo.ClientAuthorizations),
+            AuthorizationContext: RelationalAuthorizationContext.Create(
+                requestInfo.ClientAuthorizations,
+                requestInfo.ApplicationContext?.CreatorOwnershipTokenId,
+                requestInfo.ApplicationContext?.OwnershipTokenIds
+            ),
             MappingSet: mappingSet,
             QueryElements: requestInfo.QueryElements,
             AuthorizationStrategyEvaluators: requestInfo.AuthorizationStrategyEvaluators,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/TrackedChangeQueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/TrackedChangeQueryRequestHandler.cs
@@ -201,7 +201,11 @@ internal sealed class TrackedChangeQueryRequestHandler(
             PaginationParameters: requestInfo.PaginationParameters,
             ChangeVersionRange: requestInfo.ChangeVersionRange,
             TraceId: requestInfo.FrontendRequest.TraceId,
-            AuthorizationContext: RelationalAuthorizationContext.Create(requestInfo.ClientAuthorizations),
+            AuthorizationContext: RelationalAuthorizationContext.Create(
+                requestInfo.ClientAuthorizations,
+                requestInfo.ApplicationContext?.CreatorOwnershipTokenId,
+                requestInfo.ApplicationContext?.OwnershipTokenIds
+            ),
             AuthorizationStrategyEvaluators: requestInfo.AuthorizationStrategyEvaluators,
             MappingSet: mappingSet,
             ResourceModel: resourceModel,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
@@ -58,7 +58,9 @@ internal class UpdateByIdHandler(ILogger _logger, ResiliencePipeline _resilience
                     {
                         AuthorizationStrategyEvaluators = requestInfo.AuthorizationStrategyEvaluators,
                         AuthorizationContext = RelationalAuthorizationContext.Create(
-                            requestInfo.ClientAuthorizations
+                            requestInfo.ClientAuthorizations,
+                            requestInfo.ApplicationContext?.CreatorOwnershipTokenId,
+                            requestInfo.ApplicationContext?.OwnershipTokenIds
                         ),
                     }
                 ),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
@@ -62,7 +62,9 @@ internal class UpsertHandler(ILogger _logger, ResiliencePipeline _resiliencePipe
                     {
                         AuthorizationStrategyEvaluators = requestInfo.AuthorizationStrategyEvaluators,
                         AuthorizationContext = RelationalAuthorizationContext.Create(
-                            requestInfo.ClientAuthorizations
+                            requestInfo.ClientAuthorizations,
+                            requestInfo.ApplicationContext?.CreatorOwnershipTokenId,
+                            requestInfo.ApplicationContext?.OwnershipTokenIds
                         ),
                     }
                 );

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ApplicationContextRequirementMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ApplicationContextRequirementMiddleware.cs
@@ -23,9 +23,6 @@ internal sealed class ApplicationContextRequirementMiddleware(
     ILogger<ApplicationContextRequirementMiddleware> logger
 ) : IPipelineStep
 {
-    private const string ApplicationContextUnavailableError =
-        "Unable to resolve application context for the authenticated client.";
-
     public async Task Execute(RequestInfo requestInfo, Func<Task> next)
     {
         bool contextRequired =
@@ -67,17 +64,9 @@ internal sealed class ApplicationContextRequirementMiddleware(
                     "Required application context was not found - {TraceId}",
                     requestInfo.FrontendRequest.TraceId.Value
                 );
-                requestInfo.FrontendResponse = new FrontendResponse(
-                    StatusCode: 401,
-                    Body: FailureResponse.ForAuthenticationFailure(
-                        requestInfo.FrontendRequest.TraceId,
-                        [ApplicationContextUnavailableError]
-                    ),
-                    Headers: new Dictionary<string, string>
-                    {
-                        ["WWW-Authenticate"] = "Bearer error=\"invalid_token\"",
-                    },
-                    ContentType: "application/problem+json"
+                requestInfo.FrontendResponse = ApplicationContextFailureResponseFactory.Create(
+                    result,
+                    requestInfo.FrontendRequest.TraceId
                 );
                 return;
             case ApplicationContextResult.Unavailable:
@@ -85,13 +74,38 @@ internal sealed class ApplicationContextRequirementMiddleware(
                     "Required application context was unavailable - {TraceId}",
                     requestInfo.FrontendRequest.TraceId.Value
                 );
-                requestInfo.FrontendResponse = new FrontendResponse(
-                    StatusCode: 503,
-                    Body: FailureResponse.ForServiceUnavailable(requestInfo.FrontendRequest.TraceId),
-                    Headers: [],
-                    ContentType: "application/problem+json"
+                requestInfo.FrontendResponse = ApplicationContextFailureResponseFactory.Create(
+                    result,
+                    requestInfo.FrontendRequest.TraceId
                 );
                 return;
         }
     }
+}
+
+internal static class ApplicationContextFailureResponseFactory
+{
+    private const string ApplicationContextUnavailableError =
+        "Unable to resolve application context for the authenticated client.";
+
+    public static FrontendResponse Create(ApplicationContextResult result, TraceId traceId) =>
+        result switch
+        {
+            ApplicationContextResult.NotFound => new FrontendResponse(
+                StatusCode: 401,
+                Body: FailureResponse.ForAuthenticationFailure(traceId, [ApplicationContextUnavailableError]),
+                Headers: new Dictionary<string, string>
+                {
+                    ["WWW-Authenticate"] = "Bearer error=\"invalid_token\"",
+                },
+                ContentType: "application/problem+json"
+            ),
+            ApplicationContextResult.Unavailable => new FrontendResponse(
+                StatusCode: 503,
+                Body: FailureResponse.ForServiceUnavailable(traceId),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
+            _ => throw new ArgumentOutOfRangeException(nameof(result), result, null),
+        };
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ApplicationContextRequirementMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ApplicationContextRequirementMiddleware.cs
@@ -37,12 +37,6 @@ internal sealed class ApplicationContextRequirementMiddleware(
 
         if (!contextRequired)
         {
-            if (requestInfo.DeferredProfileContextFailureResponse is not null)
-            {
-                requestInfo.FrontendResponse = requestInfo.DeferredProfileContextFailureResponse;
-                return;
-            }
-
             await next();
             return;
         }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ApplicationContextRequirementMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ApplicationContextRequirementMiddleware.cs
@@ -6,6 +6,7 @@
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Response;
@@ -22,7 +23,6 @@ internal sealed class ApplicationContextRequirementMiddleware(
     ILogger<ApplicationContextRequirementMiddleware> logger
 ) : IPipelineStep
 {
-    private const string OwnershipBasedStrategy = "OwnershipBased";
     private const string ApplicationContextUnavailableError =
         "Unable to resolve application context for the authenticated client.";
 
@@ -33,7 +33,7 @@ internal sealed class ApplicationContextRequirementMiddleware(
             || (
                 requestInfo.Method is RequestMethod.GET or RequestMethod.PUT or RequestMethod.DELETE
                 && requestInfo.ResourceActionAuthStrategies.Contains(
-                    OwnershipBasedStrategy,
+                    AuthorizationStrategyNameConstants.OwnershipBased,
                     StringComparer.OrdinalIgnoreCase
                 )
             );

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ApplicationContextRequirementMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ApplicationContextRequirementMiddleware.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Frontend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Model;
+using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Response;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace EdFi.DataManagementService.Core.Middleware;
+
+/// <summary>
+/// Requires application context for POST requests and resource actions that use ownership-based
+/// authorization after their effective strategies have been selected.
+/// </summary>
+internal sealed class ApplicationContextRequirementMiddleware(
+    ILogger<ApplicationContextRequirementMiddleware> logger
+) : IPipelineStep
+{
+    private const string OwnershipBasedStrategy = "OwnershipBased";
+    private const string ApplicationContextUnavailableError =
+        "Unable to resolve application context for the authenticated client.";
+
+    public async Task Execute(RequestInfo requestInfo, Func<Task> next)
+    {
+        bool contextRequired =
+            requestInfo.Method is RequestMethod.POST
+            || (
+                requestInfo.Method is RequestMethod.GET or RequestMethod.PUT or RequestMethod.DELETE
+                && requestInfo.ResourceActionAuthStrategies.Contains(
+                    OwnershipBasedStrategy,
+                    StringComparer.OrdinalIgnoreCase
+                )
+            );
+
+        if (!contextRequired)
+        {
+            if (requestInfo.DeferredProfileContextFailureResponse is not null)
+            {
+                requestInfo.FrontendResponse = requestInfo.DeferredProfileContextFailureResponse;
+                return;
+            }
+
+            await next();
+            return;
+        }
+
+        var provider = requestInfo.ScopedServiceProvider.GetRequiredService<IApplicationContextProvider>();
+        ApplicationContextResult result = await provider.GetApplicationByClientIdAsync(
+            requestInfo.ClientAuthorizations.ClientId,
+            requestInfo.FrontendRequest.Tenant
+        );
+
+        switch (result)
+        {
+            case ApplicationContextResult.Success success:
+                requestInfo.ApplicationContext = success.ApplicationContext;
+                await next();
+                return;
+            case ApplicationContextResult.NotFound:
+                logger.LogWarning(
+                    "Required application context was not found - {TraceId}",
+                    requestInfo.FrontendRequest.TraceId.Value
+                );
+                requestInfo.FrontendResponse = new FrontendResponse(
+                    StatusCode: 401,
+                    Body: FailureResponse.ForAuthenticationFailure(
+                        requestInfo.FrontendRequest.TraceId,
+                        [ApplicationContextUnavailableError]
+                    ),
+                    Headers: new Dictionary<string, string>
+                    {
+                        ["WWW-Authenticate"] = "Bearer error=\"invalid_token\"",
+                    },
+                    ContentType: "application/problem+json"
+                );
+                return;
+            case ApplicationContextResult.Unavailable:
+                logger.LogWarning(
+                    "Required application context was unavailable - {TraceId}",
+                    requestInfo.FrontendRequest.TraceId.Value
+                );
+                requestInfo.FrontendResponse = new FrontendResponse(
+                    StatusCode: 503,
+                    Body: FailureResponse.ForServiceUnavailable(requestInfo.FrontendRequest.TraceId),
+                    Headers: [],
+                    ContentType: "application/problem+json"
+                );
+                return;
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProfileResolutionMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProfileResolutionMiddleware.cs
@@ -59,27 +59,29 @@ internal class ProfileResolutionMiddleware(
         // Get application context to find ApplicationId
         var applicationContextProvider =
             requestInfo.ScopedServiceProvider.GetRequiredService<IApplicationContextProvider>();
-        ApplicationContext? appContext = await applicationContextProvider.GetApplicationByClientIdAsync(
-            requestInfo.ClientAuthorizations.ClientId
-        );
+        ApplicationContextResult applicationContextResult =
+            await applicationContextProvider.GetApplicationByClientIdAsync(
+                requestInfo.ClientAuthorizations.ClientId,
+                requestInfo.FrontendRequest.Tenant
+            );
 
-        if (appContext == null)
+        if (applicationContextResult is not ApplicationContextResult.Success success)
         {
             logger.LogWarning(
-                "Application context not found for client during profile resolution. ClientId: {ClientId} - {TraceId}",
-                LoggingSanitizer.SanitizeForLogging(requestInfo.ClientAuthorizations.ClientId),
+                "Application context could not be resolved for client during profile resolution - {TraceId}",
                 requestInfo.FrontendRequest.TraceId.Value
             );
 
             // If no application context and no profile header, continue without profile
-            if (parseResult.ParsedHeader == null)
+            if (parseResult.ParsedHeader is null)
             {
                 await next();
                 return;
             }
 
-            // If profile header was specified but we can't find app context, return error
-            requestInfo.FrontendResponse = CreateProfileError(
+            // Strategy selection must run before this response is returned so a mandatory application
+            // context demand can take precedence without performing another CMS lookup.
+            requestInfo.DeferredProfileContextFailureResponse = CreateProfileError(
                 statusCode: GetNotFoundStatusCode(requestInfo.Method),
                 errorType: "urn:ed-fi:api:profile:invalid-profile-usage",
                 title: "Invalid Profile Usage",
@@ -87,8 +89,12 @@ internal class ProfileResolutionMiddleware(
                 errors: ["Unable to resolve application context for profile validation."],
                 traceId: requestInfo.FrontendRequest.TraceId
             );
+            await next();
             return;
         }
+
+        ApplicationContext appContext = success.ApplicationContext;
+        requestInfo.ApplicationContext = appContext;
 
         // Get tenant ID if multi-tenancy is enabled
         string? tenantId = requestInfo.FrontendRequest.Tenant;

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProfileResolutionMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProfileResolutionMiddleware.cs
@@ -72,13 +72,8 @@ internal class ProfileResolutionMiddleware(
                 requestInfo.FrontendRequest.TraceId.Value
             );
 
-            // If no application context and no profile header, continue without profile
-            if (parseResult.ParsedHeader is null)
-            {
-                await next();
-                return;
-            }
-
+            // Fail closed: profile resolution requires application context, whether the client named a
+            // profile explicitly or has profiles assigned for implicit selection.
             requestInfo.FrontendResponse = ApplicationContextFailureResponseFactory.Create(
                 applicationContextResult,
                 requestInfo.FrontendRequest.TraceId

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProfileResolutionMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProfileResolutionMiddleware.cs
@@ -81,14 +81,11 @@ internal class ProfileResolutionMiddleware(
 
             // Strategy selection must run before this response is returned so a mandatory application
             // context demand can take precedence without performing another CMS lookup.
-            requestInfo.DeferredProfileContextFailureResponse = CreateProfileError(
-                statusCode: GetNotFoundStatusCode(requestInfo.Method),
-                errorType: "urn:ed-fi:api:profile:invalid-profile-usage",
-                title: "Invalid Profile Usage",
-                detail: "The request construction was invalid with respect to usage of a data policy.",
-                errors: ["Unable to resolve application context for profile validation."],
-                traceId: requestInfo.FrontendRequest.TraceId
-            );
+            requestInfo.DeferredProfileContextFailureResponse =
+                ApplicationContextFailureResponseFactory.Create(
+                    applicationContextResult,
+                    requestInfo.FrontendRequest.TraceId
+                );
             await next();
             return;
         }
@@ -167,18 +164,6 @@ internal class ProfileResolutionMiddleware(
         }
 
         return requestInfo.FrontendRequest.Headers.TryGetValue(headerName, out var value) ? value : null;
-    }
-
-    private static int GetNotFoundStatusCode(RequestMethod method)
-    {
-        // GET uses 406 Not Acceptable, POST/PUT use 415 Unsupported Media Type
-        return method switch
-        {
-            RequestMethod.GET => 406,
-            RequestMethod.POST => 415,
-            RequestMethod.PUT => 415,
-            _ => throw new InvalidOperationException($"Unexpected method for profile resolution: {method}"),
-        };
     }
 
     private static FrontendResponse CreateProfileError(

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProfileResolutionMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProfileResolutionMiddleware.cs
@@ -79,14 +79,10 @@ internal class ProfileResolutionMiddleware(
                 return;
             }
 
-            // Strategy selection must run before this response is returned so a mandatory application
-            // context demand can take precedence without performing another CMS lookup.
-            requestInfo.DeferredProfileContextFailureResponse =
-                ApplicationContextFailureResponseFactory.Create(
-                    applicationContextResult,
-                    requestInfo.FrontendRequest.TraceId
-                );
-            await next();
+            requestInfo.FrontendResponse = ApplicationContextFailureResponseFactory.Create(
+                applicationContextResult,
+                requestInfo.FrontendRequest.TraceId
+            );
             return;
         }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
@@ -182,12 +182,6 @@ internal class RequestInfo(
     public ApplicationContext? ApplicationContext { get; set; }
 
     /// <summary>
-    /// The application-context failure response to return after resource-action strategy selection when
-    /// an explicit profile could not be validated because application context did not resolve.
-    /// </summary>
-    public IFrontendResponse? DeferredProfileContextFailureResponse { get; set; }
-
-    /// <summary>
     /// ApiDetails retrieved from the token, used for resource authorization.
     /// This will be null when the frontend passes the request, and will be populated
     /// by the JWT authentication middleware in Core.

--- a/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
@@ -182,8 +182,8 @@ internal class RequestInfo(
     public ApplicationContext? ApplicationContext { get; set; }
 
     /// <summary>
-    /// The method-specific profile response to return after resource-action strategy selection when
-    /// an explicit profile could not be validated because application context was unavailable.
+    /// The application-context failure response to return after resource-action strategy selection when
+    /// an explicit profile could not be validated because application context did not resolve.
     /// </summary>
     public IFrontendResponse? DeferredProfileContextFailureResponse { get; set; }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
@@ -6,6 +6,7 @@
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.ApiSchema;
+using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Model;
@@ -173,6 +174,18 @@ internal class RequestInfo(
     /// ResourceActionAuthStrategies for the request
     /// </summary>
     public IReadOnlyList<string> ResourceActionAuthStrategies { get; set; } = [];
+
+    /// <summary>
+    /// The application context resolved for a request that requires ownership configuration.
+    /// Null when the request has not required application context or resolution did not succeed.
+    /// </summary>
+    public ApplicationContext? ApplicationContext { get; set; }
+
+    /// <summary>
+    /// The method-specific profile response to return after resource-action strategy selection when
+    /// an explicit profile could not be validated because application context was unavailable.
+    /// </summary>
+    public IFrontendResponse? DeferredProfileContextFailureResponse { get; set; }
 
     /// <summary>
     /// ApiDetails retrieved from the token, used for resource authorization.

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/ConfigurationServiceResponseHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/ConfigurationServiceResponseHandler.cs
@@ -10,6 +10,8 @@ namespace EdFi.DataManagementService.Core.Security;
 public class ConfigurationServiceResponseHandler(ILogger<ConfigurationServiceResponseHandler> logger)
     : DelegatingHandler
 {
+    internal static readonly HttpRequestOptionsKey<bool> AllowNotFoundResponse = new("AllowNotFoundResponse");
+
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken
@@ -17,7 +19,14 @@ public class ConfigurationServiceResponseHandler(ILogger<ConfigurationServiceRes
     {
         var response = await base.SendAsync(request, cancellationToken);
 
-        if (!response.IsSuccessStatusCode)
+        bool allowsNotFoundResponse =
+            request.Options.TryGetValue(AllowNotFoundResponse, out bool allowNotFoundResponse)
+            && allowNotFoundResponse;
+
+        if (
+            !response.IsSuccessStatusCode
+            && !(response.StatusCode is System.Net.HttpStatusCode.NotFound && allowsNotFoundResponse)
+        )
         {
             var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
             var statusCode = response.StatusCode;

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RelationalWriteSmokeTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RelationalWriteSmokeTests.cs
@@ -413,18 +413,25 @@ public class Given_A_Host_Using_The_Relational_Backend
                     );
 
                 var applicationContextProvider = A.Fake<IApplicationContextProvider>();
+                var applicationContextResult = new ApplicationContextResult.Success(
+                    new ApplicationContext(
+                        Id: 1,
+                        ApplicationId: 1,
+                        ClientId: "smoke-client",
+                        ClientUuid: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                        DataStoreIds: [1],
+                        CreatorOwnershipTokenId: null,
+                        OwnershipTokenIds: []
+                    )
+                );
                 A.CallTo(() =>
                         applicationContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null)
                     )
-                    .Returns(
-                        Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound())
-                    );
+                    .Returns(applicationContextResult);
                 A.CallTo(() =>
                         applicationContextProvider.ReloadApplicationByClientIdAsync(A<string>._, tenant: null)
                     )
-                    .Returns(
-                        Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound())
-                    );
+                    .Returns(applicationContextResult);
 
                 var resourceKeyValidator = A.Fake<IResourceKeyValidator>();
                 A.CallTo(() =>

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RelationalWriteSmokeTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RelationalWriteSmokeTests.cs
@@ -413,10 +413,18 @@ public class Given_A_Host_Using_The_Relational_Backend
                     );
 
                 var applicationContextProvider = A.Fake<IApplicationContextProvider>();
-                A.CallTo(() => applicationContextProvider.GetApplicationByClientIdAsync(A<string>._))
-                    .Returns(Task.FromResult<ApplicationContext?>(null));
-                A.CallTo(() => applicationContextProvider.ReloadApplicationByClientIdAsync(A<string>._))
-                    .Returns(Task.FromResult<ApplicationContext?>(null));
+                A.CallTo(() =>
+                        applicationContextProvider.GetApplicationByClientIdAsync(A<string>._, tenant: null)
+                    )
+                    .Returns(
+                        Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound())
+                    );
+                A.CallTo(() =>
+                        applicationContextProvider.ReloadApplicationByClientIdAsync(A<string>._, tenant: null)
+                    )
+                    .Returns(
+                        Task.FromResult<ApplicationContextResult>(new ApplicationContextResult.NotFound())
+                    );
 
                 var resourceKeyValidator = A.Fake<IResourceKeyValidator>();
                 A.CallTo(() =>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
@@ -85,6 +85,18 @@ public abstract class ApiIntegrationTestBase
     /// <summary>Enables ASP.NET Core response compression for scenarios that exercise coding variants.</summary>
     protected virtual bool EnableAspNetCompression => false;
 
+    /// <summary>Enables the <c>/{tenant}</c> route-qualifier segment for multitenancy-aware scenarios.</summary>
+    protected virtual bool MultiTenancy => false;
+
+    /// <summary>
+    /// When supplied, replaces only the singleton CMS-facing <c>IConfigurationServiceApplicationProvider</c>
+    /// instead of the whole <c>IApplicationContextProvider</c>, so a scenario can observe the real per-request
+    /// memoization performed by the production <c>CachedApplicationContextProvider</c>. Null keeps every other
+    /// scenario's historical always-stable fake.
+    /// </summary>
+    protected virtual IConfigurationServiceApplicationProvider? ApplicationContextConfigurationProviderOverride =>
+        null;
+
     /// <summary>Enables the DMS DocumentCache read-acceleration path for cache-backed read scenarios.</summary>
     protected virtual bool EnableDocumentCacheReadAcceleration => false;
 
@@ -189,6 +201,8 @@ public abstract class ApiIntegrationTestBase
         var clientNamespacePrefixes = ClientNamespacePrefixes;
         var assignedProfileNames = AssignedProfileNames;
         var suppressHydratedRowsOnce = SuppressHydratedRowsOnce;
+        var multiTenancy = MultiTenancy;
+        var applicationContextConfigurationProviderOverride = ApplicationContextConfigurationProviderOverride;
 
         _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
@@ -202,6 +216,7 @@ public abstract class ApiIntegrationTestBase
             builder.UseSetting("AppSettings:StartupStatusFilePath", startupStatusFilePath);
             builder.UseSetting("AppSettings:Datastore", Datastore);
             builder.UseSetting("AppSettings:BypassAuthorization", BypassAuthorization ? "true" : "false");
+            builder.UseSetting("AppSettings:MultiTenancy", multiTenancy ? "true" : "false");
             builder.UseSetting(
                 "AppSettings:EnableAspNetCompression",
                 EnableAspNetCompression ? "true" : "false"
@@ -254,7 +269,8 @@ public abstract class ApiIntegrationTestBase
                     documentCacheReadAcquisitionFailureRecorder,
                     documentCacheDirectFillTimeoutRecorder,
                     documentCacheReadTelemetryRecorder,
-                    assignedProfileNames
+                    assignedProfileNames,
+                    applicationContextConfigurationProviderOverride
                 );
 
                 if (queryRecorder is not null)

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesRegistration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesRegistration.cs
@@ -39,6 +39,12 @@ internal static class ExternalDoublesRegistration
     /// Collects the real provider exceptions observed while <paramref name="providerFailureTransform"/> is
     /// active, so a scenario can assert genuine <c>SqlException</c> provenance.
     /// </param>
+    /// <param name="applicationContextConfigurationProvider">
+    /// When supplied, replaces only the singleton CMS-facing <c>IConfigurationServiceApplicationProvider</c>
+    /// and leaves the production scoped <c>CachedApplicationContextProvider</c> registration in place, so a
+    /// scenario can observe the real per-request memoization instead of the always-stable fake. Null keeps
+    /// the historical behavior of replacing <c>IApplicationContextProvider</c> outright.
+    /// </param>
     public static void RegisterAll(
         IServiceCollection services,
         FixtureContext fixture,
@@ -55,7 +61,8 @@ internal static class ExternalDoublesRegistration
         DocumentCacheReadAcquisitionFailureRecorder? documentCacheReadAcquisitionFailureRecorder = null,
         DocumentCacheDirectFillTimeoutRecorder? documentCacheDirectFillTimeoutRecorder = null,
         DocumentCacheReadTelemetryRecorder? documentCacheReadTelemetryRecorder = null,
-        IReadOnlyList<string>? assignedProfileNames = null
+        IReadOnlyList<string>? assignedProfileNames = null,
+        IConfigurationServiceApplicationProvider? applicationContextConfigurationProvider = null
     )
     {
         if (
@@ -71,7 +78,17 @@ internal static class ExternalDoublesRegistration
         services.RemoveAll<IJwtValidationService>();
         services.RemoveAll<IConfigurationManager<OpenIdConnectConfiguration>>();
         services.RemoveAll<IClaimSetProvider>();
-        services.RemoveAll<IApplicationContextProvider>();
+        if (applicationContextConfigurationProvider is null)
+        {
+            services.RemoveAll<IApplicationContextProvider>();
+        }
+        else
+        {
+            // Leave the production scoped IApplicationContextProvider registration (CachedApplicationContextProvider)
+            // in place and swap only the CMS-facing dependency it wraps, so per-request memoization is real.
+            services.RemoveAll<IConfigurationServiceApplicationProvider>();
+            services.AddSingleton(applicationContextConfigurationProvider);
+        }
         services.RemoveAll<IDataStoreProvider>();
         services.RemoveAll<IProfileCmsProvider>();
         services.RemoveAll<IStartupProcessExit>();
@@ -101,7 +118,10 @@ internal static class ExternalDoublesRegistration
 
         services.AddSingleton(FakeOidcConfigurationManager.Stable());
         services.AddSingleton(claimSetProvider);
-        services.AddSingleton<IApplicationContextProvider>(FakeApplicationContextProvider.Stable());
+        if (applicationContextConfigurationProvider is null)
+        {
+            services.AddSingleton<IApplicationContextProvider>(FakeApplicationContextProvider.Stable());
+        }
         services.AddSingleton<IDataStoreProvider>(
             FakeDataStoreProvider.WithSingleInstance(
                 id: ExternalDoublesConstants.StableDataStoreId,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeApplicationContextProvider.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeApplicationContextProvider.cs
@@ -24,13 +24,14 @@ internal static class FakeApplicationContextProvider
             ExternalDoublesConstants.StableApplicationId,
             ExternalDoublesConstants.SmokeClientId,
             ExternalDoublesConstants.StableClientUuid,
-            [ExternalDoublesConstants.StableDataStoreId]
+            [ExternalDoublesConstants.StableDataStoreId],
+            CreatorOwnershipTokenId: null,
+            OwnershipTokenIds: []
         );
+        ApplicationContextResult result = new ApplicationContextResult.Success(context);
 
-        A.CallTo(() => fake.GetApplicationByClientIdAsync(A<string>._))
-            .Returns(Task.FromResult<ApplicationContext?>(context));
-        A.CallTo(() => fake.ReloadApplicationByClientIdAsync(A<string>._))
-            .Returns(Task.FromResult<ApplicationContext?>(context));
+        A.CallTo(() => fake.GetApplicationByClientIdAsync(A<string>._, A<string?>._)).Returns(result);
+        A.CallTo(() => fake.ReloadApplicationByClientIdAsync(A<string>._, A<string?>._)).Returns(result);
 
         return fake;
     }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/RecordingConfigurationServiceApplicationProvider.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/RecordingConfigurationServiceApplicationProvider.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Replaces the singleton <see cref="IConfigurationServiceApplicationProvider"/> underneath the real,
+/// scoped <see cref="CachedApplicationContextProvider"/> so a scenario can observe how many times the
+/// simulated CMS call fires per HTTP request while the production per-request memoization stays in
+/// the request path. Every call is recorded before the configured <paramref name="resolve"/> result
+/// is returned.
+/// </summary>
+internal sealed class RecordingConfigurationServiceApplicationProvider(
+    Func<string, string?, ApplicationContextResult> resolve
+) : IConfigurationServiceApplicationProvider
+{
+    private readonly object _lock = new();
+    private readonly List<(string ClientId, string? Tenant)> _invocations = [];
+
+    public IReadOnlyList<(string ClientId, string? Tenant)> Invocations
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _invocations];
+            }
+        }
+    }
+
+    public Task<ApplicationContextResult> GetApplicationByClientIdAsync(string clientId, string? tenant)
+    {
+        lock (_lock)
+        {
+            _invocations.Add((clientId, tenant));
+        }
+
+        return Task.FromResult(resolve(clientId, tenant));
+    }
+
+    public Task<ApplicationContextResult> ReloadApplicationByClientIdAsync(string clientId, string? tenant) =>
+        GetApplicationByClientIdAsync(clientId, tenant);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ApplicationContextIntegrationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ApplicationContextIntegrationScenario.cs
@@ -104,6 +104,47 @@ internal static class ApplicationContextIntegrationScenario
         AssertNoApplicationContextDetailLeaked(body);
     }
 
+    public static async Task It_requires_application_context_for_ownership_authorized_get_put_and_delete(
+        ApiIntegrationHarness harness,
+        RecordingConfigurationServiceApplicationProvider provider,
+        string tenant
+    )
+    {
+        string resourceId = Guid.NewGuid().ToString();
+        string resourcePath = $"{string.Format(StudentsEndpointFormat, tenant)}/{resourceId}";
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(resourcePath);
+        string getBody = await getResponse.Content.ReadAsStringAsync();
+        AssertRequiredContextNotFound(getResponse, getBody);
+
+        JsonObject payload = new()
+        {
+            ["id"] = resourceId,
+            ["studentUniqueId"] = "app-context-ownership-update-001",
+            ["firstName"] = "Ada",
+        };
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, resourcePath)
+        {
+            Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json"),
+        };
+        using HttpResponseMessage putResponse = await harness.HttpClient.SendAsync(putRequest);
+        string putBody = await putResponse.Content.ReadAsStringAsync();
+        AssertRequiredContextNotFound(putResponse, putBody);
+
+        using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(resourcePath);
+        string deleteBody = await deleteResponse.Content.ReadAsStringAsync();
+        AssertRequiredContextNotFound(deleteResponse, deleteBody);
+
+        (string ClientId, string? Tenant)[] ownershipInvocations =
+        [
+            .. provider.Invocations.Where(invocation => invocation.Tenant == tenant),
+        ];
+        ownershipInvocations.Should().HaveCount(3);
+        ownershipInvocations
+            .Should()
+            .OnlyContain(invocation => invocation.ClientId == ExternalDoublesConstants.SmokeClientId);
+    }
+
     private static async Task<HttpResponseMessage> PostStudentAsync(
         ApiIntegrationHarness harness,
         string tenant,
@@ -121,6 +162,13 @@ internal static class ApplicationContextIntegrationScenario
         };
 
         return await harness.HttpClient.SendAsync(request);
+    }
+
+    private static void AssertRequiredContextNotFound(HttpResponseMessage response, string body)
+    {
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized, body);
+        response.Headers.WwwAuthenticate.ToString().Should().Contain("invalid_token");
+        AssertNoApplicationContextDetailLeaked(body);
     }
 
     /// <summary>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ApplicationContextIntegrationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ApplicationContextIntegrationScenario.cs
@@ -20,6 +20,8 @@ namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
 internal static class ApplicationContextIntegrationScenario
 {
     private const string StudentsEndpointFormat = "/{0}/data/ed-fi/students";
+    private const string ProfiledStudentWritableContentType =
+        "application/vnd.ed-fi.student.testprofile.writable+json";
 
     public static async Task It_resolves_application_context_at_most_once_per_request(
         ApiIntegrationHarness harness,
@@ -104,6 +106,20 @@ internal static class ApplicationContextIntegrationScenario
         AssertNoApplicationContextDetailLeaked(body);
     }
 
+    public static async Task It_fails_closed_for_profiled_invalid_puts_before_document_validation(
+        ApiIntegrationHarness harness,
+        string notFoundTenant,
+        string unavailableTenant
+    )
+    {
+        await AssertProfiledInvalidPutFailsClosedAsync(harness, notFoundTenant, HttpStatusCode.Unauthorized);
+        await AssertProfiledInvalidPutFailsClosedAsync(
+            harness,
+            unavailableTenant,
+            HttpStatusCode.ServiceUnavailable
+        );
+    }
+
     public static async Task It_requires_application_context_for_ownership_authorized_get_put_and_delete(
         ApiIntegrationHarness harness,
         RecordingConfigurationServiceApplicationProvider provider,
@@ -162,6 +178,29 @@ internal static class ApplicationContextIntegrationScenario
         };
 
         return await harness.HttpClient.SendAsync(request);
+    }
+
+    private static async Task AssertProfiledInvalidPutFailsClosedAsync(
+        ApiIntegrationHarness harness,
+        string tenant,
+        HttpStatusCode expectedStatusCode
+    )
+    {
+        string resourcePath = $"{string.Format(StudentsEndpointFormat, tenant)}/{Guid.NewGuid()}";
+        using var request = new HttpRequestMessage(HttpMethod.Put, resourcePath)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, ProfiledStudentWritableContentType),
+        };
+        using HttpResponseMessage response = await harness.HttpClient.SendAsync(request);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(expectedStatusCode, body);
+        if (expectedStatusCode == HttpStatusCode.Unauthorized)
+        {
+            response.Headers.WwwAuthenticate.ToString().Should().Contain("invalid_token");
+        }
+
+        AssertNoApplicationContextDetailLeaked(body);
     }
 
     private static void AssertRequiredContextNotFound(HttpResponseMessage response, string body)

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ApplicationContextIntegrationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ApplicationContextIntegrationScenario.cs
@@ -120,45 +120,104 @@ internal static class ApplicationContextIntegrationScenario
         );
     }
 
-    public static async Task It_requires_application_context_for_ownership_authorized_get_put_and_delete(
+    /// <summary>
+    /// The delete pipeline carries no ProfileResolutionMiddleware, so the only application-context demand a
+    /// DELETE raises is ApplicationContextRequirementMiddleware's, and it is raised only after
+    /// ResourceActionAuthorizationMiddleware has selected OwnershipBased for the action. On a tenant no other
+    /// scenario touches, that single recorded lookup is the ownership gate itself and the 401 is the gate
+    /// failing closed - drop the gate from the delete pipeline and the lookup count falls to zero.
+    /// </summary>
+    public static async Task It_requires_application_context_at_the_ownership_gate_for_delete(
         ApiIntegrationHarness harness,
         RecordingConfigurationServiceApplicationProvider provider,
         string tenant
     )
     {
-        string resourceId = Guid.NewGuid().ToString();
-        string resourcePath = $"{string.Format(StudentsEndpointFormat, tenant)}/{resourceId}";
-
-        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(resourcePath);
-        string getBody = await getResponse.Content.ReadAsStringAsync();
-        AssertRequiredContextNotFound(getResponse, getBody);
-
-        JsonObject payload = new()
-        {
-            ["id"] = resourceId,
-            ["studentUniqueId"] = "app-context-ownership-update-001",
-            ["firstName"] = "Ada",
-        };
-        using var putRequest = new HttpRequestMessage(HttpMethod.Put, resourcePath)
-        {
-            Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json"),
-        };
-        using HttpResponseMessage putResponse = await harness.HttpClient.SendAsync(putRequest);
-        string putBody = await putResponse.Content.ReadAsStringAsync();
-        AssertRequiredContextNotFound(putResponse, putBody);
+        string resourcePath = $"{string.Format(StudentsEndpointFormat, tenant)}/{Guid.NewGuid()}";
 
         using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(resourcePath);
         string deleteBody = await deleteResponse.Content.ReadAsStringAsync();
         AssertRequiredContextNotFound(deleteResponse, deleteBody);
 
-        (string ClientId, string? Tenant)[] ownershipInvocations =
+        provider
+            .Invocations.Where(invocation => invocation.Tenant == tenant)
+            .Should()
+            .ContainSingle()
+            .Which.ClientId.Should()
+            .Be(ExternalDoublesConstants.SmokeClientId);
+    }
+
+    /// <summary>
+    /// Ownership-authorized GET and PUT require application context too, but their pipelines resolve profiles
+    /// first: ProfileResolutionMiddleware raises the request's first demand and fails closed on it before any
+    /// strategy has been selected, and the scoped CachedApplicationContextProvider memoizes that outcome for
+    /// the rest of the request. What a served response can prove for those two methods is therefore the
+    /// requirement itself - context is resolved before either is served, a request that cannot resolve it is
+    /// refused without disclosure, and a request that resolves it runs on past every demand - not which
+    /// middleware raised the demand. That the gate still follows strategy selection on both pipelines is held by
+    /// PipelineOrderingTests.It_places_the_application_context_gate_immediately_after_strategy_selection, and
+    /// its ownership branch by
+    /// ApplicationContextRequirementMiddlewareTests.It_requires_application_context_for_OwnershipBased_resource_actions.
+    /// </summary>
+    public static async Task It_requires_application_context_for_ownership_authorized_gets_and_puts(
+        ApiIntegrationHarness harness,
+        RecordingConfigurationServiceApplicationProvider provider,
+        string notFoundTenant,
+        string successTenant
+    )
+    {
+        string unresolvableId = Guid.NewGuid().ToString();
+        string unresolvablePath = $"{string.Format(StudentsEndpointFormat, notFoundTenant)}/{unresolvableId}";
+
+        using HttpResponseMessage unresolvableGet = await harness.HttpClient.GetAsync(unresolvablePath);
+        string unresolvableGetBody = await unresolvableGet.Content.ReadAsStringAsync();
+        AssertRequiredContextNotFound(unresolvableGet, unresolvableGetBody);
+
+        using HttpResponseMessage unresolvablePut = await PutStudentAsync(
+            harness,
+            unresolvablePath,
+            unresolvableId,
+            studentUniqueId: "app-context-ownership-update-001"
+        );
+        string unresolvablePutBody = await unresolvablePut.Content.ReadAsStringAsync();
+        AssertRequiredContextNotFound(unresolvablePut, unresolvablePutBody);
+
+        (string ClientId, string? Tenant)[] unresolvableInvocations =
         [
-            .. provider.Invocations.Where(invocation => invocation.Tenant == tenant),
+            .. provider.Invocations.Where(invocation => invocation.Tenant == notFoundTenant),
         ];
-        ownershipInvocations.Should().HaveCount(3);
-        ownershipInvocations
+        unresolvableInvocations.Should().HaveCount(2);
+        unresolvableInvocations
             .Should()
             .OnlyContain(invocation => invocation.ClientId == ExternalDoublesConstants.SmokeClientId);
+
+        // The same two requests against a tenant the provider resolves must clear every application-context
+        // demand the pipeline raises - profile resolution's and the ownership gate's - so neither may answer
+        // with either required-context failure. One simulated CMS call covers both requests here, against one
+        // per request above: only a resolved context is cacheable, so the failures re-ask on every request
+        // while the success is served to the second request from the cache the first one filled.
+        string resolvableId = Guid.NewGuid().ToString();
+        string resolvablePath = $"{string.Format(StudentsEndpointFormat, successTenant)}/{resolvableId}";
+
+        using HttpResponseMessage resolvableGet = await harness.HttpClient.GetAsync(resolvablePath);
+        string resolvableGetBody = await resolvableGet.Content.ReadAsStringAsync();
+        AssertRequiredContextSatisfied(resolvableGet, resolvableGetBody);
+
+        using HttpResponseMessage resolvablePut = await PutStudentAsync(
+            harness,
+            resolvablePath,
+            resolvableId,
+            studentUniqueId: "app-context-ownership-success-001"
+        );
+        string resolvablePutBody = await resolvablePut.Content.ReadAsStringAsync();
+        AssertRequiredContextSatisfied(resolvablePut, resolvablePutBody);
+
+        provider
+            .Invocations.Where(invocation => invocation.Tenant == successTenant)
+            .Should()
+            .ContainSingle()
+            .Which.ClientId.Should()
+            .Be(ExternalDoublesConstants.SmokeClientId);
     }
 
     private static async Task<HttpResponseMessage> PostStudentAsync(
@@ -173,6 +232,28 @@ internal static class ApplicationContextIntegrationScenario
             HttpMethod.Post,
             string.Format(StudentsEndpointFormat, tenant)
         )
+        {
+            Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json"),
+        };
+
+        return await harness.HttpClient.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> PutStudentAsync(
+        ApiIntegrationHarness harness,
+        string resourcePath,
+        string resourceId,
+        string studentUniqueId
+    )
+    {
+        JsonObject payload = new()
+        {
+            ["id"] = resourceId,
+            ["studentUniqueId"] = studentUniqueId,
+            ["firstName"] = "Ada",
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, resourcePath)
         {
             Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json"),
         };
@@ -208,6 +289,19 @@ internal static class ApplicationContextIntegrationScenario
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized, body);
         response.Headers.WwwAuthenticate.ToString().Should().Contain("invalid_token");
         AssertNoApplicationContextDetailLeaked(body);
+    }
+
+    /// <summary>
+    /// Asserts a request cleared every application-context demand rather than being turned back by one. The
+    /// served status is deliberately not pinned: what follows the last demand is the resource's own outcome,
+    /// which belongs to the authorization and handler tests, while the two required-context failures are the
+    /// only answers this scenario is entitled to rule out.
+    /// </summary>
+    private static void AssertRequiredContextSatisfied(HttpResponseMessage response, string body)
+    {
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized, body);
+        response.StatusCode.Should().NotBe(HttpStatusCode.ServiceUnavailable, body);
+        response.Headers.WwwAuthenticate.ToString().Should().NotContain("invalid_token");
     }
 
     /// <summary>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ApplicationContextIntegrationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ApplicationContextIntegrationScenario.cs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using FluentAssertions;
+
+namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+/// <summary>
+/// Real-HTTP-pipeline coverage for the DMS-1373 application-context provider: per-request demand is
+/// memoized to a single simulated CMS call, tenants resolve independent contexts, and the required-context
+/// failure mapping (401 NotFound / 503 Unavailable) never discloses ownership or provider internals. Hard-coded
+/// for the ProfileRootOnlyMerge fixture's Student shape, matching <see cref="CrudRoundTripScenario"/>.
+/// </summary>
+internal static class ApplicationContextIntegrationScenario
+{
+    private const string StudentsEndpointFormat = "/{0}/data/ed-fi/students";
+
+    public static async Task It_resolves_application_context_at_most_once_per_request(
+        ApiIntegrationHarness harness,
+        RecordingConfigurationServiceApplicationProvider provider,
+        string tenant
+    )
+    {
+        using HttpResponseMessage response = await PostStudentAsync(
+            harness,
+            tenant,
+            studentUniqueId: "app-context-call-count-001"
+        );
+        string body = await response.Content.ReadAsStringAsync();
+
+        // The upsert pipeline demands application context three times - once from ProfileResolutionMiddleware
+        // and twice from ApplicationContextRequirementMiddleware (once before, once after resource-action
+        // authorization) - so a single simulated CMS call proves the scoped CachedApplicationContextProvider
+        // memoized the first result for the rest of the request.
+        response.StatusCode.Should().Be(HttpStatusCode.Created, body);
+        provider.Invocations.Should().ContainSingle(invocation => invocation.Tenant == tenant);
+    }
+
+    public static async Task It_resolves_independent_contexts_per_tenant(
+        ApiIntegrationHarness harness,
+        RecordingConfigurationServiceApplicationProvider provider,
+        string firstTenant,
+        string secondTenant
+    )
+    {
+        using HttpResponseMessage firstResponse = await PostStudentAsync(
+            harness,
+            firstTenant,
+            studentUniqueId: "app-context-tenant-isolation-001"
+        );
+        string firstBody = await firstResponse.Content.ReadAsStringAsync();
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.Created, firstBody);
+
+        using HttpResponseMessage secondResponse = await PostStudentAsync(
+            harness,
+            secondTenant,
+            studentUniqueId: "app-context-tenant-isolation-002"
+        );
+        string secondBody = await secondResponse.Content.ReadAsStringAsync();
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.Created, secondBody);
+
+        // Each tenant must reach the simulated CMS independently: a shared cache key across tenants would
+        // let the second request reuse the first tenant's cached success without ever calling the provider.
+        provider.Invocations.Should().Contain(invocation => invocation.Tenant == firstTenant);
+        provider.Invocations.Should().Contain(invocation => invocation.Tenant == secondTenant);
+    }
+
+    public static async Task It_maps_not_found_to_401_without_disclosure(
+        ApiIntegrationHarness harness,
+        string tenant
+    )
+    {
+        using HttpResponseMessage response = await PostStudentAsync(
+            harness,
+            tenant,
+            studentUniqueId: "app-context-not-found-001"
+        );
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized, body);
+        response.Headers.WwwAuthenticate.ToString().Should().Contain("invalid_token");
+        AssertNoApplicationContextDetailLeaked(body);
+    }
+
+    public static async Task It_maps_unavailable_to_503_without_disclosure(
+        ApiIntegrationHarness harness,
+        string tenant
+    )
+    {
+        using HttpResponseMessage response = await PostStudentAsync(
+            harness,
+            tenant,
+            studentUniqueId: "app-context-unavailable-001"
+        );
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable, body);
+        AssertNoApplicationContextDetailLeaked(body);
+    }
+
+    private static async Task<HttpResponseMessage> PostStudentAsync(
+        ApiIntegrationHarness harness,
+        string tenant,
+        string studentUniqueId
+    )
+    {
+        JsonObject payload = new() { ["studentUniqueId"] = studentUniqueId, ["firstName"] = "Ada" };
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            string.Format(StudentsEndpointFormat, tenant)
+        )
+        {
+            Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json"),
+        };
+
+        return await harness.HttpClient.SendAsync(request);
+    }
+
+    /// <summary>
+    /// The served body must never carry ownership token values, the internal result-type names, or
+    /// provider/exception detail, regardless of which required-context failure produced it.
+    /// </summary>
+    private static void AssertNoApplicationContextDetailLeaked(string body)
+    {
+        string[] forbiddenFragments =
+        [
+            "ownershipToken",
+            "OwnershipToken",
+            "CreatorOwnershipTokenId",
+            "ApplicationContextResult",
+            "ApplicationContext.NotFound",
+            "ApplicationContext.Unavailable",
+            "Exception",
+            "   at ",
+        ];
+
+        foreach (var fragment in forbiddenFragments)
+        {
+            body.Should()
+                .NotContain(
+                    fragment,
+                    $"the served response must not leak application-context detail '{fragment}'"
+                );
+        }
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ApplicationContextIntegration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ApplicationContextIntegration.cs
@@ -4,6 +4,8 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Security;
+using EdFi.DataManagementService.Core.Security;
 using EdFi.DataManagementService.Tests.Integration.Doubles;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
 using EdFi.DataManagementService.Tests.Integration.Mssql;
@@ -23,6 +25,7 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
     private const string FirstIsolationTenant = "app-context-tenant-a";
     private const string SecondIsolationTenant = "app-context-tenant-b";
     private const string NotFoundTenant = "app-context-not-found-tenant";
+    private const string OwnershipNotFoundTenant = "app-context-ownership-not-found-tenant";
     private const string UnavailableTenant = "app-context-unavailable-tenant";
 
     private readonly RecordingConfigurationServiceApplicationProvider _applicationContextProvider = new(
@@ -32,6 +35,17 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
     protected override FixtureKey Fixture => FixtureKey.ProfileRootOnlyMerge;
 
     protected override bool MultiTenancy => true;
+
+    protected override bool BypassAuthorization => false;
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        new ConfigurableClaimSetProvider(
+            fixture,
+            static (_, action) =>
+                action is "Read" or "Update" or "Delete"
+                    ? [AuthorizationStrategyNameConstants.OwnershipBased]
+                    : [AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired]
+        );
 
     protected override IConfigurationServiceApplicationProvider? ApplicationContextConfigurationProviderOverride =>
         _applicationContextProvider;
@@ -67,10 +81,19 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
             UnavailableTenant
         );
 
+    [Test]
+    public Task It_requires_application_context_for_ownership_authorized_get_put_and_delete() =>
+        ApplicationContextIntegrationScenario.It_requires_application_context_for_ownership_authorized_get_put_and_delete(
+            Harness,
+            _applicationContextProvider,
+            OwnershipNotFoundTenant
+        );
+
     private static ApplicationContextResult Resolve(string clientId, string? tenant) =>
         tenant switch
         {
             NotFoundTenant => new ApplicationContextResult.NotFound(),
+            OwnershipNotFoundTenant => new ApplicationContextResult.NotFound(),
             UnavailableTenant => new ApplicationContextResult.Unavailable(),
             FirstIsolationTenant => Success(applicationId: 201),
             SecondIsolationTenant => Success(applicationId: 202),

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ApplicationContextIntegration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ApplicationContextIntegration.cs
@@ -27,6 +27,8 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
     private const string NotFoundTenant = "app-context-not-found-tenant";
     private const string OwnershipNotFoundTenant = "app-context-ownership-not-found-tenant";
     private const string UnavailableTenant = "app-context-unavailable-tenant";
+    private const string ProfileNotFoundTenant = "app-context-profile-not-found-tenant";
+    private const string ProfileUnavailableTenant = "app-context-profile-unavailable-tenant";
 
     private readonly RecordingConfigurationServiceApplicationProvider _applicationContextProvider = new(
         Resolve
@@ -82,6 +84,14 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
         );
 
     [Test]
+    public Task It_fails_closed_for_profiled_invalid_puts_before_document_validation() =>
+        ApplicationContextIntegrationScenario.It_fails_closed_for_profiled_invalid_puts_before_document_validation(
+            Harness,
+            ProfileNotFoundTenant,
+            ProfileUnavailableTenant
+        );
+
+    [Test]
     public Task It_requires_application_context_for_ownership_authorized_get_put_and_delete() =>
         ApplicationContextIntegrationScenario.It_requires_application_context_for_ownership_authorized_get_put_and_delete(
             Harness,
@@ -95,6 +105,8 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
             NotFoundTenant => new ApplicationContextResult.NotFound(),
             OwnershipNotFoundTenant => new ApplicationContextResult.NotFound(),
             UnavailableTenant => new ApplicationContextResult.Unavailable(),
+            ProfileNotFoundTenant => new ApplicationContextResult.NotFound(),
+            ProfileUnavailableTenant => new ApplicationContextResult.Unavailable(),
             FirstIsolationTenant => Success(applicationId: 201),
             SecondIsolationTenant => Success(applicationId: 202),
             _ => Success(applicationId: 200),

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ApplicationContextIntegration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ApplicationContextIntegration.cs
@@ -26,6 +26,8 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
     private const string SecondIsolationTenant = "app-context-tenant-b";
     private const string NotFoundTenant = "app-context-not-found-tenant";
     private const string OwnershipNotFoundTenant = "app-context-ownership-not-found-tenant";
+    private const string OwnershipGetPutNotFoundTenant = "app-context-ownership-get-put-not-found-tenant";
+    private const string OwnershipSuccessTenant = "app-context-ownership-success-tenant";
     private const string UnavailableTenant = "app-context-unavailable-tenant";
     private const string ProfileNotFoundTenant = "app-context-profile-not-found-tenant";
     private const string ProfileUnavailableTenant = "app-context-profile-unavailable-tenant";
@@ -92,11 +94,20 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
         );
 
     [Test]
-    public Task It_requires_application_context_for_ownership_authorized_get_put_and_delete() =>
-        ApplicationContextIntegrationScenario.It_requires_application_context_for_ownership_authorized_get_put_and_delete(
+    public Task It_requires_application_context_at_the_ownership_gate_for_delete() =>
+        ApplicationContextIntegrationScenario.It_requires_application_context_at_the_ownership_gate_for_delete(
             Harness,
             _applicationContextProvider,
             OwnershipNotFoundTenant
+        );
+
+    [Test]
+    public Task It_requires_application_context_for_ownership_authorized_gets_and_puts() =>
+        ApplicationContextIntegrationScenario.It_requires_application_context_for_ownership_authorized_gets_and_puts(
+            Harness,
+            _applicationContextProvider,
+            OwnershipGetPutNotFoundTenant,
+            OwnershipSuccessTenant
         );
 
     private static ApplicationContextResult Resolve(string clientId, string? tenant) =>
@@ -104,6 +115,8 @@ public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrat
         {
             NotFoundTenant => new ApplicationContextResult.NotFound(),
             OwnershipNotFoundTenant => new ApplicationContextResult.NotFound(),
+            OwnershipGetPutNotFoundTenant => new ApplicationContextResult.NotFound(),
+            OwnershipSuccessTenant => Success(applicationId: 203),
             UnavailableTenant => new ApplicationContextResult.Unavailable(),
             ProfileNotFoundTenant => new ApplicationContextResult.NotFound(),
             ProfileUnavailableTenant => new ApplicationContextResult.Unavailable(),

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ApplicationContextIntegration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ApplicationContextIntegration.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Mssql;
+
+/// <summary>
+/// Real-HTTP-pipeline coverage for the DMS-1373 tenant-aware application-context provider: request-scoped
+/// memoization, tenant isolation, and the fail-closed 401/503 mapping with no ownership disclosure. The
+/// production scoped <c>CachedApplicationContextProvider</c> stays wired; only the CMS-facing
+/// <c>IConfigurationServiceApplicationProvider</c> underneath it is replaced.
+/// </summary>
+public sealed class Given_Mssql_ApplicationContextIntegration : MssqlApiIntegrationTestBase
+{
+    private const string CallCountTenant = "app-context-call-count-tenant";
+    private const string FirstIsolationTenant = "app-context-tenant-a";
+    private const string SecondIsolationTenant = "app-context-tenant-b";
+    private const string NotFoundTenant = "app-context-not-found-tenant";
+    private const string UnavailableTenant = "app-context-unavailable-tenant";
+
+    private readonly RecordingConfigurationServiceApplicationProvider _applicationContextProvider = new(
+        Resolve
+    );
+
+    protected override FixtureKey Fixture => FixtureKey.ProfileRootOnlyMerge;
+
+    protected override bool MultiTenancy => true;
+
+    protected override IConfigurationServiceApplicationProvider? ApplicationContextConfigurationProviderOverride =>
+        _applicationContextProvider;
+
+    [Test]
+    public Task It_resolves_application_context_at_most_once_per_request() =>
+        ApplicationContextIntegrationScenario.It_resolves_application_context_at_most_once_per_request(
+            Harness,
+            _applicationContextProvider,
+            CallCountTenant
+        );
+
+    [Test]
+    public Task It_resolves_independent_contexts_per_tenant() =>
+        ApplicationContextIntegrationScenario.It_resolves_independent_contexts_per_tenant(
+            Harness,
+            _applicationContextProvider,
+            FirstIsolationTenant,
+            SecondIsolationTenant
+        );
+
+    [Test]
+    public Task It_maps_not_found_to_401_without_disclosure() =>
+        ApplicationContextIntegrationScenario.It_maps_not_found_to_401_without_disclosure(
+            Harness,
+            NotFoundTenant
+        );
+
+    [Test]
+    public Task It_maps_unavailable_to_503_without_disclosure() =>
+        ApplicationContextIntegrationScenario.It_maps_unavailable_to_503_without_disclosure(
+            Harness,
+            UnavailableTenant
+        );
+
+    private static ApplicationContextResult Resolve(string clientId, string? tenant) =>
+        tenant switch
+        {
+            NotFoundTenant => new ApplicationContextResult.NotFound(),
+            UnavailableTenant => new ApplicationContextResult.Unavailable(),
+            FirstIsolationTenant => Success(applicationId: 201),
+            SecondIsolationTenant => Success(applicationId: 202),
+            _ => Success(applicationId: 200),
+        };
+
+    private static ApplicationContextResult Success(long applicationId) =>
+        new ApplicationContextResult.Success(
+            new ApplicationContext(
+                Id: applicationId,
+                ApplicationId: applicationId,
+                ClientId: ExternalDoublesConstants.SmokeClientId,
+                ClientUuid: ExternalDoublesConstants.StableClientUuid,
+                DataStoreIds: [ExternalDoublesConstants.StableDataStoreId],
+                CreatorOwnershipTokenId: null,
+                OwnershipTokenIds: []
+            )
+        );
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ApplicationContextIntegration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ApplicationContextIntegration.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Postgresql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Postgresql;
+
+/// <summary>
+/// Real-HTTP-pipeline coverage for the DMS-1373 tenant-aware application-context provider: request-scoped
+/// memoization, tenant isolation, and the fail-closed 401/503 mapping with no ownership disclosure. The
+/// production scoped <c>CachedApplicationContextProvider</c> stays wired; only the CMS-facing
+/// <c>IConfigurationServiceApplicationProvider</c> underneath it is replaced.
+/// </summary>
+public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlApiIntegrationTestBase
+{
+    private const string CallCountTenant = "app-context-call-count-tenant";
+    private const string FirstIsolationTenant = "app-context-tenant-a";
+    private const string SecondIsolationTenant = "app-context-tenant-b";
+    private const string NotFoundTenant = "app-context-not-found-tenant";
+    private const string UnavailableTenant = "app-context-unavailable-tenant";
+
+    private readonly RecordingConfigurationServiceApplicationProvider _applicationContextProvider = new(
+        Resolve
+    );
+
+    protected override FixtureKey Fixture => FixtureKey.ProfileRootOnlyMerge;
+
+    protected override bool MultiTenancy => true;
+
+    protected override IConfigurationServiceApplicationProvider? ApplicationContextConfigurationProviderOverride =>
+        _applicationContextProvider;
+
+    [Test]
+    public Task It_resolves_application_context_at_most_once_per_request() =>
+        ApplicationContextIntegrationScenario.It_resolves_application_context_at_most_once_per_request(
+            Harness,
+            _applicationContextProvider,
+            CallCountTenant
+        );
+
+    [Test]
+    public Task It_resolves_independent_contexts_per_tenant() =>
+        ApplicationContextIntegrationScenario.It_resolves_independent_contexts_per_tenant(
+            Harness,
+            _applicationContextProvider,
+            FirstIsolationTenant,
+            SecondIsolationTenant
+        );
+
+    [Test]
+    public Task It_maps_not_found_to_401_without_disclosure() =>
+        ApplicationContextIntegrationScenario.It_maps_not_found_to_401_without_disclosure(
+            Harness,
+            NotFoundTenant
+        );
+
+    [Test]
+    public Task It_maps_unavailable_to_503_without_disclosure() =>
+        ApplicationContextIntegrationScenario.It_maps_unavailable_to_503_without_disclosure(
+            Harness,
+            UnavailableTenant
+        );
+
+    private static ApplicationContextResult Resolve(string clientId, string? tenant) =>
+        tenant switch
+        {
+            NotFoundTenant => new ApplicationContextResult.NotFound(),
+            UnavailableTenant => new ApplicationContextResult.Unavailable(),
+            FirstIsolationTenant => Success(applicationId: 201),
+            SecondIsolationTenant => Success(applicationId: 202),
+            _ => Success(applicationId: 200),
+        };
+
+    private static ApplicationContextResult Success(long applicationId) =>
+        new ApplicationContextResult.Success(
+            new ApplicationContext(
+                Id: applicationId,
+                ApplicationId: applicationId,
+                ClientId: ExternalDoublesConstants.SmokeClientId,
+                ClientUuid: ExternalDoublesConstants.StableClientUuid,
+                DataStoreIds: [ExternalDoublesConstants.StableDataStoreId],
+                CreatorOwnershipTokenId: null,
+                OwnershipTokenIds: []
+            )
+        );
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ApplicationContextIntegration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ApplicationContextIntegration.cs
@@ -4,6 +4,8 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Security;
+using EdFi.DataManagementService.Core.Security;
 using EdFi.DataManagementService.Tests.Integration.Doubles;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
 using EdFi.DataManagementService.Tests.Integration.Postgresql;
@@ -23,6 +25,7 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
     private const string FirstIsolationTenant = "app-context-tenant-a";
     private const string SecondIsolationTenant = "app-context-tenant-b";
     private const string NotFoundTenant = "app-context-not-found-tenant";
+    private const string OwnershipNotFoundTenant = "app-context-ownership-not-found-tenant";
     private const string UnavailableTenant = "app-context-unavailable-tenant";
 
     private readonly RecordingConfigurationServiceApplicationProvider _applicationContextProvider = new(
@@ -32,6 +35,17 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
     protected override FixtureKey Fixture => FixtureKey.ProfileRootOnlyMerge;
 
     protected override bool MultiTenancy => true;
+
+    protected override bool BypassAuthorization => false;
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        new ConfigurableClaimSetProvider(
+            fixture,
+            static (_, action) =>
+                action is "Read" or "Update" or "Delete"
+                    ? [AuthorizationStrategyNameConstants.OwnershipBased]
+                    : [AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired]
+        );
 
     protected override IConfigurationServiceApplicationProvider? ApplicationContextConfigurationProviderOverride =>
         _applicationContextProvider;
@@ -67,10 +81,19 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
             UnavailableTenant
         );
 
+    [Test]
+    public Task It_requires_application_context_for_ownership_authorized_get_put_and_delete() =>
+        ApplicationContextIntegrationScenario.It_requires_application_context_for_ownership_authorized_get_put_and_delete(
+            Harness,
+            _applicationContextProvider,
+            OwnershipNotFoundTenant
+        );
+
     private static ApplicationContextResult Resolve(string clientId, string? tenant) =>
         tenant switch
         {
             NotFoundTenant => new ApplicationContextResult.NotFound(),
+            OwnershipNotFoundTenant => new ApplicationContextResult.NotFound(),
             UnavailableTenant => new ApplicationContextResult.Unavailable(),
             FirstIsolationTenant => Success(applicationId: 201),
             SecondIsolationTenant => Success(applicationId: 202),

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ApplicationContextIntegration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ApplicationContextIntegration.cs
@@ -26,6 +26,8 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
     private const string SecondIsolationTenant = "app-context-tenant-b";
     private const string NotFoundTenant = "app-context-not-found-tenant";
     private const string OwnershipNotFoundTenant = "app-context-ownership-not-found-tenant";
+    private const string OwnershipGetPutNotFoundTenant = "app-context-ownership-get-put-not-found-tenant";
+    private const string OwnershipSuccessTenant = "app-context-ownership-success-tenant";
     private const string UnavailableTenant = "app-context-unavailable-tenant";
     private const string ProfileNotFoundTenant = "app-context-profile-not-found-tenant";
     private const string ProfileUnavailableTenant = "app-context-profile-unavailable-tenant";
@@ -92,11 +94,20 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
         );
 
     [Test]
-    public Task It_requires_application_context_for_ownership_authorized_get_put_and_delete() =>
-        ApplicationContextIntegrationScenario.It_requires_application_context_for_ownership_authorized_get_put_and_delete(
+    public Task It_requires_application_context_at_the_ownership_gate_for_delete() =>
+        ApplicationContextIntegrationScenario.It_requires_application_context_at_the_ownership_gate_for_delete(
             Harness,
             _applicationContextProvider,
             OwnershipNotFoundTenant
+        );
+
+    [Test]
+    public Task It_requires_application_context_for_ownership_authorized_gets_and_puts() =>
+        ApplicationContextIntegrationScenario.It_requires_application_context_for_ownership_authorized_gets_and_puts(
+            Harness,
+            _applicationContextProvider,
+            OwnershipGetPutNotFoundTenant,
+            OwnershipSuccessTenant
         );
 
     private static ApplicationContextResult Resolve(string clientId, string? tenant) =>
@@ -104,6 +115,8 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
         {
             NotFoundTenant => new ApplicationContextResult.NotFound(),
             OwnershipNotFoundTenant => new ApplicationContextResult.NotFound(),
+            OwnershipGetPutNotFoundTenant => new ApplicationContextResult.NotFound(),
+            OwnershipSuccessTenant => Success(applicationId: 203),
             UnavailableTenant => new ApplicationContextResult.Unavailable(),
             ProfileNotFoundTenant => new ApplicationContextResult.NotFound(),
             ProfileUnavailableTenant => new ApplicationContextResult.Unavailable(),

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ApplicationContextIntegration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ApplicationContextIntegration.cs
@@ -27,6 +27,8 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
     private const string NotFoundTenant = "app-context-not-found-tenant";
     private const string OwnershipNotFoundTenant = "app-context-ownership-not-found-tenant";
     private const string UnavailableTenant = "app-context-unavailable-tenant";
+    private const string ProfileNotFoundTenant = "app-context-profile-not-found-tenant";
+    private const string ProfileUnavailableTenant = "app-context-profile-unavailable-tenant";
 
     private readonly RecordingConfigurationServiceApplicationProvider _applicationContextProvider = new(
         Resolve
@@ -82,6 +84,14 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
         );
 
     [Test]
+    public Task It_fails_closed_for_profiled_invalid_puts_before_document_validation() =>
+        ApplicationContextIntegrationScenario.It_fails_closed_for_profiled_invalid_puts_before_document_validation(
+            Harness,
+            ProfileNotFoundTenant,
+            ProfileUnavailableTenant
+        );
+
+    [Test]
     public Task It_requires_application_context_for_ownership_authorized_get_put_and_delete() =>
         ApplicationContextIntegrationScenario.It_requires_application_context_for_ownership_authorized_get_put_and_delete(
             Harness,
@@ -95,6 +105,8 @@ public sealed class Given_Postgresql_ApplicationContextIntegration : PostgresqlA
             NotFoundTenant => new ApplicationContextResult.NotFound(),
             OwnershipNotFoundTenant => new ApplicationContextResult.NotFound(),
             UnavailableTenant => new ApplicationContextResult.Unavailable(),
+            ProfileNotFoundTenant => new ApplicationContextResult.NotFound(),
+            ProfileUnavailableTenant => new ApplicationContextResult.Unavailable(),
             FirstIsolationTenant => Success(applicationId: 201),
             SecondIsolationTenant => Success(applicationId: 202),
             _ => Success(applicationId: 200),


### PR DESCRIPTION
Extends DMS application-context retrieval so the creator and read/modify ownership tokens
maintained by CMS reach the relational authorization pipeline.

`ApplicationContext` now carries a nullable `CreatorOwnershipTokenId` and a non-null read-only
`OwnershipTokenIds` collection read from `GET /v3/apiClients/{clientId}`. These stay separate from
the JWT-derived `ClientAuthorizations` — no ownership claim or identity-provider mapper is added —
and are propagated into `RelationalAuthorizationContext` alongside the existing client
authorizations. The DMS-1060 ownership SQL strategy is not implemented here.

Application-context lookup returns typed `Success`, `NotFound`, and `Unavailable` results, with a
malformed successful CMS response classified as unavailable. `NotFound` maps to an invalid-token
401; `Unavailable` maps to 503. A request-scoped holder memoizes the first outcome, so an
authenticated resource request resolves the context at most once. Context is required for every
POST, and for GET, PUT, and DELETE whose selected authorization strategies include
`OwnershipBased`; profile resolution independently requires it because it needs an `ApplicationId`
before strategies are known.

The existing application-context cache is kept and made tenant-aware: the tenant participates in
the cache key, and the CMS provider sends a `Tenant` header on the individual request when a tenant
is present, omitting it for single-tenant requests. `docs/CACHING-STRATEGY.md` is updated to the
resulting runtime contract, including the breadth of the profile-resolution dependency.

## Note to consider

The ownership-token contract drift raised in review was resolved in one direction: DMS exposes
ownership token ids as sorted-distinct, normalized at the `ConfigurationServiceApplicationProvider`
success boundary, rather than rejecting duplicate or unsorted CMS values. This keeps DMS decoupled
from CMS query ordering while giving downstream authorization a deterministic list. Presence,
short-range, and max-count validation are unchanged, and a genuinely invalid response still maps to
`Unavailable`.
