### PR TITLE
[DMS-1474] Reduce CI Job-Minutes on the DMS Pull Request Workflow

### DIFF
--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -510,16 +510,32 @@ jobs:
           $totalBytes = ($stagedFiles | Measure-Object -Property Length -Sum).Sum
           Write-Output "Staged $($stagedFiles.Count) files ($([math]::Round($totalBytes / 1MB, 1)) MB) to $artifactRoot"
 
+      - name: Archive DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Uploaded as a tar rather than as a directory path, because upload-artifact zips a
+          # directory and the zip handoff does not carry Unix mode bits: everything arrives 755/644.
+          # The staged tree contains files that must arrive executable - Playwright's
+          # .playwright/node/*/node, which the driver spawns, and the apphost beside each executable
+          # project - and nothing in a --no-build consumer re-applies the bit, since Playwright's own
+          # chmod target only runs as part of a build. A directory upload therefore produces an
+          # artifact that downloads cleanly and then fails at run time with permission denied.
+          #
+          # -C <root> . archives the directory's contents, dotfiles included, which is also what
+          # keeps the .playwright tree in the artifact now that include-hidden-files is gone.
+          tar -czf TestArtifacts/dms-build-output.tar.gz -C TestArtifacts/dms-build-output .
+          ls -l TestArtifacts/dms-build-output.tar.gz
+
       - name: Upload DMS Build Output
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
           name: dms-build-output
-          path: TestArtifacts/dms-build-output
-          # upload-artifact ignores hidden files by default. The staged output contains the
-          # Playwright driver under bin/Release/net10.0/.playwright - 930 files including the node
-          # binary the driver executes - so without this the consumers download build output that
-          # looks complete and fails at run time in the Playwright-backed lanes.
-          include-hidden-files: true
+          path: TestArtifacts/dms-build-output.tar.gz
+          # The tar is already gzipped; zipping it again costs minutes on a multi-gigabyte tree and
+          # saves nothing.
+          compression-level: 0
           if-no-files-found: error
           retention-days: 1
 
@@ -556,7 +572,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Restore .NET tools
         if: success()
@@ -1770,7 +1796,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Run DMS E2E (IdentityProvider ${{ matrix.identityprovider }}, Shard ${{ matrix.shard }})
         id: e2e
@@ -1943,7 +1979,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Add Kafka hostname to /etc/hosts
         run: echo "127.0.0.1 dms-kafka1" | sudo tee -a /etc/hosts
@@ -2122,7 +2168,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Run DMS E2E (partition sizing)
         id: e2e_partition_sizing
@@ -2301,7 +2357,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Run SQL Server DMS E2E (IdentityProvider ${{ matrix.identityprovider }}, representative)
         id: e2e
@@ -2516,7 +2582,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Run DS 6.1 SQL Server DMS E2E (version-coupled scenarios)
         id: e2e_ds61_mssql
@@ -2758,7 +2834,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Run Instance Management E2E Tests
         if: success()
@@ -2944,7 +3030,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Run SQL Server Instance Management E2E Tests
         id: e2e
@@ -3151,7 +3247,17 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: dms-build-output
-          path: .
+          path: ${{ runner.temp }}/dms-build-output
+
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Preflight DMS Schema Compile
         run: |

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -244,6 +244,7 @@ jobs:
             "eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1",
             "eng/ci/tests/DmsChangeCategories.Tests.ps1",
             "eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1",
+            "eng/ci/tests/UnitTestCoverage.Tests.ps1",
             "eng/ci/tests/PullCiImages.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-Management.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-WorkflowInputs.Tests.ps1",

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -297,6 +297,15 @@ jobs:
     needs: detect-fresh-build-changes
     # Draft-gated: BuildAndPublish plus four package builds and two scratch-consumer compiles is one
     # of the most expensive jobs here, and nothing about packaging is feedback a draft needs.
+    #
+    # Deliberately NOT a dms-build-output consumer, even though it does compile the solution. Its
+    # target is BuildAndPublish, not Build, and the difference is the whole point of the job:
+    # BuildAndPublish regenerates src/dms/Directory.Build.props to version-stamp the assemblies
+    # before compiling them, restores in locked mode, and publishes output the shared artifact does
+    # not stage. The shared producer runs plain Build, so its assemblies carry the tracked props
+    # version; packing those would emit packages whose assembly version disagrees with the package
+    # version they are labelled with. eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1 pins this
+    # exclusion together with the reason, so the decision has to be revisited if the reason moves.
     if: >-
       github.event_name != 'pull_request' ||
       (needs.detect-fresh-build-changes.outputs.dms_relevant == 'true' &&
@@ -561,10 +570,15 @@ jobs:
         # they can share its fixture types) but are pure unit tests that need no Docker. build-dms.ps1
         # UnitTest only runs *.Tests.Unit projects and the instance E2E shard jobs filter on shard tags,
         # so without this step these tests would run in no PR job. They are selected by the
-        # InstanceFixtureUnit category and run standalone here.
+        # InstanceFixtureUnit category and run standalone here, against the downloaded build output
+        # like every other step in this job: without --no-build this recompiles the project and its
+        # whole ProjectReference graph, because the artifact stages bin without the intermediate
+        # output an incremental build would need.
         run: >-
           dotnet test src/dms/tests/EdFi.InstanceManagement.Tests.E2E/EdFi.InstanceManagement.Tests.E2E.csproj
           --configuration ${{ env.CONFIGURATION }}
+          --no-build
+          --no-restore
           --filter "Category=InstanceFixtureUnit"
           --logger "trx;LogFileName=instance-fixture-unit.trx"
 

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -506,6 +506,11 @@ jobs:
         with:
           name: dms-build-output
           path: TestArtifacts/dms-build-output
+          # upload-artifact ignores hidden files by default. The staged output contains the
+          # Playwright driver under bin/Release/net10.0/.playwright - 930 files including the node
+          # binary the driver executes - so without this the consumers download build output that
+          # looks complete and fails at run time in the Playwright-backed lanes.
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -413,9 +413,12 @@ jobs:
             -PackageVersion $packageVersion `
             -NuGetPackagesDirectory (Join-Path $env:RUNNER_TEMP "nuget-verify-custom-validation")
 
-  run-unit-tests:
-    name: Run Unit Tests
+  build-dms-solution:
+    name: Build DMS Solution
     needs: detect-fresh-build-changes
+    # Gated on DMS relevance only, and deliberately not draft-gated: run-unit-tests depends on this
+    # producer, so draft-gating here would skip unit tests on every draft DMS pull request through
+    # the dependency.
     if: >-
       github.event_name != 'pull_request' ||
       needs.detect-fresh-build-changes.outputs.dms_relevant == 'true'
@@ -444,6 +447,102 @@ jobs:
 
       - name: Build
         run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }}
+
+      - name: Stage DMS Build Output
+        run: |
+          $configuration = "${{ env.CONFIGURATION }}"
+          $artifactRoot = "./TestArtifacts/dms-build-output"
+
+          if (Test-Path $artifactRoot) {
+            Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+          }
+
+          $repositoryRoot = (Get-Location).Path
+
+          # Compiled output for every project, plus the per-project NuGet evaluation markers that
+          # `dotnet test --no-build` and `dotnet run --no-build` read when they evaluate a project
+          # without compiling it. obj/$configuration is deliberately excluded: --no-build evaluates
+          # the project but never reads intermediate output or reference assemblies.
+          # The directories are resolved first and then walked with -LiteralPath. A wildcard -Path
+          # combined with -Recurse makes Get-ChildItem treat the last segment as a name filter, so
+          # "./src/dms/*/*/bin/$configuration" -Recurse -File searches for files *named*
+          # "$configuration" and silently matches nothing.
+          $binDirectories = @(Get-ChildItem -Path "./src/dms/*/*/bin/$configuration" -Directory -Force)
+          $objDirectories = @(Get-ChildItem -Path "./src/dms/*/*/obj" -Directory -Force)
+
+          $stagedFiles = @(
+            $binDirectories | ForEach-Object {
+              Get-ChildItem -LiteralPath $_.FullName -Recurse -File -Force
+            }
+            $objDirectories | ForEach-Object {
+              Get-ChildItem -LiteralPath $_.FullName -File -Force
+            } | Where-Object {
+              $_.Name -in @('project.assets.json', 'project.nuget.cache') -or
+              $_.Name -like '*.csproj.nuget.g.props' -or
+              $_.Name -like '*.csproj.nuget.g.targets'
+            }
+          )
+
+          # An empty set means the build produced nothing where this expects it, which would upload
+          # an empty artifact and fail every consumer with a confusing missing-assembly error.
+          if ($stagedFiles.Count -eq 0) {
+            throw "No build output found to stage. Expected compiled output under src/dms/*/*/bin/$configuration."
+          }
+
+          # Staged at repository-relative paths so a consumer extracting the artifact over its own
+          # checkout root gets every file exactly where its own build would have written it.
+          foreach ($file in $stagedFiles) {
+            $relativePath = [System.IO.Path]::GetRelativePath($repositoryRoot, $file.FullName)
+            $destination = Join-Path $artifactRoot $relativePath
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destination) | Out-Null
+            Copy-Item -LiteralPath $file.FullName -Destination $destination -Force
+          }
+
+          $totalBytes = ($stagedFiles | Measure-Object -Property Length -Sum).Sum
+          Write-Output "Staged $($stagedFiles.Count) files ($([math]::Round($totalBytes / 1MB, 1)) MB) to $artifactRoot"
+
+      - name: Upload DMS Build Output
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
+        with:
+          name: dms-build-output
+          path: TestArtifacts/dms-build-output
+          if-no-files-found: error
+          retention-days: 1
+
+  run-unit-tests:
+    name: Run Unit Tests
+    needs: [detect-fresh-build-changes, build-dms-solution]
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-fresh-build-changes.outputs.dms_relevant == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout the Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Nuget packages
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Restore .NET tools
         if: success()
@@ -1558,7 +1657,7 @@ jobs:
 
   run-e2e-tests:
     name: Run PostgreSQL DMS E2E (${{ matrix.identityprovider }}, Shard ${{ matrix.shard }})
-    needs: build-ci-docker-images
+    needs: [build-ci-docker-images, build-dms-solution]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1648,8 +1747,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
-        run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }} -IdentityProvider ${{matrix.identityprovider}}
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Run DMS E2E (IdentityProvider ${{ matrix.identityprovider }}, Shard ${{ matrix.shard }})
         id: e2e
@@ -1733,7 +1835,7 @@ jobs:
   # (EdFi.DataManagementService.Tests.E2E.filtered.trx).
   run-e2e-tests-ds61:
     name: Run PostgreSQL DMS E2E (DS 6.1, version-coupled)
-    needs: build-ci-docker-images
+    needs: [build-ci-docker-images, build-dms-solution]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1818,8 +1920,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
-        run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }} -IdentityProvider self-contained
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Add Kafka hostname to /etc/hosts
         run: echo "127.0.0.1 dms-kafka1" | sudo tee -a /etc/hosts
@@ -1909,7 +2014,7 @@ jobs:
   # writes the filtered TRX (EdFi.DataManagementService.Tests.E2E.filtered.trx).
   run-e2e-tests-partition-sizing:
     name: Run PostgreSQL DMS E2E (partition sizing, isolated page size)
-    needs: build-ci-docker-images
+    needs: [build-ci-docker-images, build-dms-solution]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1994,8 +2099,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
-        run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }} -IdentityProvider self-contained
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Run DMS E2E (partition sizing)
         id: e2e_partition_sizing
@@ -2081,7 +2189,7 @@ jobs:
   # runs regardless of outcome, and diagnostic artifacts are sanitized before any upload or report.
   run-e2e-tests-mssql:
     name: Run SQL Server DMS E2E (${{ matrix.identityprovider }}, representative)
-    needs: build-ci-docker-images
+    needs: [build-ci-docker-images, build-dms-solution]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -2170,8 +2278,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
-        run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }} -IdentityProvider ${{matrix.identityprovider}}
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Run SQL Server DMS E2E (IdentityProvider ${{ matrix.identityprovider }}, representative)
         id: e2e
@@ -2297,7 +2408,7 @@ jobs:
   # (EdFi.DataManagementService.Tests.E2E.filtered.trx).
   run-e2e-tests-mssql-ds61:
     name: Run SQL Server DMS E2E (DS 6.1, version-coupled)
-    needs: build-ci-docker-images
+    needs: [build-ci-docker-images, build-dms-solution]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -2382,8 +2493,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
-        run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }} -IdentityProvider self-contained
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Run DS 6.1 SQL Server DMS E2E (version-coupled scenarios)
         id: e2e_ds61_mssql
@@ -2532,7 +2646,7 @@ jobs:
 
   run-instance-management-e2e-tests:
     name: Run Instance Management E2E Tests (Shard ${{ matrix.shard }})
-    needs: build-ci-docker-images
+    needs: [build-ci-docker-images, build-dms-solution]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -2621,8 +2735,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
-        run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }}
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Run Instance Management E2E Tests
         if: success()
@@ -2715,7 +2832,7 @@ jobs:
   # sanitized before any upload or report.
   run-instance-management-e2e-tests-mssql:
     name: Run SQL Server Instance Management E2E Tests (Shard ${{ matrix.shard }})
-    needs: build-ci-docker-images
+    needs: [build-ci-docker-images, build-dms-solution]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -2804,8 +2921,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
-        run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }}
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Run SQL Server Instance Management E2E Tests
         id: e2e
@@ -2923,7 +3043,7 @@ jobs:
 
   build-and-start-dms:
     name: Build and Start DMS, Download OpenAPI Specs
-    needs: build-ci-docker-images
+    needs: [build-ci-docker-images, build-dms-solution]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3008,8 +3128,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
-        run: ./build-dms.ps1 Build -Configuration ${{ env.CONFIGURATION }}
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: .
 
       - name: Preflight DMS Schema Compile
         run: |
@@ -3362,6 +3485,7 @@ jobs:
       - run-bootstrap-pester-tests
       - verify-lock-files
       - verify-dms-packages
+      - build-dms-solution
       - run-unit-tests
       - build-integration-test-assemblies
       - build-ci-docker-images

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -67,66 +67,66 @@ jobs:
 
       - name: Detect files that require a fresh rebuild
         id: detect
-        shell: bash
+        shell: pwsh
+        env:
+          # Read through the environment rather than interpolated into the script body, so a ref
+          # or SHA can never be parsed as PowerShell.
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          # emit <fresh_build_required> <dms_relevant>
-          emit() {
-            echo "fresh_build_required=$1" >> "$GITHUB_OUTPUT"
-            echo "dms_relevant=$2" >> "$GITHUB_OUTPUT"
+          # PowerShell 7.4 makes a non-zero native exit code terminating under
+          # ErrorActionPreference Stop, which this step must not be: a git failure is handled
+          # below by running the full suite, not by failing the job.
+          $PSNativeCommandUseErrorActionPreference = $false
+
+          # The classification rules live in eng/ci/dms-change-categories.psm1 so Pester can
+          # exercise them directly. Producing the changed-file list stays here, because only the
+          # workflow knows the diff base. Any failure to produce a trustworthy list leaves
+          # $diffUnavailable set, and the classifier then reports the full suite.
+          $changedFilePath = Join-Path $env:RUNNER_TEMP "dms-changed-files.txt"
+          $diffUnavailable = $false
+
+          switch ($env:EVENT_NAME) {
+            "pull_request" {
+              git fetch --no-tags origin "$($env:BASE_REF):refs/remotes/origin/$($env:BASE_REF)"
+
+              if ($LASTEXITCODE -ne 0) {
+                $diffUnavailable = $true
+              }
+              else {
+                git diff --no-renames --name-only "origin/$($env:BASE_REF)...HEAD" |
+                  Set-Content -LiteralPath $changedFilePath
+
+                if ($LASTEXITCODE -ne 0) {
+                  $diffUnavailable = $true
+                }
+              }
+            }
+            "merge_group" {
+              if ([string]::IsNullOrWhiteSpace($env:MERGE_GROUP_BASE_SHA)) {
+                $diffUnavailable = $true
+              }
+              else {
+                git diff --no-renames --name-only $env:MERGE_GROUP_BASE_SHA $env:HEAD_SHA |
+                  Set-Content -LiteralPath $changedFilePath
+
+                if ($LASTEXITCODE -ne 0) {
+                  $diffUnavailable = $true
+                }
+              }
+            }
           }
 
-          # Non-pull_request events (merge_group, workflow_dispatch) always run the full
-          # suite, so dms_relevant is reported true and only fresh_build_required is meaningful.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            emit true true
-            exit 0
-          fi
+          ./eng/ci/Write-DmsChangeCategories.ps1 `
+            -EventName $env:EVENT_NAME `
+            -ChangedFilePath $changedFilePath `
+            -DiffUnavailable:$diffUnavailable
 
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
-            changed_files="$(git diff --no-renames --name-only "origin/${{ github.base_ref }}...HEAD")"
-          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            base_sha="${{ github.event.merge_group.base_sha }}"
-
-            if [[ -z "$base_sha" ]] || ! changed_files="$(git diff --no-renames --name-only "$base_sha" "${{ github.sha }}")"; then
-              emit true true
-              exit 0
-            fi
-          else
-            # Unreachable with the current triggers: workflow_dispatch returned above and the
-            # only other events are pull_request and merge_group. Run the full suite rather
-            # than infer a diff base for an event this script does not model.
-            emit true true
-            exit 0
-          fi
-
-          fresh_build_required=false
-          # For merge_group, force dms_relevant true so nothing is skipped when
-          # validating the merged result; only pull_request narrows to the changed area.
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            dms_relevant=false
-          else
-            dms_relevant=true
-          fi
-
-          while IFS= read -r file; do
-            case "$file" in
-              src/Directory.Packages.props|src/nuget.config|src/dms/Dockerfile|src/config/Dockerfile|eng/docker-compose/*)
-                fresh_build_required=true
-                ;;
-            esac
-            # src/config counts as DMS-relevant: the DMS E2E lanes (incl. the DS 6.1
-            # version-coupled lane) bring up the Config Service built from src/config, so
-            # config-only changes (e.g. ds61 Claims.json, ClaimsProvider, ResourceClaim
-            # seeding) must still trigger this workflow's DMS + DS 6.1 validation.
-            case "$file" in
-              .github/actions/*|.github/workflows/*|build-dms.ps1|eng/*|src/Directory.Packages.props|src/nuget.config|src/dms/*|src/config/*)
-                dms_relevant=true
-                ;;
-            esac
-          done <<< "$changed_files"
-
-          emit "$fresh_build_required" "$dms_relevant"
+          # The step's own success is decided by the classifier having run, not by the exit code
+          # of the last git command, which is deliberately tolerated above.
+          exit 0
 
   scan-actions-bidi:
     name: Scan Actions, scan all files for BIDI Trojan Attacks
@@ -217,6 +217,7 @@ jobs:
             "eng/ci/tests/BuildScriptTestGuards.Tests.ps1",
             "eng/ci/tests/Sanitize-E2EArtifacts.Tests.ps1",
             "eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1",
+            "eng/ci/tests/DmsChangeCategories.Tests.ps1",
             "eng/ci/tests/PullCiImages.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-Management.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-WorkflowInputs.Tests.ps1",

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -11,7 +11,16 @@ on:
   # PRs regardless of which files changed. detect-fresh-build-changes computes dms_relevant and
   # the heavy jobs skip when no DMS-relevant file changed, so idle PRs stay cheap and the gate
   # still reports (a skipped dependency counts as a pass).
+  # The default type set is opened, synchronize and reopened. Declaring types replaces that set
+  # outright, so all three are listed alongside ready_for_review. ready_for_review is what makes
+  # draft gating safe: the expensive jobs below skip while a pull request is a draft, and marking it
+  # ready fires this trigger so the full suite validates it before review.
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - main
 
@@ -59,6 +68,10 @@ jobs:
       # suite while this workflow still runs and reports dms-ci-gate. src/config counts as
       # DMS-relevant, so a config-only PR does not skip.
       dms_relevant: ${{ steps.detect.outputs.dms_relevant }}
+      # True while a pull request is a draft. Only the expensive roots and leaves gate on it, so a
+      # draft still gets the cheap lanes and still gets a reporting dms-ci-gate; ready_for_review is
+      # in the trigger types above, so marking the PR ready re-runs the full suite.
+      draft: ${{ steps.detect.outputs.draft }}
     steps:
       - name: Checkout the Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -75,6 +88,8 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
           HEAD_SHA: ${{ github.sha }}
+          # Empty on merge_group and workflow_dispatch, which have no pull request.
+          PULL_REQUEST_IS_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           # PowerShell 7.4 makes a non-zero native exit code terminating under
           # ErrorActionPreference Stop, which this step must not be: a git failure is handled
@@ -122,7 +137,8 @@ jobs:
           ./eng/ci/Write-DmsChangeCategories.ps1 `
             -EventName $env:EVENT_NAME `
             -ChangedFilePath $changedFilePath `
-            -DiffUnavailable:$diffUnavailable
+            -DiffUnavailable:$diffUnavailable `
+            -IsDraft:($env:PULL_REQUEST_IS_DRAFT -eq 'true')
 
           # The step's own success is decided by the classifier having run, not by the exit code
           # of the last git command, which is deliberately tolerated above.
@@ -218,6 +234,7 @@ jobs:
             "eng/ci/tests/Sanitize-E2EArtifacts.Tests.ps1",
             "eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1",
             "eng/ci/tests/DmsChangeCategories.Tests.ps1",
+            "eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1",
             "eng/ci/tests/PullCiImages.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-Management.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-WorkflowInputs.Tests.ps1",
@@ -268,9 +285,12 @@ jobs:
   verify-dms-packages:
     name: Verify DMS Packages
     needs: detect-fresh-build-changes
+    # Draft-gated: BuildAndPublish plus four package builds and two scratch-consumer compiles is one
+    # of the most expensive jobs here, and nothing about packaging is feedback a draft needs.
     if: >-
       github.event_name != 'pull_request' ||
-      needs.detect-fresh-build-changes.outputs.dms_relevant == 'true'
+      (needs.detect-fresh-build-changes.outputs.dms_relevant == 'true' &&
+      needs.detect-fresh-build-changes.outputs.draft != 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -459,9 +479,12 @@ jobs:
   build-integration-test-assemblies:
     name: Build Integration Test Assemblies
     needs: detect-fresh-build-changes
+    # Draft-gated. This is the root of every integration lane, so gating it here skips all eight
+    # through their needs rather than repeating the condition on each.
     if: >-
       github.event_name != 'pull_request' ||
-      needs.detect-fresh-build-changes.outputs.dms_relevant == 'true'
+      (needs.detect-fresh-build-changes.outputs.dms_relevant == 'true' &&
+      needs.detect-fresh-build-changes.outputs.draft != 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -615,9 +638,12 @@ jobs:
   build-ci-docker-images:
     name: Build CI Docker Images
     needs: detect-fresh-build-changes
+    # Draft-gated. This is the root of every E2E, instance-E2E and OpenAPI lane, so gating it here
+    # skips that whole family through their needs.
     if: >-
       github.event_name != 'pull_request' ||
-      needs.detect-fresh-build-changes.outputs.dms_relevant == 'true'
+      (needs.detect-fresh-build-changes.outputs.dms_relevant == 'true' &&
+      needs.detect-fresh-build-changes.outputs.draft != 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1200,9 +1226,11 @@ jobs:
   run-cli-integration-tests:
     name: Run CLI Integration Tests (${{ matrix.cli }})
     needs: detect-fresh-build-changes
+    # Draft-gated: two matrix legs, each a separate restore, build and test.
     if: >-
       github.event_name != 'pull_request' ||
-      needs.detect-fresh-build-changes.outputs.dms_relevant == 'true'
+      (needs.detect-fresh-build-changes.outputs.dms_relevant == 'true' &&
+      needs.detect-fresh-build-changes.outputs.draft != 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3189,10 +3217,14 @@ jobs:
         run-backend-mssql-integration-tests,
         run-dms-api-mssql-integration-tests,
       ]
+    # Draft-gated as well as DMS-gated. Unlike the lanes above this one skips through its own
+    # condition rather than a needs chain, so without the draft clause it would run on a draft and
+    # summarize an empty download directory.
     if: >-
       always() &&
       (github.event_name != 'pull_request' ||
-      needs.detect-fresh-build-changes.outputs.dms_relevant == 'true')
+      (needs.detect-fresh-build-changes.outputs.dms_relevant == 'true' &&
+      needs.detect-fresh-build-changes.outputs.draft != 'true'))
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -72,6 +72,15 @@ jobs:
       # draft still gets the cheap lanes and still gets a reporting dms-ci-gate; ready_for_review is
       # in the trigger types above, so marking the PR ready re-runs the full suite.
       draft: ${{ steps.detect.outputs.draft }}
+      # Promoted-suite categories. Six integration lanes that have caught nothing at pull request
+      # time run only when a changed file reaches them; merge_group and workflow_dispatch always
+      # report every category true, so the merge queue still runs the full suite. Anything
+      # DMS-relevant that the classifier does not recognise sets all four, so a new project
+      # directory is validated by everything until it is classified.
+      backend_mssql_relevant: ${{ steps.detect.outputs.backend_mssql_relevant }}
+      dms_api_relevant: ${{ steps.detect.outputs.dms_api_relevant }}
+      schematools_relevant: ${{ steps.detect.outputs.schematools_relevant }}
+      cdc_relevant: ${{ steps.detect.outputs.cdc_relevant }}
     steps:
       - name: Checkout the Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -771,7 +780,13 @@ jobs:
 
   run-backend-mssql-integration-tests:
     name: Run Backend MSSQL Integration Tests (${{ matrix.shard-name }})
-    needs: build-integration-test-assemblies
+    needs: [detect-fresh-build-changes, build-integration-test-assemblies]
+    # Path-promoted. This suite has caught nothing at pull request time, so it runs on a pull
+    # request only when a changed file reaches it; merge_group and workflow_dispatch always run
+    # it, which is the recovery path for anything a pull request skipped.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-fresh-build-changes.outputs.backend_mssql_relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -877,7 +892,13 @@ jobs:
 
   run-dms-api-mssql-integration-tests:
     name: Run DMS API MSSQL Integration Tests
-    needs: build-integration-test-assemblies
+    needs: [detect-fresh-build-changes, build-integration-test-assemblies]
+    # Path-promoted. This suite has caught nothing at pull request time, so it runs on a pull
+    # request only when a changed file reaches it; merge_group and workflow_dispatch always run
+    # it, which is the recovery path for anything a pull request skipped.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-fresh-build-changes.outputs.dms_api_relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1033,7 +1054,13 @@ jobs:
 
   run-dms-api-postgresql-integration-tests:
     name: Run DMS API PostgreSQL Integration Tests
-    needs: build-integration-test-assemblies
+    needs: [detect-fresh-build-changes, build-integration-test-assemblies]
+    # Path-promoted. This suite has caught nothing at pull request time, so it runs on a pull
+    # request only when a changed file reaches it; merge_group and workflow_dispatch always run
+    # it, which is the recovery path for anything a pull request skipped.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-fresh-build-changes.outputs.dms_api_relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1101,7 +1128,13 @@ jobs:
 
   run-backend-cdc-integration-tests:
     name: Run Backend CDC Integration Tests
-    needs: build-integration-test-assemblies
+    needs: [detect-fresh-build-changes, build-integration-test-assemblies]
+    # Path-promoted. This suite has caught nothing at pull request time, so it runs on a pull
+    # request only when a changed file reaches it; merge_group and workflow_dispatch always run
+    # it, which is the recovery path for anything a pull request skipped.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-fresh-build-changes.outputs.cdc_relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1363,7 +1396,13 @@ jobs:
 
   run-schematools-postgresql-integration-tests:
     name: Run SchemaTools PostgreSQL Integration Tests
-    needs: build-integration-test-assemblies
+    needs: [detect-fresh-build-changes, build-integration-test-assemblies]
+    # Path-promoted. This suite has caught nothing at pull request time, so it runs on a pull
+    # request only when a changed file reaches it; merge_group and workflow_dispatch always run
+    # it, which is the recovery path for anything a pull request skipped.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-fresh-build-changes.outputs.schematools_relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1437,7 +1476,13 @@ jobs:
 
   run-schematools-mssql-integration-tests:
     name: Run SchemaTools MSSQL Integration Tests
-    needs: build-integration-test-assemblies
+    needs: [detect-fresh-build-changes, build-integration-test-assemblies]
+    # Path-promoted. This suite has caught nothing at pull request time, so it runs on a pull
+    # request only when a changed file reaches it; merge_group and workflow_dispatch always run
+    # it, which is the recovery path for anything a pull request skipped.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-fresh-build-changes.outputs.schematools_relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -632,7 +632,10 @@ jobs:
 
   build-integration-test-assemblies:
     name: Build Integration Test Assemblies
-    needs: detect-fresh-build-changes
+    needs: [detect-fresh-build-changes, build-dms-solution]
+    # Both a consumer and a producer: it takes the shared build output and republishes the much
+    # smaller slice the eight integration lanes need, so they download megabytes rather than
+    # gigabytes. All five projects it stages are in the solution the shared build already compiles.
     # Draft-gated. This is the root of every integration lane, so gating it here skips all eight
     # through their needs rather than repeating the condition on each.
     if: >-
@@ -662,45 +665,21 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Restore and Build Integration Test Projects
-        run: |
-          $configuration = "${{ env.CONFIGURATION }}"
-          $projects = @(
-            @{
-              Name = "backend-mssql"
-              Project = "./src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/EdFi.DataManagementService.Backend.Mssql.Tests.Integration.csproj"
-              Assembly = "EdFi.DataManagementService.Backend.Mssql.Tests.Integration.dll"
-            },
-            @{
-              Name = "dms-api"
-              Project = "./src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj"
-              Assembly = "EdFi.DataManagementService.Tests.Integration.dll"
-            },
-            @{
-              Name = "backend-postgresql"
-              Project = "./src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration.csproj"
-              Assembly = "EdFi.DataManagementService.Backend.Postgresql.Tests.Integration.dll"
-            },
-            @{
-              Name = "backend-cdc"
-              Project = "./src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Integration/EdFi.DataManagementService.Backend.Cdc.Tests.Integration.csproj"
-              Assembly = "EdFi.DataManagementService.Backend.Cdc.Tests.Integration.dll"
-            },
-            @{
-              Name = "schematools"
-              Project = "./src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Integration/EdFi.DataManagementService.SchemaTools.Tests.Integration.csproj"
-              Assembly = "EdFi.DataManagementService.SchemaTools.Tests.Integration.dll"
-            }
-          )
+      - name: Download DMS Build Output
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: dms-build-output
+          path: ${{ runner.temp }}/dms-build-output
 
-          foreach ($project in $projects) {
-            dotnet restore $project.Project --verbosity:normal
-            dotnet build $project.Project `
-              -c $configuration `
-              --no-restore `
-              -v normal `
-              --nologo
-          }
+      - name: Extract DMS Build Output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # -p so the recorded modes are applied exactly. Without it tar masks them with the
+          # runner's umask, and the execute bit this artifact depends on would survive only because
+          # the image happens to use umask 022 - a property of the runner, not of the handoff.
+          tar -xzpf "$RUNNER_TEMP/dms-build-output/dms-build-output.tar.gz" -C .
 
       - name: Stage Integration Test Assemblies
         run: |
@@ -1812,7 +1791,7 @@ jobs:
         id: e2e
         if: success()
         run: |
-          ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category=@e2e-ci-shard-${{ matrix.shard }}'
+          ./build-dms.ps1 E2ETest -UsePrebuiltOutput -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category=@e2e-ci-shard-${{ matrix.shard }}'
 
       - name: Export DMS E2E Docker Logs
         if: always() && steps.e2e.outcome == 'failure'
@@ -2000,7 +1979,7 @@ jobs:
         env:
           KAFKA_BOOTSTRAP_SERVERS: dms-kafka1:9092
         run: |
-          ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider self-contained -EnvironmentFile './.env.e2e' -DataStandardVersion 6.1 -TestFilter 'Category=@StandardVersion-6_1'
+          ./build-dms.ps1 E2ETest -UsePrebuiltOutput -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider self-contained -EnvironmentFile './.env.e2e' -DataStandardVersion 6.1 -TestFilter 'Category=@StandardVersion-6_1'
 
       - name: Export DMS E2E Docker Logs
         if: always() && steps.e2e_ds61.outcome == 'failure'
@@ -2186,7 +2165,7 @@ jobs:
         env:
           KAFKA_BOOTSTRAP_SERVERS: dms-kafka1:9092
         run: |
-          ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider self-contained -EnvironmentFile './.env.cursorpartitions.e2e' -TestFilter 'Category=@CursorPartitionSizing'
+          ./build-dms.ps1 E2ETest -UsePrebuiltOutput -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider self-contained -EnvironmentFile './.env.cursorpartitions.e2e' -TestFilter 'Category=@CursorPartitionSizing'
 
       - name: Export DMS E2E Docker Logs
         if: always() && steps.e2e_partition_sizing.outcome == 'failure'
@@ -2383,7 +2362,7 @@ jobs:
           $diagDir = "${{ github.workspace }}/logs/e2e-mssql-${{ matrix.identityprovider }}"
           New-Item -ItemType Directory -Path $diagDir -Force | Out-Null
           $diagFile = Join-Path $diagDir 'build-dms-setup.log'
-          & pwsh -NoProfile -File ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -DatabaseEngine mssql -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category=@MssqlRepresentative' *> $diagFile
+          & pwsh -NoProfile -File ./build-dms.ps1 E2ETest -UsePrebuiltOutput -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -DatabaseEngine mssql -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category=@MssqlRepresentative' *> $diagFile
           $buildExitCode = $LASTEXITCODE
           if ($buildExitCode -ne 0) {
               throw "build-dms.ps1 E2ETest failed with exit code $buildExitCode. See the sanitized build-dms-setup.log artifact."
@@ -2604,7 +2583,7 @@ jobs:
           $diagDir = "${{ github.workspace }}/logs/e2e-mssql-ds61"
           New-Item -ItemType Directory -Path $diagDir -Force | Out-Null
           $diagFile = Join-Path $diagDir 'build-dms-setup.log'
-          & pwsh -NoProfile -File ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -DatabaseEngine mssql -IdentityProvider self-contained -EnvironmentFile './.env.e2e' -DataStandardVersion 6.1 -TestFilter 'Category=@StandardVersion-6_1' *> $diagFile
+          & pwsh -NoProfile -File ./build-dms.ps1 E2ETest -UsePrebuiltOutput -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -DatabaseEngine mssql -IdentityProvider self-contained -EnvironmentFile './.env.e2e' -DataStandardVersion 6.1 -TestFilter 'Category=@StandardVersion-6_1' *> $diagFile
           $buildExitCode = $LASTEXITCODE
           if ($buildExitCode -ne 0) {
               throw "build-dms.ps1 E2ETest (DS 6.1) failed with exit code $buildExitCode. See the sanitized build-dms-setup.log artifact."
@@ -2852,7 +2831,7 @@ jobs:
           DMS_API_URL: http://localhost:8080
         run: |
           # Build script handles Docker environment setup, database configuration, and test execution
-          ./build-dms.ps1 InstanceE2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -TestFilter 'Category=@instance-management-ci-shard-${{ matrix.shard }}'
+          ./build-dms.ps1 InstanceE2ETest -UsePrebuiltOutput -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -TestFilter 'Category=@instance-management-ci-shard-${{ matrix.shard }}'
 
       - name: Export Docker Logs
         if: failure()
@@ -3058,7 +3037,7 @@ jobs:
           $diagDir = "${{ github.workspace }}/logs"
           New-Item -ItemType Directory -Path $diagDir -Force | Out-Null
           $diagFile = Join-Path $diagDir 'build-dms-setup.log'
-          & pwsh -NoProfile -File ./build-dms.ps1 InstanceE2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -DatabaseEngine mssql -TestFilter 'Category=@instance-management-ci-shard-${{ matrix.shard }}' *> $diagFile
+          & pwsh -NoProfile -File ./build-dms.ps1 InstanceE2ETest -UsePrebuiltOutput -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -DatabaseEngine mssql -TestFilter 'Category=@instance-management-ci-shard-${{ matrix.shard }}' *> $diagFile
           $buildExitCode = $LASTEXITCODE
           if ($buildExitCode -ne 0) {
               throw "build-dms.ps1 InstanceE2ETest failed with exit code $buildExitCode. See the sanitized build-dms-setup.log artifact."

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -12,15 +12,19 @@ on:
   # the heavy jobs skip when no DMS-relevant file changed, so idle PRs stay cheap and the gate
   # still reports (a skipped dependency counts as a pass).
   # The default type set is opened, synchronize and reopened. Declaring types replaces that set
-  # outright, so all three are listed alongside ready_for_review. ready_for_review is what makes
-  # draft gating safe: the expensive jobs below skip while a pull request is a draft, and marking it
-  # ready fires this trigger so the full suite validates it before review.
+  # outright, so all three are listed alongside the two draft transitions. ready_for_review is what
+  # makes draft gating safe: the expensive jobs below skip while a pull request is a draft, and
+  # marking it ready fires this trigger so the full suite validates it before review.
+  # converted_to_draft is the cost side of the same gate: the cancel-in-progress concurrency group
+  # cancels the in-flight run, and the replacement run classifies as a draft, so its expensive jobs
+  # skip instead of finishing for a pull request that just declared itself not ready.
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
       - ready_for_review
+      - converted_to_draft
     branches:
       - main
 
@@ -537,6 +541,8 @@ jobs:
           # saves nothing.
           compression-level: 0
           if-no-files-found: error
+          # Same retention as dms-integration-test-assemblies. Once it expires, re-running a single
+          # failed consumer fails at the download step; a "re-run all jobs" regenerates the artifact.
           retention-days: 1
 
   run-unit-tests:

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -112,6 +112,14 @@ param(
     [switch]
     $SkipDockerBuild,
 
+    # Run the E2E routes against compiled output that already exists instead of building it here.
+    # Off by default, so the documented direct commands stay self-sufficient: E2ETest and
+    # InstanceE2ETest provision their databases with CLIs built on demand, and InstanceE2ETest builds
+    # its test project. CI sets it, because those jobs extract the shared build artifact first and
+    # rebuilding it is the cost the artifact exists to remove.
+    [switch]
+    $UsePrebuiltOutput,
+
     # Opts into the seed phase after the stack starts. For StartEnvironment, forwarded to the
     # bootstrap wrapper so it uses the documented API-based seed path. E2ETest rejects this switch
     # because its database is reset and provisioned by provision-e2e-database.ps1 before tests run.
@@ -765,15 +773,15 @@ function Invoke-E2EDatabaseProvisioning {
     try {
         Push-Location "$PSScriptRoot/eng/docker-compose"
         $provisionOutput = @()
-        # -UsePrebuiltTools: this route already requires compiled output, because the test run that
-        # follows resolves a built assembly and never builds one. Provisioning would otherwise
-        # restore and rebuild ApiSchemaDownloader and SchemaTools - and through SchemaTools' project
-        # references, Core and Backend.Ddl - inside every E2E job that just downloaded that output.
+        # Provisioning otherwise restores and rebuilds ApiSchemaDownloader and SchemaTools - and
+        # through SchemaTools' project references, Core and Backend.Ddl - inside every E2E job that
+        # just downloaded exactly that output. Left on for a direct local run, which has no artifact
+        # to reuse.
         ./provision-e2e-database.ps1 `
             -EnvironmentFile $E2ETestSettings.EnvironmentFile `
             -DatabaseEngine $E2ETestSettings.DatabaseEngine `
             -Configuration $Configuration `
-            -UsePrebuiltTools 6>&1 |
+            -UsePrebuiltTools:$UsePrebuiltOutput 6>&1 |
             Tee-Object -Variable provisionOutput |
             ForEach-Object { Write-Host ([string]$_) }
 
@@ -1689,15 +1697,10 @@ function RunInstanceE2E {
         Write-Output "Normalized test filter for VSTest: '$TestFilter' -> '$normalizedTestFilter'"
     }
 
-    # --no-build/--no-restore for the same reason the other test paths carry them: nothing on the
-    # InstanceE2ETest route compiles, so this ran a full restore and build of the project and its
-    # project references every time, including in CI where the compiled output was already present.
     $dotNetTestArguments = @(
         $testProject,
         "--configuration",
         $Configuration,
-        "--no-build",
-        "--no-restore",
         "--logger",
         "trx;LogFileName=$trxFile",
         "--logger",
@@ -1706,6 +1709,14 @@ function RunInstanceE2E {
         "normal",
         "--nologo"
     )
+
+    if ($UsePrebuiltOutput) {
+        # Unlike the other test paths this one builds by default, because it is the only test command
+        # documented as a standalone run: it starts Docker, provisions the route-context databases and
+        # runs the tests, with no prior build expected. CI extracted the shared build artifact first,
+        # so there the build is pure duplication of the project and its whole reference graph.
+        $dotNetTestArguments += @("--no-build", "--no-restore")
+    }
 
     if (-not [string]::IsNullOrWhiteSpace($normalizedTestFilter)) {
         $dotNetTestArguments += @("--filter", $normalizedTestFilter)
@@ -1780,10 +1791,10 @@ function InstanceE2ETests {
             DatabaseEngine          = $instanceSettings.DatabaseEngine
             EnvironmentFile         = $instanceSettings.EnvironmentFile
             ResolvedEnvironmentFile = $instanceSettings.ResolvedEnvironmentFile
-            # This route already requires compiled output - RunInstanceE2E runs the tests with
-            # --no-build - so the three route-context provisioning calls the setup makes must not
-            # rebuild the CLIs the shared build artifact already provided.
-            UsePrebuiltTools        = $true
+            # The three route-context provisioning calls the setup makes must not rebuild the CLIs
+            # the shared build artifact already provided. Off for a direct local run, which is what
+            # keeps this command self-sufficient.
+            UsePrebuiltTools        = $UsePrebuiltOutput
         }
         if ($SkipDockerBuild) {
             $setupParameters.SkipDockerBuild = $true

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -563,8 +563,15 @@ function RunTests {
         $ResultNameSuffix
     )
 
-    # @() so $testAssemblies[-1] below is well defined when exactly one assembly matches: the
-    # pipeline hands back a bare FileInfo in that case rather than a single-element array.
+    # Unit tests are collected in one run so coverage can be measured across the whole set. Every
+    # other filter runs assembly by assembly.
+    if ($Filter.Equals("*.Tests.Unit")) {
+        RunUnitTestsWithCoverage
+        return
+    }
+
+    # @() because the pipeline hands back a bare FileInfo when exactly one assembly matches, and the
+    # loop below has to be able to treat the result as a collection either way.
     $testAssemblies = @(
         Get-RequiredTestAssembly -SolutionRoot $solutionRoot -Filter $Filter -Configuration $Configuration |
             Sort-Object -Property { $_.Name.Length }
@@ -588,82 +595,135 @@ function RunTests {
 
         $target = $_.FullName
 
-        if ($Filter.Equals("*.Tests.Unit")) {
-            # For unit tests, we need to collect coverage but not check thresholds yet
-            $isLastTest = $_ -eq $testAssemblies[-1]
-
-            if ($isLastTest) {
-                # Last test: generate final reports and check thresholds
-                Invoke-Execute {
-                    dotnet tool run coverlet -- $($_) `
-                        --target dotnet --targetargs "test $target --logger:console --logger:trx --nologo --blame"`
-                        --exclude "[EdFi.DataManagementService.Tests.E2E]*" `
-                        --exclude "[EdFi.DataManagementService.Tests.Integration]*" `
-                        --exclude "[EdFi.DataManagementService.Backend.Tests.Integration.Common]*" `
-                        --exclude "[EdFi.DataManagementService.Performance.Harness]*" `
-                        --threshold $thresholdCoverage `
-                        --threshold-type line `
-                        --threshold-type branch `
-                        --threshold-stat total `
-                        --format json `
-                        --format cobertura `
-                        --merge-with "coverage.json"
-                }
+        $fileNameNoExt = $_.Name.subString(0, $_.Name.length - 4)
+        $trxFileName =
+            if ([string]::IsNullOrWhiteSpace($ResultNameSuffix)) {
+                "$fileNameNoExt.trx"
             }
             else {
-                # Not the last test: just collect coverage without threshold check
-                Invoke-Execute {
-                    dotnet tool run coverlet -- $($_) `
-                        --target dotnet --targetargs "test $target --logger:console --logger:trx --nologo --blame"`
-                        --exclude "[EdFi.DataManagementService.Tests.E2E]*" `
-                        --exclude "[EdFi.DataManagementService.Tests.Integration]*" `
-                        --exclude "[EdFi.DataManagementService.Backend.Tests.Integration.Common]*" `
-                        --exclude "[EdFi.DataManagementService.Performance.Harness]*" `
-                        --format json `
-                        --merge-with "coverage.json"
-                }
+                "$fileNameNoExt.$ResultNameSuffix.trx"
             }
+
+        $trxFilePath = Join-Path $testResults $trxFileName
+
+        # Set Query Handler for E2E tests
+        if ($Filter -like "*E2E*") {
+            $dirPath = Split-Path -parent $($_)
+            SetAuthenticationServiceURL($dirPath)
         }
-        else {
-            $fileNameNoExt = $_.Name.subString(0, $_.Name.length - 4)
-            $trxFileName =
-                if ([string]::IsNullOrWhiteSpace($ResultNameSuffix)) {
-                    "$fileNameNoExt.trx"
-                }
-                else {
-                    "$fileNameNoExt.$ResultNameSuffix.trx"
-                }
 
-            $trxFilePath = Join-Path $testResults $trxFileName
+        $dotNetTestArguments = @(
+            $target,
+            "--no-build",
+            "--no-restore",
+            "-v",
+            "normal",
+            "--logger",
+            "trx;LogFileName=$trxFilePath",
+            "--logger",
+            "console",
+            "--nologo"
+        )
 
-            # Set Query Handler for E2E tests
-            if ($Filter -like "*E2E*") {
-                $dirPath = Split-Path -parent $($_)
-                SetAuthenticationServiceURL($dirPath)
-            }
+        if (-not [string]::IsNullOrWhiteSpace($normalizedTestFilter)) {
+            $dotNetTestArguments += @("--filter", $normalizedTestFilter)
+        }
 
-            $dotNetTestArguments = @(
-                $target,
-                "--no-build",
-                "--no-restore",
-                "-v",
-                "normal",
-                "--logger",
-                "trx;LogFileName=$trxFilePath",
-                "--logger",
-                "console",
-                "--nologo"
-            )
-
-            if (-not [string]::IsNullOrWhiteSpace($normalizedTestFilter)) {
-                $dotNetTestArguments += @("--filter", $normalizedTestFilter)
-            }
-
-            Invoke-Execute {
-                dotnet test @dotNetTestArguments
-            }
+        Invoke-Execute {
+            dotnet test @dotNetTestArguments
         }
     }
+}
+
+function RunUnitTestsWithCoverage {
+    # One `dotnet test` over a generated solution filter covering every *.Tests.Unit project.
+    #
+    # What this replaces: each assembly was wrapped in coverlet.console, which rewrote every DLL in
+    # that project's output directory on disk, ran the tests, then restored the directory - once per
+    # assembly, accumulating into a coverage.json that grew each pass. The threshold was applied only
+    # to whichever assembly happened to sort last by name length, and a failure in any assembly
+    # aborted the run before the later ones executed. The collector instruments in-process instead,
+    # the whole set runs even when one project fails, and the threshold is applied once to the merged
+    # total.
+    $unitTestProjects = @(
+        Get-RequiredUnitTestProject -SolutionRoot $solutionRoot -Filter "*.Tests.Unit" |
+            Sort-Object -Property Name
+    )
+
+    Write-Output "Unit Test Projects List"
+    Write-Output $unitTestProjects
+    Write-Output "End Unit Test Projects List"
+
+    if (-not (Test-Path $testResults)) {
+        New-Item -ItemType Directory -Path $testResults -Force | Out-Null
+    }
+
+    $collectorOutput = Join-Path $testResults "unit-coverage"
+    $mergedOutput = Join-Path $testResults "unit-coverage-merged"
+
+    foreach ($staleDirectory in @($collectorOutput, $mergedOutput)) {
+        if (Test-Path $staleDirectory) {
+            # A report left by an earlier run would otherwise be merged into this one's total.
+            Remove-Item -LiteralPath $staleDirectory -Recurse -Force
+        }
+    }
+
+    if (Test-Path $coverageOutputFile) {
+        # Cleared up front so a run that fails before the merge cannot leave the previous run's
+        # report behind, where the workflow's hashFiles check and Coverage would read it as this
+        # run's result.
+        Remove-Item -LiteralPath $coverageOutputFile -Force
+    }
+
+    $solutionFilterPath = Join-Path $testResults "dms-unit-tests.slnf"
+    $solutionFilterContent = ConvertTo-SolutionFilterContent `
+        -SolutionPath ([System.IO.Path]::GetRelativePath($testResults, $defaultSolution)) `
+        -ProjectPath @(
+            $unitTestProjects | ForEach-Object {
+                [System.IO.Path]::GetRelativePath($solutionRoot, $_.FullName)
+            }
+        )
+
+    # The filter is generated rather than tracked so it cannot drift from the projects on disk.
+    [System.IO.File]::WriteAllText(
+        $solutionFilterPath,
+        $solutionFilterContent,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+
+    Invoke-Execute {
+        dotnet test $solutionFilterPath `
+            --configuration $Configuration `
+            --no-build `
+            --no-restore `
+            --blame `
+            --collect:"XPlat Code Coverage" `
+            --settings "$PSScriptRoot/eng/ci/coverlet.runsettings" `
+            --results-directory $collectorOutput `
+            --logger "trx" `
+            --logger "console" `
+            --nologo
+    }
+
+    # Each switch and its value must be ONE argument. A `--` earlier in a native command's arguments
+    # puts PowerShell's parser into a mode where `-name:"value"` is emitted as two arguments,
+    # `-name:` and the value, and ReportGenerator then reports "No report files specified" for an
+    # invocation that looks correct. Quoting the whole `-name:value` token is what keeps it together.
+    Invoke-Execute {
+        dotnet tool run reportgenerator -- `
+            "-reports:$collectorOutput/**/coverage.cobertura.xml" `
+            "-targetdir:$mergedOutput" `
+            "-reporttypes:Cobertura"
+    }
+
+    # $coverageOutputFile is relative, so this lands beside the caller exactly where the previous
+    # driver left it - which is what the workflow's hashFiles check and `build-dms.ps1 Coverage`
+    # both look for.
+    Copy-Item -LiteralPath (Join-Path $mergedOutput "Cobertura.xml") -Destination $coverageOutputFile -Force
+
+    $measured = Assert-CoverageThreshold -Path $coverageOutputFile -Threshold $thresholdCoverage
+
+    Write-Output "Coverage: line $($measured.LinePercentage)%, branch $($measured.BranchPercentage)% (threshold $($measured.Threshold)%)"
 }
 
 function UnitTests {
@@ -1952,7 +2012,15 @@ function Invoke-TestExecution {
 }
 
 function Invoke-Coverage {
-    dotnet tool run reportgenerator -- -reports:"$coverageOutputFile" -targetdir:"$targetDir" -reporttypes:Html
+    # Whole-token quoting for the same reason as the unit-test merge above, and Invoke-Execute so a
+    # ReportGenerator failure fails the command. Without the exit-code check this reported success
+    # while writing no report at all, which is indistinguishable from a report nobody reads.
+    Invoke-Execute {
+        dotnet tool run reportgenerator -- `
+            "-reports:$coverageOutputFile" `
+            "-targetdir:$targetDir" `
+            "-reporttypes:Html"
+    }
 }
 
 function Invoke-BuildPackage {

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -713,6 +713,13 @@ function RunUnitTestsWithCoverage {
             --nologo
     }
 
+    # A runtime datacollector failure does not fail dotnet test - that project's report just never
+    # exists - and the merge below only fails when it finds zero reports, so the count is asserted
+    # here to keep the threshold from being evaluated against a silently shifted total.
+    Assert-CoverageReportPerProject `
+        -CollectorOutputPath $collectorOutput `
+        -ExpectedProjectName @($unitTestProjects | ForEach-Object { $_.Name })
+
     # Each switch and its value must be ONE argument. A `--` earlier in a native command's arguments
     # puts PowerShell's parser into a mode where `-name:"value"` is emitted as two arguments,
     # `-name:` and the value, and ReportGenerator then reports "No report files specified" for an

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -765,10 +765,15 @@ function Invoke-E2EDatabaseProvisioning {
     try {
         Push-Location "$PSScriptRoot/eng/docker-compose"
         $provisionOutput = @()
+        # -UsePrebuiltTools: this route already requires compiled output, because the test run that
+        # follows resolves a built assembly and never builds one. Provisioning would otherwise
+        # restore and rebuild ApiSchemaDownloader and SchemaTools - and through SchemaTools' project
+        # references, Core and Backend.Ddl - inside every E2E job that just downloaded that output.
         ./provision-e2e-database.ps1 `
             -EnvironmentFile $E2ETestSettings.EnvironmentFile `
             -DatabaseEngine $E2ETestSettings.DatabaseEngine `
-            -Configuration $Configuration 6>&1 |
+            -Configuration $Configuration `
+            -UsePrebuiltTools 6>&1 |
             Tee-Object -Variable provisionOutput |
             ForEach-Object { Write-Host ([string]$_) }
 
@@ -1775,6 +1780,10 @@ function InstanceE2ETests {
             DatabaseEngine          = $instanceSettings.DatabaseEngine
             EnvironmentFile         = $instanceSettings.EnvironmentFile
             ResolvedEnvironmentFile = $instanceSettings.ResolvedEnvironmentFile
+            # This route already requires compiled output - RunInstanceE2E runs the tests with
+            # --no-build - so the three route-context provisioning calls the setup makes must not
+            # rebuild the CLIs the shared build artifact already provided.
+            UsePrebuiltTools        = $true
         }
         if ($SkipDockerBuild) {
             $setupParameters.SkipDockerBuild = $true

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -724,9 +724,13 @@ function RunUnitTestsWithCoverage {
     # puts PowerShell's parser into a mode where `-name:"value"` is emitted as two arguments,
     # `-name:` and the value, and ReportGenerator then reports "No report files specified" for an
     # invocation that looks correct. Quoting the whole `-name:value` token is what keeps it together.
+    #
+    # The reports glob is single-level for the same reason Assert-CoverageReportPerProject only
+    # counts first-level directories: the trx logger copies every report a second time, deeper,
+    # under <trx name>/In/<machine>/, and a recursive ** would merge each report twice.
     Invoke-Execute {
         dotnet tool run reportgenerator -- `
-            "-reports:$collectorOutput/**/coverage.cobertura.xml" `
+            "-reports:$collectorOutput/*/coverage.cobertura.xml" `
             "-targetdir:$mergedOutput" `
             "-reporttypes:Cobertura"
     }

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -1684,10 +1684,15 @@ function RunInstanceE2E {
         Write-Output "Normalized test filter for VSTest: '$TestFilter' -> '$normalizedTestFilter'"
     }
 
+    # --no-build/--no-restore for the same reason the other test paths carry them: nothing on the
+    # InstanceE2ETest route compiles, so this ran a full restore and build of the project and its
+    # project references every time, including in CI where the compiled output was already present.
     $dotNetTestArguments = @(
         $testProject,
         "--configuration",
         $Configuration,
+        "--no-build",
+        "--no-restore",
         "--logger",
         "trx;LogFileName=$trxFile",
         "--logger",

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -165,56 +165,37 @@ local setups still produce a useful test run.
 
 ## Running Unit Tests and Generate Code Coverage Report
 
-> [!CAUTION]
-> The DMS unit tests include code coverage analysis, which requires installation
-> of two additional tools:
+> [!NOTE]
+> The coverage tooling (ReportGenerator) is pinned in the repository tool
+> manifest (`.config/dotnet-tools.json`), so restore it once per clone:
 >
 > ```shell
-> dotnet tool install --global coverlet.console
-> dotnet tool install --global dotnet-reportgenerator-globaltool
+> dotnet tool restore
 > ```
 
-To run the unit tests locally, execute the following command in a PowerShell
-terminal:
+The unit test command runs the compiled assemblies without building them, so
+build first, then run the tests, in a PowerShell terminal:
 
 ```shell
 # From base directory
+./build-dms.ps1 Build -Configuration Debug
 ./build-dms.ps1 UnitTest -Configuration Debug
 ```
 
-The previous command should generate two files in the base directory, which
-contain all the merged results from the unit tests execution.
-
-```none
-coverage.cobertura.xml
-coverage.json
-```
+`UnitTest` runs every `*.Tests.Unit` project in a single `dotnet test` pass
+with the XPlat Code Coverage collector, merges the per-project results with
+ReportGenerator, and writes the merged Cobertura report to
+`coverage.cobertura.xml` in the base directory. The command fails if the merged
+`line` or `branch` coverage total falls below the threshold (currently 58%).
 
 After completing the Unit Tests execution, run the following command to generate
-the HTML coverage report.
+the HTML coverage report from the merged file.
 
 ```shell
 # From base directory
-reportgenerator -reports:"coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
+./build-dms.ps1 Coverage
 ```
 
-A Coverage Report folder will be created. Open that folder and look for the
+A `coveragereport` folder will be created. Open that folder and look for the
 index.html file, which should contain a detailed report with the coverage
 results.
-
-### Coverlet Parameters
-
-We are currently evaluating `line` and `branch` metrics from the Total
-coverage. If the total coverage is less than our threshold, the build will fail.
-
-Total: Ensures the total combined coverage result of all modules isn't less than
-the threshold
-
-```none
-    --threshold-type line
-    --threshold-type branch
-    --threshold-stat total
-```
-
-To evaluate coverage by modules, we need to remove the `--threshold-stat total`
-option. This will compare the threshold value by `line` and `branch` instead.

--- a/eng/build-helpers.psm1
+++ b/eng/build-helpers.psm1
@@ -224,6 +224,49 @@ function ConvertTo-SolutionFilterContent {
 
 <#
     .DESCRIPTION
+    Assert that a collector run produced exactly one coverage.cobertura.xml per test project. A
+    runtime datacollector failure does not fail dotnet test - the project's report just never
+    exists - and the ReportGenerator merge only fails on zero reports, so without this check the
+    threshold gate would be evaluated against a total that silently lost the projects that failed
+    to report. The collector writes each report into a GUID-named directory, so a shortfall cannot
+    be traced to a specific project; the message names the full expected list instead.
+#>
+function Assert-CoverageReportPerProject {
+    param (
+        # Directory the collector wrote its per-project results into
+        [string]
+        $CollectorOutputPath,
+
+        # Names of the test projects the run was expected to produce reports for
+        [string[]]
+        $ExpectedProjectName
+    )
+
+    # The collector writes each report as <results-dir>/<guid>/coverage.cobertura.xml. The trx
+    # logger shares that directory and copies every attachment a second time, deeper, as
+    # <trx name>/In/<machine>/coverage.cobertura.xml - so only reports directly inside first-level
+    # directories are counted here, or a healthy run would fail as double-counted.
+    $reports = @(
+        if (Test-Path -LiteralPath $CollectorOutputPath -PathType Container) {
+            Get-ChildItem -LiteralPath $CollectorOutputPath -Directory |
+                ForEach-Object {
+                    Get-ChildItem -LiteralPath $_.FullName -File -Filter "coverage.cobertura.xml"
+                }
+        }
+    )
+
+    if ($reports.Count -ne $ExpectedProjectName.Count) {
+        throw (
+            "Expected one coverage.cobertura.xml per unit test project " +
+            "($($ExpectedProjectName.Count): $($ExpectedProjectName -join ', ')) " +
+            "but found $($reports.Count) under '$CollectorOutputPath'. " +
+            "Merging that set would evaluate the coverage threshold against a silently shifted total."
+        )
+    }
+}
+
+<#
+    .DESCRIPTION
     Enforce a total line and branch coverage threshold against a Cobertura report, reproducing
     coverlet's --threshold-type line --threshold-type branch --threshold-stat total. The rates are
     read as XML attributes rather than matched out of the file's text, and parsed with the invariant
@@ -279,8 +322,10 @@ function Assert-CoverageThreshold {
             [ref] $parsedRate
         )
 
-        if (-not $parsed) {
-            throw "Coverage report '$Path' declares $rateName as '$rawRate', which is not a number, so the $Threshold% threshold cannot be enforced."
+        # TryParse under NumberStyles::Float accepts NaN and the infinities, and NaN fails every
+        # -lt comparison, so without the finiteness check a non-finite rate would pass the gate.
+        if (-not $parsed -or -not [double]::IsFinite($parsedRate)) {
+            throw "Coverage report '$Path' declares $rateName as '$rawRate', which is not a finite number, so the $Threshold% threshold cannot be enforced."
         }
 
         # Held as the raw rate, unrounded. Rounding to a display percentage before the comparison

--- a/eng/build-helpers.psm1
+++ b/eng/build-helpers.psm1
@@ -171,4 +171,135 @@ function Write-MessageColorOutput
     $host.UI.RawUI.ForegroundColor = $fc
 }
 
+<#
+    .DESCRIPTION
+    Resolve the test projects a unit-test run must cover, failing rather than reporting an empty
+    glob as success - the same rule Get-RequiredTestAssembly applies to assemblies.
+#>
+function Get-RequiredUnitTestProject {
+    param (
+        # Root of the solution whose test projects are being searched
+        [string]
+        $SolutionRoot,
+
+        # Project directory filter, e.g. "*.Tests.Unit"
+        [string]
+        $Filter
+    )
+
+    # The wildcard carries the file pattern rather than a -Filter argument: a -Filter combined with
+    # a wildcard directory path silently matches nothing here, which would read as "no unit tests".
+    $projectPath = "$SolutionRoot/*/$Filter/$Filter.csproj"
+
+    $projects = @(Get-ChildItem -Path $projectPath)
+
+    if ($projects.Count -eq 0) {
+        throw "no test projects found in $projectPath. Nothing matching '$Filter' exists, so this target would run zero tests."
+    }
+
+    return $projects
+}
+
+<#
+    .DESCRIPTION
+    Build the contents of a solution filter (.slnf). SolutionPath is relative to the filter file;
+    each ProjectPath is relative to the solution file, matching how the solution itself records them.
+#>
+function ConvertTo-SolutionFilterContent {
+    param (
+        [string]
+        $SolutionPath,
+
+        [string[]]
+        $ProjectPath
+    )
+
+    return [pscustomobject]@{
+        solution = [pscustomobject]@{
+            path     = $SolutionPath
+            projects = @($ProjectPath)
+        }
+    } | ConvertTo-Json -Depth 4
+}
+
+<#
+    .DESCRIPTION
+    Enforce a total line and branch coverage threshold against a Cobertura report, reproducing
+    coverlet's --threshold-type line --threshold-type branch --threshold-stat total. The rates are
+    read as XML attributes rather than matched out of the file's text, and parsed with the invariant
+    culture: on a comma-decimal machine, culture-sensitive parsing turns 0.61 into 61 and the gate
+    passes no matter what was measured. Returns the measured percentages so a caller can report them.
+#>
+function Assert-CoverageThreshold {
+    param (
+        # Path to a Cobertura coverage report
+        [string]
+        $Path,
+
+        # Minimum acceptable percentage, applied to line and branch totals independently
+        [int]
+        $Threshold
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Coverage report '$Path' was not produced, so the $Threshold% threshold cannot be enforced. Treating a missing report as a pass would silently disable the coverage gate."
+    }
+
+    try {
+        [xml] $report = Get-Content -LiteralPath $Path -Raw
+    }
+    catch {
+        throw "Coverage report '$Path' is not valid XML, so the $Threshold% threshold cannot be enforced: $($_.Exception.Message)"
+    }
+
+    # Deliberately not $report.coverage: ReportGenerator writes a
+    # <!DOCTYPE coverage SYSTEM ...> declaration ahead of the root element, and the dotted XML
+    # adapter then matches the DocumentType node as well and hands back both. DocumentElement names
+    # the root and only the root.
+    $coverage = $report.DocumentElement
+
+    if ($null -eq $coverage -or $coverage.Name -ne 'coverage') {
+        throw "Coverage report '$Path' has no <coverage> root element, so the $Threshold% threshold cannot be enforced."
+    }
+
+    $measured = [ordered]@{}
+
+    foreach ($rateName in @('line-rate', 'branch-rate')) {
+        $rawRate = $coverage.GetAttribute($rateName)
+
+        if ([string]::IsNullOrWhiteSpace($rawRate)) {
+            throw "Coverage report '$Path' does not declare $rateName, so the $Threshold% threshold cannot be enforced."
+        }
+
+        $parsedRate = 0.0
+        $parsed = [double]::TryParse(
+            $rawRate,
+            [System.Globalization.NumberStyles]::Float,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [ref] $parsedRate
+        )
+
+        if (-not $parsed) {
+            throw "Coverage report '$Path' declares $rateName as '$rawRate', which is not a number, so the $Threshold% threshold cannot be enforced."
+        }
+
+        $measured[$rateName] = [math]::Round($parsedRate * 100, 2)
+    }
+
+    $below = @(
+        $measured.Keys | Where-Object { $measured[$_] -lt $Threshold }
+    )
+
+    if ($below.Count -gt 0) {
+        $detail = ($measured.Keys | ForEach-Object { "$_ $($measured[$_])%" }) -join ', '
+        throw "Coverage is below the $Threshold% threshold for $($below -join ' and '). Measured: $detail."
+    }
+
+    return [pscustomobject]@{
+        LinePercentage   = $measured['line-rate']
+        BranchPercentage = $measured['branch-rate']
+        Threshold        = $Threshold
+    }
+}
+
 Export-ModuleMember -Function *

--- a/eng/build-helpers.psm1
+++ b/eng/build-helpers.psm1
@@ -283,21 +283,30 @@ function Assert-CoverageThreshold {
             throw "Coverage report '$Path' declares $rateName as '$rawRate', which is not a number, so the $Threshold% threshold cannot be enforced."
         }
 
-        $measured[$rateName] = [math]::Round($parsedRate * 100, 2)
+        # Held as the raw rate, unrounded. Rounding to a display percentage before the comparison
+        # opens a false-pass window just under the gate: 0.57995 is 57.995%, which rounds to 58.00
+        # and would pass a threshold it is below.
+        $measured[$rateName] = $parsedRate
     }
 
+    # Compared as rates rather than percentages. Scaling to a percentage first makes an
+    # exactly-at-threshold report fail, because 0.58 * 100 is 57.99999999999999 as a double, while
+    # 0.58 and 58 / 100.0 are the same double. Comparing rates is what keeps the boundary exact in
+    # both directions.
+    $thresholdRate = $Threshold / 100.0
+
     $below = @(
-        $measured.Keys | Where-Object { $measured[$_] -lt $Threshold }
+        $measured.Keys | Where-Object { $measured[$_] -lt $thresholdRate }
     )
 
     if ($below.Count -gt 0) {
-        $detail = ($measured.Keys | ForEach-Object { "$_ $($measured[$_])%" }) -join ', '
+        $detail = ($measured.Keys | ForEach-Object { "$_ $([math]::Round($measured[$_] * 100, 2))%" }) -join ', '
         throw "Coverage is below the $Threshold% threshold for $($below -join ' and '). Measured: $detail."
     }
 
     return [pscustomobject]@{
-        LinePercentage   = $measured['line-rate']
-        BranchPercentage = $measured['branch-rate']
+        LinePercentage   = [math]::Round($measured['line-rate'] * 100, 2)
+        BranchPercentage = [math]::Round($measured['branch-rate'] * 100, 2)
         Threshold        = $Threshold
     }
 }

--- a/eng/ci/Write-DmsChangeCategories.ps1
+++ b/eng/ci/Write-DmsChangeCategories.ps1
@@ -22,6 +22,8 @@
         which is correct for events that never compute a diff.
     .PARAMETER DiffUnavailable
         Set when no trustworthy changed-file list could be produced, forcing the full suite.
+    .PARAMETER IsDraft
+        Set when the event is a pull request still in draft.
     .PARAMETER OutputPath
         Destination for the key=value lines. Defaults to $GITHUB_OUTPUT; when neither is set the
         lines go to standard output so the script can be run by hand.
@@ -37,6 +39,9 @@ param(
 
     [switch]
     $DiffUnavailable,
+
+    [switch]
+    $IsDraft,
 
     [string]
     $OutputPath = $env:GITHUB_OUTPUT
@@ -54,7 +59,8 @@ if (-not [string]::IsNullOrWhiteSpace($ChangedFilePath) -and (Test-Path -Literal
 $category = Get-DmsChangeCategory `
     -EventName $EventName `
     -ChangedFile $changedFile `
-    -DiffUnavailable:$DiffUnavailable
+    -DiffUnavailable:$DiffUnavailable `
+    -IsDraft:$IsDraft
 
 $lines = @(
     $category.PSObject.Properties | ForEach-Object {

--- a/eng/ci/Write-DmsChangeCategories.ps1
+++ b/eng/ci/Write-DmsChangeCategories.ps1
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+<#
+    .SYNOPSIS
+        Writes the DMS pull request workflow's change-detection outputs to $GITHUB_OUTPUT.
+    .DESCRIPTION
+        The thin workflow-facing wrapper around Get-DmsChangeCategory. The workflow owns producing
+        the changed-file list, because only it knows the diff base; this script owns turning that
+        list into GitHub Actions step outputs.
+
+        Flags are emitted as lowercase "true"/"false" because that is what the workflow's `if:`
+        expressions compare against.
+    .PARAMETER EventName
+        The GitHub event name.
+    .PARAMETER ChangedFilePath
+        A file holding the changed paths, one per line. A missing file is treated as an empty list,
+        which is correct for events that never compute a diff.
+    .PARAMETER DiffUnavailable
+        Set when no trustworthy changed-file list could be produced, forcing the full suite.
+    .PARAMETER OutputPath
+        Destination for the key=value lines. Defaults to $GITHUB_OUTPUT; when neither is set the
+        lines go to standard output so the script can be run by hand.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]
+    $EventName,
+
+    [string]
+    $ChangedFilePath,
+
+    [switch]
+    $DiffUnavailable,
+
+    [string]
+    $OutputPath = $env:GITHUB_OUTPUT
+)
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module -Name (Join-Path $PSScriptRoot 'dms-change-categories.psm1') -Force
+
+$changedFile = @()
+if (-not [string]::IsNullOrWhiteSpace($ChangedFilePath) -and (Test-Path -LiteralPath $ChangedFilePath -PathType Leaf)) {
+    $changedFile = @(Get-Content -LiteralPath $ChangedFilePath)
+}
+
+$category = Get-DmsChangeCategory `
+    -EventName $EventName `
+    -ChangedFile $changedFile `
+    -DiffUnavailable:$DiffUnavailable
+
+$lines = @(
+    $category.PSObject.Properties | ForEach-Object {
+        "$($_.Name)=$(([string]$_.Value).ToLowerInvariant())"
+    }
+)
+
+# Echoed to the log as well as the output file: the classification decides which lanes run, so when
+# a lane is unexpectedly skipped this is the first thing worth reading.
+$lines | ForEach-Object { Write-Output $_ }
+
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    Add-Content -LiteralPath $OutputPath -Value $lines
+}

--- a/eng/ci/coverlet.runsettings
+++ b/eng/ci/coverlet.runsettings
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-License-Identifier: Apache-2.0
+    Licensed to the Ed-Fi Alliance under one or more agreements.
+    The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+    See the LICENSE and NOTICES files in the project root for more information.
+
+    Coverage configuration for the DMS unit-test lane. The module exclusions are carried over
+    verbatim from the coverlet.console arguments this replaced; nothing was added, so the measured
+    set changes only as much as switching from on-disk instrumentation to the in-process collector
+    forces it to.
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Exclude>[EdFi.DataManagementService.Tests.E2E]*,[EdFi.DataManagementService.Tests.Integration]*,[EdFi.DataManagementService.Backend.Tests.Integration.Common]*,[EdFi.DataManagementService.Performance.Harness]*</Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/eng/ci/dms-change-categories.psm1
+++ b/eng/ci/dms-change-categories.psm1
@@ -42,6 +42,168 @@ $script:DmsRelevantPathPrefix = @(
     'src/config/'
 )
 
+# Promoted-suite categories. Each names one or two integration lanes that a pull request runs only
+# when its changed files reach them; the merge queue always runs all of them. The two DMS-API lanes
+# share one category because they share one test project and one in-process pipeline, and the two
+# SchemaTools lanes share one because they share one CLI - splitting either by dialect would let a
+# provider-only change skip the lane that exercises that provider.
+$script:CategoryName = @(
+    'backend_mssql_relevant'
+    'dms_api_relevant'
+    'schematools_relevant'
+    'cdc_relevant'
+)
+
+# Paths that reach every promoted lane: shared source, build and CI infrastructure, and the
+# generators and models every suite compiles against. Only DMS-relevant paths reach this table, so
+# the broad '.github/' prefix here cannot promote a file the relevance rules already rejected.
+$script:AllCategoryExactPath = @(
+    'build-dms.ps1'
+    'src/Directory.Packages.props'
+    'src/nuget.config'
+    'src/dms/Directory.Build.props'
+    'src/dms/Directory.Build.targets'
+    'src/dms/EdFi.DataManagementService.sln'
+    'src/dms/EdFi.DataManagementService-Docker.sln'
+)
+
+$script:AllCategoryPathPrefix = @(
+    '.github/'
+    'eng/'
+    'src/dms/core/'
+    'src/dms/backend/EdFi.DataManagementService.Backend/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.External/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/'
+    'src/dms/backend/Fixtures/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel.Tests.Unit/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.Plans/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.Ddl/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/'
+    'src/dms/backend/EdFi.DataManagementService.Backend.Ddl.PublicContract.CompileCheck/'
+    # The SQL Server provider backs every MSSQL lane, and the CDC suite is SQL-Server-only.
+    'src/dms/backend/EdFi.DataManagementService.Backend.Mssql/'
+)
+
+# Paths that reach only some promoted lanes, or none. First match wins, so the specific entries
+# precede the directory catch-alls below them. An empty category list means "known, and no promoted
+# lane exercises it" - which is what keeps such a path out of the fail-open rule.
+$script:NarrowPathCategory = @(
+    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/'; Category = @('backend_mssql_relevant') }
+    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/'; Category = @() }
+    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/'; Category = @('dms_api_relevant', 'schematools_relevant') }
+    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Cdc/'; Category = @('cdc_relevant') }
+    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Integration/'; Category = @('cdc_relevant') }
+    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Unit/'; Category = @('cdc_relevant') }
+    @{ Prefix = 'src/dms/frontend/'; Category = @('dms_api_relevant') }
+    @{ Prefix = 'src/dms/tests/EdFi.DataManagementService.Tests.Integration/'; Category = @('dms_api_relevant') }
+    @{ Prefix = 'src/dms/clis/EdFi.DataManagementService.SchemaTools/'; Category = @('schematools_relevant') }
+    @{ Prefix = 'src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Integration/'; Category = @('schematools_relevant') }
+    @{ Prefix = 'src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Unit/'; Category = @('schematools_relevant') }
+    @{ Prefix = 'src/dms/clis/EdFi.DataManagementService.SchemaGenerator.Pgsql.Tests.Integration/'; Category = @('schematools_relevant') }
+    # No promoted lane builds the other CLIs, the E2E and unit test projects, or the Configuration
+    # Service. They are still DMS-relevant, so their own lanes still run.
+    @{ Prefix = 'src/dms/clis/'; Category = @() }
+    @{ Prefix = 'src/dms/tests/'; Category = @() }
+    @{ Prefix = 'src/config/'; Category = @() }
+)
+
+function Get-DmsCategoryDefault {
+    <#
+    .SYNOPSIS
+        A fresh category set with every promoted category at one starting value.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [bool]
+        $InitialValue
+    )
+
+    $set = [ordered]@{}
+    foreach ($name in $script:CategoryName) {
+        $set[$name] = $InitialValue
+    }
+
+    return $set
+}
+
+function Get-DmsCategoryForPath {
+    <#
+    .SYNOPSIS
+        The promoted categories one DMS-relevant path reaches.
+    .DESCRIPTION
+        Only call this for a path that already classified as DMS-relevant. An unrecognised path
+        returns every category, so a new project directory is validated by everything until someone
+        classifies it. That is the failure mode this design can afford; the opposite - a new
+        directory silently skipping every promoted lane - is the one it cannot. A path that matches
+        a known narrow rule with no categories returns nothing, which is how a known-but-unpromoted
+        area stays out of the fail-open rule.
+    #>
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path
+    )
+
+    if (
+        Test-DmsChangedFileMatch `
+            -Path $Path `
+            -ExactPath $script:AllCategoryExactPath `
+            -PathPrefix $script:AllCategoryPathPrefix
+    ) {
+        return $script:CategoryName
+    }
+
+    foreach ($rule in $script:NarrowPathCategory) {
+        if ($Path.StartsWith($rule.Prefix, [System.StringComparison]::Ordinal)) {
+            return $rule.Category
+        }
+    }
+
+    return $script:CategoryName
+}
+
+function ConvertTo-DmsChangeCategoryResult {
+    <#
+    .SYNOPSIS
+        Flattens the flags into the object the workflow wrapper turns into step outputs.
+    #>
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [bool]
+        $FreshBuildRequired,
+
+        [Parameter(Mandatory)]
+        [bool]
+        $DmsRelevant,
+
+        [Parameter(Mandatory)]
+        [bool]
+        $Draft,
+
+        [Parameter(Mandatory)]
+        [System.Collections.Specialized.OrderedDictionary]
+        $Category
+    )
+
+    $result = [ordered]@{
+        fresh_build_required = $FreshBuildRequired
+        dms_relevant         = $DmsRelevant
+        draft                = $Draft
+    }
+
+    foreach ($name in $Category.Keys) {
+        $result[$name] = [bool] $Category[$name]
+    }
+
+    return [pscustomobject] $result
+}
+
 function Test-DmsChangedFileMatch {
     <#
     .SYNOPSIS
@@ -84,9 +246,9 @@ function Get-DmsChangeCategory {
     .SYNOPSIS
         Classifies an event's changed files into the flags the DMS pull request workflow gates on.
     .DESCRIPTION
-        Returns fresh_build_required and dms_relevant. Only pull_request narrows: merge_group
-        validates the merged result, so nothing may be skipped there, and every other event runs the
-        full suite.
+        Returns fresh_build_required, dms_relevant, draft, and one flag per promoted-suite category.
+        Only pull_request narrows: merge_group validates the merged result, so nothing may be
+        skipped there, and every other event runs the full suite.
     .PARAMETER EventName
         The GitHub event name - pull_request, merge_group, or anything else (today only
         workflow_dispatch).
@@ -123,15 +285,19 @@ function Get-DmsChangeCategory {
     $draft = $IsDraft.IsPresent -and $EventName -eq 'pull_request'
 
     if ($DiffUnavailable -or ($EventName -ne 'pull_request' -and $EventName -ne 'merge_group')) {
-        return [pscustomobject]@{
-            fresh_build_required = $true
-            dms_relevant         = $true
-            draft                = $draft
-        }
+        return ConvertTo-DmsChangeCategoryResult `
+            -FreshBuildRequired $true `
+            -DmsRelevant $true `
+            -Draft $draft `
+            -Category (Get-DmsCategoryDefault -InitialValue $true)
     }
 
+    # merge_group validates the merged result, so every promoted lane runs there too; only
+    # pull_request narrows to the changed area.
+    $narrows = $EventName -eq 'pull_request'
     $freshBuildRequired = $false
-    $dmsRelevant = $EventName -ne 'pull_request'
+    $dmsRelevant = -not $narrows
+    $category = Get-DmsCategoryDefault -InitialValue (-not $narrows)
 
     foreach ($path in $ChangedFile) {
         if ([string]::IsNullOrWhiteSpace($path)) {
@@ -148,20 +314,30 @@ function Get-DmsChangeCategory {
         }
 
         if (
-            Test-DmsChangedFileMatch `
-                -Path $path `
-                -ExactPath $script:DmsRelevantExactPath `
-                -PathPrefix $script:DmsRelevantPathPrefix
+            -not (
+                Test-DmsChangedFileMatch `
+                    -Path $path `
+                    -ExactPath $script:DmsRelevantExactPath `
+                    -PathPrefix $script:DmsRelevantPathPrefix
+            )
         ) {
-            $dmsRelevant = $true
+            # Not DMS-relevant at all - documentation, editor configuration and the like. It cannot
+            # make a promoted suite relevant either, so it must not reach the fail-open rule.
+            continue
+        }
+
+        $dmsRelevant = $true
+
+        foreach ($name in (Get-DmsCategoryForPath -Path $path)) {
+            $category[$name] = $true
         }
     }
 
-    return [pscustomobject]@{
-        fresh_build_required = $freshBuildRequired
-        dms_relevant         = $dmsRelevant
-        draft                = $draft
-    }
+    return ConvertTo-DmsChangeCategoryResult `
+        -FreshBuildRequired $freshBuildRequired `
+        -DmsRelevant $dmsRelevant `
+        -Draft $draft `
+        -Category $category
 }
 
 Export-ModuleMember -Function Get-DmsChangeCategory

--- a/eng/ci/dms-change-categories.psm1
+++ b/eng/ci/dms-change-categories.psm1
@@ -30,6 +30,11 @@ $script:FreshBuildPathPrefix = @(
 # DMS validation. Note that only .github/actions and .github/workflows qualify, not all of .github.
 $script:DmsRelevantExactPath = @(
     'build-dms.ps1'
+    # Imported by build-dms.ps1, so a change to it changes what every lane's build step runs.
+    'package-helpers.psm1'
+    # Pins the dotnet local tools the build path runs via `dotnet tool run` - the coverage merge's
+    # reportgenerator among them - so a pin change must not skip the jobs that consume the tool.
+    '.config/dotnet-tools.json'
     'src/Directory.Packages.props'
     'src/nuget.config'
 )
@@ -59,6 +64,9 @@ $script:CategoryName = @(
 # the broad '.github/' prefix here cannot promote a file the relevance rules already rejected.
 $script:AllCategoryExactPath = @(
     'build-dms.ps1'
+    # Classified exactly like build-dms.ps1: one is imported by it, the other pins the tools it runs.
+    'package-helpers.psm1'
+    '.config/dotnet-tools.json'
     'src/Directory.Packages.props'
     'src/nuget.config'
     'src/dms/Directory.Build.props'
@@ -94,6 +102,9 @@ $script:AllCategoryPathPrefix = @(
 $script:NarrowPathCategory = @(
     @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/'; Category = @('backend_mssql_relevant') }
     @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/'; Category = @() }
+    # The always-on unit-test job is the only suite that runs Backend.Tests.Unit; no promoted lane
+    # builds or runs it.
+    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/'; Category = @() }
     @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/'; Category = @('dms_api_relevant', 'schematools_relevant') }
     # Also reaches the backend MSSQL lane. The MSSQL integration project references
     # Backend.Cdc and holds the only DB-backed CDC tests in the suite, because the CDC lane

--- a/eng/ci/dms-change-categories.psm1
+++ b/eng/ci/dms-change-categories.psm1
@@ -107,9 +107,11 @@ $script:NarrowPathCategory = @(
     @{ Prefix = 'src/dms/clis/EdFi.DataManagementService.SchemaTools/'; Category = @('schematools_relevant') }
     @{ Prefix = 'src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Integration/'; Category = @('schematools_relevant') }
     @{ Prefix = 'src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Unit/'; Category = @('schematools_relevant') }
-    @{ Prefix = 'src/dms/clis/EdFi.DataManagementService.SchemaGenerator.Pgsql.Tests.Integration/'; Category = @('schematools_relevant') }
     # No promoted lane builds the other CLIs, the E2E and unit test projects, or the Configuration
-    # Service. They are still DMS-relevant, so their own lanes still run.
+    # Service. They are still DMS-relevant, so the always-on jobs still run, and dedicated lanes
+    # cover some of them: src/config has its own workflow, and the CLI integration matrix runs
+    # exactly ApiSchemaDownloader and OpenApiGenerator. DocumentCacheAdmin.Tests.Integration runs
+    # in no workflow at all.
     @{ Prefix = 'src/dms/clis/'; Category = @() }
     @{ Prefix = 'src/dms/tests/'; Category = @() }
     @{ Prefix = 'src/config/'; Category = @() }

--- a/eng/ci/dms-change-categories.psm1
+++ b/eng/ci/dms-change-categories.psm1
@@ -95,7 +95,11 @@ $script:NarrowPathCategory = @(
     @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/'; Category = @('backend_mssql_relevant') }
     @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/'; Category = @() }
     @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/'; Category = @('dms_api_relevant', 'schematools_relevant') }
-    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Cdc/'; Category = @('cdc_relevant') }
+    # Also reaches the backend MSSQL lane. The MSSQL integration project references
+    # Backend.Cdc and holds the only DB-backed CDC tests in the suite, because the CDC lane
+    # itself runs with --filter "Category!=DatabaseIntegration". Classifying CDC source as
+    # cdc-only would skip every DB-backed CDC test on a change to CDC source.
+    @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Cdc/'; Category = @('cdc_relevant', 'backend_mssql_relevant') }
     @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Integration/'; Category = @('cdc_relevant') }
     @{ Prefix = 'src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Unit/'; Category = @('cdc_relevant') }
     @{ Prefix = 'src/dms/frontend/'; Category = @('dms_api_relevant') }

--- a/eng/ci/dms-change-categories.psm1
+++ b/eng/ci/dms-change-categories.psm1
@@ -96,6 +96,10 @@ function Get-DmsChangeCategory {
     .PARAMETER DiffUnavailable
         Set when no trustworthy file list could be produced - a missing merge-group base SHA, or a
         failed git diff. Narrowing requires a trustworthy list, so this forces the full suite.
+    .PARAMETER IsDraft
+        Set when the event is a pull request still in draft. Reported as the draft flag, which the
+        expensive jobs gate on. It is independent of the file classification: a draft is a statement
+        about the pull request, not about what it changed, so it survives the full-suite paths below.
     #>
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -108,13 +112,21 @@ function Get-DmsChangeCategory {
         $ChangedFile = @(),
 
         [switch]
-        $DiffUnavailable
+        $DiffUnavailable,
+
+        [switch]
+        $IsDraft
     )
+
+    # Only a pull request can be a draft. Guarded here as well as in the workflow so a payload that
+    # carries a stale value on another event cannot silently gate the merge queue.
+    $draft = $IsDraft.IsPresent -and $EventName -eq 'pull_request'
 
     if ($DiffUnavailable -or ($EventName -ne 'pull_request' -and $EventName -ne 'merge_group')) {
         return [pscustomobject]@{
             fresh_build_required = $true
             dms_relevant         = $true
+            draft                = $draft
         }
     }
 
@@ -148,6 +160,7 @@ function Get-DmsChangeCategory {
     return [pscustomobject]@{
         fresh_build_required = $freshBuildRequired
         dms_relevant         = $dmsRelevant
+        draft                = $draft
     }
 }
 

--- a/eng/ci/dms-change-categories.psm1
+++ b/eng/ci/dms-change-categories.psm1
@@ -17,6 +17,10 @@
 $script:FreshBuildExactPath = @(
     'src/Directory.Packages.props'
     'src/nuget.config'
+    # Copied into both Docker build contexts on the same COPY line as the two files above, and its
+    # severity settings are build-affecting under TreatWarningsAsErrors, so it is classified
+    # exactly like them.
+    'src/.editorconfig'
     'src/dms/Dockerfile'
     'src/config/Dockerfile'
 )
@@ -37,6 +41,7 @@ $script:DmsRelevantExactPath = @(
     '.config/dotnet-tools.json'
     'src/Directory.Packages.props'
     'src/nuget.config'
+    'src/.editorconfig'
 )
 
 $script:DmsRelevantPathPrefix = @(
@@ -69,6 +74,8 @@ $script:AllCategoryExactPath = @(
     '.config/dotnet-tools.json'
     'src/Directory.Packages.props'
     'src/nuget.config'
+    # Every project under src compiles against its analyzer severities.
+    'src/.editorconfig'
     'src/dms/Directory.Build.props'
     'src/dms/Directory.Build.targets'
     'src/dms/EdFi.DataManagementService.sln'

--- a/eng/ci/dms-change-categories.psm1
+++ b/eng/ci/dms-change-categories.psm1
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+# Classifier for the On DMS Pull Request workflow's change detection. The rules used to live in an
+# inline bash step, where nothing in the repository could execute them and a mistake was only
+# observable by running CI. They are pure - a file list in, a set of flags out - so they belong in a
+# module that Pester can call directly. Producing the file list stays in the workflow, because only
+# the workflow knows the diff base.
+
+# Paths whose change forces a fresh Docker rebuild. The exact list carries whole-file paths; the
+# prefix list carries directory roots, and a prefix match crosses directory separators the same way
+# the bash `case` glob it replaces did.
+$script:FreshBuildExactPath = @(
+    'src/Directory.Packages.props'
+    'src/nuget.config'
+    'src/dms/Dockerfile'
+    'src/config/Dockerfile'
+)
+
+$script:FreshBuildPathPrefix = @(
+    'eng/docker-compose/'
+)
+
+# Paths whose change makes a pull request DMS-relevant. src/config counts: the DMS E2E lanes bring
+# up the Configuration Service built from src/config, so a config-only change still has to trigger
+# DMS validation. Note that only .github/actions and .github/workflows qualify, not all of .github.
+$script:DmsRelevantExactPath = @(
+    'build-dms.ps1'
+    'src/Directory.Packages.props'
+    'src/nuget.config'
+)
+
+$script:DmsRelevantPathPrefix = @(
+    '.github/actions/'
+    '.github/workflows/'
+    'eng/'
+    'src/dms/'
+    'src/config/'
+)
+
+function Test-DmsChangedFileMatch {
+    <#
+    .SYNOPSIS
+        Reports whether one repository-relative path matches a category's exact-path or
+        directory-prefix list.
+    .DESCRIPTION
+        Comparisons are ordinal and case-sensitive because Git paths are case-sensitive and the
+        bash `case` statement this replaces was too. A case-insensitive comparison would classify
+        SRC/dms/Foo.cs as DMS-relevant on a repository that can also contain src/dms/Foo.cs.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path,
+
+        [string[]]
+        $ExactPath = @(),
+
+        [string[]]
+        $PathPrefix = @()
+    )
+
+    foreach ($candidate in $ExactPath) {
+        if ([string]::Equals($Path, $candidate, [System.StringComparison]::Ordinal)) {
+            return $true
+        }
+    }
+
+    foreach ($prefix in $PathPrefix) {
+        if ($Path.StartsWith($prefix, [System.StringComparison]::Ordinal)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-DmsChangeCategory {
+    <#
+    .SYNOPSIS
+        Classifies an event's changed files into the flags the DMS pull request workflow gates on.
+    .DESCRIPTION
+        Returns fresh_build_required and dms_relevant. Only pull_request narrows: merge_group
+        validates the merged result, so nothing may be skipped there, and every other event runs the
+        full suite.
+    .PARAMETER EventName
+        The GitHub event name - pull_request, merge_group, or anything else (today only
+        workflow_dispatch).
+    .PARAMETER ChangedFile
+        Repository-relative, forward-slash separated paths changed by the event. Blank entries are
+        ignored, so a trailing newline in the diff output is harmless.
+    .PARAMETER DiffUnavailable
+        Set when no trustworthy file list could be produced - a missing merge-group base SHA, or a
+        failed git diff. Narrowing requires a trustworthy list, so this forces the full suite.
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $EventName,
+
+        [string[]]
+        $ChangedFile = @(),
+
+        [switch]
+        $DiffUnavailable
+    )
+
+    if ($DiffUnavailable -or ($EventName -ne 'pull_request' -and $EventName -ne 'merge_group')) {
+        return [pscustomobject]@{
+            fresh_build_required = $true
+            dms_relevant         = $true
+        }
+    }
+
+    $freshBuildRequired = $false
+    $dmsRelevant = $EventName -ne 'pull_request'
+
+    foreach ($path in $ChangedFile) {
+        if ([string]::IsNullOrWhiteSpace($path)) {
+            continue
+        }
+
+        if (
+            Test-DmsChangedFileMatch `
+                -Path $path `
+                -ExactPath $script:FreshBuildExactPath `
+                -PathPrefix $script:FreshBuildPathPrefix
+        ) {
+            $freshBuildRequired = $true
+        }
+
+        if (
+            Test-DmsChangedFileMatch `
+                -Path $path `
+                -ExactPath $script:DmsRelevantExactPath `
+                -PathPrefix $script:DmsRelevantPathPrefix
+        ) {
+            $dmsRelevant = $true
+        }
+    }
+
+    return [pscustomobject]@{
+        fresh_build_required = $freshBuildRequired
+        dms_relevant         = $dmsRelevant
+    }
+}
+
+Export-ModuleMember -Function Get-DmsChangeCategory

--- a/eng/ci/tests/DmsChangeCategories.Tests.ps1
+++ b/eng/ci/tests/DmsChangeCategories.Tests.ps1
@@ -107,6 +107,11 @@ Describe "DMS pull request change classifier" {
                 # The SQL Server provider backs every MSSQL lane, and CDC is SQL-Server-only.
                 @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.Mssql/Something.cs" }
                 @{ Path = "build-dms.ps1" }
+                # Imported by build-dms.ps1, so it is classified exactly like build-dms.ps1.
+                @{ Path = "package-helpers.psm1" }
+                # Pins the dotnet local tools build-dms.ps1 runs, the coverage merge's
+                # reportgenerator among them.
+                @{ Path = ".config/dotnet-tools.json" }
                 @{ Path = "eng/build-helpers.psm1" }
                 @{ Path = ".github/workflows/on-dms-pullrequest.yml" }
                 @{ Path = "src/Directory.Packages.props" }
@@ -168,6 +173,9 @@ Describe "DMS pull request change classifier" {
                 # project must not promote anything either - but it is a known path, so it must not
                 # fail open.
                 @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/Something.cs" }
+                # Only the always-on unit-test job runs Backend.Tests.Unit, so it must not fail
+                # open into every promoted lane.
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Something.cs" }
                 @{ Path = "src/dms/clis/EdFi.DataManagementService.OpenApiGenerator/Something.cs" }
                 @{ Path = "src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin/Something.cs" }
                 @{ Path = "src/dms/tests/EdFi.DataManagementService.Tests.E2E/Something.cs" }
@@ -355,6 +363,8 @@ Describe "DMS pull request change classifier" {
 
         It "treats <Path> as DMS-relevant" -ForEach @(
             @{ Path = "build-dms.ps1" }
+            @{ Path = "package-helpers.psm1" }
+            @{ Path = ".config/dotnet-tools.json" }
             @{ Path = ".github/actions/pull-ci-images/action.yml" }
             @{ Path = ".github/workflows/on-dms-pullrequest.yml" }
             @{ Path = "eng/build-helpers.psm1" }

--- a/eng/ci/tests/DmsChangeCategories.Tests.ps1
+++ b/eng/ci/tests/DmsChangeCategories.Tests.ps1
@@ -115,6 +115,10 @@ Describe "DMS pull request change classifier" {
                 @{ Path = "eng/build-helpers.psm1" }
                 @{ Path = ".github/workflows/on-dms-pullrequest.yml" }
                 @{ Path = "src/Directory.Packages.props" }
+                # Copied into both Docker build contexts beside Directory.Packages.props, and its
+                # severity settings are build-affecting under TreatWarningsAsErrors, so it is
+                # classified exactly like that file.
+                @{ Path = "src/.editorconfig" }
                 @{ Path = "src/dms/Directory.Build.props" }
                 @{ Path = "src/dms/EdFi.DataManagementService.sln" }
             ) {
@@ -373,6 +377,7 @@ Describe "DMS pull request change classifier" {
             @{ Path = "src/config/backend/Something.cs" }
             @{ Path = "src/Directory.Packages.props" }
             @{ Path = "src/nuget.config" }
+            @{ Path = "src/.editorconfig" }
         ) {
             (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @($Path)).dms_relevant |
                 Should -BeTrue
@@ -397,6 +402,7 @@ Describe "DMS pull request change classifier" {
         It "requires a fresh rebuild for <Path>" -ForEach @(
             @{ Path = "src/Directory.Packages.props" }
             @{ Path = "src/nuget.config" }
+            @{ Path = "src/.editorconfig" }
             @{ Path = "src/dms/Dockerfile" }
             @{ Path = "src/config/Dockerfile" }
             @{ Path = "eng/docker-compose/postgresql.yml" }

--- a/eng/ci/tests/DmsChangeCategories.Tests.ps1
+++ b/eng/ci/tests/DmsChangeCategories.Tests.ps1
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+# Behavioral specs for the On DMS Pull Request change classifier. These import the real module and
+# call it; nothing here reads workflow or script source text. The classifier decides which CI lanes
+# run, and until it was extracted from an inline bash step there was no way to exercise it outside a
+# CI run.
+
+Describe "DMS pull request change classifier" {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        Import-Module (Join-Path $script:repoRoot "eng/ci/dms-change-categories.psm1") -Force
+    }
+
+    AfterAll {
+        Remove-Module dms-change-categories -Force -ErrorAction SilentlyContinue
+    }
+
+    Context "Events that always validate the full tree" {
+        It "runs everything for workflow_dispatch, whatever the file list says" {
+            $result = Get-DmsChangeCategory -EventName "workflow_dispatch" -ChangedFile @("docs/README.md")
+
+            $result.fresh_build_required | Should -BeTrue
+            $result.dms_relevant | Should -BeTrue
+        }
+
+        It "runs everything for an event the classifier does not model" {
+            # The bash this replaces had an explicit unreachable branch that ran the full suite
+            # rather than infer a diff base. Adding a trigger must not silently start narrowing.
+            $result = Get-DmsChangeCategory -EventName "schedule" -ChangedFile @("docs/README.md")
+
+            $result.fresh_build_required | Should -BeTrue
+            $result.dms_relevant | Should -BeTrue
+        }
+
+        It "runs everything for <EventName> when no trustworthy diff could be produced" -ForEach @(
+            @{ EventName = "merge_group" }
+            @{ EventName = "pull_request" }
+        ) {
+            # Narrowing needs a trustworthy file list. Without one the only safe answer is the full
+            # suite - skipping a lane because git failed would hide the failure behind a green gate.
+            $result = Get-DmsChangeCategory -EventName $EventName -ChangedFile @() -DiffUnavailable
+
+            $result.fresh_build_required | Should -BeTrue
+            $result.dms_relevant | Should -BeTrue
+        }
+    }
+
+    Context "merge_group never narrows" {
+        It "reports DMS-relevant even for a docs-only merge group" {
+            $result = Get-DmsChangeCategory -EventName "merge_group" -ChangedFile @("docs/README.md")
+
+            $result.dms_relevant | Should -BeTrue
+            $result.fresh_build_required | Should -BeFalse
+        }
+
+        It "still detects a fresh-rebuild path in a merge group" {
+            $result = Get-DmsChangeCategory -EventName "merge_group" -ChangedFile @("eng/docker-compose/postgresql.yml")
+
+            $result.dms_relevant | Should -BeTrue
+            $result.fresh_build_required | Should -BeTrue
+        }
+    }
+
+    Context "pull_request narrows to the changed area" {
+        It "reports nothing relevant for an empty file list" {
+            $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @()
+
+            $result.fresh_build_required | Should -BeFalse
+            $result.dms_relevant | Should -BeFalse
+        }
+
+        It "ignores blank entries left by a trailing newline" {
+            $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @("", "   ", $null)
+
+            $result.fresh_build_required | Should -BeFalse
+            $result.dms_relevant | Should -BeFalse
+        }
+
+        It "treats <Path> as DMS-relevant" -ForEach @(
+            @{ Path = "build-dms.ps1" }
+            @{ Path = ".github/actions/pull-ci-images/action.yml" }
+            @{ Path = ".github/workflows/on-dms-pullrequest.yml" }
+            @{ Path = "eng/build-helpers.psm1" }
+            @{ Path = "eng/ci/tests/DmsChangeCategories.Tests.ps1" }
+            @{ Path = "src/dms/core/EdFi.DataManagementService.Core/Something.cs" }
+            @{ Path = "src/config/backend/Something.cs" }
+            @{ Path = "src/Directory.Packages.props" }
+            @{ Path = "src/nuget.config" }
+        ) {
+            (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @($Path)).dms_relevant |
+                Should -BeTrue
+        }
+
+        It "does not treat <Path> as DMS-relevant" -ForEach @(
+            @{ Path = "docs/README.md" }
+            # Only .github/actions and .github/workflows qualify, not all of .github.
+            @{ Path = ".github/dependabot.yml" }
+            @{ Path = ".github/CODEOWNERS" }
+            # Prefix matching must not spill past the directory boundary.
+            @{ Path = "engineering/notes.md" }
+            @{ Path = "src/Directory.Build.props" }
+            # Exact-path entries are whole paths, not prefixes.
+            @{ Path = "build-dms.ps1.bak" }
+            @{ Path = "README.md" }
+        ) {
+            (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @($Path)).dms_relevant |
+                Should -BeFalse
+        }
+
+        It "requires a fresh rebuild for <Path>" -ForEach @(
+            @{ Path = "src/Directory.Packages.props" }
+            @{ Path = "src/nuget.config" }
+            @{ Path = "src/dms/Dockerfile" }
+            @{ Path = "src/config/Dockerfile" }
+            @{ Path = "eng/docker-compose/postgresql.yml" }
+            # The bash glob this replaces matched across directory separators, so a nested
+            # docker-compose file counts too.
+            @{ Path = "eng/docker-compose/tests/BootstrapSeedDelivery.Tests.ps1" }
+        ) {
+            (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @($Path)).fresh_build_required |
+                Should -BeTrue
+        }
+
+        It "does not require a fresh rebuild for <Path>" -ForEach @(
+            @{ Path = "src/dms/core/EdFi.DataManagementService.Core/Something.cs" }
+            @{ Path = "eng/build-helpers.psm1" }
+            @{ Path = "build-dms.ps1" }
+            # Exact match only: a differently named Dockerfile is DMS-relevant but not a rebuild
+            # trigger.
+            @{ Path = "src/dms/Dockerfile.other" }
+            @{ Path = "src/dms/Nuget.Dockerfile" }
+        ) {
+            (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @($Path)).fresh_build_required |
+                Should -BeFalse
+        }
+
+        It "matches paths case-sensitively, as Git does" {
+            $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @("SRC/DMS/Core/Something.cs")
+
+            $result.dms_relevant | Should -BeFalse
+            $result.fresh_build_required | Should -BeFalse
+        }
+
+        It "combines flags across a mixed file list" {
+            $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @(
+                "docs/README.md",
+                "src/dms/core/EdFi.DataManagementService.Core/Something.cs",
+                "src/dms/Dockerfile"
+            )
+
+            $result.dms_relevant | Should -BeTrue
+            $result.fresh_build_required | Should -BeTrue
+        }
+
+        It "reports DMS-relevant without a fresh rebuild when only source changed" {
+            $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @(
+                "src/dms/core/EdFi.DataManagementService.Core/Something.cs",
+                "src/dms/backend/EdFi.DataManagementService.Backend/Other.cs"
+            )
+
+            $result.dms_relevant | Should -BeTrue
+            $result.fresh_build_required | Should -BeFalse
+        }
+    }
+}
+
+Describe "Write-DmsChangeCategories output contract" {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        $script:writeScript = Join-Path $script:repoRoot "eng/ci/Write-DmsChangeCategories.ps1"
+    }
+
+    BeforeEach {
+        $script:outputPath = Join-Path $TestDrive ([guid]::NewGuid().ToString() + ".txt")
+        $script:changedFilePath = Join-Path $TestDrive ([guid]::NewGuid().ToString() + ".list")
+    }
+
+    It "writes lowercase flags the workflow if: expressions can compare against" {
+        Set-Content -LiteralPath $script:changedFilePath -Value @(
+            "docs/README.md"
+            "src/dms/Dockerfile"
+        )
+
+        & $script:writeScript `
+            -EventName "pull_request" `
+            -ChangedFilePath $script:changedFilePath `
+            -OutputPath $script:outputPath | Out-Null
+
+        $written = @(Get-Content -LiteralPath $script:outputPath)
+
+        $written | Should -Contain "fresh_build_required=true"
+        $written | Should -Contain "dms_relevant=true"
+    }
+
+    It "writes false rather than omitting a flag when nothing is relevant" {
+        Set-Content -LiteralPath $script:changedFilePath -Value "docs/README.md"
+
+        & $script:writeScript `
+            -EventName "pull_request" `
+            -ChangedFilePath $script:changedFilePath `
+            -OutputPath $script:outputPath | Out-Null
+
+        $written = @(Get-Content -LiteralPath $script:outputPath)
+
+        $written | Should -Contain "fresh_build_required=false"
+        $written | Should -Contain "dms_relevant=false"
+    }
+
+    It "treats a missing changed-file list as an empty list" {
+        # workflow_dispatch never computes a diff, so the file the workflow names does not exist.
+        & $script:writeScript `
+            -EventName "workflow_dispatch" `
+            -ChangedFilePath (Join-Path $TestDrive "never-written.list") `
+            -OutputPath $script:outputPath | Out-Null
+
+        $written = @(Get-Content -LiteralPath $script:outputPath)
+
+        $written | Should -Contain "fresh_build_required=true"
+        $written | Should -Contain "dms_relevant=true"
+    }
+
+    It "appends rather than replacing, so it cannot clobber another step's outputs" {
+        Set-Content -LiteralPath $script:outputPath -Value "existing_output=kept"
+        Set-Content -LiteralPath $script:changedFilePath -Value "docs/README.md"
+
+        & $script:writeScript `
+            -EventName "pull_request" `
+            -ChangedFilePath $script:changedFilePath `
+            -OutputPath $script:outputPath | Out-Null
+
+        @(Get-Content -LiteralPath $script:outputPath) | Should -Contain "existing_output=kept"
+    }
+}

--- a/eng/ci/tests/DmsChangeCategories.Tests.ps1
+++ b/eng/ci/tests/DmsChangeCategories.Tests.ps1
@@ -50,6 +50,42 @@ Describe "DMS pull request change classifier" {
         }
     }
 
+    Context "Draft reporting" {
+        It "reports draft for a draft pull request" {
+            (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @("src/dms/x.cs") -IsDraft).draft |
+                Should -BeTrue
+        }
+
+        It "does not report draft for a ready pull request" {
+            (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @("src/dms/x.cs")).draft |
+                Should -BeFalse
+        }
+
+        It "never reports draft for <EventName>, whatever the payload carried" -ForEach @(
+            @{ EventName = "merge_group" }
+            @{ EventName = "workflow_dispatch" }
+        ) {
+            # A draft is a statement about a pull request. If a stale payload value ever reached
+            # another event, gating the merge queue on it would skip the full suite it exists to run.
+            (Get-DmsChangeCategory -EventName $EventName -ChangedFile @("src/dms/x.cs") -IsDraft).draft |
+                Should -BeFalse
+        }
+
+        It "still reports draft when the diff could not be produced" {
+            # Draft state does not depend on the file list, so the fail-open path must not lose it.
+            (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @() -DiffUnavailable -IsDraft).draft |
+                Should -BeTrue
+        }
+
+        It "reports draft alongside, not instead of, the file classification" {
+            $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @("src/dms/Dockerfile") -IsDraft
+
+            $result.draft | Should -BeTrue
+            $result.dms_relevant | Should -BeTrue
+            $result.fresh_build_required | Should -BeTrue
+        }
+    }
+
     Context "merge_group never narrows" {
         It "reports DMS-relevant even for a docs-only merge group" {
             $result = Get-DmsChangeCategory -EventName "merge_group" -ChangedFile @("docs/README.md")
@@ -222,6 +258,31 @@ Describe "Write-DmsChangeCategories output contract" {
 
         $written | Should -Contain "fresh_build_required=true"
         $written | Should -Contain "dms_relevant=true"
+    }
+
+    It "emits the draft flag the workflow gates on" {
+        Set-Content -LiteralPath $script:changedFilePath -Value "src/dms/x.cs"
+
+        & $script:writeScript `
+            -EventName "pull_request" `
+            -ChangedFilePath $script:changedFilePath `
+            -IsDraft `
+            -OutputPath $script:outputPath | Out-Null
+
+        @(Get-Content -LiteralPath $script:outputPath) | Should -Contain "draft=true"
+    }
+
+    It "emits draft=false rather than omitting it on a ready pull request" {
+        # An omitted output evaluates to the empty string, which would silently satisfy
+        # `draft != 'true'` today and hide a wiring mistake later.
+        Set-Content -LiteralPath $script:changedFilePath -Value "src/dms/x.cs"
+
+        & $script:writeScript `
+            -EventName "pull_request" `
+            -ChangedFilePath $script:changedFilePath `
+            -OutputPath $script:outputPath | Out-Null
+
+        @(Get-Content -LiteralPath $script:outputPath) | Should -Contain "draft=false"
     }
 
     It "appends rather than replacing, so it cannot clobber another step's outputs" {

--- a/eng/ci/tests/DmsChangeCategories.Tests.ps1
+++ b/eng/ci/tests/DmsChangeCategories.Tests.ps1
@@ -50,6 +50,216 @@ Describe "DMS pull request change classifier" {
         }
     }
 
+    Context "Promoted-suite categories" {
+        BeforeAll {
+            $script:allCategory = @(
+                'backend_mssql_relevant'
+                'dms_api_relevant'
+                'schematools_relevant'
+                'cdc_relevant'
+            )
+
+            function Get-SetCategory {
+                # The promoted categories a single changed path turns on, for a ready pull request.
+                param([Parameter(Mandatory)] [string] $Path)
+
+                $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @($Path)
+
+                return @(
+                    $script:allCategory | Where-Object { $result.$_ }
+                ) | Sort-Object
+            }
+        }
+
+        Context "Events that never narrow" {
+            It "reports every category for <EventName>" -ForEach @(
+                @{ EventName = "merge_group" }
+                @{ EventName = "workflow_dispatch" }
+            ) {
+                # The merge queue is the recovery path for everything a pull request skipped, so it
+                # must never inherit a category decision.
+                $result = Get-DmsChangeCategory -EventName $EventName -ChangedFile @("docs/README.md")
+
+                foreach ($name in $script:allCategory) {
+                    $result.$name | Should -BeTrue -Because "$name must be true for $EventName"
+                }
+            }
+
+            It "reports every category when the diff could not be produced" {
+                $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @() -DiffUnavailable
+
+                foreach ($name in $script:allCategory) {
+                    $result.$name | Should -BeTrue -Because "$name must be true when nothing can be classified"
+                }
+            }
+        }
+
+        Context "Shared paths reach every promoted lane" {
+            It "<Path> sets every category" -ForEach @(
+                @{ Path = "src/dms/core/EdFi.DataManagementService.Core/Something.cs" }
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend/Something.cs" }
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.External/Something.cs" }
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Something.cs" }
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.Plans/Something.cs" }
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.Ddl/Something.cs" }
+                @{ Path = "src/dms/backend/Fixtures/authoritative/ds-5.2/inputs/x.json" }
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/Something.cs" }
+                # The SQL Server provider backs every MSSQL lane, and CDC is SQL-Server-only.
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.Mssql/Something.cs" }
+                @{ Path = "build-dms.ps1" }
+                @{ Path = "eng/build-helpers.psm1" }
+                @{ Path = ".github/workflows/on-dms-pullrequest.yml" }
+                @{ Path = "src/Directory.Packages.props" }
+                @{ Path = "src/dms/Directory.Build.props" }
+                @{ Path = "src/dms/EdFi.DataManagementService.sln" }
+            ) {
+                Get-SetCategory -Path $Path |
+                    Should -Be @('backend_mssql_relevant', 'cdc_relevant', 'dms_api_relevant', 'schematools_relevant')
+            }
+        }
+
+        Context "Narrow paths reach only their own lanes" {
+            It "<Path> sets exactly <Expected>" -ForEach @(
+                @{
+                    Path     = "src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/Something.cs"
+                    Expected = @('backend_mssql_relevant')
+                }
+                @{
+                    Path     = "src/dms/backend/EdFi.DataManagementService.Backend.Cdc/Something.cs"
+                    Expected = @('cdc_relevant')
+                }
+                @{
+                    Path     = "src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Integration/Something.cs"
+                    Expected = @('cdc_relevant')
+                }
+                @{
+                    Path     = "src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Unit/Something.cs"
+                    Expected = @('cdc_relevant')
+                }
+                @{
+                    Path     = "src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Something.cs"
+                    Expected = @('dms_api_relevant')
+                }
+                @{
+                    Path     = "src/dms/tests/EdFi.DataManagementService.Tests.Integration/Something.cs"
+                    Expected = @('dms_api_relevant')
+                }
+                @{
+                    Path     = "src/dms/clis/EdFi.DataManagementService.SchemaTools/Something.cs"
+                    Expected = @('schematools_relevant')
+                }
+                @{
+                    Path     = "src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Integration/Something.cs"
+                    Expected = @('schematools_relevant')
+                }
+                @{
+                    Path     = "src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Something.cs"
+                    Expected = @('dms_api_relevant', 'schematools_relevant')
+                }
+            ) {
+                Get-SetCategory -Path $Path | Should -Be (@($Expected) | Sort-Object)
+            }
+        }
+
+        Context "Known paths that no promoted lane exercises" {
+            It "<Path> sets no category" -ForEach @(
+                # Backend PostgreSQL Integration is deliberately not promoted, so its own test
+                # project must not promote anything either - but it is a known path, so it must not
+                # fail open.
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/Something.cs" }
+                @{ Path = "src/dms/clis/EdFi.DataManagementService.OpenApiGenerator/Something.cs" }
+                @{ Path = "src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin/Something.cs" }
+                @{ Path = "src/dms/tests/EdFi.DataManagementService.Tests.E2E/Something.cs" }
+                @{ Path = "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/Something.cs" }
+                @{ Path = "src/dms/tests/EdFi.DataManagementService.Tests.Unit/Something.cs" }
+                @{ Path = "src/config/backend/Something.cs" }
+                @{ Path = "docs/README.md" }
+            ) {
+                Get-SetCategory -Path $Path | Should -BeNullOrEmpty
+            }
+
+            It "still reports those DMS paths as DMS-relevant" {
+                # Not promoting a lane must not stop the file's own lanes from running.
+                (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @("src/config/backend/Something.cs")).dms_relevant |
+                    Should -BeTrue
+            }
+        }
+
+        Context "Unclassified DMS paths fail open" {
+            It "<Path> sets every category" -ForEach @(
+                @{ Path = "src/dms/backend/EdFi.DataManagementService.Backend.SomethingNew/File.cs" }
+                @{ Path = "src/dms/somethingnew/File.cs" }
+                @{ Path = "src/dms/Dockerfile" }
+                @{ Path = "src/dms/run.sh" }
+            ) {
+                # A directory nobody has classified yet is validated by everything. The opposite
+                # failure - a new directory silently skipping every promoted lane - is the one this
+                # design cannot afford.
+                Get-SetCategory -Path $Path |
+                    Should -Be @('backend_mssql_relevant', 'cdc_relevant', 'dms_api_relevant', 'schematools_relevant')
+            }
+
+            It "does not fail open for a path that is not DMS-relevant at all" {
+                Get-SetCategory -Path "docs/architecture/notes.md" | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "Category matching respects directory boundaries" {
+            It "treats Backend and Backend.Mssql.Tests.Integration as different projects" {
+                # A prefix that ignored the boundary would fold the narrow lane into the shared one
+                # and silently promote everything.
+                Get-SetCategory -Path "src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/x.cs" |
+                    Should -Be @('backend_mssql_relevant')
+            }
+
+            It "treats Postgresql and Postgresql.Tests.Integration as different projects" {
+                Get-SetCategory -Path "src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/x.cs" |
+                    Should -Be @('dms_api_relevant', 'schematools_relevant')
+
+                Get-SetCategory -Path "src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/x.cs" |
+                    Should -BeNullOrEmpty
+            }
+
+            It "matches category paths case-sensitively, as Git does" {
+                Get-SetCategory -Path "SRC/DMS/backend/EdFi.DataManagementService.Backend.Cdc/x.cs" |
+                    Should -BeNullOrEmpty
+            }
+        }
+
+        Context "Categories combine across a file list" {
+            It "unions the categories of every changed file" {
+                $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @(
+                    "src/dms/backend/EdFi.DataManagementService.Backend.Cdc/x.cs",
+                    "src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/y.cs"
+                )
+
+                $result.cdc_relevant | Should -BeTrue
+                $result.dms_api_relevant | Should -BeTrue
+                $result.backend_mssql_relevant | Should -BeFalse
+                $result.schematools_relevant | Should -BeFalse
+            }
+
+            It "lets one shared file promote everything regardless of its neighbours" {
+                $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @(
+                    "src/dms/tests/EdFi.DataManagementService.Tests.E2E/x.cs",
+                    "src/dms/core/EdFi.DataManagementService.Core/y.cs"
+                )
+
+                foreach ($name in $script:allCategory) {
+                    $result.$name | Should -BeTrue -Because "$name must follow a core change"
+                }
+            }
+
+            It "reports no category for an empty file list on a pull request" {
+                $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @()
+
+                foreach ($name in $script:allCategory) {
+                    $result.$name | Should -BeFalse
+                }
+            }
+        }
+    }
+
     Context "Draft reporting" {
         It "reports draft for a draft pull request" {
             (Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @("src/dms/x.cs") -IsDraft).draft |
@@ -283,6 +493,24 @@ Describe "Write-DmsChangeCategories output contract" {
             -OutputPath $script:outputPath | Out-Null
 
         @(Get-Content -LiteralPath $script:outputPath) | Should -Contain "draft=false"
+    }
+
+    It "emits every promoted category flag the workflow gates on" {
+        Set-Content -LiteralPath $script:changedFilePath -Value "src/dms/backend/EdFi.DataManagementService.Backend.Cdc/x.cs"
+
+        & $script:writeScript `
+            -EventName "pull_request" `
+            -ChangedFilePath $script:changedFilePath `
+            -OutputPath $script:outputPath | Out-Null
+
+        $written = @(Get-Content -LiteralPath $script:outputPath)
+
+        # Written whether true or false: an omitted output evaluates to the empty string, which
+        # never equals 'true', so a missing flag would look exactly like a deliberate skip.
+        $written | Should -Contain "cdc_relevant=true"
+        $written | Should -Contain "backend_mssql_relevant=false"
+        $written | Should -Contain "dms_api_relevant=false"
+        $written | Should -Contain "schematools_relevant=false"
     }
 
     It "appends rather than replacing, so it cannot clobber another step's outputs" {

--- a/eng/ci/tests/DmsChangeCategories.Tests.ps1
+++ b/eng/ci/tests/DmsChangeCategories.Tests.ps1
@@ -125,8 +125,9 @@ Describe "DMS pull request change classifier" {
                     Expected = @('backend_mssql_relevant')
                 }
                 @{
+                    # CDC source reaches the backend MSSQL lane as well; see the dedicated spec below.
                     Path     = "src/dms/backend/EdFi.DataManagementService.Backend.Cdc/Something.cs"
-                    Expected = @('cdc_relevant')
+                    Expected = @('backend_mssql_relevant', 'cdc_relevant')
                 }
                 @{
                     Path     = "src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Integration/Something.cs"
@@ -220,6 +221,28 @@ Describe "DMS pull request change classifier" {
                     Should -BeNullOrEmpty
             }
 
+            It "promotes the backend MSSQL lane for a change to CDC source" {
+                # EdFi.DataManagementService.Backend.Mssql.Tests.Integration references
+                # EdFi.DataManagementService.Backend.Cdc and holds the only DB-backed CDC tests in
+                # the suite - MssqlCdcSourcePositionAdapterTests is [Category("DatabaseIntegration")]
+                # and [Category("MssqlIntegration")]. The promoted CDC lane cannot cover them: it
+                # runs with --filter "Category!=DatabaseIntegration". Without this category a CDC
+                # source change ran no DB-backed CDC test at all.
+                Get-SetCategory -Path "src/dms/backend/EdFi.DataManagementService.Backend.Cdc/CdcSourcePositionAdapter.cs" |
+                    Should -Contain 'backend_mssql_relevant'
+            }
+
+            It "leaves the CDC test projects reaching only the CDC lane" {
+                # The reference runs from the MSSQL integration project to CDC *source*, not to the
+                # CDC test projects, so those stay narrow.
+                foreach ($path in @(
+                        "src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Integration/x.cs"
+                        "src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Unit/x.cs"
+                    )) {
+                    Get-SetCategory -Path $path | Should -Be @('cdc_relevant')
+                }
+            }
+
             It "matches category paths case-sensitively, as Git does" {
                 Get-SetCategory -Path "SRC/DMS/backend/EdFi.DataManagementService.Backend.Cdc/x.cs" |
                     Should -BeNullOrEmpty
@@ -228,8 +251,11 @@ Describe "DMS pull request change classifier" {
 
         Context "Categories combine across a file list" {
             It "unions the categories of every changed file" {
+                # Deliberately the CDC integration test project rather than CDC source: that path
+                # reaches one lane, so this stays a test about unioning rather than about the
+                # backend MSSQL promotion, which has its own spec.
                 $result = Get-DmsChangeCategory -EventName "pull_request" -ChangedFile @(
-                    "src/dms/backend/EdFi.DataManagementService.Backend.Cdc/x.cs",
+                    "src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Integration/x.cs",
                     "src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/y.cs"
                 )
 
@@ -496,7 +522,9 @@ Describe "Write-DmsChangeCategories output contract" {
     }
 
     It "emits every promoted category flag the workflow gates on" {
-        Set-Content -LiteralPath $script:changedFilePath -Value "src/dms/backend/EdFi.DataManagementService.Backend.Cdc/x.cs"
+        # The CDC integration test project, not CDC source: this spec needs categories that stay
+        # false to prove a false flag is still written.
+        Set-Content -LiteralPath $script:changedFilePath -Value "src/dms/backend/EdFi.DataManagementService.Backend.Cdc.Tests.Integration/x.cs"
 
         & $script:writeScript `
             -EventName "pull_request" `

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -612,6 +612,28 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             $block | Should -Not -Match 'dms-build-output'
         }
 
+        It "E2E provisioning reuses the artifact rather than rebuilding the CLIs" {
+            # provision-e2e-database.ps1 runs ApiSchemaDownloader and SchemaTools through dotnet run,
+            # which builds by default. It stays self-sufficient for the local setup scripts that call
+            # it directly, so the opt-in has to come from the build path - and this is the only
+            # caller that can promise compiled output, whether from a local build or the artifact.
+            # Asserted here because it is the shared-artifact contract that makes the opt-in correct;
+            # the script's own behaviour is owned by the docker-compose tests.
+            $buildScript = Get-Content -LiteralPath $script:buildScriptPath -Raw
+
+            $buildScript | Should -Match '(?s)function Invoke-E2EDatabaseProvisioning.*?-UsePrebuiltTools'
+        }
+
+        It "instance E2E provisioning reuses the artifact rather than rebuilding the CLIs" {
+            # The instance lanes reach provisioning through their own setup script rather than
+            # Invoke-E2EDatabaseProvisioning, so the DMS-route opt-in above does not cover them and
+            # they would otherwise keep rebuilding. Both halves are pinned here because both are the
+            # same shared-artifact contract.
+            $buildScript = Get-Content -LiteralPath $script:buildScriptPath -Raw
+
+            $buildScript | Should -Match '(?s)\$setupParameters = @\{.*?UsePrebuiltTools\s*=\s*\$true'
+        }
+
         It "no build-dms.ps1 test path rebuilds what the artifact already provides" {
             # The workflow guard above sees only commands written in the workflow. Consumers reach
             # their tests through build-dms.ps1, so a test path that omits --no-build there

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -38,6 +38,10 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
         )
         $script:lines = (Get-Content -LiteralPath $script:workflowPath -Raw) -split "\r?\n"
 
+        $script:buildScriptPath = [System.IO.Path]::GetFullPath(
+            (Join-Path $PSScriptRoot "../../../build-dms.ps1")
+        )
+
         function Get-JobBlock {
             # Text of a top-level job (two-space key) up to the next top-level job key or EOF.
             param([Parameter(Mandatory)] [string] $JobName)
@@ -522,6 +526,24 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             $block | Should -Not -Match 'build-dms\.ps1 Build'
         }
 
+        It "<JobName> compiles nothing of its own" -ForEach $buildOutputConsumer {
+            # Wider than the solution-build check above, because a consumer can recompile without
+            # ever naming build-dms.ps1: a bare `dotnet test <project>` builds that project and its
+            # whole ProjectReference graph. The producer stages bin only, so such a step has no
+            # intermediate output to reuse and pays close to a full compile - exactly the redundancy
+            # the shared artifact exists to remove. Scoped to the consumer set: the artifact
+            # producers and the jobs that build only their own matrix project are supposed to build.
+            $chunks = [string[]] (Get-StepChunk -JobName $JobName)
+
+            $compiling = @(
+                $chunks | Where-Object {
+                    $_ -match 'dotnet (test|build|run|publish)\b' -and $_ -notmatch '--no-build'
+                }
+            )
+
+            $compiling | Should -BeNullOrEmpty
+        }
+
         It "<JobName> downloads the artifact before the first step needing compiled output" -ForEach $buildOutputConsumer {
             $chunks = [string[]] (Get-StepChunk -JobName $JobName)
 
@@ -562,6 +584,49 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
 
             $block | Should -Match 'name: dms-integration-test-assemblies'
             $block | Should -Not -Match 'dms-build-output'
+        }
+    }
+
+    Context "Package verification is deliberately not a shared-build consumer" {
+        # It is the one job DMS-1474 counts among the redundant solution builds that does not become
+        # a consumer, so the decision is pinned here rather than left as an omission from the
+        # consumer list. The last two assertions carry the reason, so that if the ground it rests on
+        # moves, this fails and forces the exclusion to be decided again instead of inherited.
+
+        It "runs BuildAndPublish rather than the shared Build target" {
+            $block = Get-JobBlock -JobName 'verify-dms-packages'
+
+            $block | Should -Match 'build-dms\.ps1 BuildAndPublish'
+            $block | Should -Not -Match 'build-dms\.ps1 Build\b'
+        }
+
+        It "neither needs nor downloads the shared build output" {
+            Get-JobNeed -JobName 'verify-dms-packages' | Should -Not -Contain 'build-dms-solution'
+            (Get-JobBlock -JobName 'verify-dms-packages') | Should -Not -Match 'name: dms-build-output'
+        }
+
+        It "states in the workflow why it is excluded" {
+            $block = Get-JobBlock -JobName 'verify-dms-packages'
+
+            $block | Should -Match 'dms-build-output'
+            $block | Should -Match 'version-stamp'
+        }
+
+        It "BuildAndPublish still stamps the version before it compiles" {
+            # The shared producer runs the plain Build target, so its assemblies carry the version in
+            # the tracked props file. This job's packages must carry the release version instead, and
+            # only the stamping step ahead of the compile puts it there.
+            $buildScript = Get-Content -LiteralPath $script:buildScriptPath -Raw
+
+            $buildScript | Should -Match 'BuildAndPublish \{[^}]*Invoke-SetAssemblyInfo[^}]*Invoke-Build'
+        }
+
+        It "version stamping rewrites the props file that governs the shared build" {
+            $buildScript = Get-Content -LiteralPath $script:buildScriptPath -Raw
+
+            $buildScript | Should -Match 'function SetDMSAssemblyInfo'
+            $buildScript | Should -Match 'Directory\.Build\.props'
+            $buildScript | Should -Match '<VersionPrefix>'
         }
     }
 }

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -593,7 +593,11 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
 
             $compiling = @(
                 $chunks | Where-Object {
-                    $_ -match 'dotnet (test|build|run|publish)\b' -and $_ -notmatch '--no-build'
+                    # Judged on non-comment lines only: a step whose explanatory comment names
+                    # --no-build would otherwise satisfy the guard with the real argument deleted.
+                    $code = (($_ -split "\r?\n") | Where-Object { $_ -notmatch '^\s*#' }) -join "`n"
+
+                    $code -match 'dotnet (test|build|run|publish)\b' -and $code -notmatch '--no-build'
                 }
             )
 

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -274,12 +274,14 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
     }
 
     Context "Pull request trigger types" {
-        It "declares exactly the three default types plus ready_for_review" {
+        It "declares exactly the three default types plus the two draft transitions" {
             # Declaring types replaces the default set outright. Dropping synchronize would stop CI
             # running on new pushes; omitting ready_for_review would leave a draft-gated pull request
-            # permanently unvalidated once marked ready.
+            # permanently unvalidated once marked ready. converted_to_draft is the cost side of the
+            # same gate: with cancel-in-progress concurrency, converting cancels the in-flight run
+            # and the replacement classifies as a draft, so its expensive jobs skip.
             @(Get-PullRequestTriggerType) | Sort-Object |
-                Should -Be @('opened', 'ready_for_review', 'reopened', 'synchronize')
+                Should -Be @('converted_to_draft', 'opened', 'ready_for_review', 'reopened', 'synchronize')
         }
 
         It "still restricts the trigger to pull requests targeting main" {

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -137,6 +137,61 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             'test-timing-summary'
         )
 
+        function Get-JobNeed {
+            # The job-level `needs:`, whether written inline (`needs: a`, `needs: [a, b]`) or as a
+            # block sequence.
+            param([Parameter(Mandatory)] [string] $JobName)
+
+            $block = Get-JobBlock -JobName $JobName
+            if ($null -eq $block) {
+                throw "Job '$JobName' was not found in $script:workflowPath."
+            }
+
+            $blockLines = $block -split "`n"
+            for ($i = 0; $i -lt $blockLines.Count; $i++) {
+                if ($blockLines[$i] -notmatch '^    needs:\s*(.*)$') {
+                    continue
+                }
+
+                $inline = $Matches[1].Trim()
+                if (-not [string]::IsNullOrWhiteSpace($inline)) {
+                    return @(
+                        ($inline.Trim('[', ']') -split ',') |
+                            ForEach-Object { $_.Trim() } |
+                            Where-Object { $_ }
+                    )
+                }
+
+                $names = @()
+                for ($j = $i + 1; $j -lt $blockLines.Count; $j++) {
+                    if ([string]::IsNullOrWhiteSpace($blockLines[$j])) {
+                        continue
+                    }
+                    if ($blockLines[$j] -match '^      \[?\s*$') {
+                        continue
+                    }
+                    if ($blockLines[$j] -match '^      -?\s*([A-Za-z0-9_-]+),?\s*$') {
+                        $names += $Matches[1]
+                        continue
+                    }
+                    break
+                }
+
+                return $names
+            }
+
+            return @()
+        }
+
+        $script:promotedLane = @(
+            @{ JobName = 'run-backend-mssql-integration-tests'; Category = 'backend_mssql_relevant' }
+            @{ JobName = 'run-dms-api-mssql-integration-tests'; Category = 'dms_api_relevant' }
+            @{ JobName = 'run-dms-api-postgresql-integration-tests'; Category = 'dms_api_relevant' }
+            @{ JobName = 'run-backend-cdc-integration-tests'; Category = 'cdc_relevant' }
+            @{ JobName = 'run-schematools-postgresql-integration-tests'; Category = 'schematools_relevant' }
+            @{ JobName = 'run-schematools-mssql-integration-tests'; Category = 'schematools_relevant' }
+        )
+
         $script:notDraftGatedJob = @(
             'detect-fresh-build-changes'
             'scan-actions-bidi'
@@ -172,6 +227,87 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
 
             $block | Should -Match '(?m)^      fresh_build_required:\s*\$\{\{\s*steps\.detect\.outputs\.fresh_build_required\s*\}\}\s*$'
             $block | Should -Match '(?m)^      dms_relevant:\s*\$\{\{\s*steps\.detect\.outputs\.dms_relevant\s*\}\}\s*$'
+        }
+    }
+
+    Context "Path-promoted integration lanes" {
+        It "<JobName> gates on <Category>" -ForEach @(
+            @{ JobName = 'run-backend-mssql-integration-tests'; Category = 'backend_mssql_relevant' }
+            @{ JobName = 'run-dms-api-mssql-integration-tests'; Category = 'dms_api_relevant' }
+            @{ JobName = 'run-dms-api-postgresql-integration-tests'; Category = 'dms_api_relevant' }
+            @{ JobName = 'run-backend-cdc-integration-tests'; Category = 'cdc_relevant' }
+            @{ JobName = 'run-schematools-postgresql-integration-tests'; Category = 'schematools_relevant' }
+            @{ JobName = 'run-schematools-mssql-integration-tests'; Category = 'schematools_relevant' }
+        ) {
+            Get-JobIfCondition -JobName $JobName |
+                Should -Match "needs\.detect-fresh-build-changes\.outputs\.$Category == 'true'"
+        }
+
+        It "<JobName> still runs the full suite for non-pull_request events" -ForEach @(
+            @{ JobName = 'run-backend-mssql-integration-tests' }
+            @{ JobName = 'run-dms-api-mssql-integration-tests' }
+            @{ JobName = 'run-dms-api-postgresql-integration-tests' }
+            @{ JobName = 'run-backend-cdc-integration-tests' }
+            @{ JobName = 'run-schematools-postgresql-integration-tests' }
+            @{ JobName = 'run-schematools-mssql-integration-tests' }
+        ) {
+            Get-JobIfCondition -JobName $JobName | Should -Match "github\.event_name != 'pull_request'"
+        }
+
+        It "<JobName> needs both the detector and the assembly build" -ForEach @(
+            @{ JobName = 'run-backend-mssql-integration-tests' }
+            @{ JobName = 'run-dms-api-mssql-integration-tests' }
+            @{ JobName = 'run-dms-api-postgresql-integration-tests' }
+            @{ JobName = 'run-backend-cdc-integration-tests' }
+            @{ JobName = 'run-schematools-postgresql-integration-tests' }
+            @{ JobName = 'run-schematools-mssql-integration-tests' }
+        ) {
+            # The detector supplies the category output; without it in needs the expression reads
+            # empty and the lane never runs. build-integration-test-assemblies supplies the test
+            # assemblies and the inherited draft skip.
+            $needs = Get-JobNeed -JobName $JobName
+
+            $needs | Should -Contain 'detect-fresh-build-changes'
+            $needs | Should -Contain 'build-integration-test-assemblies'
+        }
+
+        It "leaves Backend PostgreSQL Integration unpromoted" {
+            # Deliberately out of scope: PostgreSQL is the default engine, so this is the lane most
+            # likely to catch a shared-backend regression at pull request time.
+            Get-JobIfCondition -JobName 'run-backend-postgresql-integration-tests' |
+                Should -Not -Match 'outputs\.(backend_mssql|dms_api|schematools|cdc)_relevant'
+        }
+
+        It "leaves the other integration lanes unpromoted" -ForEach @(
+            @{ JobName = 'run-schematools-cli-integration-tests' }
+            @{ JobName = 'run-cli-integration-tests' }
+        ) {
+            Get-JobIfCondition -JobName $JobName |
+                Should -Not -Match 'outputs\.(backend_mssql|dms_api|schematools|cdc)_relevant'
+        }
+
+        It "declares every category output the workflow consumes" {
+            # An output referenced but not declared evaluates to the empty string, never equals
+            # 'true', and silently skips its lane on every pull request forever. This is the one
+            # mistake in this design that no test of the classifier could catch.
+            $consumed = @(
+                [regex]::Matches(
+                    ($script:lines -join "`n"),
+                    'needs\.detect-fresh-build-changes\.outputs\.([A-Za-z0-9_]+)'
+                ) | ForEach-Object { $_.Groups[1].Value }
+            ) | Sort-Object -Unique
+
+            $declared = @(
+                ((Get-JobBlock 'detect-fresh-build-changes') -split "`n") |
+                    Where-Object { $_ -match '^      ([A-Za-z0-9_]+):\s*\$\{\{' } |
+                    ForEach-Object { [regex]::Match($_, '^      ([A-Za-z0-9_]+):').Groups[1].Value }
+            ) | Sort-Object -Unique
+
+            $consumed.Count | Should -BeGreaterThan 0
+
+            foreach ($name in $consumed) {
+                $declared | Should -Contain $name
+            }
         }
     }
 

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -16,7 +16,7 @@
 # No YAML parser is available in this lane, so (following DmsPullRequestMssqlWorkflow.Tests.ps1)
 # named blocks are extracted by their two-space job key and invariants are asserted inside them.
 
-# The nine jobs that each ran their own solution build before the shared build artifact landed.
+# The ten jobs that each ran their own solution build before the shared build artifact landed.
 # Declared at file scope rather than in BeforeAll because Pester binds -ForEach during discovery,
 # which happens before any BeforeAll body has run.
 $buildOutputConsumer = @(

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -29,6 +29,10 @@ $buildOutputConsumer = @(
     @{ JobName = 'run-instance-management-e2e-tests' }
     @{ JobName = 'run-instance-management-e2e-tests-mssql' }
     @{ JobName = 'build-and-start-dms' }
+    # Also a producer: it stages the much smaller dms-integration-test-assemblies for the eight
+    # integration lanes. It is a consumer all the same - the five projects it used to compile are in
+    # the solution the shared build already builds.
+    @{ JobName = 'build-integration-test-assemblies' }
 )
 
 Describe "on-dms-pullrequest.yml CI budget wiring" {
@@ -578,7 +582,10 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
                 $chunks,
                 [Predicate[string]] {
                     $args[0] -match 'build-dms\.ps1 (UnitTest|E2ETest|InstanceE2ETest)' -or
-                    $args[0] -match 'preflight-dms-schema-compile\.ps1'
+                    $args[0] -match 'preflight-dms-schema-compile\.ps1' -or
+                    # The integration-assembly producer's first use of compiled output is the copy
+                    # that builds its own artifact, not a test command.
+                    $args[0] -match 'Stage Integration Test Assemblies'
                 }
             )
 
@@ -603,13 +610,15 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             Get-JobNeed -JobName 'dms-ci-gate' | Should -Contain 'build-dms-solution'
         }
 
-        It "build-integration-test-assemblies keeps its own artifact contract" {
-            # Deliberately not re-staged from dms-build-output: that would couple the six fast
-            # integration lanes to a much larger download.
+        It "build-integration-test-assemblies still publishes its own artifact" {
+            # It consumes the shared build like every other consumer - the assertions for that come
+            # from the consumer list above - but it stays a producer too. The eight integration lanes
+            # download this much smaller artifact, and coupling them to the full build output instead
+            # would undo that.
             $block = Get-JobBlock -JobName 'build-integration-test-assemblies'
 
             $block | Should -Match 'name: dms-integration-test-assemblies'
-            $block | Should -Not -Match 'dms-build-output'
+            $block | Should -Match 'Stage Integration Test Assemblies'
         }
 
         It "E2E provisioning reuses the artifact rather than rebuilding the CLIs" {
@@ -621,7 +630,7 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             # the script's own behaviour is owned by the docker-compose tests.
             $buildScript = Get-Content -LiteralPath $script:buildScriptPath -Raw
 
-            $buildScript | Should -Match '(?s)function Invoke-E2EDatabaseProvisioning.*?-UsePrebuiltTools'
+            $buildScript | Should -Match '(?s)function Invoke-E2EDatabaseProvisioning.*?-UsePrebuiltTools:\$UsePrebuiltOutput'
         }
 
         It "instance E2E provisioning reuses the artifact rather than rebuilding the CLIs" {
@@ -631,7 +640,35 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             # same shared-artifact contract.
             $buildScript = Get-Content -LiteralPath $script:buildScriptPath -Raw
 
-            $buildScript | Should -Match '(?s)\$setupParameters = @\{.*?UsePrebuiltTools\s*=\s*\$true'
+            $buildScript | Should -Match '(?s)\$setupParameters = @\{.*?UsePrebuiltTools\s*=\s*\$UsePrebuiltOutput'
+        }
+
+        It "reusing prebuilt output is opt-in, so the documented local commands still build" {
+            # build-dms.ps1 InstanceE2ETest is documented as a standalone command that starts Docker,
+            # provisions and runs the tests. On main it needed no prior host build, and it must not
+            # start needing one: only the CI callers, which have just extracted the shared artifact,
+            # opt out of building.
+            $buildScript = Get-Content -LiteralPath $script:buildScriptPath -Raw
+
+            $buildScript | Should -Match '\[switch\]\s*\r?\n?\s*\$UsePrebuiltOutput'
+            $buildScript | Should -Match '(?s)function RunInstanceE2E.*?if \(\$UsePrebuiltOutput\).*?--no-build'
+        }
+
+        It "every CI E2E call site opts into prebuilt output" {
+            # The other half of the contract above. With the switch defaulting off, a call site that
+            # forgets it silently goes back to rebuilding after downloading the artifact - which is
+            # exactly the defect this replaced, so it is asserted at every call site rather than once.
+            # Anchored on the ./ path so the three `throw "build-dms.ps1 E2ETest failed ..."` message
+            # strings in the MSSQL lanes are not counted as call sites.
+            $e2eInvocation = @(
+                $script:lines | Where-Object { $_ -match '\./build-dms\.ps1 (E2ETest|InstanceE2ETest)\b' }
+            )
+
+            $e2eInvocation.Count | Should -Be 7
+
+            foreach ($invocation in $e2eInvocation) {
+                $invocation | Should -Match '-UsePrebuiltOutput'
+            }
         }
 
         It "no build-dms.ps1 test path rebuilds what the artifact already provides" {

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -486,6 +486,14 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             $block | Should -Match 'if-no-files-found: error'
         }
 
+        It "the producer uploads hidden files" {
+            # upload-artifact ignores hidden files by default, and the staged tree carries the
+            # Playwright driver under bin/Release/net10.0/.playwright. Dropping it produces an
+            # artifact that looks complete, downloads without error, and fails at run time in every
+            # Playwright-backed lane - the worst shape a missing file can take.
+            (Get-JobBlock -JobName 'build-dms-solution') | Should -Match 'include-hidden-files: true'
+        }
+
         It "build-dms-solution runs on DMS relevance and is not draft-gated" {
             # A draft-gated producer would skip run-unit-tests through the dependency, which is the
             # opposite of keeping fast feedback on draft pull requests.

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+# Guardrails for the CI-budget wiring in .github/workflows/on-dms-pullrequest.yml.
+#
+# The classification behind these decisions is exercised directly by DmsChangeCategories.Tests.ps1.
+# What is left here is the wiring itself - which trigger types fire, which jobs consume which
+# output, and whether the aggregate gate still reports - and that wiring has no runtime seam: it is
+# declarative YAML evaluated by GitHub, so a mistake shows up as a lane that silently never runs
+# behind a green required check. Scope is deliberately narrow: only the decisions DMS-1474 makes.
+#
+# No YAML parser is available in this lane, so (following DmsPullRequestMssqlWorkflow.Tests.ps1)
+# named blocks are extracted by their two-space job key and invariants are asserted inside them.
+
+Describe "on-dms-pullrequest.yml CI budget wiring" {
+    BeforeAll {
+        $script:workflowPath = [System.IO.Path]::GetFullPath(
+            (Join-Path $PSScriptRoot "../../../.github/workflows/on-dms-pullrequest.yml")
+        )
+        $script:lines = (Get-Content -LiteralPath $script:workflowPath -Raw) -split "\r?\n"
+
+        function Get-JobBlock {
+            # Text of a top-level job (two-space key) up to the next top-level job key or EOF.
+            param([Parameter(Mandatory)] [string] $JobName)
+
+            $startIndex = -1
+            for ($i = 0; $i -lt $script:lines.Count; $i++) {
+                if ($script:lines[$i] -match "^  $([regex]::Escape($JobName)):\s*$") {
+                    $startIndex = $i
+                    break
+                }
+            }
+            if ($startIndex -lt 0) {
+                return $null
+            }
+
+            $endIndex = $script:lines.Count
+            for ($j = $startIndex + 1; $j -lt $script:lines.Count; $j++) {
+                if ($script:lines[$j] -match '^  [A-Za-z0-9_-]+:\s*$') {
+                    $endIndex = $j
+                    break
+                }
+            }
+
+            return ($script:lines[$startIndex..($endIndex - 1)] -join "`n")
+        }
+
+        function Get-JobIfCondition {
+            # The job-level `if:` flattened to one line, so a folded scalar and an inline condition
+            # are compared the same way. Job keys sit at two spaces, so the job's own `if:` is the
+            # first four-space one in the block; a step's `if:` is indented further and never wins.
+            param([Parameter(Mandatory)] [string] $JobName)
+
+            $block = Get-JobBlock -JobName $JobName
+            if ($null -eq $block) {
+                throw "Job '$JobName' was not found in $script:workflowPath."
+            }
+
+            $blockLines = $block -split "`n"
+            for ($i = 0; $i -lt $blockLines.Count; $i++) {
+                if ($blockLines[$i] -notmatch '^    if:\s*(.*)$') {
+                    continue
+                }
+
+                $inline = $Matches[1].Trim()
+                if ($inline -notin @('>-', '>', '|', '|-')) {
+                    return $inline
+                }
+
+                $continuation = @()
+                for ($j = $i + 1; $j -lt $blockLines.Count; $j++) {
+                    if ([string]::IsNullOrWhiteSpace($blockLines[$j])) {
+                        continue
+                    }
+                    if ($blockLines[$j] -notmatch '^      \S') {
+                        break
+                    }
+                    $continuation += $blockLines[$j].Trim()
+                }
+
+                return ($continuation -join ' ')
+            }
+
+            # A job with no condition at all. Distinct from a job whose condition is empty text,
+            # and the correct answer for "is this job draft-gated?" either way.
+            return ''
+        }
+
+        function Get-TriggerBlock {
+            # Everything from the `on:` key to the `jobs:` key.
+            $startIndex = [array]::FindIndex($script:lines, [Predicate[string]] { $args[0] -match '^on:\s*$' })
+            $endIndex = [array]::FindIndex($script:lines, [Predicate[string]] { $args[0] -match '^jobs:\s*$' })
+
+            if ($startIndex -lt 0 -or $endIndex -lt 0) {
+                throw "Could not locate the on:/jobs: boundary in $script:workflowPath."
+            }
+
+            return ($script:lines[$startIndex..($endIndex - 1)] -join "`n")
+        }
+
+        function Get-PullRequestTriggerType {
+            # The list items under `pull_request:` -> `types:`.
+            $triggerLines = (Get-TriggerBlock) -split "`n"
+            $types = @()
+            $inTypes = $false
+
+            for ($i = 0; $i -lt $triggerLines.Count; $i++) {
+                if ($triggerLines[$i] -match '^    types:\s*$') {
+                    $inTypes = $true
+                    continue
+                }
+
+                if (-not $inTypes) {
+                    continue
+                }
+
+                if ($triggerLines[$i] -match '^      - (\S+)\s*$') {
+                    $types += $Matches[1]
+                    continue
+                }
+
+                break
+            }
+
+            return $types
+        }
+
+        $script:draftGatedJob = @(
+            'build-ci-docker-images'
+            'build-integration-test-assemblies'
+            'verify-dms-packages'
+            'run-cli-integration-tests'
+            'test-timing-summary'
+        )
+
+        $script:notDraftGatedJob = @(
+            'detect-fresh-build-changes'
+            'scan-actions-bidi'
+            'run-bootstrap-pester-tests'
+            'verify-lock-files'
+            'run-unit-tests'
+            'dms-ci-gate'
+        )
+    }
+
+    Context "Pull request trigger types" {
+        It "declares exactly the three default types plus ready_for_review" {
+            # Declaring types replaces the default set outright. Dropping synchronize would stop CI
+            # running on new pushes; omitting ready_for_review would leave a draft-gated pull request
+            # permanently unvalidated once marked ready.
+            @(Get-PullRequestTriggerType) | Sort-Object |
+                Should -Be @('opened', 'ready_for_review', 'reopened', 'synchronize')
+        }
+
+        It "still restricts the trigger to pull requests targeting main" {
+            (Get-TriggerBlock) | Should -Match '(?m)^      - main\s*$'
+        }
+    }
+
+    Context "The detector publishes the draft flag" {
+        It "declares draft as a job output" {
+            Get-JobBlock 'detect-fresh-build-changes' |
+                Should -Match '(?m)^      draft:\s*\$\{\{\s*steps\.detect\.outputs\.draft\s*\}\}\s*$'
+        }
+
+        It "still declares the two pre-existing outputs" {
+            $block = Get-JobBlock 'detect-fresh-build-changes'
+
+            $block | Should -Match '(?m)^      fresh_build_required:\s*\$\{\{\s*steps\.detect\.outputs\.fresh_build_required\s*\}\}\s*$'
+            $block | Should -Match '(?m)^      dms_relevant:\s*\$\{\{\s*steps\.detect\.outputs\.dms_relevant\s*\}\}\s*$'
+        }
+    }
+
+    Context "Draft pull requests skip the expensive jobs" {
+        It "<JobName> is draft-gated" -ForEach @(
+            @{ JobName = 'build-ci-docker-images' }
+            @{ JobName = 'build-integration-test-assemblies' }
+            @{ JobName = 'verify-dms-packages' }
+            @{ JobName = 'run-cli-integration-tests' }
+            @{ JobName = 'test-timing-summary' }
+        ) {
+            Get-JobIfCondition -JobName $JobName |
+                Should -Match "needs\.detect-fresh-build-changes\.outputs\.draft != 'true'"
+        }
+
+        It "<JobName> keeps its DMS-relevance gate as well" -ForEach @(
+            @{ JobName = 'build-ci-docker-images' }
+            @{ JobName = 'build-integration-test-assemblies' }
+            @{ JobName = 'verify-dms-packages' }
+            @{ JobName = 'run-cli-integration-tests' }
+            @{ JobName = 'test-timing-summary' }
+        ) {
+            # Draft gating narrows; it must not replace the docs-only skip that already existed.
+            Get-JobIfCondition -JobName $JobName |
+                Should -Match "needs\.detect-fresh-build-changes\.outputs\.dms_relevant == 'true'"
+        }
+
+        It "<JobName> still runs the full suite for non-pull_request events" -ForEach @(
+            @{ JobName = 'build-ci-docker-images' }
+            @{ JobName = 'build-integration-test-assemblies' }
+            @{ JobName = 'verify-dms-packages' }
+            @{ JobName = 'run-cli-integration-tests' }
+            @{ JobName = 'test-timing-summary' }
+        ) {
+            # The merge queue is the recovery path for everything this ticket skips at PR time, so
+            # no gate may ever apply to merge_group or workflow_dispatch.
+            Get-JobIfCondition -JobName $JobName |
+                Should -Match "github\.event_name != 'pull_request'"
+        }
+    }
+
+    Context "Draft pull requests keep fast feedback and a reporting gate" {
+        It "<JobName> is not draft-gated" -ForEach @(
+            @{ JobName = 'detect-fresh-build-changes' }
+            @{ JobName = 'scan-actions-bidi' }
+            @{ JobName = 'run-bootstrap-pester-tests' }
+            @{ JobName = 'verify-lock-files' }
+            @{ JobName = 'run-unit-tests' }
+            @{ JobName = 'dms-ci-gate' }
+        ) {
+            Get-JobIfCondition -JobName $JobName | Should -Not -Match 'outputs\.draft'
+        }
+    }
+
+    Context "The aggregate gate reports on every pull request" {
+        It "runs unconditionally" {
+            # dms-ci-gate is the merge queue's required check. It has to run and report even when
+            # every dependency skipped, which is exactly the draft case.
+            Get-JobIfCondition -JobName 'dms-ci-gate' | Should -Be 'always()'
+        }
+
+        It "still counts an intentional skip as a pass" {
+            # This is what makes draft gating safe: skipped dependencies must not fail the gate.
+            Get-JobBlock 'dms-ci-gate' | Should -Match "\`$result -ne 'success' -and \`$result -ne 'skipped'"
+        }
+
+        It "depends only on jobs that exist" {
+            # A dependency naming a job that is not defined makes the whole workflow invalid, and a
+            # renamed job silently dropping out of the gate would make the gate green while its
+            # lane never ran.
+            $gateLines = (Get-JobBlock 'dms-ci-gate') -split "`n"
+            $needs = @()
+            $inNeeds = $false
+
+            foreach ($line in $gateLines) {
+                if ($line -match '^    needs:\s*$') {
+                    $inNeeds = $true
+                    continue
+                }
+                if (-not $inNeeds) {
+                    continue
+                }
+                if ($line -match '^      - (\S+)\s*$') {
+                    $needs += $Matches[1]
+                    continue
+                }
+                break
+            }
+
+            $needs.Count | Should -BeGreaterThan 0
+
+            $definedJob = @(
+                $script:lines |
+                    Where-Object { $_ -match '^  ([A-Za-z0-9_-]+):\s*$' } |
+                    ForEach-Object { ($_ -replace '^\s+', '') -replace ':\s*$', '' }
+            )
+
+            foreach ($dependency in $needs) {
+                $definedJob | Should -Contain $dependency
+            }
+        }
+    }
+}

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -16,6 +16,21 @@
 # No YAML parser is available in this lane, so (following DmsPullRequestMssqlWorkflow.Tests.ps1)
 # named blocks are extracted by their two-space job key and invariants are asserted inside them.
 
+# The nine jobs that each ran their own solution build before the shared build artifact landed.
+# Declared at file scope rather than in BeforeAll because Pester binds -ForEach during discovery,
+# which happens before any BeforeAll body has run.
+$buildOutputConsumer = @(
+    @{ JobName = 'run-unit-tests' }
+    @{ JobName = 'run-e2e-tests' }
+    @{ JobName = 'run-e2e-tests-ds61' }
+    @{ JobName = 'run-e2e-tests-partition-sizing' }
+    @{ JobName = 'run-e2e-tests-mssql' }
+    @{ JobName = 'run-e2e-tests-mssql-ds61' }
+    @{ JobName = 'run-instance-management-e2e-tests' }
+    @{ JobName = 'run-instance-management-e2e-tests-mssql' }
+    @{ JobName = 'build-and-start-dms' }
+)
+
 Describe "on-dms-pullrequest.yml CI budget wiring" {
     BeforeAll {
         $script:workflowPath = [System.IO.Path]::GetFullPath(
@@ -200,6 +215,54 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             'run-unit-tests'
             'dms-ci-gate'
         )
+
+        function Get-StepChunk {
+            # The job's steps as ordered text chunks, split on the six-space `- ` step markers. Order
+            # matters here as much as presence: a download step that lands after the step consuming
+            # the build output is present and still useless.
+            param([Parameter(Mandatory)] [string] $JobName)
+
+            $block = Get-JobBlock -JobName $JobName
+            if ($null -eq $block) {
+                throw "Job '$JobName' was not found in $script:workflowPath."
+            }
+
+            $blockLines = $block -split "`n"
+            $stepsIndex = -1
+            for ($i = 0; $i -lt $blockLines.Count; $i++) {
+                if ($blockLines[$i] -match '^    steps:\s*$') {
+                    $stepsIndex = $i
+                    break
+                }
+            }
+
+            if ($stepsIndex -lt 0) {
+                throw "Job '$JobName' has no steps: block in $script:workflowPath."
+            }
+
+            $chunks = [System.Collections.Generic.List[string]]::new()
+            $current = $null
+
+            for ($i = $stepsIndex + 1; $i -lt $blockLines.Count; $i++) {
+                if ($blockLines[$i] -match '^      - ') {
+                    if ($null -ne $current) {
+                        $chunks.Add($current -join "`n")
+                    }
+                    $current = @($blockLines[$i])
+                    continue
+                }
+
+                if ($null -ne $current) {
+                    $current += $blockLines[$i]
+                }
+            }
+
+            if ($null -ne $current) {
+                $chunks.Add($current -join "`n")
+            }
+
+            return $chunks.ToArray()
+        }
     }
 
     Context "Pull request trigger types" {
@@ -408,6 +471,89 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             foreach ($dependency in $needs) {
                 $definedJob | Should -Contain $dependency
             }
+        }
+    }
+
+    Context "One shared solution build feeds every build consumer" {
+        It "build-dms-solution exists and uploads the dms-build-output artifact" {
+            $block = Get-JobBlock -JobName 'build-dms-solution'
+
+            $block | Should -Not -BeNullOrEmpty
+            $block | Should -Match 'actions/upload-artifact'
+            $block | Should -Match 'name: dms-build-output'
+            # An empty artifact has to fail the producer rather than fail nine consumers later with
+            # a confusing missing-assembly error.
+            $block | Should -Match 'if-no-files-found: error'
+        }
+
+        It "build-dms-solution runs on DMS relevance and is not draft-gated" {
+            # A draft-gated producer would skip run-unit-tests through the dependency, which is the
+            # opposite of keeping fast feedback on draft pull requests.
+            $condition = Get-JobIfCondition -JobName 'build-dms-solution'
+
+            $condition | Should -Match 'dms_relevant'
+            $condition | Should -Not -Match 'draft'
+        }
+
+        It "<JobName> depends on build-dms-solution" -ForEach $buildOutputConsumer {
+            Get-JobNeed -JobName $JobName | Should -Contain 'build-dms-solution'
+        }
+
+        It "<JobName> downloads dms-build-output" -ForEach $buildOutputConsumer {
+            $block = Get-JobBlock -JobName $JobName
+
+            $block | Should -Match 'actions/download-artifact'
+            $block | Should -Match 'name: dms-build-output'
+        }
+
+        It "<JobName> no longer runs its own solution build" -ForEach $buildOutputConsumer {
+            # Anchored on the run line rather than the step name, so renaming a step cannot hide a
+            # build that is still happening.
+            $block = Get-JobBlock -JobName $JobName
+
+            $block | Should -Not -Match 'build-dms\.ps1 Build'
+        }
+
+        It "<JobName> downloads the artifact before the first step needing compiled output" -ForEach $buildOutputConsumer {
+            $chunks = [string[]] (Get-StepChunk -JobName $JobName)
+
+            $downloadIndex = [array]::FindIndex(
+                $chunks, [Predicate[string]] { $args[0] -match 'name: dms-build-output' }
+            )
+            $firstUseIndex = [array]::FindIndex(
+                $chunks,
+                [Predicate[string]] {
+                    $args[0] -match 'build-dms\.ps1 (UnitTest|E2ETest|InstanceE2ETest)' -or
+                    $args[0] -match 'preflight-dms-schema-compile\.ps1'
+                }
+            )
+
+            $downloadIndex | Should -BeGreaterThan -1
+            $firstUseIndex | Should -BeGreaterThan -1
+            $downloadIndex | Should -BeLessThan $firstUseIndex
+        }
+
+        It "only the producer runs a solution build, with no inert -IdentityProvider" {
+            # -IdentityProvider never affected Build; it was carried along by copy-paste and is
+            # removed with the deleted steps. The producer is the one remaining Build call site.
+            $buildLines = @($script:lines | Where-Object { $_ -match 'build-dms\.ps1 Build\b' })
+
+            $buildLines.Count | Should -Be 1
+            $buildLines[0] | Should -Not -Match '-IdentityProvider'
+            (Get-JobBlock -JobName 'build-dms-solution') | Should -Match 'build-dms\.ps1 Build'
+        }
+
+        It "the aggregate gate waits on the producer" {
+            Get-JobNeed -JobName 'dms-ci-gate' | Should -Contain 'build-dms-solution'
+        }
+
+        It "build-integration-test-assemblies keeps its own artifact contract" {
+            # Deliberately not re-staged from dms-build-output: that would couple the six fast
+            # integration lanes to a much larger download.
+            $block = Get-JobBlock -JobName 'build-integration-test-assemblies'
+
+            $block | Should -Match 'name: dms-integration-test-assemblies'
+            $block | Should -Not -Match 'dms-build-output'
         }
     }
 }

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -490,12 +490,22 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             $block | Should -Match 'if-no-files-found: error'
         }
 
-        It "the producer uploads hidden files" {
-            # upload-artifact ignores hidden files by default, and the staged tree carries the
-            # Playwright driver under bin/Release/net10.0/.playwright. Dropping it produces an
-            # artifact that looks complete, downloads without error, and fails at run time in every
-            # Playwright-backed lane - the worst shape a missing file can take.
-            (Get-JobBlock -JobName 'build-dms-solution') | Should -Match 'include-hidden-files: true'
+        It "the producer ships a tar archive rather than a directory tree" {
+            # The artifact carries files that have to arrive executable - Playwright's
+            # .playwright/node/*/node, which the driver spawns, and the apphost beside each
+            # executable project. upload-artifact zips a directory path, and the zip handoff drops
+            # Unix mode bits: everything lands 755/644. Nothing in a --no-build consumer re-applies
+            # them, so a directory upload produces an artifact that downloads cleanly and then fails
+            # at run time with permission denied. tar records the modes and carries them through.
+            $block = Get-JobBlock -JobName 'build-dms-solution'
+
+            # -C <staged root> . archives the directory's contents, dotfiles included, so the
+            # .playwright tree needs no separate opt-in the way include-hidden-files was.
+            $block | Should -Match 'tar -czf [^\r\n]*dms-build-output\.tar\.gz -C [^\r\n]*dms-build-output \.'
+            $block | Should -Match 'path: [^\r\n]*dms-build-output\.tar\.gz'
+            # Re-compressing an already gzipped archive costs minutes on a multi-gigabyte tree and
+            # buys nothing.
+            $block | Should -Match 'compression-level: 0'
         }
 
         It "build-dms-solution runs on DMS relevance and is not draft-gated" {
@@ -544,11 +554,25 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             $compiling | Should -BeNullOrEmpty
         }
 
-        It "<JobName> downloads the artifact before the first step needing compiled output" -ForEach $buildOutputConsumer {
+        It "<JobName> extracts the archive with permissions preserved" -ForEach $buildOutputConsumer {
+            # -p rather than relying on the runner's umask: umask 022 happens to leave the execute
+            # bit alone, but that is a property of the runner image, not of the handoff, and this
+            # artifact's correctness rests on the execute bit surviving.
+            $block = Get-JobBlock -JobName $JobName
+
+            $block | Should -Match 'tar -xzpf [^\r\n]*dms-build-output\.tar\.gz'
+        }
+
+        It "<JobName> extracts the artifact before the first step needing compiled output" -ForEach $buildOutputConsumer {
+            # Ordering is asserted against the extract, not the download: an artifact that has been
+            # downloaded but not unpacked is exactly as useless as one that never arrived.
             $chunks = [string[]] (Get-StepChunk -JobName $JobName)
 
             $downloadIndex = [array]::FindIndex(
                 $chunks, [Predicate[string]] { $args[0] -match 'name: dms-build-output' }
+            )
+            $extractIndex = [array]::FindIndex(
+                $chunks, [Predicate[string]] { $args[0] -match 'tar -xzpf' }
             )
             $firstUseIndex = [array]::FindIndex(
                 $chunks,
@@ -559,8 +583,10 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             )
 
             $downloadIndex | Should -BeGreaterThan -1
+            $extractIndex | Should -BeGreaterThan -1
             $firstUseIndex | Should -BeGreaterThan -1
-            $downloadIndex | Should -BeLessThan $firstUseIndex
+            $downloadIndex | Should -BeLessThan $extractIndex
+            $extractIndex | Should -BeLessThan $firstUseIndex
         }
 
         It "only the producer runs a solution build, with no inert -IdentityProvider" {
@@ -584,6 +610,31 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
 
             $block | Should -Match 'name: dms-integration-test-assemblies'
             $block | Should -Not -Match 'dms-build-output'
+        }
+
+        It "no build-dms.ps1 test path rebuilds what the artifact already provides" {
+            # The workflow guard above sees only commands written in the workflow. Consumers reach
+            # their tests through build-dms.ps1, so a test path that omits --no-build there
+            # recompiles just as surely and is invisible to a YAML scan. Asserted per function so a
+            # fourth test path added later cannot inherit a pass from its siblings.
+            $buildScript = Get-Content -LiteralPath $script:buildScriptPath -Raw
+            $functionBlock = [regex]::Split($buildScript, '(?m)^function ') |
+                Select-Object -Skip 1 |
+                # Anchored at the start of a line so a comment or a Write-Output that merely names
+                # the command is not mistaken for one, which the parameter documentation above the
+                # functions and the two explanatory comments inside them would otherwise trip.
+                Where-Object { $_ -match '(?m)^\s*dotnet test\b' }
+
+            $functionBlock | Should -Not -BeNullOrEmpty
+
+            foreach ($block in $functionBlock) {
+                $name = ($block -split '\s', 2)[0]
+
+                # The invocation and the flags can be separated by an argument array, so the
+                # function body as a whole is the unit, not the command line.
+                $block | Should -Match '--no-build' -Because "$name invokes dotnet test"
+                $block | Should -Match '--no-restore' -Because "$name invokes dotnet test"
+            }
         }
     }
 

--- a/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
+++ b/eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1
@@ -113,6 +113,45 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             return ''
         }
 
+        function Get-GateDependency {
+            # The dash-list entries under dms-ci-gate's needs:.
+            $gateLines = (Get-JobBlock 'dms-ci-gate') -split "`n"
+            $needs = @()
+            $inNeeds = $false
+
+            foreach ($line in $gateLines) {
+                if ($line -match '^    needs:\s*$') {
+                    $inNeeds = $true
+                    continue
+                }
+                if (-not $inNeeds) {
+                    continue
+                }
+                if ($line -match '^      - (\S+)\s*$') {
+                    $needs += $Matches[1]
+                    continue
+                }
+                break
+            }
+
+            return $needs
+        }
+
+        function Get-DefinedJob {
+            # Every top-level job key. Scanning starts after the jobs: key because the trigger
+            # types under on: sit at the same two-space indent and would otherwise count as jobs.
+            $jobsIndex = [array]::FindIndex($script:lines, [Predicate[string]] { $args[0] -match '^jobs:\s*$' })
+            if ($jobsIndex -lt 0) {
+                throw "Could not locate the jobs: key in $script:workflowPath."
+            }
+
+            return @(
+                $script:lines[($jobsIndex + 1)..($script:lines.Count - 1)] |
+                    Where-Object { $_ -match '^  ([A-Za-z0-9_-]+):\s*$' } |
+                    ForEach-Object { ($_ -replace '^\s+', '') -replace ':\s*$', '' }
+            )
+        }
+
         function Get-TriggerBlock {
             # Everything from the `on:` key to the `jobs:` key.
             $startIndex = [array]::FindIndex($script:lines, [Predicate[string]] { $args[0] -match '^on:\s*$' })
@@ -451,35 +490,36 @@ Describe "on-dms-pullrequest.yml CI budget wiring" {
             # A dependency naming a job that is not defined makes the whole workflow invalid, and a
             # renamed job silently dropping out of the gate would make the gate green while its
             # lane never ran.
-            $gateLines = (Get-JobBlock 'dms-ci-gate') -split "`n"
-            $needs = @()
-            $inNeeds = $false
-
-            foreach ($line in $gateLines) {
-                if ($line -match '^    needs:\s*$') {
-                    $inNeeds = $true
-                    continue
-                }
-                if (-not $inNeeds) {
-                    continue
-                }
-                if ($line -match '^      - (\S+)\s*$') {
-                    $needs += $Matches[1]
-                    continue
-                }
-                break
-            }
-
+            $needs = Get-GateDependency
             $needs.Count | Should -BeGreaterThan 0
 
-            $definedJob = @(
-                $script:lines |
-                    Where-Object { $_ -match '^  ([A-Za-z0-9_-]+):\s*$' } |
-                    ForEach-Object { ($_ -replace '^\s+', '') -replace ':\s*$', '' }
-            )
+            $definedJob = Get-DefinedJob
 
             foreach ($dependency in $needs) {
                 $definedJob | Should -Contain $dependency
+            }
+        }
+
+        It "depends on every job that is not deliberately non-blocking" {
+            # The inverse of the subset check above, which cannot catch a lane dropped from needs:
+            # the gate would stay green while that lane failed. Every defined job must be a gate
+            # dependency unless it is on this deliberate exclusion list.
+            $nonBlockingJob = @(
+                # Qualification lane: runs only on workflow_dispatch, never on a pull request or in
+                # the merge queue.
+                'run-backend-cdc-connector-template-smoke-tests'
+                # Informational reporting; the workflow deliberately omits these so they can never
+                # block a merge.
+                'test-timing-summary'
+                'event_file'
+                # The gate cannot depend on itself.
+                'dms-ci-gate'
+            )
+
+            $needs = Get-GateDependency
+
+            foreach ($job in (Get-DefinedJob | Where-Object { $_ -notin $nonBlockingJob })) {
+                $needs | Should -Contain $job -Because "job '$job' must fail the gate when it fails"
             }
         }
     }

--- a/eng/ci/tests/UnitTestCoverage.Tests.ps1
+++ b/eng/ci/tests/UnitTestCoverage.Tests.ps1
@@ -108,6 +108,39 @@ Describe "Unit test coverage threshold gate" {
         }
     }
 
+    Context "The threshold boundary is exact in both directions" {
+        It "throws on a <RateName> that is below the threshold but rounds to 58.00" -ForEach @(
+            @{ RateName = 'line-rate'; Line = '0.57995'; Branch = '0.99' }
+            @{ RateName = 'line-rate'; Line = '0.579999'; Branch = '0.99' }
+            @{ RateName = 'branch-rate'; Line = '0.99'; Branch = '0.57995' }
+            @{ RateName = 'branch-rate'; Line = '0.99'; Branch = '0.579999' }
+        ) {
+            # Comparing display percentages passes these: 57.995 and 57.9999 both round to 58.00, so
+            # the gate would accept coverage it is meant to reject. The real merged report carries
+            # rates at this precision - line-rate="0.8338407252748307" - so the window is reachable.
+            {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate $Line -BranchRate $Branch) -Threshold 58
+            } | Should -Throw -ExpectedMessage "*$RateName*"
+        }
+
+        It "still passes a rate that is exactly at the threshold" {
+            # The other direction of the same boundary. Scaling to a percentage before comparing
+            # fails this case, because 0.58 * 100 is 57.99999999999999 as a double.
+            $measured = Assert-CoverageThreshold `
+                -Path (Add-CoberturaReportFixture -LineRate "0.58" -BranchRate "0.58") -Threshold 58
+
+            $measured.LinePercentage | Should -Be 58
+            $measured.BranchPercentage | Should -Be 58
+        }
+
+        It "passes a rate a hair above the threshold" {
+            $measured = Assert-CoverageThreshold `
+                -Path (Add-CoberturaReportFixture -LineRate "0.580001" -BranchRate "0.580001") -Threshold 58
+
+            $measured.LinePercentage | Should -Be 58
+        }
+    }
+
     Context "Reports that cannot be evaluated fail rather than pass" {
         It "throws when the report was never produced" {
             # A silently missing report is how a coverage gate stops gating without anyone noticing.

--- a/eng/ci/tests/UnitTestCoverage.Tests.ps1
+++ b/eng/ci/tests/UnitTestCoverage.Tests.ps1
@@ -160,6 +160,25 @@ Describe "Unit test coverage threshold gate" {
                 Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -OmitLineRate) -Threshold 58
             } | Should -Throw -ExpectedMessage "*line-rate*"
         }
+
+        It "throws when a rate is <Rate> rather than treating it as passing" -ForEach @(
+            @{ Rate = 'NaN' }
+            @{ Rate = 'Infinity' }
+            @{ Rate = '-Infinity' }
+        ) {
+            # TryParse under NumberStyles::Float accepts the special values, and NaN fails every
+            # -lt comparison, so without a finiteness check a NaN rate sails past a gate that is
+            # documented as fail-closed.
+            {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate $Rate -BranchRate $Rate) -Threshold 58
+            } | Should -Throw -ExpectedMessage "*finite*"
+        }
+
+        It "throws when a rate is not numeric at all" {
+            {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate "abc") -Threshold 58
+            } | Should -Throw -ExpectedMessage "*finite*"
+        }
     }
 
     Context "The report shape ReportGenerator actually writes" {
@@ -220,6 +239,118 @@ Describe "Unit test coverage threshold gate" {
                 [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
             }
         }
+    }
+}
+
+Describe "One collector report per unit test project" {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        Import-Module (Join-Path $script:repoRoot "eng/build-helpers.psm1") -Force
+
+        function Add-CollectorReportFixture {
+            # One GUID-named subdirectory per report - the shape the XPlat collector writes under
+            # --results-directory, which is also why a missing report cannot be traced back to the
+            # project that failed to produce it.
+            param([string] $CollectorRoot, [int] $Count)
+
+            for ($i = 0; $i -lt $Count; $i++) {
+                $directory = Join-Path $CollectorRoot ([guid]::NewGuid().ToString())
+                New-Item -ItemType Directory -Path $directory -Force | Out-Null
+                Set-Content -LiteralPath (Join-Path $directory "coverage.cobertura.xml") -Value "<coverage />"
+            }
+        }
+
+        function Add-TrxAttachmentCopyFixture {
+            # The trx logger shares the collector's results directory and copies every attachment a
+            # second time, as <trx name>/In/<machine>/coverage.cobertura.xml. Real runs always carry
+            # these copies, so fixtures must too: a count validated without them passes here and
+            # fails on every healthy real run.
+            param([string] $CollectorRoot, [int] $Count)
+
+            for ($i = 0; $i -lt $Count; $i++) {
+                $directory = Join-Path $CollectorRoot "user_machine_2026-01-01_00_00_0$i/In/MACHINE"
+                New-Item -ItemType Directory -Path $directory -Force | Out-Null
+                Set-Content -LiteralPath (Join-Path $directory "coverage.cobertura.xml") -Value "<coverage />"
+            }
+        }
+    }
+
+    AfterAll {
+        Remove-Module build-helpers -Force -ErrorAction SilentlyContinue
+    }
+
+    BeforeEach {
+        $script:collectorRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:collectorRoot -Force | Out-Null
+    }
+
+    It "passes when every project produced a report, with the trx copies present" {
+        Add-CollectorReportFixture -CollectorRoot $script:collectorRoot -Count 2
+        Add-TrxAttachmentCopyFixture -CollectorRoot $script:collectorRoot -Count 2
+
+        {
+            Assert-CoverageReportPerProject -CollectorOutputPath $script:collectorRoot `
+                -ExpectedProjectName @("A.Tests.Unit.csproj", "B.Tests.Unit.csproj")
+        } | Should -Not -Throw
+    }
+
+    It "does not accept the trx logger's attachment copies in place of collector reports" {
+        # The copies are made from the collector's attachments, so if the collector produced
+        # nothing there is nothing real behind them either way - only first-level collector
+        # directories may satisfy the count.
+        Add-TrxAttachmentCopyFixture -CollectorRoot $script:collectorRoot -Count 2
+
+        {
+            Assert-CoverageReportPerProject -CollectorOutputPath $script:collectorRoot `
+                -ExpectedProjectName @("A.Tests.Unit.csproj", "B.Tests.Unit.csproj")
+        } | Should -Throw -ExpectedMessage "*found 0*"
+    }
+
+    It "throws when a project's report is missing" {
+        # A runtime datacollector failure does not fail dotnet test; the report just never exists,
+        # and the merge would evaluate the threshold against a silently shifted total.
+        Add-CollectorReportFixture -CollectorRoot $script:collectorRoot -Count 1
+        Add-TrxAttachmentCopyFixture -CollectorRoot $script:collectorRoot -Count 1
+
+        {
+            Assert-CoverageReportPerProject -CollectorOutputPath $script:collectorRoot `
+                -ExpectedProjectName @("A.Tests.Unit.csproj", "B.Tests.Unit.csproj")
+        } | Should -Throw -ExpectedMessage "*found 1*"
+    }
+
+    It "throws when no report exists at all" {
+        {
+            Assert-CoverageReportPerProject -CollectorOutputPath (Join-Path $script:collectorRoot "never-created") `
+                -ExpectedProjectName @("A.Tests.Unit.csproj")
+        } | Should -Throw -ExpectedMessage "*found 0*"
+    }
+
+    It "throws when extra reports appear, not only when reports are missing" {
+        # More reports than projects means something outside this run's project list is about to be
+        # merged into the gated total - as wrong as a missing report, just in the other direction.
+        Add-CollectorReportFixture -CollectorRoot $script:collectorRoot -Count 3
+
+        {
+            Assert-CoverageReportPerProject -CollectorOutputPath $script:collectorRoot `
+                -ExpectedProjectName @("A.Tests.Unit.csproj", "B.Tests.Unit.csproj")
+        } | Should -Throw -ExpectedMessage "*found 3*"
+    }
+
+    It "names the expected projects and the searched directory so the failure is diagnosable" {
+        Add-CollectorReportFixture -CollectorRoot $script:collectorRoot -Count 1
+
+        $thrown = $null
+        try {
+            Assert-CoverageReportPerProject -CollectorOutputPath $script:collectorRoot `
+                -ExpectedProjectName @("A.Tests.Unit.csproj", "B.Tests.Unit.csproj")
+        }
+        catch {
+            $thrown = $_.Exception.Message
+        }
+
+        $thrown | Should -BeLike "*A.Tests.Unit.csproj*"
+        $thrown | Should -BeLike "*B.Tests.Unit.csproj*"
+        $thrown | Should -BeLike "*$($script:collectorRoot)*"
     }
 }
 
@@ -445,6 +576,14 @@ Describe "build-dms.ps1 unit test coverage wiring" {
         It "enforces the threshold through the shared helper" {
             Get-InvokedCommandName -FunctionAst (Get-FunctionAst 'RunUnitTestsWithCoverage') |
                 Should -Contain 'Assert-CoverageThreshold'
+        }
+
+        It "asserts one collector report per project before the merge" {
+            # A runtime datacollector failure does not fail dotnet test, and the merge glob only
+            # fails on zero reports, so without this the threshold would be evaluated against a
+            # total that silently lost every project whose collector died.
+            Get-InvokedCommandName -FunctionAst (Get-FunctionAst 'RunUnitTestsWithCoverage') |
+                Should -Contain 'Assert-CoverageReportPerProject'
         }
 
         It "still routes the unit filter through the coverage path" {

--- a/eng/ci/tests/UnitTestCoverage.Tests.ps1
+++ b/eng/ci/tests/UnitTestCoverage.Tests.ps1
@@ -1,0 +1,536 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+# Specs for the DMS unit-test coverage path. The threshold gate, the project discovery and the
+# solution-filter contents are real functions in eng/build-helpers.psm1 and are exercised directly
+# here. The two contexts at the end assert over build-dms.ps1's parsed syntax tree and over the
+# project files themselves, because "the console driver is gone" and "every unit test project can
+# actually report coverage" are invariants with no runtime seam short of a full build.
+
+Describe "Unit test coverage threshold gate" {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        Import-Module (Join-Path $script:repoRoot "eng/build-helpers.psm1") -Force
+
+        function Add-CoberturaReportFixture {
+            param(
+                [string] $LineRate = "0.60",
+                [string] $BranchRate = "0.60",
+                [switch] $OmitLineRate,
+                [switch] $OmitDoctype,
+                [switch] $WrongRoot,
+                [switch] $Malformed
+            )
+
+            $path = Join-Path $TestDrive ([guid]::NewGuid().ToString() + ".xml")
+
+            if ($Malformed) {
+                Set-Content -LiteralPath $path -Value "<coverage line-rate=`"0.9`""
+                return $path
+            }
+
+            # The DOCTYPE is present by default because ReportGenerator writes one, and it is the
+            # whole reason this helper cannot read the root through the dotted XML adapter. A fixture
+            # without it passes against code that breaks on the real merged report.
+            $doctype =
+                if ($OmitDoctype) { "" }
+                else { "<!DOCTYPE coverage SYSTEM `"http://cobertura.sourceforge.net/xml/coverage-04.dtd`">`n" }
+
+            $lineAttribute = if ($OmitLineRate) { "" } else { " line-rate=`"$LineRate`"" }
+            $rootName = if ($WrongRoot) { "report" } else { "coverage" }
+
+            Set-Content -LiteralPath $path -Value (
+                "<?xml version=`"1.0`" encoding=`"utf-8`"?>`n" +
+                $doctype +
+                "<$rootName$lineAttribute branch-rate=`"$BranchRate`"><packages /></$rootName>"
+            )
+
+            return $path
+        }
+    }
+
+    AfterAll {
+        Remove-Module build-helpers -Force -ErrorAction SilentlyContinue
+    }
+
+    Context "Passing coverage" {
+        It "passes when both rates are exactly at the threshold" {
+            # 58 is the shipped threshold; an off-by-one here would tighten or loosen the gate for
+            # every pull request.
+            $path = Add-CoberturaReportFixture -LineRate "0.58" -BranchRate "0.58"
+
+            $measured = Assert-CoverageThreshold -Path $path -Threshold 58
+
+            $measured.LinePercentage | Should -Be 58
+            $measured.BranchPercentage | Should -Be 58
+            $measured.Threshold | Should -Be 58
+        }
+
+        It "passes when both rates are above the threshold" {
+            $measured = Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate "0.9012" -BranchRate "0.7") -Threshold 58
+
+            $measured.LinePercentage | Should -Be 90.12
+            $measured.BranchPercentage | Should -Be 70
+        }
+    }
+
+    Context "Failing coverage" {
+        It "throws when the line rate is below the threshold" {
+            {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate "0.5799" -BranchRate "0.99") -Threshold 58
+            } | Should -Throw -ExpectedMessage "*line-rate*"
+        }
+
+        It "throws when the branch rate is below the threshold" {
+            # The branch total is enforced independently of the line total, as coverlet's
+            # --threshold-type line --threshold-type branch did.
+            {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate "0.99" -BranchRate "0.10") -Threshold 58
+            } | Should -Throw -ExpectedMessage "*branch-rate*"
+        }
+
+        It "reports both measured rates so the failure is diagnosable" {
+            $thrown = $null
+            try {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate "0.42" -BranchRate "0.31") -Threshold 58
+            }
+            catch {
+                $thrown = $_.Exception.Message
+            }
+
+            $thrown | Should -BeLike "*42*"
+            $thrown | Should -BeLike "*31*"
+            $thrown | Should -BeLike "*58*"
+        }
+    }
+
+    Context "Reports that cannot be evaluated fail rather than pass" {
+        It "throws when the report was never produced" {
+            # A silently missing report is how a coverage gate stops gating without anyone noticing.
+            {
+                Assert-CoverageThreshold -Path (Join-Path $TestDrive "never-written.xml") -Threshold 58
+            } | Should -Throw -ExpectedMessage "*was not produced*"
+        }
+
+        It "throws when the report is not valid XML" {
+            {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -Malformed) -Threshold 58
+            } | Should -Throw
+        }
+
+        It "throws when the report declares no line rate" {
+            {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -OmitLineRate) -Threshold 58
+            } | Should -Throw -ExpectedMessage "*line-rate*"
+        }
+    }
+
+    Context "The report shape ReportGenerator actually writes" {
+        It "reads the rates from a report carrying a DOCTYPE declaration" {
+            # ReportGenerator's merged Cobertura opens with <!DOCTYPE coverage SYSTEM ...>. With that
+            # present the dotted adapter returns the DocumentType node alongside the root element, so
+            # reading through it threw "[System.String] does not contain a method named GetAttribute"
+            # against every real merged report while a DOCTYPE-less fixture passed.
+            $measured = Add-CoberturaReportFixture -LineRate "0.8338" -BranchRate "0.7617" |
+                ForEach-Object { Assert-CoverageThreshold -Path $_ -Threshold 58 }
+
+            $measured.LinePercentage | Should -Be 83.38
+            $measured.BranchPercentage | Should -Be 76.17
+        }
+
+        It "also reads a report with no DOCTYPE" {
+            # The collector's own per-project reports have none.
+            $measured = Add-CoberturaReportFixture -LineRate "0.71" -BranchRate "0.66" -OmitDoctype |
+                ForEach-Object { Assert-CoverageThreshold -Path $_ -Threshold 58 }
+
+            $measured.LinePercentage | Should -Be 71
+        }
+
+        It "throws when the root element is not <coverage>" {
+            {
+                Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -WrongRoot) -Threshold 58
+            } | Should -Throw -ExpectedMessage "*no <coverage> root element*"
+        }
+    }
+
+    Context "Rates are parsed independently of the machine's culture" {
+        It "still measures 61.5% under a comma-decimal culture" {
+            # Culture-sensitive parsing reads "0.615" as 615 on a de-DE machine, and the gate then
+            # passes no matter what was measured.
+            $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+            try {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::new('de-DE')
+
+                $measured = Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate "0.615" -BranchRate "0.615") -Threshold 58
+
+                $measured.LinePercentage | Should -Be 61.5
+            }
+            finally {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+            }
+        }
+
+        It "still fails a below-threshold report under a comma-decimal culture" {
+            $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+            try {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::new('de-DE')
+
+                {
+                    Assert-CoverageThreshold -Path (Add-CoberturaReportFixture -LineRate "0.10" -BranchRate "0.10") -Threshold 58
+                } | Should -Throw
+            }
+            finally {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+            }
+        }
+    }
+}
+
+Describe "Unit test project discovery and solution filter" {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        Import-Module (Join-Path $script:repoRoot "eng/build-helpers.psm1") -Force
+
+        function Add-ProjectFixture {
+            param([string] $SolutionRoot, [string] $Group, [string] $ProjectName)
+
+            $directory = Join-Path $SolutionRoot "$Group/$ProjectName"
+            New-Item -ItemType Directory -Path $directory -Force | Out-Null
+            $projectPath = Join-Path $directory "$ProjectName.csproj"
+            Set-Content -LiteralPath $projectPath -Value "<Project />"
+
+            return $projectPath
+        }
+    }
+
+    AfterAll {
+        Remove-Module build-helpers -Force -ErrorAction SilentlyContinue
+    }
+
+    BeforeEach {
+        $script:solutionRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:solutionRoot -Force | Out-Null
+    }
+
+    Context "Get-RequiredUnitTestProject" {
+        It "throws when nothing matches, instead of reporting a zero-test run as success" {
+            # Same rule Get-RequiredTestAssembly enforces: an empty glob must not look like a pass.
+            {
+                Get-RequiredUnitTestProject -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit"
+            } | Should -Throw -ExpectedMessage "*no test projects found*"
+        }
+
+        It "names the searched path so the cause is diagnosable" {
+            $thrown = $null
+            try {
+                Get-RequiredUnitTestProject -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit"
+            }
+            catch {
+                $thrown = $_.Exception.Message
+            }
+
+            $thrown | Should -BeLike "*$($script:solutionRoot)*"
+        }
+
+        It "finds every matching project across solution groups" {
+            Add-ProjectFixture -SolutionRoot $script:solutionRoot -Group "core" -ProjectName "EdFi.Core.Tests.Unit" | Out-Null
+            Add-ProjectFixture -SolutionRoot $script:solutionRoot -Group "backend" -ProjectName "EdFi.Backend.Tests.Unit" | Out-Null
+            Add-ProjectFixture -SolutionRoot $script:solutionRoot -Group "clis" -ProjectName "EdFi.Cli.Tests.Unit" | Out-Null
+
+            $found = @(Get-RequiredUnitTestProject -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit")
+
+            @($found.Name) | Sort-Object |
+                Should -Be @("EdFi.Backend.Tests.Unit.csproj", "EdFi.Cli.Tests.Unit.csproj", "EdFi.Core.Tests.Unit.csproj")
+        }
+
+        It "does not pick up integration test projects" {
+            Add-ProjectFixture -SolutionRoot $script:solutionRoot -Group "core" -ProjectName "EdFi.Core.Tests.Unit" | Out-Null
+            Add-ProjectFixture -SolutionRoot $script:solutionRoot -Group "backend" -ProjectName "EdFi.Backend.Tests.Integration" | Out-Null
+
+            $found = @(Get-RequiredUnitTestProject -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit")
+
+            @($found.Name) | Should -Be @("EdFi.Core.Tests.Unit.csproj")
+        }
+
+        It "returns a single match as a collection, not a bare file" {
+            Add-ProjectFixture -SolutionRoot $script:solutionRoot -Group "core" -ProjectName "EdFi.Core.Tests.Unit" | Out-Null
+
+            @(Get-RequiredUnitTestProject -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit").Count | Should -Be 1
+        }
+    }
+
+    Context "ConvertTo-SolutionFilterContent" {
+        It "produces a filter naming the solution and every project" {
+            $content = ConvertTo-SolutionFilterContent `
+                -SolutionPath "..\src\dms\EdFi.DataManagementService.sln" `
+                -ProjectPath @("core\A\A.csproj", "backend\B\B.csproj")
+
+            $parsed = $content | ConvertFrom-Json
+
+            $parsed.solution.path | Should -Be "..\src\dms\EdFi.DataManagementService.sln"
+            @($parsed.solution.projects) | Should -Be @("core\A\A.csproj", "backend\B\B.csproj")
+        }
+
+        It "keeps a single project as a JSON array" {
+            # A bare string here would make the filter invalid and dotnet test would run nothing.
+            # Asserted against the JSON text: @() around a parsed scalar would hide exactly the
+            # single-element collapse this is guarding against.
+            $content = ConvertTo-SolutionFilterContent -SolutionPath "x.sln" -ProjectPath @("core\A\A.csproj")
+
+            $content | Should -Match '"projects"\s*:\s*\['
+            @(($content | ConvertFrom-Json).solution.projects).Count | Should -Be 1
+        }
+    }
+}
+
+Describe "build-dms.ps1 unit test coverage wiring" {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        $script:buildScript = Join-Path $script:repoRoot "build-dms.ps1"
+
+        $parseErrors = $null
+        $script:buildAst = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:buildScript, [ref]$null, [ref]$parseErrors
+        )
+
+        if (@($parseErrors).Count -gt 0) {
+            throw "Failed to parse '$script:buildScript': $(@($parseErrors)[0].Message)"
+        }
+
+        function Get-FunctionAst {
+            param([Parameter(Mandatory)] [string] $FunctionName)
+
+            $functionAst = $script:buildAst.FindAll(
+                { param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                    $node.Name -eq $FunctionName },
+                $true
+            ) | Select-Object -First 1
+
+            if ($null -eq $functionAst) {
+                throw "Function '$FunctionName' was not found in '$script:buildScript'."
+            }
+
+            return $functionAst
+        }
+
+        function Get-InvokedCommandName {
+            param([System.Management.Automation.Language.Ast] $FunctionAst)
+
+            return @(
+                $FunctionAst.FindAll(
+                    { param($node) $node -is [System.Management.Automation.Language.CommandAst] },
+                    $true
+                ) |
+                    ForEach-Object { $_.GetCommandName() } |
+                    Where-Object { $_ }
+            )
+        }
+
+        function Get-CommandExtentText {
+            param(
+                [System.Management.Automation.Language.Ast] $FunctionAst,
+
+                [Parameter(Mandatory)]
+                [string] $CommandName
+            )
+
+            $commands = $FunctionAst.FindAll(
+                { param($node) $node -is [System.Management.Automation.Language.CommandAst] },
+                $true
+            )
+
+            $matching = @($commands | Where-Object { $_.GetCommandName() -eq $CommandName })
+
+            if ($matching.Count -eq 0) {
+                throw "No '$CommandName' command was found in the function under test."
+            }
+
+            return @($matching | ForEach-Object { $_.Extent.Text })
+        }
+    }
+
+    Context "The coverlet console driver is gone" {
+        It "no function in the build script invokes the coverlet tool" {
+            # Anchored on real command invocations rather than file text, so a comment mentioning
+            # coverlet does not satisfy or break this.
+            $coverletInvocations = @(
+                $script:buildAst.FindAll(
+                    { param($node) $node -is [System.Management.Automation.Language.CommandAst] },
+                    $true
+                ) |
+                    Where-Object { $_.Extent.Text -match '(?m)^\s*dotnet tool run coverlet\b' }
+            )
+
+            $coverletInvocations | Should -BeNullOrEmpty
+        }
+
+        It "the unit test path no longer decides coverage from whichever assembly sorted last" {
+            Get-InvokedCommandName -FunctionAst (Get-FunctionAst 'RunUnitTestsWithCoverage') |
+                Should -Not -Contain 'Get-RequiredTestAssembly'
+        }
+
+        It "resolves its projects through the shared zero-test guard" {
+            # The DMS-1301 invariant carried onto the new path: a raw Get-ChildItem here would let an
+            # empty glob report a zero-test run as success, which is what that guard exists to stop.
+            $invoked = Get-InvokedCommandName -FunctionAst (Get-FunctionAst 'RunUnitTestsWithCoverage')
+
+            $invoked | Should -Contain 'Get-RequiredUnitTestProject'
+            $invoked | Should -Not -Contain 'Get-ChildItem'
+        }
+    }
+
+    Context "The unit test path uses the collector, merges, and enforces the threshold" {
+        It "collects XPlat Code Coverage with the repository runsettings" {
+            $dotnetCalls = Get-CommandExtentText -FunctionAst (Get-FunctionAst 'RunUnitTestsWithCoverage') -CommandName 'dotnet'
+            $testCall = @($dotnetCalls | Where-Object { $_ -match '\bdotnet test\b' })
+
+            $testCall.Count | Should -Be 1
+            $testCall[0] | Should -Match 'XPlat Code Coverage'
+            $testCall[0] | Should -Match 'coverlet\.runsettings'
+        }
+
+        It "keeps console and trx logging for CI feedback" {
+            $dotnetCalls = Get-CommandExtentText -FunctionAst (Get-FunctionAst 'RunUnitTestsWithCoverage') -CommandName 'dotnet'
+            $testCall = @($dotnetCalls | Where-Object { $_ -match '\bdotnet test\b' })[0]
+
+            $testCall | Should -Match '"trx"'
+            $testCall | Should -Match '"console"'
+        }
+
+        It "merges the per-project reports with reportgenerator" {
+            $extents = Get-CommandExtentText -FunctionAst (Get-FunctionAst 'RunUnitTestsWithCoverage') -CommandName 'dotnet'
+
+            @($extents | Where-Object { $_ -match 'reportgenerator' -and $_ -match 'reporttypes:Cobertura' }).Count |
+                Should -Be 1
+        }
+
+        It "enforces the threshold through the shared helper" {
+            Get-InvokedCommandName -FunctionAst (Get-FunctionAst 'RunUnitTestsWithCoverage') |
+                Should -Contain 'Assert-CoverageThreshold'
+        }
+
+        It "still routes the unit filter through the coverage path" {
+            Get-InvokedCommandName -FunctionAst (Get-FunctionAst 'RunTests') |
+                Should -Contain 'RunUnitTestsWithCoverage'
+        }
+    }
+
+    Context "ReportGenerator receives its switches as whole arguments" {
+        It "<FunctionName> passes no dangling switch to reportgenerator" -ForEach @(
+            @{ FunctionName = 'RunUnitTestsWithCoverage' }
+            @{ FunctionName = 'Invoke-Coverage' }
+        ) {
+            # `dotnet tool run <tool> --` requires a `--`, and after one PowerShell emits a
+            # `-name:"value"` argument as two arguments: `-name:` and the value on its own.
+            # ReportGenerator then reports "No report files specified" and writes nothing, for an
+            # invocation that reads correctly in the source. The signature of the broken form is an
+            # argument whose text is just the switch, ending in a colon; the whole `-name:value`
+            # token has to be quoted together. Verified against ReportGenerator 5.5.11 under both
+            # $PSNativeCommandArgumentPassing modes.
+            $reportGeneratorCalls = @(
+                (Get-FunctionAst $FunctionName).FindAll(
+                    { param($node)
+                        $node -is [System.Management.Automation.Language.CommandAst] -and
+                        $node.Extent.Text -match 'reportgenerator' },
+                    $true
+                )
+            )
+
+            $reportGeneratorCalls.Count | Should -BeGreaterThan 0
+
+            $danglingSwitches = @(
+                $reportGeneratorCalls |
+                    ForEach-Object { $_.CommandElements } |
+                    Where-Object { $_.Extent.Text -match '^-{1,2}[a-zA-Z]+:$' } |
+                    ForEach-Object { $_.Extent.Text }
+            )
+
+            $danglingSwitches | Should -BeNullOrEmpty
+        }
+
+        It "Invoke-Coverage fails the command when reportgenerator fails" {
+            # Unwrapped, a non-zero exit was swallowed and the script still reported success, so a
+            # coverage report that was never written looked exactly like one nobody opened.
+            Get-InvokedCommandName -FunctionAst (Get-FunctionAst 'Invoke-Coverage') |
+                Should -Contain 'Invoke-Execute'
+        }
+    }
+
+    Context "A failed run cannot leave the previous run's report behind" {
+        It "clears the root coverage report before collecting" {
+            # The workflow gates its report step on hashFiles('coverage.cobertura.xml'). A stale file
+            # there would be published as this run's coverage after a run that never got to merge.
+            $removals = @(
+                (Get-FunctionAst 'RunUnitTestsWithCoverage').FindAll(
+                    { param($node)
+                        $node -is [System.Management.Automation.Language.CommandAst] -and
+                        $node.GetCommandName() -eq 'Remove-Item' },
+                    $true
+                ) | ForEach-Object { $_.Extent.Text }
+            )
+
+            @($removals | Where-Object { $_ -match '\$coverageOutputFile' }) | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context "The shipped threshold is unchanged" {
+        It "still enforces 58" {
+            $assignment = $script:buildAst.FindAll(
+                { param($node)
+                    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                    $node.Left.Extent.Text -eq '$thresholdCoverage' },
+                $true
+            ) | Select-Object -First 1
+
+            $assignment | Should -Not -BeNullOrEmpty
+            $assignment.Right.Extent.Text | Should -Be '58'
+        }
+
+        It "still writes the root coverage report the workflow and Coverage command look for" {
+            $assignment = $script:buildAst.FindAll(
+                { param($node)
+                    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                    $node.Left.Extent.Text -eq '$coverageOutputFile' },
+                $true
+            ) | Select-Object -First 1
+
+            $assignment.Right.Extent.Text | Should -Be '"coverage.cobertura.xml"'
+        }
+    }
+}
+
+Describe "Unit test projects can report coverage" {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        $script:unitTestProject = @(
+            Get-ChildItem -Path (Join-Path $script:repoRoot "src/dms/*/*.Tests.Unit/*.Tests.Unit.csproj")
+        )
+    }
+
+    It "finds the DMS unit test projects" {
+        $script:unitTestProject.Count | Should -BeGreaterThan 0
+    }
+
+    It "every unit test project references coverlet.collector" {
+        # The collector is loaded from the test assembly's own output. A unit test project without
+        # this reference runs its tests and contributes nothing to coverage - silently moving the
+        # measured total that the 58% gate is applied to.
+        $missing = @(
+            $script:unitTestProject | Where-Object {
+                [xml] $project = Get-Content -LiteralPath $_.FullName -Raw
+
+                $null -eq (
+                    $project.Project.ItemGroup.PackageReference |
+                        Where-Object { $_.Include -eq 'coverlet.collector' }
+                )
+            } | ForEach-Object { $_.Name }
+        )
+
+        $missing | Should -BeNullOrEmpty
+    }
+}

--- a/eng/docker-compose/provision-e2e-database.ps1
+++ b/eng/docker-compose/provision-e2e-database.ps1
@@ -33,7 +33,15 @@ param(
     # idempotency guard, so the PostgreSQL invocation is unaffected when this parameter is
     # omitted.
     [ValidateSet("postgresql", "mssql")]
-    [string]$DatabaseEngine = "postgresql"
+    [string]$DatabaseEngine = "postgresql",
+
+    # Reuse already-compiled CLI output instead of letting `dotnet run` restore and build the
+    # ApiSchemaDownloader and SchemaTools projects below. Opt-in rather than the default because the
+    # direct callers - both setup-local-dms.ps1 scripts - build nothing themselves, and that
+    # build-on-demand is what lets this script provision from a fresh worktree. Only build-dms.ps1
+    # can promise compiled output: its E2ETest and InstanceE2ETest routes already require a prior
+    # build for the tests themselves, and in CI the shared build artifact supplies it.
+    [switch]$UsePrebuiltTools
 )
 
 Set-StrictMode -Version Latest
@@ -389,12 +397,17 @@ else {
 
 $script:ResolvedSchemaDirectory =
     Join-Path ([System.IO.Path]::GetTempPath()) "dms-e2e-schema-$([Guid]::NewGuid().ToString('N'))"
+# Appended to both CLI invocations rather than replacing their arguments, so --no-launch-profile -
+# the reason the downloader call overrode the helper's --no-build default in the first place -
+# survives either way.
+$script:PrebuiltToolDotnetRunArgs = if ($UsePrebuiltTools) { @("--no-build", "--no-restore") } else { @() }
+
 $schemaFiles = @(Resolve-SchemaFilesFromEnvironmentFile `
         -EnvironmentFilePath $environmentFilePath `
         -Configuration $Configuration `
         -RepoRoot $repoRoot `
         -SchemaDirectory $script:ResolvedSchemaDirectory `
-        -DownloaderDotnetRunArgs @("--no-launch-profile"))
+        -DownloaderDotnetRunArgs (@("--no-launch-profile") + $script:PrebuiltToolDotnetRunArgs))
 
 try {
     Write-Information "Dropping E2E database if it exists: $e2eDatabaseName" -InformationAction Continue
@@ -435,7 +448,8 @@ try {
 
     $provisionArgs = @(
         "run",
-        "--no-launch-profile",
+        "--no-launch-profile"
+    ) + $script:PrebuiltToolDotnetRunArgs + @(
         "--configuration",
         $Configuration,
         "--project",

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -332,10 +332,38 @@ exit $ExitCode
             $params | Should -Contain "Configuration"
             $params | Should -Contain "PostgresContainerName"
             $params | Should -Contain "DatabaseEngine"
+            # Opt-in only. The direct local callers (both setup-local-dms.ps1 scripts) build nothing
+            # themselves, so this script has to stay self-sufficient by default; the build path is
+            # the only caller that can promise compiled output.
+            $params | Should -Contain "UsePrebuiltTools"
             $params | Should -Not -Contain "SchemaToolPath"
             $params | Should -Not -Contain "DataStoreId"
             $params | Should -Not -Contain "SchoolYear"
-            $params.Count | Should -Be 5
+            $params.Count | Should -Be 6
+        }
+
+        It "provision-e2e-database.ps1 reuses prebuilt CLI output only when asked" {
+            # Both CLI invocations are dotnet run against a project, which restores and builds by
+            # default - and SchemaTools' project references reach Core and Backend.Ddl, so that is a
+            # large share of a solution build paid inside every E2E job. The workflow's E2E consumers
+            # extract the shared artifact before reaching here, so they must not pay it again; a
+            # developer running this script straight from setup-local-dms.ps1 has no build to reuse
+            # and must.
+            $content = Get-Content -LiteralPath $script:repo.E2EProvisionScript -Raw
+
+            # Guarded by the switch, not unconditional.
+            $content | Should -Match '\$UsePrebuiltTools'
+            # --no-launch-profile is preserved rather than replaced: it is why the downloader call
+            # overrode the helper's --no-build default in the first place.
+            $content | Should -Match '--no-launch-profile'
+
+            $noBuildLine = @(
+                ($content -split "\r?\n") | Where-Object { $_ -match '--no-build' }
+            )
+
+            # One for the downloader arguments, one for the SchemaTools provisioning arguments.
+            $noBuildLine.Count | Should -BeGreaterOrEqual 2
+            $content | Should -Match '--no-restore'
         }
 
         It "provision-e2e-database.ps1 owns explicit E2E database reset and SchemaTools provisioning" {

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -357,13 +357,19 @@ exit $ExitCode
             # overrode the helper's --no-build default in the first place.
             $content | Should -Match '--no-launch-profile'
 
-            $noBuildLine = @(
-                ($content -split "\r?\n") | Where-Object { $_ -match '--no-build' }
-            )
+            # Both flags live on one shared argument set, gated by the switch.
+            $content | Should -Match '\$script:PrebuiltToolDotnetRunArgs\s*=\s*if \(\$UsePrebuiltTools\) \{ @\("--no-build", "--no-restore"\) \} else \{ @\(\) \}'
 
-            # One for the downloader arguments, one for the SchemaTools provisioning arguments.
-            $noBuildLine.Count | Should -BeGreaterOrEqual 2
-            $content | Should -Match '--no-restore'
+            # And both CLI invocations - the downloader arguments and the SchemaTools provisioning
+            # arguments - consume that set, so neither can silently fall back to rebuilding.
+            $argSetConsumer = @(
+                ($content -split "\r?\n") | Where-Object {
+                    $_ -notmatch '^\s*#' -and
+                    $_ -match '\$script:PrebuiltToolDotnetRunArgs' -and
+                    $_ -notmatch '\$script:PrebuiltToolDotnetRunArgs\s*='
+                }
+            )
+            $argSetConsumer.Count | Should -Be 2
         }
 
         It "provision-e2e-database.ps1 owns explicit E2E database reset and SchemaTools provisioning" {

--- a/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Unit/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Unit.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Unit/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Unit.csproj
@@ -14,6 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.CodeAnalysis" />

--- a/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Unit/packages.lock.json
+++ b/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Unit/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.2, )",
+        "resolved": "6.0.2",
+        "contentHash": "bJShQ6uWRTQ100ZeyiMqcFlhP7WJ+bCuabUs885dJiBEzMsJMSFr7BOyeCw4rgvQokteGi5rKQTlkhfQPUXg2A=="
+      },
       "FakeItEasy": {
         "type": "Direct",
         "requested": "[8.3.0, )",

--- a/src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Unit/EdFi.DataManagementService.SchemaTools.Tests.Unit.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Unit/EdFi.DataManagementService.SchemaTools.Tests.Unit.csproj
@@ -11,6 +11,10 @@
         <PackageReference Include="FakeItEasy" />
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.CodeAnalysis" />

--- a/src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Unit/packages.lock.json
+++ b/src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Unit/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.2, )",
+        "resolved": "6.0.2",
+        "contentHash": "bJShQ6uWRTQ100ZeyiMqcFlhP7WJ+bCuabUs885dJiBEzMsJMSFr7BOyeCw4rgvQokteGi5rKQTlkhfQPUXg2A=="
+      },
       "FakeItEasy": {
         "type": "Direct",
         "requested": "[8.3.0, )",

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -67,7 +67,13 @@ param(
     $EnvironmentFile = "./.env.routeContext.e2e",
 
     [string]
-    $ResolvedEnvironmentFile
+    $ResolvedEnvironmentFile,
+
+    # Forwarded to each provisioning call so its CLI invocations reuse compiled output instead of
+    # letting `dotnet run` rebuild them. Opt-in, and off by default, because this script is also run
+    # directly by a developer who has built nothing; only the build path can promise compiled output.
+    [switch]
+    $UsePrebuiltTools
 )
 
 function Assert-PostgresRouteContextSchema {
@@ -372,6 +378,10 @@ try {
     #    verify each with the engine-dispatched schema check.
     Write-Host "`nProvisioning and verifying route-context test databases..." -ForegroundColor Cyan
     $provisionE2EDatabaseScript = Join-Path $dockerComposeDir "provision-e2e-database.ps1"
+    # Reported because it is the difference between provisioning compiling the CLIs and reusing an
+    # existing build, which is the first thing worth knowing when provisioning fails in one context
+    # and not the other.
+    Write-Host "Provisioning CLI mode: $(if ($UsePrebuiltTools) { 'reusing prebuilt output' } else { 'building on demand' })" -ForegroundColor DarkGray
     # PostgreSQL verification connects as the resolved role, not a hardcoded superuser, so a stack
     # started with a non-default POSTGRES_USER still verifies. Resolved with Compose precedence
     # (ambient wins) because Compose interpolates POSTGRES_USER into the container the same way
@@ -387,7 +397,8 @@ try {
                 -EnvironmentFile $resolvedEnvironmentFile `
                 -DatabaseEngine $DatabaseEngine `
                 -DatabaseName $db `
-                -Configuration Release
+                -Configuration Release `
+                -UsePrebuiltTools:$UsePrebuiltTools
         }
 
         if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
Reduces the job-minutes consumed by `on-dms-pullrequest.yml` on every pull request, implementing the four proposals from [DMS-1474](https://edfi.atlassian.net/browse/DMS-1474).

## Changes

### 1. Path-conditional promotion of the integration lanes

A `detect-fresh-build-changes` job classifies the PR diff into change categories (`dms_relevant`, `backend_mssql_relevant`, `dms_api_relevant`, `cdc_relevant`, `schematools_relevant`) using rules in `eng/ci/dms-change-categories.psm1`, and the zero-failure integration lanes run only when a changed file reaches them. Safety properties:

- The required **DMS CI Gate** check still reports on every PR: it runs with `if: always()`, treats `success`/`skipped` as pass, and fails on anything else, so a path-skipped lane can never hide a failure.
- **Fail-open**: any failure to produce a trustworthy changed-file list (fetch/diff error, missing merge-group base) runs the full suite.
- `merge_group` and `workflow_dispatch` always run the full suite, so nothing is deferred past the PR without a merge-queue backstop.

### 2. Shared build artifact

`build-dms-solution` builds the solution once and publishes the output as a `dms-build-output` artifact; the ten jobs that each ran their own `build-dms.ps1 Build` (measured: 15 matrix-expanded job instances, ~61.5 minutes of job time per run) now download and extract it and run with `--no-build`.

- The output travels as a **tar**, not a directory upload, because upload-artifact's zip handoff drops Unix mode bits and the tree contains files that must arrive executable (Playwright's node driver, project apphosts) with nothing to re-apply the bit under `--no-build`.
- `verify-dms-packages` is deliberately **not** a consumer: `BuildAndPublish` stamps versioned assembly info, so sharing the plain-`Build` output would mislabel packages.
- Prebuilt-output reuse is opt-in (`-UsePrebuiltOutput` / `-UsePrebuiltTools`), so local developer entry points keep their build-on-demand behavior.

### 3. XPlat coverage collector

Unit-test coverage moves from the per-assembly coverlet.console driver to the `XPlat Code Coverage` collector with merged Cobertura output: **3,354 s → 643 s** for the same 11 projects / 13,772 tests. The 58% threshold is retained and now compares raw Cobertura rates (exact at the boundary in both directions, no rounding artifacts).

Notable side effect: the old driver's merged report **omitted `EdFi.DataManagementService.Core` entirely**, so the gate had been measuring roughly half of the measurable lines. The new report includes it (Core enters at ~86.7% line coverage; every other package matches the old numbers to 4 decimals).

### 4. Draft-PR gating

`pull_request.types` gains `ready_for_review`, and the expensive job roots (packaging, Docker image builds, the integration/E2E roots, fresh-rebuild) skip while a PR is a draft. Cheap lanes and the reporting gate still run on drafts, and marking ready triggers a full run.

## Guard tests

The classification rules are exercised directly by `eng/ci/tests/DmsChangeCategories.Tests.ps1`, and `eng/ci/tests/DmsPullRequestCiBudget.Tests.ps1` / `eng/ci/tests/UnitTestCoverage.Tests.ps1` pin the workflow wiring itself (trigger types, job conditions, artifact contracts, gate membership). These are deliberate source-level assertions over the YAML: the wiring is declarative with no runtime seam, and a mistake shows up as a lane that silently never runs behind a green required check. 631 Pester tests across the touched suites pass.

## Honest sizing note

Path promotion alone skips promoted-lane runs on only ~9% of recent main-history commits (most DMS commits touch shared code); the larger recurring savings come from the shared build artifact, the coverage collector change, and draft gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DMS-1474]: https://edfi.atlassian.net/browse/DMS-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ