### PR TITLE
[DMS-1060] Implement ownership-based authorization for GET-by-id, POST, PUT, and DELETE

### DIFF
--- a/reference/design/backend-redesign/design-docs/ownership-token-maintenance.md
+++ b/reference/design/backend-redesign/design-docs/ownership-token-maintenance.md
@@ -275,6 +275,14 @@ the creator token in the read/modify collection.
 An ownership token may be assigned to multiple API clients within the same tenant. Sharing a token
 grants those clients access to documents stamped with that token.
 
+### Descriptors
+
+Descriptors: stamping is in scope, enforcement is not. Descriptor creates stamp
+`CreatedByOwnershipTokenId` like any other create, but descriptor GET-by-id, POST, PUT, and DELETE
+configured with `OwnershipBased` remain fail-closed at `501` in DMS-1060. Ownership enforcement for
+descriptors is not implemented in this story. The GET-by-id, PUT, and DELETE statements above
+therefore describe relationally stored resources.
+
 ## CMS Persistence Contract
 
 CMS will add the following PostgreSQL and SQL Server structures.
@@ -689,9 +697,13 @@ The approved handoff:
 2. adds the CMS application-context paragraphs above to both tickets: DMS-1060 consumes both
    ownership fields for POST stamping and single-record authorization, while DMS-1410 consumes
    `OwnershipTokenIds` for GET-many filtering only;
-3. retains DMS-1060's POST stamping and single-record authorization ProblemDetails, batching, and
+3. retains DMS-1060's POST stamping, single-record authorization ProblemDetails, and
    database-provider acceptance criteria, while assigning GET-many filtering and removal of the
-   temporary GET-many 501 only to DMS-1410; and
+   temporary GET-many 501 only to DMS-1410. Batching is not restated here: the accepted batching
+   deviations, including GET-by-id ownership running as one added command ahead of hydration, are
+   owned by the [DMS-1060 story mirror](../epics/14-authorization/11-ownership-auth-strategy.md)
+   and recorded in
+   [`08-write-roundtrip-batching.md`](../epics/07-relational-write-path/08-write-roundtrip-batching.md); and
 4. retains the defensive SQL Server failure at 2,000 or more tokens for both consumers.
 
 ## Acceptance Criteria Traceability

--- a/reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md
@@ -237,6 +237,7 @@ has a recorded command count yet.
 | Namespace authorization only | 4 (adds the authorization command and `ShouldRetryPostHydrationReadBoundaryAsync`) |
 | Namespace and relationship authorization | 5 |
 | Custom-view authorization | unrecorded. A regular resource adds one command for the view-contract probe that precedes the membership run; the `cv1` statement itself joins the authorization command. A descriptor GET-by-id has no authorization command to join — it evaluates namespace in memory — so its membership query is an added command alongside that probe |
+| Ownership authorization | one command more than the same variant without it. The ownership check does not join the authorization command; see the deviation recorded below |
 
 ### Descriptor Writes
 
@@ -341,6 +342,23 @@ design, and doing so inside a write-path story would put read-path correctness a
 therefore records the deviation and changes nothing on this path; the read path must not regress and
 read regression coverage is run. A follow-on story is recommended for co-batching authorized
 GET-by-id.
+
+### Ownership GET-by-id: One Added Command
+
+`OwnershipBased` adds one command to GET-by-id, on the ownership-configured read path only. It does not
+join the authorization command the namespace and relationship checks share, because it is not an `AUTH1`
+statement against that carrier: it runs ahead of hydration and reconstitution so a denial is decided
+before any representation is built, and the stale-target retry above it is preserved unchanged.
+
+The write and delete paths do not pay this. There the ownership statement genuinely shares the
+operation's roundtrip — `RelationalCompositeStoredAuthorization` appends it into the same composite
+command as the custom-view and namespace statements, after them and before the relationship statement,
+which is what makes statement order the precedence order. Only the read path adds a command, and only
+when ownership is configured for the action.
+
+Collapsing it belongs with the co-batching follow-on recommended for authorized GET-by-id above: the
+ownership check would join whatever carrier that story establishes. DMS-1060 records the deviation and
+changes nothing else on this path.
 
 ### Descriptor Writes: Verification Only
 

--- a/reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md
@@ -356,6 +356,13 @@ command as the custom-view and namespace statements, after them and before the r
 which is what makes statement order the precedence order. Only the read path adds a command, and only
 when ownership is configured for the action.
 
+That append is budget-guarded like the namespace one, so sharing the roundtrip is the ordinary case rather
+than a guarantee: when the composite plan does not fit the command's parameter budget, the ownership
+statement takes an ordered same-session segment ahead of the mutation or delete instead. On SQL Server a
+near-ceiling namespace prefix list combined with a large ownership token list reaches this well below the
+2,000-token cap. The command count changes; authorization-before-mutation ordering and the precedence
+order above do not.
+
 Collapsing it belongs with the co-batching follow-on recommended for authorized GET-by-id above: the
 ownership check would join whatever carrier that story establishes. DMS-1060 records the deviation and
 changes nothing else on this path.

--- a/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
+++ b/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
@@ -15,7 +15,10 @@ Implement ownership-based authorization for single-record operations per:
 `ApplicationContext`, not JWT claims. DMS resolves and caches this context through
 `GET /v3/apiClients/{clientId}`.
 
-CMS limits assignments to 1,999 ownership tokens; DMS defensively fails at 2,000 or more.
+CMS limits assignments to 1,999 ownership tokens; DMS defensively fails at 2,000 or more when
+`OwnershipTokenIds` is evaluated for an existing stored document. A POST that resolves to create does
+not evaluate `OwnershipTokenIds`, because no stored ownership token exists yet; it stamps
+`CreatorOwnershipTokenId` and proceeds.
 
 ## Acceptance Criteria
 
@@ -29,6 +32,9 @@ CMS limits assignments to 1,999 ownership tokens; DMS defensively fails at 2,000
 - GET-by-id checks the stored token before hydration and reconstitution and returns 403 on null or mismatch.
 - PUT checks the stored token before mutation and never changes it.
 - DELETE checks the stored token before deletion.
+- A POST that resolves to create does not evaluate `OwnershipTokenIds`, so the 2,000-token defensive
+  cap does not deny a true create. A POST that resolves to update applies the cap after target
+  resolution and fails closed before DML.
 - `OwnershipTokenIds` authorizes reads and mutations, while the single `CreatorOwnershipTokenId` is only for creation stamping.
 - Failures use `AUTH1` with the configured strategy index and map to `auth.md` sections 2.13 and 2.14.
 - POST and PUT run the ownership check as a statement in the write's first-phase command, after the

--- a/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
+++ b/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
@@ -31,16 +31,24 @@ CMS limits assignments to 1,999 ownership tokens; DMS defensively fails at 2,000
 - DELETE checks the stored token before deletion.
 - `OwnershipTokenIds` authorizes reads and mutations, while the single `CreatorOwnershipTokenId` is only for creation stamping.
 - Failures use `AUTH1` with the configured strategy index and map to `auth.md` sections 2.13 and 2.14.
-- The write and delete paths co-batch the ownership check into the operation's own command: it is appended to the
-  same composite command as the guarded mutation or delete, after the custom-view and namespace statements and
-  before the relationship statement, so statement order is precedence order and the `AUTH1` abort discards the
-  later statements in that command.
-- The co-batch is budget-guarded, so it is not unconditional. When the composite plan does not fit the command's
-  parameter budget, ownership runs instead as an ordered segment on the same session and transaction, ahead of the
-  mutation or delete. The guard is provider-independent, but in practice only SQL Server's 2,098 usable parameters
-  (`MssqlCommandLimits.MaxUserParametersPerCommand`) are low enough to trip it, and a near-ceiling namespace prefix
-  list combined with a large token list can trip it well below the 2,000-token cap. That costs commands but
-  preserves authorization-before-mutation ordering and the precedence order above.
+- POST and PUT run the ownership check as a statement in the write's first-phase command, after the
+  custom-view and namespace statements and before the relationship statement and the current-state
+  hydration that command also carries, so statement order is precedence order. It is not in the same
+  command as the mutation: the proposed checks and the DML form a second command, because they bind
+  values taken from the finalized merged root row, which does not exist until the first command's
+  hydration is decoded and the merge runs. A denial aborts the later first-phase statements and the
+  second command is never sent, so no DML is issued.
+- DELETE co-batches the ownership check into the same command as the deletes on the ordinary path, in
+  that same custom-view then namespace then ownership then relationship order. The `AUTH1` abort
+  therefore discards the deletes that rode the command with it, which is why a denied delete leaves the
+  row present.
+- Either arrangement is budget-guarded, so neither is unconditional. When the composite plan does not fit
+  the command's parameter budget, ownership runs instead as an ordered segment on the same session and
+  transaction, ahead of the hydration or the deletes it would otherwise have shared a command with. The
+  guard is provider-independent, but in practice only SQL Server's 2,098 usable parameters
+  (`MssqlCommandLimits.MaxUserParametersPerCommand`) are low enough to trip it, and a near-ceiling
+  namespace prefix list combined with a large token list can trip it well below the 2,000-token cap. That
+  costs commands but preserves authorization-before-mutation ordering and the precedence order above.
 - GET-by-id is the one path that never co-batches: the ownership check is one additional command, because it is
   not an `AUTH1` statement against the carrier the namespace and relationship checks share, and it runs ahead of
   hydration so a denial is decided before any representation is built. Accepted deviation, recorded alongside the

--- a/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
+++ b/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
@@ -63,3 +63,15 @@ not evaluate `OwnershipTokenIds`, because no stored ownership token exists yet; 
 - PostgreSQL and SQL Server are supported; SQL Server uses parameterized `IN` below 2,000 ownership tokens and fails at 2,000 or more without a TVP.
 
 NOTE: GET-many ownership filtering is implemented by [DMS-1410](https://edfi.atlassian.net/browse/DMS-1410) in `11b-ownership-auth-get-many.md`.
+
+## Implementation Decisions
+
+- Descriptor ownership: stamping is in scope, enforcement is not. Descriptor creates stamp
+  `CreatedByOwnershipTokenId`, but descriptor GET-by-id, POST, PUT, and DELETE configured with
+  `OwnershipBased` stay fail-closed at `501` in DMS-1060.
+- POST create token cap: a POST that resolves to create does not evaluate `OwnershipTokenIds`, because
+  there is no stored ownership token to authorize. The 2,000-token defensive cap applies after target
+  resolution only when POST resolves to update, and then fails closed before DML.
+- GET-by-id batching: GET-by-id runs ownership as one added command ahead of hydration and
+  reconstitution. This is an accepted deviation from sharing the operation's database roundtrip and is
+  recorded in `reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md`.

--- a/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
+++ b/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
@@ -20,12 +20,32 @@ CMS limits assignments to 1,999 ownership tokens; DMS defensively fails at 2,000
 ## Acceptance Criteria
 
 - POST stamps every newly created document from `CreatorOwnershipTokenId`, including resources not configured with `OwnershipBased`; a missing creator token stamps null.
-- GET-by-id checks the stored token before reconstitution and returns 403 on null or mismatch.
+- Descriptors: stamping is in scope, enforcement is not. A descriptor create stamps
+  `CreatedByOwnershipTokenId` like any other create, because stamping never consults the configured
+  strategies. Ownership *enforcement* on descriptors is out of scope: a descriptor GET-by-id, POST, PUT or
+  DELETE whose action is configured with `OwnershipBased` stays fail-closed at `501`, so that configuration
+  is refused rather than honoured. The operations named in this story's title are those of relationally
+  stored resources.
+- GET-by-id checks the stored token before hydration and reconstitution and returns 403 on null or mismatch.
 - PUT checks the stored token before mutation and never changes it.
 - DELETE checks the stored token before deletion.
 - `OwnershipTokenIds` authorizes reads and mutations, while the single `CreatorOwnershipTokenId` is only for creation stamping.
 - Failures use `AUTH1` with the configured strategy index and map to `auth.md` sections 2.13 and 2.14.
-- Checks share the operation's database roundtrip and abort later statements in the batch.
+- The write and delete paths co-batch the ownership check into the operation's own command: it is appended to the
+  same composite command as the guarded mutation or delete, after the custom-view and namespace statements and
+  before the relationship statement, so statement order is precedence order and the `AUTH1` abort discards the
+  later statements in that command.
+- The co-batch is budget-guarded, so it is not unconditional. When the composite plan does not fit the command's
+  parameter budget, ownership runs instead as an ordered segment on the same session and transaction, ahead of the
+  mutation or delete. The guard is provider-independent, but in practice only SQL Server's 2,098 usable parameters
+  (`MssqlCommandLimits.MaxUserParametersPerCommand`) are low enough to trip it, and a near-ceiling namespace prefix
+  list combined with a large token list can trip it well below the 2,000-token cap. That costs commands but
+  preserves authorization-before-mutation ordering and the precedence order above.
+- GET-by-id is the one path that never co-batches: the ownership check is one additional command, because it is
+  not an `AUTH1` statement against the carrier the namespace and relationship checks share, and it runs ahead of
+  hydration so a denial is decided before any representation is built. Accepted deviation, recorded alongside the
+  authorized-GET-by-id one in
+  `reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md`.
 - Ownership executes last among AND strategies and composes with the other configured strategies.
 - PostgreSQL and SQL Server are supported; SQL Server uses parameterized `IN` below 2,000 ownership tokens and fails at 2,000 or more without a TVP.
 

--- a/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
+++ b/reference/design/backend-redesign/epics/14-authorization/11-ownership-auth-strategy.md
@@ -49,10 +49,9 @@ CMS limits assignments to 1,999 ownership tokens; DMS defensively fails at 2,000
   (`MssqlCommandLimits.MaxUserParametersPerCommand`) are low enough to trip it, and a near-ceiling
   namespace prefix list combined with a large token list can trip it well below the 2,000-token cap. That
   costs commands but preserves authorization-before-mutation ordering and the precedence order above.
-- GET-by-id is the one path that never co-batches: the ownership check is one additional command, because it is
-  not an `AUTH1` statement against the carrier the namespace and relationship checks share, and it runs ahead of
-  hydration so a denial is decided before any representation is built. Accepted deviation, recorded alongside the
-  authorized-GET-by-id one in
+- GET-by-id runs the ownership check as one added command ahead of hydration, rather than in the
+  operation's database roundtrip. This accepted deviation follows the existing stored-authorization
+  GET-by-id shape and is recorded alongside the authorized-GET-by-id one in
   `reference/design/backend-redesign/epics/07-relational-write-path/08-write-roundtrip-batching.md`.
 - Ownership executes last among AND strategies and composes with the other configured strategies.
 - PostgreSQL and SQL Server are supported; SQL Server uses parameterized `IN` below 2,000 ownership tokens and fails at 2,000 or more without a TVP.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/OwnershipAuthorizationSecurityConfigurationMessages.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/OwnershipAuthorizationSecurityConfigurationMessages.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+
+namespace EdFi.DataManagementService.Backend.External;
+
+/// <summary>
+/// Single source for the ownership-authorization security-configuration (HTTP 500) messages, mirroring
+/// <see cref="NamespaceAuthorizationSecurityConfigurationMessages"/> so both the relational backend and
+/// Core's ProblemDetails formatter use identical wording.
+/// </summary>
+/// <remarks>
+/// No message discloses an ownership token value. A count is safe to report — it tells an operator what to
+/// fix — but the tokens themselves identify other clients' data partitions.
+/// </remarks>
+public static class OwnershipAuthorizationSecurityConfigurationMessages
+{
+    /// <summary>
+    /// The ownership AUTH1 failure payload returned by the authorization provider (the <c>own1|index|kind</c>
+    /// metadata) cannot be attributed to the request's planned ownership check — either the request planned
+    /// none, or the payload's configured strategy index is not the planned check's. Fails closed as a
+    /// security-configuration (HTTP 500) rather than as a 403 attributed to a strategy that did not deny the
+    /// request.
+    /// </summary>
+    public const string InvalidAuthorizationMetadata =
+        "The ownership authorization failure payload returned by the authorization provider is invalid and cannot be mapped to the configured ownership authorization plan.";
+
+    /// <summary>
+    /// The client's ownership-token list reaches the defensive limit for <c>OwnershipBased</c> authorization.
+    /// Provider-independent: the same limit applies on PostgreSQL and SQL Server.
+    /// </summary>
+    public static string TokenCapExceeded(int ownershipTokenCount) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "The API client has {0} ownership tokens, which reaches the supported limit for OwnershipBased authorization. Configure fewer than 2,000 ownership tokens.",
+            ownershipTokenCount
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorWriteTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorWriteTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Data;
+using System.Globalization;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
@@ -458,6 +459,134 @@ public class Given_MssqlDescriptorWriteHandler
         probe.Parameters.Add(new SqlParameter("@documentUuid", documentUuid.Value));
         var stillThere = await probe.ExecuteScalarAsync();
         stillThere.Should().NotBeNull("mismatched If-Match must not delete the descriptor row");
+    }
+
+    /// <summary>
+    /// Descriptor creates use their own inline insert SQL rather than the shared document-row builder, so the
+    /// stamp needs live-provider coverage of its own. Unit tests inspect the emitted statement; only a real
+    /// engine proves the column round-trips.
+    /// </summary>
+    [Test]
+    public async Task It_stamps_the_creator_ownership_token_on_a_descriptor_create()
+    {
+        var handler = ResolveHandler();
+        var request = CreatePostRequest(
+            _database.Fixture.SchoolTypeDescriptorResource,
+            """
+            {
+                "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+                "codeValue": "OwnershipStamped",
+                "shortDescription": "Ownership Stamped"
+            }
+            """
+        ) with
+        {
+            RelationalAuthorizationContext = new RelationalAuthorizationContext(
+                [],
+                [],
+                creatorOwnershipTokenId: 42,
+                ownershipTokenIds: []
+            ),
+        };
+
+        var result = await handler.HandlePostAsync(request);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync(request.DocumentUuid)).Should().Be((short)42);
+    }
+
+    [Test]
+    public async Task It_stamps_null_on_a_descriptor_create_when_the_client_has_no_creator_token()
+    {
+        var handler = ResolveHandler();
+        var request = CreatePostRequest(
+            _database.Fixture.SchoolTypeDescriptorResource,
+            """
+            {
+                "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+                "codeValue": "OwnershipUnstamped",
+                "shortDescription": "Ownership Unstamped"
+            }
+            """
+        ) with
+        {
+            RelationalAuthorizationContext = new RelationalAuthorizationContext(
+                [],
+                [],
+                creatorOwnershipTokenId: null,
+                ownershipTokenIds: [7]
+            ),
+        };
+
+        var result = await handler.HandlePostAsync(request);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync(request.DocumentUuid)).Should().BeNull();
+    }
+
+    /// <summary>
+    /// A descriptor upsert-as-update must leave the stored token alone, even though its request carries a
+    /// different creator token that a create would have stamped.
+    /// </summary>
+    [Test]
+    public async Task It_leaves_the_stored_token_unchanged_on_a_descriptor_post_as_update()
+    {
+        var handler = ResolveHandler();
+        var resource = _database.Fixture.SchoolTypeDescriptorResource;
+        const string CreateBody = """
+            {
+                "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+                "codeValue": "OwnershipUpsert",
+                "shortDescription": "Ownership Upsert"
+            }
+            """;
+        const string UpsertBody = """
+            {
+                "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+                "codeValue": "OwnershipUpsert",
+                "shortDescription": "Ownership Upsert Changed"
+            }
+            """;
+
+        var createRequest = CreatePostRequest(resource, CreateBody) with
+        {
+            RelationalAuthorizationContext = new RelationalAuthorizationContext(
+                [],
+                [],
+                creatorOwnershipTokenId: 42,
+                ownershipTokenIds: []
+            ),
+        };
+        (await handler.HandlePostAsync(createRequest)).Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var upsertRequest = CreatePostRequest(resource, UpsertBody) with
+        {
+            RelationalAuthorizationContext = new RelationalAuthorizationContext(
+                [],
+                [],
+                creatorOwnershipTokenId: 7,
+                ownershipTokenIds: []
+            ),
+        };
+        (await handler.HandlePostAsync(upsertRequest)).Should().BeOfType<UpsertResult.UpdateSuccess>();
+
+        (await ReadStoredOwnershipTokenAsync(createRequest.DocumentUuid)).Should().Be((short)42);
+    }
+
+    private async Task<short?> ReadStoredOwnershipTokenAsync(DocumentUuid documentUuid)
+    {
+        await using var connection = new SqlConnection(_database.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT [CreatedByOwnershipTokenId]
+            FROM [dms].[Document]
+            WHERE [DocumentUuid] = @documentUuid;
+            """;
+        command.Parameters.AddWithValue("@documentUuid", documentUuid.Value);
+
+        var value = await command.ExecuteScalarAsync();
+        return value is null or DBNull ? null : Convert.ToInt16(value, CultureInfo.InvariantCulture);
     }
 
     // ── Helper methods ──────────────────────────────────────────────────

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalDeleteAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalDeleteAuthorizationTests.cs
@@ -638,8 +638,14 @@ public class Given_A_Mssql_Relational_Delete_Authorization_With_A_Synthetic_EdOr
         );
     }
 
+    /// <summary>
+    /// OwnershipBased is the only strategy in the relationship classifier's known-but-not-enabled set, so
+    /// once Delete is enforced this composition plans instead of returning a 501. These rows were seeded
+    /// without an ownership token, which is auth.md 2.14 — and the row assertions below are the point: a
+    /// denial must leave the row exactly where it was.
+    /// </summary>
     [Test]
-    public async Task It_returns_501_and_security_configuration_failures_before_deleting()
+    public async Task It_denies_and_reports_security_configuration_failures_before_deleting()
     {
         var knownUnsupportedSeed = _authorizationRootChildSeeds[7];
 
@@ -655,13 +661,11 @@ public class Given_A_Mssql_Relational_Delete_Authorization_With_A_Synthetic_EdOr
             RelationshipAuthorizationCrudTestSupport.EdOrgOnlyPlusKnownUnsupportedStrategyNames
         );
 
-        var notImplemented = knownUnsupportedResult
+        knownUnsupportedResult
             .Should()
-            .BeOfType<DeleteResult.DeleteFailureNotImplemented>()
-            .Subject;
-        notImplemented
-            .FailureMessage.Should()
-            .Contain(RelationshipAuthorizationCrudTestSupport.OwnershipBased);
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
         var securityConfiguration = securityConfigurationResult
             .Should()
             .BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalGetByIdAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalGetByIdAuthorizationTests.cs
@@ -49,7 +49,12 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
         AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
         AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
     ];
-    private static readonly IReadOnlyList<string> _normalPlusKnownUnsupportedStrategy =
+
+    /// <summary>
+    /// OwnershipBased is enforced for GET-by-id and withheld everywhere else, so this composition plans
+    /// rather than returning the known-but-not-enabled 501 that the write and query routes still return.
+    /// </summary>
+    private static readonly IReadOnlyList<string> _normalPlusOwnershipStrategy =
     [
         AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
         AuthorizationStrategyNameConstants.OwnershipBased,
@@ -538,16 +543,22 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
         _context.AssertNoHydration();
     }
 
+    /// <summary>
+    /// OwnershipBased composed with a supported relationship strategy. It is an AND filter running before the
+    /// relationship OR group, so it decides first: these rows were seeded without an ownership token, which
+    /// is auth.md 2.14 and stops the read before hydration even though the relationship claim would have
+    /// authorized it.
+    /// </summary>
     [Test]
-    public async Task It_returns_501_for_known_but_not_enabled_mixed_strategies()
+    public async Task It_denies_an_unstamped_row_for_ownership_composed_with_a_relationship_strategy()
     {
-        var result = await GetRootChildAsync(
-            _authorizationRootChildSeeds[0],
-            _normalPlusKnownUnsupportedStrategy
-        );
+        var result = await GetRootChildAsync(_authorizationRootChildSeeds[0], _normalPlusOwnershipStrategy);
 
-        var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
         _context.AssertNoHydration();
     }
 
@@ -559,7 +570,7 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
             RelationshipAuthorizationCrudTestSupport.ChildOnlyEdOrgResourceName,
             _authorizationChildOnlySeed.DocumentUuid,
             [ClaimEducationOrganizationId],
-            _normalPlusKnownUnsupportedStrategy
+            _normalPlusOwnershipStrategy
         );
 
         var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalOwnershipStampingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalOwnershipStampingTests.cs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Mssql;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using static EdFi.DataManagementService.Backend.Tests.Common.NoProfileUpdateSemanticsScenarios;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Live-provider coverage for <c>dms.Document.CreatedByOwnershipTokenId</c> stamping on SQL Server.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The unit tests assert the emitted SQL and parameter binding; only a live provider can prove the column
+/// actually round-trips. Two things specifically need a real engine: that a nullable <c>smallint</c> parameter
+/// declared as <see cref="DbType.Int16"/> binds for both a value and a null, and that an update genuinely
+/// leaves the stored token alone rather than merely omitting it from a statement the unit tests inspected.
+/// </para>
+/// <para>
+/// Stamping only — this suite asserts nothing about ownership enforcement, which is not yet wired.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+[Category("Authorization")]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category(MssqlCiShards.Shard1)]
+public class Given_A_Mssql_Relational_Write_With_Ownership_Stamping
+{
+    private const short CreatorToken = 42;
+    private const short OtherToken = 7;
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(FixtureRelativePath);
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await _database.ResetAsync();
+        _serviceProvider = CreateServiceProvider();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public async Task It_stamps_the_creator_ownership_token_on_a_create()
+    {
+        var createResult = await ExecuteCreateAsync(CreatorToken);
+
+        createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A client with no creator token stamps null. This is the case the declared parameter type exists for: a
+    /// null reaches the driver as <c>DBNull</c>, which carries no type of its own.
+    /// </summary>
+    [Test]
+    public async Task It_stamps_null_when_the_client_has_no_creator_token()
+    {
+        var createResult = await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().BeNull();
+    }
+
+    [Test]
+    public async Task It_leaves_the_stored_token_unchanged_on_a_put()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var updateResult = await ExecuteUpdateAsync(OtherToken);
+
+        updateResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A POST that resolves to an upsert-as-update must also leave the stored token alone, even though its
+    /// request carries a creator token that a create would have stamped.
+    /// </summary>
+    [Test]
+    public async Task It_leaves_the_stored_token_unchanged_on_a_post_as_update()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var upsertResult = await ExecuteCreateAsync(OtherToken, UpdateRequestBody());
+
+        upsertResult.Should().BeOfType<UpsertResult.UpdateSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A document stamped null stays null through an update by a client that does have a creator token — an
+    /// unstamped document is permanently unreachable through ownership authorization, and an update must not
+    /// quietly repair it.
+    /// </summary>
+    [Test]
+    public async Task It_leaves_a_null_stored_token_null_on_a_put()
+    {
+        await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        await ExecuteUpdateAsync(CreatorToken);
+
+        (await ReadStoredOwnershipTokenAsync()).Should().BeNull();
+    }
+
+    private async Task<UpsertResult> ExecuteCreateAsync(
+        short? creatorOwnershipTokenId,
+        JsonNode? requestBody = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.UpsertDocument(
+            new UpsertRequest(
+                ResourceInfo: SchoolResourceInfo,
+                DocumentInfo: CreateSchoolDocumentInfo(),
+                MappingSet: _mappingSet,
+                EdfiDoc: requestBody ?? CreateRequestBody(),
+                Headers: [],
+                TraceId: new TraceId("mssql-ownership-stamping-post"),
+                DocumentUuid: SchoolDocumentUuid
+            )
+            {
+                AuthorizationContext = CreateAuthorizationContext(creatorOwnershipTokenId),
+            }
+        );
+    }
+
+    private async Task<UpdateResult> ExecuteUpdateAsync(short? creatorOwnershipTokenId)
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.UpdateDocumentById(
+            new UpdateRequest(
+                ResourceInfo: SchoolResourceInfo,
+                DocumentInfo: CreateSchoolDocumentInfo(),
+                MappingSet: _mappingSet,
+                EdfiDoc: UpdateRequestBody(),
+                Headers: [],
+                TraceId: new TraceId("mssql-ownership-stamping-put"),
+                DocumentUuid: SchoolDocumentUuid
+            )
+            {
+                AuthorizationContext = CreateAuthorizationContext(creatorOwnershipTokenId),
+            }
+        );
+    }
+
+    private static RelationalAuthorizationContext CreateAuthorizationContext(
+        short? creatorOwnershipTokenId
+    ) => new([], [], creatorOwnershipTokenId, []);
+
+    private IServiceScope CreateScopeForDatabase()
+    {
+        var scope = _serviceProvider.CreateScope();
+
+        scope
+            .ServiceProvider.GetRequiredService<IDataStoreSelection>()
+            .SetSelectedDataStore(
+                new DataStore(
+                    Id: 1,
+                    DataStoreType: "test",
+                    Name: "MssqlRelationalOwnershipStamping",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        return scope;
+    }
+
+    private async Task<short?> ReadStoredOwnershipTokenAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT [CreatedByOwnershipTokenId]
+            FROM [dms].[Document]
+            WHERE [DocumentUuid] = @documentUuid;
+            """,
+            new SqlParameter("@documentUuid", SchoolDocumentUuid.Value)
+        );
+
+        if (rows.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected exactly one document row for '{SchoolDocumentUuid.Value}', but found {rows.Count}."
+            );
+        }
+
+        var value = rows[0]["CreatedByOwnershipTokenId"];
+        return value is null or DBNull ? null : Convert.ToInt16(value, CultureInfo.InvariantCulture);
+    }
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = new();
+
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddScoped<IDataStoreSelection, DataStoreSelection>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddMssqlBackendIntegrationTestServices();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalOwnershipStampingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalOwnershipStampingTests.cs
@@ -285,6 +285,125 @@ public class Given_A_Mssql_Relational_Write_With_Ownership_Stamping
             .Contain("2,000");
     }
 
+    // ----- Delete enforcement ----------------------------------------------
+
+    /// <summary>
+    /// An owner may delete. Proves the co-batched ownership statement authorizes and the deletes in the same
+    /// command still run, rather than the check aborting a batch that carried them.
+    /// </summary>
+    [Test]
+    public async Task It_deletes_a_document_whose_stored_token_the_reader_holds()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipDeleteAsync([OtherToken, CreatorToken]);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        (await CountStoredDocumentsAsync()).Should().Be(0);
+    }
+
+    /// <summary>
+    /// A non-owner may not, and the row survives. The deletes rode the same command the ownership statement
+    /// aborted, so the abort rolled them back — this is the assertion that a denial cannot destroy data.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_delete_whose_stored_token_the_reader_does_not_hold_and_leaves_the_row()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipDeleteAsync([OtherToken]);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        (await CountStoredDocumentsAsync()).Should().Be(1);
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A document created without a token can be deleted by nobody: auth.md 2.14, and the row stays.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_delete_whose_stored_ownership_token_was_never_assigned()
+    {
+        await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        var result = await ExecuteOwnershipDeleteAsync([CreatorToken]);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        (await CountStoredDocumentsAsync()).Should().Be(1);
+    }
+
+    /// <summary>
+    /// The denial outranks a stale If-Match. Telling a non-owner its etag is stale would disclose that the
+    /// row changed, so the ownership decision is the one reported.
+    /// </summary>
+    [Test]
+    public async Task It_reports_an_ownership_delete_denial_over_a_stale_if_match()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipDeleteAsync([OtherToken], ifMatch: "\"stale-etag\"");
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>();
+        (await CountStoredDocumentsAsync()).Should().Be(1);
+    }
+
+    private async Task<DeleteResult> ExecuteOwnershipDeleteAsync(
+        IReadOnlyList<short> ownershipTokenIds,
+        string? ifMatch = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.DeleteDocumentById(
+            new DeleteRequest(
+                DocumentUuid: SchoolDocumentUuid,
+                ResourceInfo: SchoolResourceInfo,
+                TraceId: new TraceId("ownership-enforcement-delete"),
+                Headers: ifMatch is null ? [] : new Dictionary<string, string> { ["If-Match"] = ifMatch },
+                MappingSet: _mappingSet
+            )
+            {
+                AuthorizationContext = new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    creatorOwnershipTokenId: null,
+                    ownershipTokenIds
+                ),
+                AuthorizationStrategyEvaluators =
+                [
+                    new AuthorizationStrategyEvaluator(
+                        AuthorizationStrategyNameConstants.OwnershipBased,
+                        [],
+                        FilterOperator.And
+                    ),
+                ],
+            }
+        );
+    }
+
+    private async Task<int> CountStoredDocumentsAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT COUNT(*) AS [DocumentCount]
+            FROM [dms].[Document]
+            WHERE [DocumentUuid] = @documentUuid;
+            """,
+            new SqlParameter("documentUuid", SchoolDocumentUuid.Value)
+        );
+
+        return Convert.ToInt32(rows[0]["DocumentCount"], CultureInfo.InvariantCulture);
+    }
+
     private async Task<GetResult> ExecuteOwnershipGetByIdAsync(
         IReadOnlyList<short> ownershipTokenIds,
         IReadOnlyList<string>? strategyNames = null

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalOwnershipStampingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalOwnershipStampingTests.cs
@@ -440,6 +440,180 @@ public class Given_A_Mssql_Relational_Write_With_Ownership_Stamping
         );
     }
 
+    // ----- Write enforcement -----------------------------------------------
+
+    /// <summary>
+    /// The live half of the D1 proof, moved here from 6.2 because a POST create cannot plan an ownership
+    /// check until the Update gate is open. <c>OwnershipBased</c> is configured and the caller holds no
+    /// tokens at all — the configuration most likely to deny if the carrier row guard were missing — and the
+    /// create still succeeds and still stamps.
+    /// </summary>
+    [Test]
+    public async Task It_creates_and_stamps_with_ownership_configured_and_no_tokens()
+    {
+        var createResult = await ExecuteOwnershipCreateAsync(CreatorToken, ownershipTokenIds: []);
+
+        createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A POST that resolves to an upsert-as-update is denied for a foreign token, and the stored row is
+    /// unchanged — including the token, which a denied write must never rewrite.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_post_as_update_for_a_foreign_token_and_leaves_the_row_unmodified()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipCreateAsync(
+            CreatorToken,
+            ownershipTokenIds: [OtherToken],
+            requestBody: UpdateRequestBody()
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    [Test]
+    public async Task It_denies_a_put_for_a_foreign_token_and_leaves_the_row_unmodified()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipUpdateAsync([OtherToken]);
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// An owner may update, and the stored token survives it. The write carries its own creator token, which
+    /// a create would have stamped, so this also proves the update path still does not rewrite it.
+    /// </summary>
+    [Test]
+    public async Task It_authorizes_a_put_for_an_owner_and_preserves_the_stored_token()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipUpdateAsync([OtherToken, CreatorToken]);
+
+        result.Should().BeOfType<UpdateResult.UpdateSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A document created without a token cannot be updated by anyone: auth.md 2.14.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_put_whose_stored_ownership_token_was_never_assigned()
+    {
+        await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        var result = await ExecuteOwnershipUpdateAsync([CreatorToken]);
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        (await ReadStoredOwnershipTokenAsync()).Should().BeNull();
+    }
+
+    /// <summary>
+    /// The denial outranks a stale If-Match, as on the delete path: telling a non-owner its etag is stale
+    /// would disclose that the row changed.
+    /// </summary>
+    [Test]
+    public async Task It_reports_an_ownership_put_denial_over_a_stale_if_match()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipUpdateAsync([OtherToken], ifMatch: "\"stale-etag\"");
+
+        result.Should().BeOfType<UpdateResult.UpdateFailureOwnershipNotAuthorized>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    private async Task<UpsertResult> ExecuteOwnershipCreateAsync(
+        short? creatorOwnershipTokenId,
+        IReadOnlyList<short> ownershipTokenIds,
+        JsonNode? requestBody = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.UpsertDocument(
+            new UpsertRequest(
+                ResourceInfo: SchoolResourceInfo,
+                DocumentInfo: CreateSchoolDocumentInfo(),
+                MappingSet: _mappingSet,
+                EdfiDoc: requestBody ?? CreateRequestBody(),
+                Headers: [],
+                TraceId: new TraceId("ownership-enforcement-post"),
+                DocumentUuid: SchoolDocumentUuid
+            )
+            {
+                AuthorizationContext = new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    creatorOwnershipTokenId,
+                    ownershipTokenIds
+                ),
+                AuthorizationStrategyEvaluators = OwnershipStrategyEvaluators,
+            }
+        );
+    }
+
+    private async Task<UpdateResult> ExecuteOwnershipUpdateAsync(
+        IReadOnlyList<short> ownershipTokenIds,
+        string? ifMatch = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.UpdateDocumentById(
+            new UpdateRequest(
+                ResourceInfo: SchoolResourceInfo,
+                DocumentInfo: CreateSchoolDocumentInfo(),
+                MappingSet: _mappingSet,
+                EdfiDoc: UpdateRequestBody(),
+                Headers: ifMatch is null ? [] : new Dictionary<string, string> { ["If-Match"] = ifMatch },
+                TraceId: new TraceId("ownership-enforcement-put"),
+                DocumentUuid: SchoolDocumentUuid
+            )
+            {
+                AuthorizationContext = new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    // A PUT carries a creator token too; a create would stamp it, an update must not.
+                    creatorOwnershipTokenId: OtherToken,
+                    ownershipTokenIds
+                ),
+                AuthorizationStrategyEvaluators = OwnershipStrategyEvaluators,
+            }
+        );
+    }
+
+    private static AuthorizationStrategyEvaluator[] OwnershipStrategyEvaluators =>
+        [
+            new AuthorizationStrategyEvaluator(
+                AuthorizationStrategyNameConstants.OwnershipBased,
+                [],
+                FilterOperator.And
+            ),
+        ];
+
     private async Task<UpsertResult> ExecuteCreateAsync(
         short? creatorOwnershipTokenId,
         JsonNode? requestBody = null

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalOwnershipStampingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalOwnershipStampingTests.cs
@@ -8,12 +8,14 @@ using System.Globalization;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
+using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
 using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,7 +37,8 @@ namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
 /// leaves the stored token alone rather than merely omitting it from a statement the unit tests inspected.
 /// </para>
 /// <para>
-/// Stamping only — this suite asserts nothing about ownership enforcement, which is not yet wired.
+/// Stamping first, then enforcement: the same seeded row proves both, because what a create stamps is
+/// exactly what a later GET-by-id has to authorize against.
 /// </para>
 /// </remarks>
 [TestFixture]
@@ -157,6 +160,165 @@ public class Given_A_Mssql_Relational_Write_With_Ownership_Stamping
         await ExecuteUpdateAsync(CreatorToken);
 
         (await ReadStoredOwnershipTokenAsync()).Should().BeNull();
+    }
+
+    // ----- Enforcement -----------------------------------------------------
+    // These execute the compiled ownership SQL against the real engine. Only a live provider can prove the
+    // SELECT CASE parses, the membership predicate binds smallint to smallint, and the AUTH1 abort device
+    // raises an error the dispatcher and mapper decode back into a response. The stamping tests above put a
+    // known token on the row, so each arm is reached by choosing which tokens the reader holds.
+
+    /// <summary>
+    /// The stored token is one of the reader's, so the read is authorized and the document is served.
+    /// </summary>
+    [Test]
+    public async Task It_authorizes_a_get_by_id_whose_stored_token_the_reader_holds()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync([OtherToken, CreatorToken]);
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+    }
+
+    /// <summary>
+    /// The stored token is not one of the reader's: auth.md 2.13. The row exists and is readable by its own
+    /// owner, so only the membership predicate can be denying it.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_get_by_id_whose_stored_token_the_reader_does_not_hold()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync([OtherToken]);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+    }
+
+    /// <summary>
+    /// A reader holding no tokens at all still runs the check rather than being short-circuited, so the
+    /// constant-false membership predicate has to be valid SQL on this engine. The row carries a token, so
+    /// this is a mismatch rather than the uninitialized case.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_get_by_id_for_a_reader_holding_no_tokens()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync([]);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+    }
+
+    /// <summary>
+    /// The stored token is null: auth.md 2.14, a different response type from 2.13 because the document can
+    /// never be reached by any client rather than merely not by this one. Reached by creating through a
+    /// client that has no creator token, which is exactly how such a row arises in practice.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_get_by_id_whose_stored_token_was_never_assigned()
+    {
+        await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        var result = await ExecuteOwnershipGetByIdAsync([CreatorToken]);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+    }
+
+    /// <summary>
+    /// The configured position travels through the emitted payload and back, so a denial is attributed to
+    /// the position OwnershipBased actually holds rather than to a normalized zero.
+    /// </summary>
+    [Test]
+    public async Task It_reports_the_configured_strategy_index_a_denial_came_from()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync(
+            [OtherToken],
+            strategyNames:
+            [
+                AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
+                AuthorizationStrategyNameConstants.OwnershipBased,
+            ]
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureOwnershipNotAuthorized>().Subject;
+        failure.OwnershipFailure.ConfiguredStrategyIndex.Should().Be(1);
+        failure.OwnershipFailure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    /// <summary>
+    /// The provider-independent defensive limit, reported before any statement is emitted. Proves the cap
+    /// terminal reaches the response on a live engine rather than the over-limit parameter list reaching the
+    /// SQL boundary.
+    /// </summary>
+    [Test]
+    public async Task It_fails_closed_for_a_get_by_id_with_an_over_cap_ownership_token_list()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync([
+            .. Enumerable
+                .Range(1, OwnershipTokenLimitExceededException.OwnershipTokenLimit)
+                .Select(static tokenId => (short)tokenId),
+        ]);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("2,000");
+    }
+
+    private async Task<GetResult> ExecuteOwnershipGetByIdAsync(
+        IReadOnlyList<short> ownershipTokenIds,
+        IReadOnlyList<string>? strategyNames = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.GetDocumentById(
+            new IntegrationRelationalGetRequest(
+                DocumentUuid: SchoolDocumentUuid,
+                ResourceInfo: SchoolResourceInfo,
+                MappingSet: _mappingSet,
+                AuthorizationStrategyEvaluators:
+                [
+                    .. (strategyNames ?? [AuthorizationStrategyNameConstants.OwnershipBased]).Select(
+                        static strategyName => new AuthorizationStrategyEvaluator(
+                            strategyName,
+                            [],
+                            FilterOperator.And
+                        )
+                    ),
+                ],
+                TraceId: new TraceId("mssql-ownership-enforcement-get")
+            )
+            {
+                AuthorizationContext = new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    creatorOwnershipTokenId: null,
+                    ownershipTokenIds
+                ),
+            }
+        );
     }
 
     private async Task<UpsertResult> ExecuteCreateAsync(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalPostAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalPostAuthorizationTests.cs
@@ -565,6 +565,40 @@ public class Given_A_Mssql_RelationalPost_Create_Authorization_With_A_Synthetic_
         _context.AssertPostCreateRelationshipAuthorizationUsesStructuredClaimParameter();
     }
 
+    /// <summary>
+    /// Ownership AND-composes ahead of the relationship OR group, so when both are configured and the
+    /// caller holds no EducationOrganization claims at all, the ownership denial is what a POST resolving
+    /// to upsert-as-update reports. Preflight cannot short-circuit the relationship NoClaims here: nothing
+    /// has read the stored token yet. The row was created without one, which is auth.md 2.14, and the row
+    /// assertions are the other half of the point — a denial must leave it exactly where it was.
+    /// </summary>
+    [Test]
+    public async Task It_reports_a_post_as_update_ownership_denial_over_a_relationship_no_claims_denial()
+    {
+        var seed = CreateRootChildSeed(
+            "ffffffff-0000-0000-0000-000000000701",
+            701,
+            "ownership-over-relationship-no-claims",
+            100,
+            []
+        );
+
+        (await PostRootChildAsync(seed)).Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var result = await _context.UpsertAuthorizationRootChildAsync(
+            seed,
+            [],
+            RelationshipAuthorizationCrudTestSupport.EdOrgOnlyPlusKnownUnsupportedStrategyNames
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        await AssertPersistedRowsAsync(seed);
+    }
+
     private async Task<UpsertResult> PostRootChildAsync(
         AuthorizationRootChildSeed seed,
         IReadOnlyList<long>? claimEducationOrganizationIds = null,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipAuthorizationAuth1FailurePayloadTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipAuthorizationAuth1FailurePayloadTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipAuthorizationAuth1FailurePayloadCodec
+{
+    [TestCase(0, OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch, "own1|0|m")]
+    [TestCase(1, OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized, "own1|1|u")]
+    [TestCase(7, OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing, "own1|7|s")]
+    public void It_encodes_the_configured_strategy_index_and_kind(
+        int configuredStrategyIndex,
+        OwnershipAuthorizationAuth1FailureKind failureKind,
+        string expectedPayload
+    )
+    {
+        var encoded = OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+            new OwnershipAuthorizationAuth1FailurePayload(configuredStrategyIndex, failureKind)
+        );
+
+        encoded.Should().Be(expectedPayload);
+    }
+
+    [TestCase(0, OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch)]
+    [TestCase(2, OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized)]
+    [TestCase(31, OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing)]
+    public void It_round_trips_every_kind(
+        int configuredStrategyIndex,
+        OwnershipAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        var original = new OwnershipAuthorizationAuth1FailurePayload(configuredStrategyIndex, failureKind);
+
+        var parsed = OwnershipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+            OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(original),
+            out var payload
+        );
+
+        parsed.Should().BeTrue();
+        payload.Should().NotBeNull();
+        payload!.ConfiguredStrategyIndex.Should().Be(configuredStrategyIndex);
+        payload.FailureKind.Should().Be(failureKind);
+    }
+
+    /// <summary>
+    /// The index in the payload is the configured strategy position, so a strategy configured after other
+    /// strategies must encode its real position rather than the constant zero an emitted ordinal would carry.
+    /// </summary>
+    [Test]
+    public void It_preserves_a_nonzero_configured_index_through_a_round_trip()
+    {
+        OwnershipAuthorizationAuth1FailurePayloadCodec
+            .TryParsePayload("own1|4|m", out var payload)
+            .Should()
+            .BeTrue();
+
+        payload!.ConfiguredStrategyIndex.Should().Be(4);
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("own1|0")]
+    [TestCase("own1|0|m|extra")]
+    [TestCase("own1|-1|m")]
+    [TestCase("own1|abc|m")]
+    [TestCase("own1|0|x")]
+    [TestCase("ns1|0|m")]
+    [TestCase("cv1|0|n")]
+    [TestCase("1|0|1|0:0:s")]
+    public void It_rejects_a_payload_it_does_not_own(string payloadText)
+    {
+        var parsed = OwnershipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+            payloadText,
+            out var payload
+        );
+
+        parsed.Should().BeFalse();
+        payload.Should().BeNull();
+    }
+
+    [Test]
+    public void It_rejects_a_negative_configured_index_at_construction()
+    {
+        Action act = () =>
+            new OwnershipAuthorizationAuth1FailurePayload(
+                -1,
+                OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch
+            );
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void It_rejects_encoding_an_unsupported_kind()
+    {
+        Action act = () =>
+            OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+                new OwnershipAuthorizationAuth1FailurePayload(0, (OwnershipAuthorizationAuth1FailureKind)999)
+            );
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void It_rejects_encoding_a_null_payload()
+    {
+        Action act = () => OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipAuthorizationFailureMapperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipAuthorizationFailureMapperTests.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipAuthorizationFailureMapper
+{
+    private static OwnershipAuthorizationAuth1FailurePayload Payload(
+        OwnershipAuthorizationAuth1FailureKind failureKind,
+        int configuredStrategyIndex = 0
+    ) => new(configuredStrategyIndex, failureKind);
+
+    [Test]
+    public void It_maps_a_mismatch_payload_to_the_2_13_failure()
+    {
+        var result = OwnershipAuthorizationFailureMapper.Map(
+            Payload(OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch, 2),
+            plannedConfiguredStrategyIndex: 2
+        );
+
+        var denied = result.Should().BeOfType<OwnershipAuthorizationAuth1MapResult.Denied>().Subject;
+        denied.Failure.FailureKind.Should().Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        denied.Failure.ConfiguredStrategyIndex.Should().Be(2);
+        denied.Failure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    [Test]
+    public void It_maps_an_uninitialized_payload_to_the_2_14_failure()
+    {
+        var result = OwnershipAuthorizationFailureMapper.Map(
+            Payload(OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized, 1),
+            plannedConfiguredStrategyIndex: 1
+        );
+
+        var denied = result.Should().BeOfType<OwnershipAuthorizationAuth1MapResult.Denied>().Subject;
+        denied
+            .Failure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        denied.Failure.ConfiguredStrategyIndex.Should().Be(1);
+    }
+
+    /// <summary>
+    /// A strategy configured after namespace and custom-view strategies still attributes correctly, which is
+    /// the case an emitted-ordinal payload could not have distinguished.
+    /// </summary>
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(3)]
+    public void It_attributes_a_denial_at_any_configured_position(int configuredStrategyIndex)
+    {
+        var result = OwnershipAuthorizationFailureMapper.Map(
+            Payload(OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch, configuredStrategyIndex),
+            configuredStrategyIndex
+        );
+
+        result
+            .Should()
+            .BeOfType<OwnershipAuthorizationAuth1MapResult.Denied>()
+            .Which.Failure.ConfiguredStrategyIndex.Should()
+            .Be(configuredStrategyIndex);
+    }
+
+    [Test]
+    public void It_reports_a_stale_stored_target_as_a_retry_signal_rather_than_a_denial()
+    {
+        var result = OwnershipAuthorizationFailureMapper.Map(
+            Payload(OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing, 0),
+            plannedConfiguredStrategyIndex: 0
+        );
+
+        result.Should().BeOfType<OwnershipAuthorizationAuth1MapResult.StaleStoredTarget>();
+    }
+
+    /// <summary>
+    /// The guardrail this mapper exists for: a payload whose configured index is not the planned check's
+    /// index becomes a security-configuration outcome, never a 403 attributed to a strategy that did not
+    /// deny the request.
+    /// </summary>
+    [TestCase(OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch)]
+    [TestCase(OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized)]
+    [TestCase(OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing)]
+    public void It_reports_an_index_mismatch_as_unmappable_for_every_kind(
+        OwnershipAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        var result = OwnershipAuthorizationFailureMapper.Map(
+            Payload(failureKind, configuredStrategyIndex: 7),
+            plannedConfiguredStrategyIndex: 1
+        );
+
+        result
+            .Should()
+            .BeOfType<OwnershipAuthorizationAuth1MapResult.Unmappable>()
+            .Which.Reason.Should()
+            .Be(OwnershipAuthorizationAuth1UnmappableReason.ConfiguredStrategyIndexMismatch);
+    }
+
+    [Test]
+    public void It_reports_an_ownership_payload_with_no_planned_check_as_unmappable()
+    {
+        var result = OwnershipAuthorizationFailureMapper.Map(
+            Payload(OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch, 0),
+            plannedConfiguredStrategyIndex: null
+        );
+
+        result
+            .Should()
+            .BeOfType<OwnershipAuthorizationAuth1MapResult.Unmappable>()
+            .Which.Reason.Should()
+            .Be(OwnershipAuthorizationAuth1UnmappableReason.NoOwnershipCheckPlanned);
+    }
+
+    /// <summary>
+    /// Attribution precedes the stale-target shortcut, so a stale payload from an unplanned check is a
+    /// security-configuration outcome rather than a retry the request never earned.
+    /// </summary>
+    [Test]
+    public void It_prefers_unmappable_over_stale_when_no_check_was_planned()
+    {
+        var result = OwnershipAuthorizationFailureMapper.Map(
+            Payload(OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing, 0),
+            plannedConfiguredStrategyIndex: null
+        );
+
+        result.Should().BeOfType<OwnershipAuthorizationAuth1MapResult.Unmappable>();
+    }
+
+    [Test]
+    public void It_rejects_a_null_payload()
+    {
+        Action act = () => OwnershipAuthorizationFailureMapper.Map(null!, 0);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipAuthorizationPlannerTests.cs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipAuthorizationPlanner
+{
+    private static ConfiguredAuthorizationStrategy Ownership(int rawConfiguredIndex) =>
+        new(AuthorizationStrategyNameConstants.OwnershipBased, rawConfiguredIndex);
+
+    /// <summary>
+    /// One check for every single-record operation. <c>Update</c> covers both write verbs, because a POST
+    /// resolves to a create or an upsert-as-update only in-session.
+    /// </summary>
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    public void It_plans_one_stored_check_for_each_single_record_operation(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        var check = OwnershipAuthorizationPlanner.Plan(operation, [Ownership(0)]);
+
+        check.RawConfiguredIndex.Should().Be(0);
+        check.StrategyName.Should().Be(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    /// <summary>
+    /// The configured position travels into the AUTH1 payload, so it must be the real one rather than a
+    /// normalized zero.
+    /// </summary>
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(4)]
+    public void It_carries_the_configured_position(int rawConfiguredIndex)
+    {
+        OwnershipAuthorizationPlanner
+            .Plan(NamespaceAuthorizationOperation.ReadSingle, [Ownership(rawConfiguredIndex)])
+            .RawConfiguredIndex.Should()
+            .Be(rawConfiguredIndex);
+    }
+
+    /// <summary>
+    /// Configuring <c>OwnershipBased</c> twice collapses to one check at the earliest occurrence. The check
+    /// reads one column against one token list, so it evaluates once however many times it is configured, and
+    /// the position where it first executes is the earliest. Stamping a later one would let a custom view
+    /// configured between them validate ahead of a terminal it actually follows.
+    /// </summary>
+    [Test]
+    public void It_collapses_repeated_configuration_to_the_earliest_occurrence()
+    {
+        OwnershipAuthorizationPlanner
+            .Plan(NamespaceAuthorizationOperation.Update, [Ownership(3), Ownership(1)])
+            .RawConfiguredIndex.Should()
+            .Be(1);
+    }
+
+    /// <summary>
+    /// The result must not depend on the caller handing the list in configured order.
+    /// </summary>
+    [Test]
+    public void It_does_not_depend_on_the_order_the_strategies_arrive_in()
+    {
+        var ascending = OwnershipAuthorizationPlanner.Plan(
+            NamespaceAuthorizationOperation.Delete,
+            [Ownership(2), Ownership(5)]
+        );
+        var descending = OwnershipAuthorizationPlanner.Plan(
+            NamespaceAuthorizationOperation.Delete,
+            [Ownership(5), Ownership(2)]
+        );
+
+        ascending.Should().Be(descending);
+    }
+
+    /// <summary>
+    /// GET-many ownership filtering is a different shape of check owned by DMS-1410, so this single-record
+    /// planner must refuse it rather than serve a plan that would filter nothing.
+    /// </summary>
+    [Test]
+    public void It_refuses_read_many()
+    {
+        Action act = () =>
+            OwnershipAuthorizationPlanner.Plan(NamespaceAuthorizationOperation.ReadMany, [Ownership(0)]);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void It_refuses_an_unrecognized_operation()
+    {
+        Action act = () =>
+            OwnershipAuthorizationPlanner.Plan((NamespaceAuthorizationOperation)999, [Ownership(0)]);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void It_refuses_an_empty_strategy_list()
+    {
+        Action act = () => OwnershipAuthorizationPlanner.Plan(NamespaceAuthorizationOperation.ReadSingle, []);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void It_refuses_a_null_strategy_list()
+    {
+        Action act = () =>
+            OwnershipAuthorizationPlanner.Plan(NamespaceAuthorizationOperation.ReadSingle, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// A non-ownership strategy arriving here means the caller's bucket split is wrong, which would
+    /// authorize the wrong strategy's subject. It must fail loudly rather than be planned as ownership.
+    /// </summary>
+    [TestCase(AuthorizationStrategyNameConstants.NamespaceBased)]
+    [TestCase(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly)]
+    [TestCase("StudentWithCTECourseEnrollments")]
+    public void It_refuses_a_strategy_that_is_not_ownership_based(string strategyName)
+    {
+        Action act = () =>
+            OwnershipAuthorizationPlanner.Plan(
+                NamespaceAuthorizationOperation.ReadSingle,
+                [Ownership(0), new ConfiguredAuthorizationStrategy(strategyName, 1)]
+            );
+
+        act.Should().Throw<ArgumentException>().WithMessage($"*{strategyName}*");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipAuthorizationSqlCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipAuthorizationSqlCompilerTests.cs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipAuthorizationSqlCompiler
+{
+    private const string DocumentIdParameterName = "documentId";
+    private const string OwnershipTokenIdsParameterName = "ownershipTokenIds";
+
+    private static OwnershipTokenParameterization Tokens(
+        SqlDialect dialect,
+        params int[] ownershipTokenIds
+    ) =>
+        OwnershipTokenParameterizationFactory.Create(
+            dialect,
+            [.. ownershipTokenIds.Select(static ownershipTokenId => (short)ownershipTokenId)],
+            OwnershipTokenIdsParameterName
+        );
+
+    private static OwnershipAuthorizationSqlSpec Spec(
+        OwnershipTokenParameterization ownershipTokenParameterization,
+        int rawConfiguredIndex = 0,
+        string? rowGuardPredicateSql = null
+    ) =>
+        new(
+            new OwnershipAuthorizationCheckSpec(rawConfiguredIndex),
+            ownershipTokenParameterization,
+            DocumentIdParameterName,
+            rowGuardPredicateSql
+        );
+
+    private static string Sql(params string[] lines) => string.Join("\n", lines) + "\n";
+
+    /// <summary>
+    /// The whole emitted shape for PostgreSQL. The arm order is the contract: authorized, then stored-null,
+    /// then no-row, then mismatch as the fallthrough. Classifying stored-null ahead of no-row keeps a row
+    /// that exists with an unassigned token reported as §2.14 rather than as a stale target.
+    /// </summary>
+    [Test]
+    public void It_compiles_a_pgsql_check_with_the_authorized_arm_then_the_three_auth1_arms()
+    {
+        var compiler = new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(Spec(Tokens(SqlDialect.Pgsql, 12)));
+
+        plan.AuthorizationSql.Should()
+            .Be(
+                Sql(
+                    "SELECT CASE",
+                    "    WHEN EXISTS (SELECT 1 FROM \"dms\".\"Document\" d WHERE d.\"DocumentId\" = @documentId AND d.\"CreatedByOwnershipTokenId\" IS NOT NULL AND d.\"CreatedByOwnershipTokenId\" = ANY(@ownershipTokenIds)) THEN 1",
+                    "    WHEN EXISTS (SELECT 1 FROM \"dms\".\"Document\" d WHERE d.\"DocumentId\" = @documentId AND d.\"CreatedByOwnershipTokenId\" IS NULL) THEN \"dms\".\"throw_error\"('AUTH1', 'own1|0|u')",
+                    "    WHEN NOT EXISTS (SELECT 1 FROM \"dms\".\"Document\" d WHERE d.\"DocumentId\" = @documentId) THEN \"dms\".\"throw_error\"('AUTH1', 'own1|0|s')",
+                    "    ELSE \"dms\".\"throw_error\"('AUTH1', 'own1|0|m')",
+                    "END;"
+                )
+            );
+        plan.ParametersInOrder.Select(static parameter => parameter.ParameterName)
+            .Should()
+            .Equal(DocumentIdParameterName, OwnershipTokenIdsParameterName);
+    }
+
+    /// <summary>
+    /// The whole emitted shape for SQL Server: a parameterized scalar <c>IN</c> list and the
+    /// <c>CAST('AUTH1 - ...' AS INT)</c> abort device. No table-valued parameter is involved, by design.
+    /// </summary>
+    [Test]
+    public void It_compiles_a_mssql_check_with_a_scalar_in_list_and_cast_auth1_dash_throws()
+    {
+        var compiler = new OwnershipAuthorizationSqlCompiler(SqlDialect.Mssql);
+
+        var plan = compiler.Compile(Spec(Tokens(SqlDialect.Mssql, 12, 34)));
+
+        plan.AuthorizationSql.Should()
+            .Be(
+                Sql(
+                    "SELECT CASE",
+                    "    WHEN EXISTS (SELECT 1 FROM [dms].[Document] d WHERE d.[DocumentId] = @documentId AND d.[CreatedByOwnershipTokenId] IS NOT NULL AND d.[CreatedByOwnershipTokenId] IN (@ownershipTokenIds_0, @ownershipTokenIds_1)) THEN 1",
+                    "    WHEN EXISTS (SELECT 1 FROM [dms].[Document] d WHERE d.[DocumentId] = @documentId AND d.[CreatedByOwnershipTokenId] IS NULL) THEN CAST('AUTH1 - own1|0|u' AS INT)",
+                    "    WHEN NOT EXISTS (SELECT 1 FROM [dms].[Document] d WHERE d.[DocumentId] = @documentId) THEN CAST('AUTH1 - own1|0|s' AS INT)",
+                    "    ELSE CAST('AUTH1 - own1|0|m' AS INT)",
+                    "END;"
+                )
+            );
+        plan.ParametersInOrder.Select(static parameter => parameter.ParameterName)
+            .Should()
+            .Equal(DocumentIdParameterName, "ownershipTokenIds_0", "ownershipTokenIds_1");
+    }
+
+    /// <summary>
+    /// PostgreSQL binds one array parameter whatever the token count, so the emitted SQL text does not grow
+    /// with the number of tokens and the command's parameter budget is unaffected by it.
+    /// </summary>
+    [Test]
+    public void It_binds_one_pgsql_array_parameter_however_many_tokens_there_are()
+    {
+        var compiler = new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var onePlan = compiler.Compile(Spec(Tokens(SqlDialect.Pgsql, 12)));
+        var manyPlan = compiler.Compile(Spec(Tokens(SqlDialect.Pgsql, 12, 34, 56)));
+
+        manyPlan.AuthorizationSql.Should().Be(onePlan.AuthorizationSql);
+        manyPlan
+            .ParametersInOrder.Select(static parameter => parameter.ParameterName)
+            .Should()
+            .Equal(DocumentIdParameterName, OwnershipTokenIdsParameterName);
+    }
+
+    /// <summary>
+    /// SQL Server emits one scalar per deduplicated token, in the parameterization's ascending order, so the
+    /// nth emitted placeholder always binds the nth token. Duplicates are collapsed before naming, which is
+    /// why four supplied tokens emit three placeholders.
+    /// </summary>
+    [Test]
+    public void It_binds_one_mssql_scalar_parameter_per_token_in_ascending_order()
+    {
+        var compiler = new OwnershipAuthorizationSqlCompiler(SqlDialect.Mssql);
+        var parameterization = Tokens(SqlDialect.Mssql, 7, 3, 5, 3);
+
+        var plan = compiler.Compile(Spec(parameterization));
+
+        parameterization.TokensInOrder.Should().Equal((short)3, (short)5, (short)7);
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "d.[CreatedByOwnershipTokenId] IN (@ownershipTokenIds_0, @ownershipTokenIds_1, @ownershipTokenIds_2)"
+            );
+        plan.ParametersInOrder.Select(static parameter => parameter.ParameterName)
+            .Should()
+            .Equal(
+                DocumentIdParameterName,
+                "ownershipTokenIds_0",
+                "ownershipTokenIds_1",
+                "ownershipTokenIds_2"
+            );
+    }
+
+    /// <summary>
+    /// A client configured for OwnershipBased that holds no tokens still runs the check, so §2.14 stays
+    /// distinguishable from §2.13, but its membership predicate is a constant false and it binds no token
+    /// parameter. Binding one would leave a parameter the SQL never references, which co-batching rejects as
+    /// a dangling parameter. The <c>IS NOT NULL</c> guard is deliberately retained so the emitted arm shape
+    /// does not vary with the token count.
+    /// </summary>
+    [Test]
+    public void It_renders_a_constant_false_pgsql_membership_predicate_and_binds_no_token_parameter()
+    {
+        var compiler = new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(Spec(Tokens(SqlDialect.Pgsql)));
+
+        plan.AuthorizationSql.Should()
+            .Be(
+                Sql(
+                    "SELECT CASE",
+                    "    WHEN EXISTS (SELECT 1 FROM \"dms\".\"Document\" d WHERE d.\"DocumentId\" = @documentId AND d.\"CreatedByOwnershipTokenId\" IS NOT NULL AND 1 = 0) THEN 1",
+                    "    WHEN EXISTS (SELECT 1 FROM \"dms\".\"Document\" d WHERE d.\"DocumentId\" = @documentId AND d.\"CreatedByOwnershipTokenId\" IS NULL) THEN \"dms\".\"throw_error\"('AUTH1', 'own1|0|u')",
+                    "    WHEN NOT EXISTS (SELECT 1 FROM \"dms\".\"Document\" d WHERE d.\"DocumentId\" = @documentId) THEN \"dms\".\"throw_error\"('AUTH1', 'own1|0|s')",
+                    "    ELSE \"dms\".\"throw_error\"('AUTH1', 'own1|0|m')",
+                    "END;"
+                )
+            );
+        plan.ParametersInOrder.Select(static parameter => parameter.ParameterName)
+            .Should()
+            .Equal(DocumentIdParameterName);
+    }
+
+    /// <summary>
+    /// The same empty-list rendering for SQL Server, where a constant is not merely tidier than an empty
+    /// list but required: <c>IN ()</c> is a syntax error.
+    /// </summary>
+    [Test]
+    public void It_renders_a_constant_false_mssql_membership_predicate_and_binds_no_token_parameter()
+    {
+        var compiler = new OwnershipAuthorizationSqlCompiler(SqlDialect.Mssql);
+
+        var plan = compiler.Compile(Spec(Tokens(SqlDialect.Mssql)));
+
+        plan.AuthorizationSql.Should()
+            .Be(
+                Sql(
+                    "SELECT CASE",
+                    "    WHEN EXISTS (SELECT 1 FROM [dms].[Document] d WHERE d.[DocumentId] = @documentId AND d.[CreatedByOwnershipTokenId] IS NOT NULL AND 1 = 0) THEN 1",
+                    "    WHEN EXISTS (SELECT 1 FROM [dms].[Document] d WHERE d.[DocumentId] = @documentId AND d.[CreatedByOwnershipTokenId] IS NULL) THEN CAST('AUTH1 - own1|0|u' AS INT)",
+                    "    WHEN NOT EXISTS (SELECT 1 FROM [dms].[Document] d WHERE d.[DocumentId] = @documentId) THEN CAST('AUTH1 - own1|0|s' AS INT)",
+                    "    ELSE CAST('AUTH1 - own1|0|m' AS INT)",
+                    "END;"
+                )
+            );
+        plan.ParametersInOrder.Select(static parameter => parameter.ParameterName)
+            .Should()
+            .Equal(DocumentIdParameterName);
+        plan.AuthorizationSql.Should().NotContain("IN ()");
+    }
+
+    /// <summary>
+    /// The payload carries the raw configured strategy index, not a normalized zero and not an emitted
+    /// statement ordinal, on every one of the three failure arms and on both dialects. The response mapper
+    /// attributes a denial by comparing this index with the planned check's, so an index that did not
+    /// survive compilation would either misattribute the denial or force a 500.
+    /// </summary>
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    public void It_carries_the_configured_strategy_index_into_every_payload_on_both_dialects(
+        int rawConfiguredIndex
+    )
+    {
+        var pgsqlSql = new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql)
+            .Compile(Spec(Tokens(SqlDialect.Pgsql, 12), rawConfiguredIndex))
+            .AuthorizationSql;
+        var mssqlSql = new OwnershipAuthorizationSqlCompiler(SqlDialect.Mssql)
+            .Compile(Spec(Tokens(SqlDialect.Mssql, 12), rawConfiguredIndex))
+            .AuthorizationSql;
+
+        foreach (var failureKindCode in new[] { "u", "s", "m" })
+        {
+            pgsqlSql
+                .Should()
+                .Contain($"\"dms\".\"throw_error\"('AUTH1', 'own1|{rawConfiguredIndex}|{failureKindCode}')");
+            mssqlSql.Should().Contain($"CAST('AUTH1 - own1|{rawConfiguredIndex}|{failureKindCode}' AS INT)");
+        }
+    }
+
+    /// <summary>
+    /// The row guard is the device that makes a co-batched check vacuous when nothing was captured — a POST
+    /// that resolved to a create. It must land as a trailing <c>WHERE</c> on the outer select, after
+    /// <c>END</c>, so a false guard yields an empty result set and no arm — the abort device included —
+    /// evaluates.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_appends_the_row_guard_as_a_trailing_where_clause(SqlDialect dialect)
+    {
+        var compiler = new OwnershipAuthorizationSqlCompiler(dialect);
+
+        var plan = compiler.Compile(
+            Spec(Tokens(dialect, 12), rowGuardPredicateSql: "EXISTS (SELECT 1 FROM captured)")
+        );
+
+        plan.AuthorizationSql.Should().EndWith("END WHERE EXISTS (SELECT 1 FROM captured);\n");
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_emits_no_where_clause_when_no_row_guard_is_supplied(SqlDialect dialect)
+    {
+        var compiler = new OwnershipAuthorizationSqlCompiler(dialect);
+
+        var plan = compiler.Compile(Spec(Tokens(dialect, 12)));
+
+        plan.AuthorizationSql.Should().EndWith("END;\n");
+    }
+
+    [Test]
+    public void It_throws_when_constructed_for_an_unsupported_dialect()
+    {
+        Action act = () => new OwnershipAuthorizationSqlCompiler((SqlDialect)999);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// A parameterization built for the other provider would emit that provider's membership syntax, so the
+    /// compiler refuses it rather than producing SQL the target server cannot parse.
+    /// </summary>
+    [Test]
+    public void It_rejects_a_parameterization_built_for_the_other_dialect()
+    {
+        Action pgsqlCompilerWithMssqlTokens = () =>
+            new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql).Compile(
+                Spec(Tokens(SqlDialect.Mssql, 12))
+            );
+        Action mssqlCompilerWithPgsqlTokens = () =>
+            new OwnershipAuthorizationSqlCompiler(SqlDialect.Mssql).Compile(
+                Spec(Tokens(SqlDialect.Pgsql, 12))
+            );
+
+        pgsqlCompilerWithMssqlTokens.Should().Throw<ArgumentException>();
+        mssqlCompilerWithPgsqlTokens.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void It_rejects_a_null_spec()
+    {
+        Action act = () => new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql).Compile(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void It_rejects_a_spec_with_no_check()
+    {
+        Action act = () =>
+            new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql).Compile(
+                new OwnershipAuthorizationSqlSpec(
+                    null!,
+                    Tokens(SqlDialect.Pgsql, 12),
+                    DocumentIdParameterName
+                )
+            );
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void It_rejects_a_spec_with_no_token_parameterization()
+    {
+        Action act = () =>
+            new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql).Compile(
+                new OwnershipAuthorizationSqlSpec(
+                    new OwnershipAuthorizationCheckSpec(0),
+                    null!,
+                    DocumentIdParameterName
+                )
+            );
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("@documentId")]
+    [TestCase("document id")]
+    public void It_rejects_an_invalid_document_id_parameter_name(string documentIdParameterName)
+    {
+        Action act = () =>
+            new OwnershipAuthorizationSqlCompiler(SqlDialect.Pgsql).Compile(
+                new OwnershipAuthorizationSqlSpec(
+                    new OwnershipAuthorizationCheckSpec(0),
+                    Tokens(SqlDialect.Pgsql, 12),
+                    documentIdParameterName
+                )
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipTokenParameterizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipTokenParameterizationTests.cs
@@ -227,46 +227,6 @@ public class Given_OwnershipTokenParameterizationFactory
 
         act.Should().Throw<ArgumentNullException>();
     }
-
-    // ── in-memory mirror of the emitted predicate ──────────────────────
-
-    [Test]
-    public void It_matches_a_stored_token_that_is_in_the_list()
-    {
-        var parameterization = OwnershipTokenParameterizationFactory.Create(
-            SqlDialect.Pgsql,
-            [3, 7],
-            BaseParameterName
-        );
-
-        parameterization.MatchesStoredToken(7).Should().BeTrue();
-    }
-
-    [TestCase((short)11)]
-    [TestCase(null)]
-    public void It_does_not_match_a_nonmatching_or_null_stored_token(short? storedOwnershipTokenId)
-    {
-        var parameterization = OwnershipTokenParameterizationFactory.Create(
-            SqlDialect.Pgsql,
-            [3, 7],
-            BaseParameterName
-        );
-
-        parameterization.MatchesStoredToken(storedOwnershipTokenId).Should().BeFalse();
-    }
-
-    [Test]
-    public void It_matches_nothing_when_the_token_list_is_empty()
-    {
-        var parameterization = OwnershipTokenParameterizationFactory.Create(
-            SqlDialect.Pgsql,
-            [],
-            BaseParameterName
-        );
-
-        parameterization.MatchesStoredToken(3).Should().BeFalse();
-        parameterization.MatchesStoredToken(null).Should().BeFalse();
-    }
 }
 
 [TestFixture]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipTokenParameterizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipTokenParameterizationTests.cs
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipTokenParameterizationFactory
+{
+    private const string BaseParameterName = "ownershipTokenIds";
+    private const int Limit = OwnershipTokenLimitExceededException.OwnershipTokenLimit;
+
+    private static IReadOnlyList<short> Tokens(int count) =>
+        [.. Enumerable.Range(1, count).Select(static value => (short)value)];
+
+    [Test]
+    public void It_binds_one_array_parameter_for_postgresql()
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            [7, 3, 3, 11],
+            BaseParameterName
+        );
+
+        parameterization.Kind.Should().Be(OwnershipTokenParameterizationKind.PgsqlArray);
+        parameterization.ParameterNamesInOrder.Should().Equal(BaseParameterName);
+        parameterization.TokensInOrder.Should().Equal((short)3, (short)7, (short)11);
+    }
+
+    [Test]
+    public void It_binds_one_scalar_parameter_per_token_for_sql_server()
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            [7, 3, 3, 11],
+            BaseParameterName
+        );
+
+        parameterization.Kind.Should().Be(OwnershipTokenParameterizationKind.MssqlScalar);
+        parameterization.TokensInOrder.Should().Equal((short)3, (short)7, (short)11);
+        parameterization
+            .ParameterNamesInOrder.Should()
+            .Equal("ownershipTokenIds_0", "ownershipTokenIds_1", "ownershipTokenIds_2");
+    }
+
+    /// <summary>
+    /// Deterministic binding order matters because the emitted SQL text is keyed by it: two requests with the
+    /// same token set must produce the same statement so the engine can reuse the plan.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_normalizes_tokens_to_distinct_ascending(SqlDialect dialect)
+    {
+        var first = OwnershipTokenParameterizationFactory.Create(dialect, [11, 3, 7, 3], BaseParameterName);
+        var second = OwnershipTokenParameterizationFactory.Create(dialect, [3, 7, 11, 11], BaseParameterName);
+
+        first.TokensInOrder.Should().Equal(second.TokensInOrder);
+        first.ParameterNamesInOrder.Should().Equal(second.ParameterNamesInOrder);
+    }
+
+    /// <summary>
+    /// An empty token list is a valid parameterization, not a failure: the stored-row check still runs so the
+    /// response can distinguish §2.14 from §2.13. This is where ownership deliberately differs from the
+    /// namespace prefix parameterization, whose empty case is a §2.9 preflight denial.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_accepts_an_empty_token_list(SqlDialect dialect)
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(dialect, [], BaseParameterName);
+
+        parameterization.TokensInOrder.Should().BeEmpty();
+        parameterization.MatchesNoToken.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_binds_no_scalar_parameters_for_an_empty_sql_server_token_list()
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            [],
+            BaseParameterName
+        );
+
+        parameterization.ParameterNamesInOrder.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_still_binds_the_array_parameter_for_an_empty_postgresql_token_list()
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            [],
+            BaseParameterName
+        );
+
+        parameterization.ParameterNamesInOrder.Should().Equal(BaseParameterName);
+    }
+
+    // ── the provider-independent cap ───────────────────────────────────
+
+    /// <summary>
+    /// 1,999 is the count CMS permits, so it must remain a working configuration on both providers.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_accepts_one_token_below_the_limit(SqlDialect dialect)
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            dialect,
+            Tokens(Limit - 1),
+            BaseParameterName
+        );
+
+        parameterization.TokensInOrder.Should().HaveCount(Limit - 1);
+    }
+
+    /// <summary>
+    /// The cap is provider-independent: PostgreSQL binds one array parameter and has no engine limit at this
+    /// size, but the limit is a defensive bound on the configuration rather than a dialect artifact.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_fails_closed_at_the_limit_on_every_provider(SqlDialect dialect)
+    {
+        Action act = () =>
+            OwnershipTokenParameterizationFactory.Create(dialect, Tokens(Limit), BaseParameterName);
+
+        act.Should()
+            .Throw<OwnershipTokenLimitExceededException>()
+            .Which.OwnershipTokenCount.Should()
+            .Be(Limit);
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_fails_closed_above_the_limit_on_every_provider(SqlDialect dialect)
+    {
+        Action act = () =>
+            OwnershipTokenParameterizationFactory.Create(dialect, Tokens(Limit + 500), BaseParameterName);
+
+        act.Should().Throw<OwnershipTokenLimitExceededException>();
+    }
+
+    /// <summary>
+    /// The guard reads the configured count, not the deduplicated one. A cap applied after deduplication
+    /// would be data-dependent — this input would slip through with 1,400 distinct tokens — which is the
+    /// opposite of what a defensive bound is for.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_applies_the_cap_before_deduplication(SqlDialect dialect)
+    {
+        // 2,600 configured entries whose distinct count is only 1,400.
+        List<short> withDuplicates = [.. Tokens(1400), .. Tokens(1200)];
+        withDuplicates.Should().HaveCount(2600);
+        withDuplicates.Distinct().Should().HaveCount(1400);
+
+        Action act = () =>
+            OwnershipTokenParameterizationFactory.Create(dialect, withDuplicates, BaseParameterName);
+
+        act.Should()
+            .Throw<OwnershipTokenLimitExceededException>()
+            .Which.OwnershipTokenCount.Should()
+            .Be(2600);
+    }
+
+    [Test]
+    public void It_reports_the_cap_message_without_disclosing_token_values()
+    {
+        var created = OwnershipTokenParameterizationFactory.TryCreate(
+            SqlDialect.Mssql,
+            Tokens(Limit),
+            BaseParameterName,
+            out var parameterization,
+            out var securityConfigurationMessage,
+            out var failureKind
+        );
+
+        created.Should().BeFalse();
+        parameterization.Should().BeNull();
+        failureKind.Should().Be(OwnershipTokenParameterizationFailureKind.TokenCapExceeded);
+        securityConfigurationMessage.Should().Contain(Limit.ToString(CultureInfo.InvariantCulture));
+        securityConfigurationMessage.Should().Contain("ownership tokens");
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_reports_success_through_try_create_below_the_limit(SqlDialect dialect)
+    {
+        var created = OwnershipTokenParameterizationFactory.TryCreate(
+            dialect,
+            [4, 9],
+            BaseParameterName,
+            out var parameterization,
+            out var securityConfigurationMessage,
+            out var failureKind
+        );
+
+        created.Should().BeTrue();
+        parameterization.Should().NotBeNull();
+        securityConfigurationMessage.Should().BeEmpty();
+        failureKind.Should().BeNull();
+    }
+
+    [Test]
+    public void It_rejects_an_unsupported_dialect()
+    {
+        Action act = () =>
+            OwnershipTokenParameterizationFactory.Create((SqlDialect)999, [1], BaseParameterName);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Test]
+    public void It_rejects_a_null_token_list()
+    {
+        Action act = () =>
+            OwnershipTokenParameterizationFactory.Create(SqlDialect.Pgsql, null!, BaseParameterName);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ── in-memory mirror of the emitted predicate ──────────────────────
+
+    [Test]
+    public void It_matches_a_stored_token_that_is_in_the_list()
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            [3, 7],
+            BaseParameterName
+        );
+
+        parameterization.MatchesStoredToken(7).Should().BeTrue();
+    }
+
+    [TestCase((short)11)]
+    [TestCase(null)]
+    public void It_does_not_match_a_nonmatching_or_null_stored_token(short? storedOwnershipTokenId)
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            [3, 7],
+            BaseParameterName
+        );
+
+        parameterization.MatchesStoredToken(storedOwnershipTokenId).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_matches_nothing_when_the_token_list_is_empty()
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            [],
+            BaseParameterName
+        );
+
+        parameterization.MatchesStoredToken(3).Should().BeFalse();
+        parameterization.MatchesStoredToken(null).Should().BeFalse();
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipTokenParameterizationValidator
+{
+    private const string BaseParameterName = "ownershipTokenIds";
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_accepts_a_parameterization_built_for_its_own_dialect(SqlDialect dialect)
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            dialect,
+            [3, 7],
+            BaseParameterName
+        );
+
+        Action act = () =>
+            OwnershipTokenParameterizationValidator.ValidateOrThrow(
+                parameterization,
+                dialect,
+                nameof(parameterization),
+                "Test"
+            );
+
+        act.Should().NotThrow();
+    }
+
+    [TestCase(SqlDialect.Pgsql, SqlDialect.Mssql)]
+    [TestCase(SqlDialect.Mssql, SqlDialect.Pgsql)]
+    public void It_rejects_a_parameterization_built_for_the_other_dialect(
+        SqlDialect builtFor,
+        SqlDialect validatedAgainst
+    )
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            builtFor,
+            [3, 7],
+            BaseParameterName
+        );
+
+        Action act = () =>
+            OwnershipTokenParameterizationValidator.ValidateOrThrow(
+                parameterization,
+                validatedAgainst,
+                nameof(parameterization),
+                "Test"
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_accepts_an_empty_token_list(SqlDialect dialect)
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(dialect, [], BaseParameterName);
+
+        Action act = () =>
+            OwnershipTokenParameterizationValidator.ValidateOrThrow(
+                parameterization,
+                dialect,
+                nameof(parameterization),
+                "Test"
+            );
+
+        act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// The factory cannot produce an over-limit parameterization, but a hand-constructed record can. The
+    /// validator is the SQL boundary's last guard, so it must reject one rather than let the compiler emit it.
+    /// </summary>
+    [Test]
+    public void It_rejects_a_hand_constructed_over_limit_parameterization()
+    {
+        var overLimit = new OwnershipTokenParameterization(
+            OwnershipTokenParameterizationKind.PgsqlArray,
+            BaseParameterName,
+            [
+                .. Enumerable
+                    .Range(1, OwnershipTokenLimitExceededException.OwnershipTokenLimit)
+                    .Select(static value => (short)value),
+            ],
+            [BaseParameterName]
+        );
+
+        Action act = () =>
+            OwnershipTokenParameterizationValidator.ValidateOrThrow(
+                overLimit,
+                SqlDialect.Pgsql,
+                nameof(overLimit),
+                "Test"
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void It_rejects_a_sql_server_parameterization_whose_name_count_does_not_match_its_token_count()
+    {
+        var mismatched = new OwnershipTokenParameterization(
+            OwnershipTokenParameterizationKind.MssqlScalar,
+            BaseParameterName,
+            [3, 7],
+            ["ownershipTokenIds_0"]
+        );
+
+        Action act = () =>
+            OwnershipTokenParameterizationValidator.ValidateOrThrow(
+                mismatched,
+                SqlDialect.Mssql,
+                nameof(mismatched),
+                "Test"
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void It_rejects_an_unsupported_dialect()
+    {
+        var parameterization = OwnershipTokenParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            [3],
+            BaseParameterName
+        );
+
+        Action act = () =>
+            OwnershipTokenParameterizationValidator.ValidateOrThrow(
+                parameterization,
+                (SqlDialect)999,
+                nameof(parameterization),
+                "Test"
+            );
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipTokenParameterizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/OwnershipTokenParameterizationTests.cs
@@ -3,7 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Globalization;
 using EdFi.DataManagementService.Backend.External;
 using FluentAssertions;
 using NUnit.Framework;
@@ -170,44 +169,6 @@ public class Given_OwnershipTokenParameterizationFactory
             .Throw<OwnershipTokenLimitExceededException>()
             .Which.OwnershipTokenCount.Should()
             .Be(2600);
-    }
-
-    [Test]
-    public void It_reports_the_cap_message_without_disclosing_token_values()
-    {
-        var created = OwnershipTokenParameterizationFactory.TryCreate(
-            SqlDialect.Mssql,
-            Tokens(Limit),
-            BaseParameterName,
-            out var parameterization,
-            out var securityConfigurationMessage,
-            out var failureKind
-        );
-
-        created.Should().BeFalse();
-        parameterization.Should().BeNull();
-        failureKind.Should().Be(OwnershipTokenParameterizationFailureKind.TokenCapExceeded);
-        securityConfigurationMessage.Should().Contain(Limit.ToString(CultureInfo.InvariantCulture));
-        securityConfigurationMessage.Should().Contain("ownership tokens");
-    }
-
-    [TestCase(SqlDialect.Pgsql)]
-    [TestCase(SqlDialect.Mssql)]
-    public void It_reports_success_through_try_create_below_the_limit(SqlDialect dialect)
-    {
-        var created = OwnershipTokenParameterizationFactory.TryCreate(
-            dialect,
-            [4, 9],
-            BaseParameterName,
-            out var parameterization,
-            out var securityConfigurationMessage,
-            out var failureKind
-        );
-
-        created.Should().BeTrue();
-        parameterization.Should().NotBeNull();
-        securityConfigurationMessage.Should().BeEmpty();
-        failureKind.Should().BeNull();
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadChangesAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadChangesAuthorizationPlannerTests.cs
@@ -1050,4 +1050,37 @@ public class ReadChangesAuthorizationPlannerTests
         );
 
     private static JsonPathExpression Path(string canonical) => new(canonical, []);
+
+    /// <summary>
+    /// Change queries are out of scope for DMS-1060, and their planner keeps its own allow-list rather than
+    /// consulting the relational one. An ownership-token list at or over the defensive cap must therefore
+    /// change nothing here: OwnershipBased stays a security-configuration outcome, never the relational
+    /// planner's token-cap terminal.
+    /// </summary>
+    [Test]
+    public void It_keeps_ownership_a_security_configuration_outcome_even_over_the_token_cap()
+    {
+        var outcome = Plan(
+            EdOrgResource(),
+            EdOrgTrackedTable(),
+            new RelationalAuthorizationContext(
+                [1L],
+                [],
+                creatorOwnershipTokenId: null,
+                ownershipTokenIds:
+                [
+                    .. Enumerable
+                        .Range(1, OwnershipTokenLimitExceededException.OwnershipTokenLimit)
+                        .Select(static value => (short)value),
+                ]
+            ),
+            AuthorizationStrategyNameConstants.OwnershipBased
+        );
+
+        outcome
+            .Should()
+            .BeOfType<ReadChangesAuthorizationPlanOutcome.SecurityConfiguration>()
+            .Which.UnavailableStrategyNames.Should()
+            .Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationAuth1DispatcherTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationAuth1DispatcherTests.cs
@@ -88,6 +88,126 @@ public class Given_RelationalAuthorizationAuth1Dispatcher
     }
 
     [Test]
+    public void It_routes_a_postgresql_ownership_payload_to_the_ownership_codec()
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: "own1|1|m",
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.Ownership>();
+        var ownership = (RelationalAuthorizationAuth1DispatchResult.Ownership)result!;
+        ownership.Payload.ConfiguredStrategyIndex.Should().Be(1);
+        ownership
+            .Payload.FailureKind.Should()
+            .Be(OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch);
+    }
+
+    [Test]
+    public void It_routes_a_sql_server_ownership_payload_via_the_AUTH1_dash_marker()
+    {
+        var sqlServerMessage =
+            "Conversion failed when converting the varchar value 'AUTH1 - own1|3|u' to data type int.";
+
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Mssql,
+            providerErrorCode: null,
+            providerMessage: sqlServerMessage,
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        var ownership = result
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.Ownership>()
+            .Subject;
+        ownership.Payload.ConfiguredStrategyIndex.Should().Be(3);
+        ownership
+            .Payload.FailureKind.Should()
+            .Be(OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized);
+    }
+
+    [Test]
+    public void It_routes_an_ownership_stale_target_payload_to_the_ownership_codec()
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: "own1|0|s",
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.Ownership>()
+            .Which.Payload.FailureKind.Should()
+            .Be(OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing);
+    }
+
+    /// <summary>
+    /// The relationship family's discriminator is <c>1|</c>, and <c>own1|…</c> contains it. A prefix match is
+    /// anchored, so ownership must not be claimed by the relationship codec regardless of arm order.
+    /// </summary>
+    [Test]
+    public void It_does_not_let_the_relationship_family_claim_an_ownership_payload()
+    {
+        RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: "own1|1|m",
+            out var result
+        );
+
+        result.Should().NotBeOfType<RelationalAuthorizationAuth1DispatchResult.Relationship>();
+    }
+
+    /// <summary>
+    /// Adding the ownership family must not change how the three existing families are routed.
+    /// </summary>
+    [TestCase("1|7|2|0:0:s,1:0:n", typeof(RelationalAuthorizationAuth1DispatchResult.Relationship))]
+    [TestCase("ns1|2|m", typeof(RelationalAuthorizationAuth1DispatchResult.Namespace))]
+    [TestCase("own1|2|m", typeof(RelationalAuthorizationAuth1DispatchResult.Ownership))]
+    public void It_keeps_each_family_isolated_by_discriminator(string payloadText, Type expectedResultType)
+    {
+        RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: payloadText,
+            out var result
+        );
+
+        result.Should().BeOfType(expectedResultType);
+    }
+
+    /// <summary>
+    /// An <c>own1</c> payload the codec cannot parse must still reach the caller as an invalid payload — a
+    /// security-configuration outcome — rather than being silently dropped.
+    /// </summary>
+    [TestCase("own1|0")]
+    [TestCase("own1|0|x")]
+    [TestCase("own1|-1|m")]
+    public void It_returns_invalid_payload_for_a_malformed_ownership_payload(string payloadText)
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: payloadText,
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.InvalidPayload>()
+            .Which.RawPayload.Should()
+            .Be(payloadText);
+    }
+
+    [Test]
     public void It_returns_invalid_payload_for_an_unknown_discriminator()
     {
         var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationAuth1DispatcherTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationAuth1DispatcherTests.cs
@@ -200,11 +200,12 @@ public class Given_RelationalAuthorizationAuth1Dispatcher
         );
 
         dispatched.Should().BeTrue();
-        result
+        var invalid = result
             .Should()
             .BeOfType<RelationalAuthorizationAuth1DispatchResult.InvalidPayload>()
-            .Which.RawPayload.Should()
-            .Be(payloadText);
+            .Subject;
+        invalid.RawPayload.Should().Be(payloadText);
+        invalid.RecognizedFamily.Should().Be(RelationalAuthorizationAuth1PayloadFamily.Ownership);
     }
 
     [Test]
@@ -221,6 +222,8 @@ public class Given_RelationalAuthorizationAuth1Dispatcher
         result.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.InvalidPayload>();
         var invalid = (RelationalAuthorizationAuth1DispatchResult.InvalidPayload)result!;
         invalid.RawPayload.Should().Be("v2|0|x");
+        // No known discriminator, so no family owns it and every mapper's catch-all is free to claim it.
+        invalid.RecognizedFamily.Should().BeNull();
     }
 
     [Test]
@@ -249,5 +252,102 @@ public class Given_RelationalAuthorizationAuth1Dispatcher
 
         dispatched.Should().BeFalse();
         result.Should().BeNull();
+    }
+
+    // ── dispatcher-owned family recognition ────────────────────────────
+
+    /// <summary>
+    /// A malformed payload still announces which family emitted it, so the mapper that owns the
+    /// discriminator can claim it and every other mapper can decline it without re-testing the raw prefix.
+    /// </summary>
+    /// <remarks>
+    /// The prefix tests used to be copied into each provider failure mapper, where a family added to one
+    /// copy and missed in another silently misattributed that family's malformed payloads. The dispatcher
+    /// is now the only place that decides, and this is what pins it for every family at once.
+    /// </remarks>
+    [TestCase("1|x|2|0:0:s", RelationalAuthorizationAuth1PayloadFamily.Relationship)]
+    [TestCase("1|7", RelationalAuthorizationAuth1PayloadFamily.Relationship)]
+    [TestCase("ns1|0", RelationalAuthorizationAuth1PayloadFamily.Namespace)]
+    [TestCase("ns1|0|x", RelationalAuthorizationAuth1PayloadFamily.Namespace)]
+    [TestCase("cv1|0", RelationalAuthorizationAuth1PayloadFamily.CustomView)]
+    [TestCase("cv1|0|x", RelationalAuthorizationAuth1PayloadFamily.CustomView)]
+    [TestCase("own1|0", RelationalAuthorizationAuth1PayloadFamily.Ownership)]
+    [TestCase("own1|0|x", RelationalAuthorizationAuth1PayloadFamily.Ownership)]
+    public void It_reports_the_recognized_family_of_a_malformed_known_family_payload(
+        string payloadText,
+        RelationalAuthorizationAuth1PayloadFamily expectedFamily
+    )
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: payloadText,
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        var invalid = result
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.InvalidPayload>()
+            .Subject;
+        invalid.RawPayload.Should().Be(payloadText);
+        invalid.RecognizedFamily.Should().Be(expectedFamily);
+    }
+
+    /// <summary>
+    /// A payload leading with no known discriminator is invalid with no family, which is what keeps the
+    /// mappers' catch-all diagnostics reachable for a payload nobody owns.
+    /// </summary>
+    [TestCase("v2|0|x")]
+    [TestCase("garbage")]
+    [TestCase("nsx1|0|m")]
+    [TestCase("own|0|m")]
+    public void It_reports_no_recognized_family_for_an_unknown_discriminator(string payloadText)
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: payloadText,
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.InvalidPayload>()
+            .Which.RecognizedFamily.Should()
+            .BeNull();
+    }
+
+    /// <summary>
+    /// The recognizer is exposed for the one caller that already holds an extracted payload, so it is pinned
+    /// directly too — including the anchored-prefix case that keeps <c>own1|</c> out of the relationship
+    /// family despite containing <c>1|</c>.
+    /// </summary>
+    [TestCase("1|7|2|0:0:s", RelationalAuthorizationAuth1PayloadFamily.Relationship)]
+    [TestCase("ns1|2|m", RelationalAuthorizationAuth1PayloadFamily.Namespace)]
+    [TestCase("cv1|2|m", RelationalAuthorizationAuth1PayloadFamily.CustomView)]
+    [TestCase("own1|2|m", RelationalAuthorizationAuth1PayloadFamily.Ownership)]
+    public void It_recognizes_each_family_from_a_raw_payload(
+        string payloadText,
+        RelationalAuthorizationAuth1PayloadFamily expectedFamily
+    )
+    {
+        RelationalAuthorizationAuth1Dispatcher.RecognizeFamily(payloadText).Should().Be(expectedFamily);
+    }
+
+    [TestCase("v2|0|x")]
+    [TestCase("garbage")]
+    public void It_recognizes_no_family_for_an_unknown_raw_payload(string payloadText)
+    {
+        RelationalAuthorizationAuth1Dispatcher.RecognizeFamily(payloadText).Should().BeNull();
+    }
+
+    [Test]
+    public void It_rejects_a_null_raw_payload()
+    {
+        Action act = () => RelationalAuthorizationAuth1Dispatcher.RecognizeFamily(null!);
+
+        act.Should().Throw<ArgumentNullException>();
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -204,8 +204,13 @@ public class Given_RelationalAuthorizationPlanner
         plan.NonNamespaceConfiguredStrategies.Should().Equal(relationshipStrategy);
     }
 
+    /// <summary>
+    /// Both AND strategies plan together for ReadSingle. The ownership check carries its configured index,
+    /// and it is not left among the non-namespace strategies the relationship classifier receives, which are
+    /// what a 501 would be built from.
+    /// </summary>
     [Test]
-    public void It_returns_still_unsupported_when_OwnershipBased_is_configured_alongside_NamespaceBased()
+    public void It_plans_ownership_alongside_namespace_for_read_single()
     {
         var resource = RootNamespaceResource();
 
@@ -220,11 +225,20 @@ public class Given_RelationalAuthorizationPlanner
             TwoPrefixContext()
         );
 
-        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.NamespaceChecks.Should().HaveCount(1);
+        plan.OwnershipCheck.Should().NotBeNull();
+        plan.OwnershipCheck!.RawConfiguredIndex.Should().Be(1);
+        plan.OwnershipCheck.StrategyName.Should().Be(AuthorizationStrategyNameConstants.OwnershipBased);
+        plan.NonNamespaceConfiguredStrategies.Should().BeEmpty();
     }
 
+    /// <summary>
+    /// OwnershipBased alone is a complete plan for ReadSingle. It needs neither a securable element nor a
+    /// root namespace column, because its subject is the same document column for every resource.
+    /// </summary>
     [Test]
-    public void It_returns_still_unsupported_when_OwnershipBased_is_configured_alone()
+    public void It_plans_ownership_configured_alone_for_read_single()
     {
         var resource = ResourceWithoutSecurableElements();
 
@@ -236,7 +250,10 @@ public class Given_RelationalAuthorizationPlanner
             TwoPrefixContext()
         );
 
-        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.NamespaceChecks.Should().BeEmpty();
+        plan.OwnershipCheck.Should().NotBeNull();
+        plan.OwnershipCheck!.RawConfiguredIndex.Should().Be(0);
     }
 
     // OwnershipBased is known-but-not-enabled for GET-many exactly as it is for every other operation:
@@ -364,12 +381,13 @@ public class Given_RelationalAuthorizationPlanner
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.SecurityConfigurationError>();
     }
 
-    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    /// <summary>
+    /// Update and Delete keep the known-but-not-enabled 501 until their own executors exist. This is the
+    /// fail-closed half of the ReadSingle flip: enabling one operation must not enable the others.
+    /// </summary>
     [TestCase(NamespaceAuthorizationOperation.Update)]
     [TestCase(NamespaceAuthorizationOperation.Delete)]
-    public void It_returns_still_unsupported_for_non_ReadMany_operations(
-        NamespaceAuthorizationOperation operation
-    )
+    public void It_returns_still_unsupported_for_write_operations(NamespaceAuthorizationOperation operation)
     {
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(),
@@ -488,6 +506,11 @@ public class Given_RelationalAuthorizationPlanner
         noUsableRootColumn.CustomViewStrategies.Should().ContainSingle();
     }
 
+    /// <summary>
+    /// A still-unsupported outcome carries the strategies the relationship classifier could not support so
+    /// the 501 can name them. Uses Update, where ownership is still withheld; for ReadSingle it now plans
+    /// instead, which is asserted separately.
+    /// </summary>
     [Test]
     public void It_carries_the_non_namespace_strategies_on_a_still_unsupported_outcome()
     {
@@ -497,7 +520,7 @@ public class Given_RelationalAuthorizationPlanner
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(),
             resource,
-            NamespaceAuthorizationOperation.ReadSingle,
+            NamespaceAuthorizationOperation.Update,
             [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0), ownership],
             TwoPrefixContext()
         );
@@ -822,15 +845,26 @@ public class Given_RelationalAuthorizationPlanner
     // flip each operation on, because only those commits can observe them.
 
     /// <summary>
-    /// Every operation is withheld at this point in the story. Each enforcement step adds its own operation
-    /// in the same commit that wires that operation's executor, so no commit exists in which a planned
-    /// ownership check has no executor.
+    /// ReadSingle is enforced from this commit on, and only ReadSingle. Each enforcement step adds its own
+    /// operation in the same commit that wires that operation's executor, so no commit exists in which a
+    /// planned ownership check has no executor.
     /// </summary>
-    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [Test]
+    public void It_enforces_ownership_for_read_single()
+    {
+        RelationalAuthorizationPlanner
+            .EnforcesOwnershipChecks(
+                NamespaceAuthorizationOperation.ReadSingle,
+                ResourceStorageKind.RelationalTables
+            )
+            .Should()
+            .BeTrue();
+    }
+
     [TestCase(NamespaceAuthorizationOperation.Update)]
     [TestCase(NamespaceAuthorizationOperation.Delete)]
     [TestCase(NamespaceAuthorizationOperation.ReadMany)]
-    public void It_withholds_ownership_enforcement_for_every_operation(
+    public void It_withholds_ownership_enforcement_for_every_operation_but_read_single(
         NamespaceAuthorizationOperation operation
     )
     {
@@ -880,7 +914,8 @@ public class Given_RelationalAuthorizationPlanner
     /// An over-cap ownership-token list must not produce the cap terminal while the operation is withheld:
     /// the strategy is not enforced, so there is nothing for the cap to gate. It keeps its 501.
     /// </summary>
-    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
     [TestCase(NamespaceAuthorizationOperation.ReadMany)]
     public void It_does_not_report_the_token_cap_while_the_gate_withholds_the_operation(
         NamespaceAuthorizationOperation operation
@@ -895,6 +930,58 @@ public class Given_RelationalAuthorizationPlanner
         );
 
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
+    /// <summary>
+    /// Now that ReadSingle is enforced, the cap terminal is reachable: it reports the configured token count
+    /// so an operator can see what to reduce, and never a token value.
+    /// </summary>
+    [Test]
+    public void It_reports_the_token_cap_for_read_single()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            ResourceWithoutSecurableElements(),
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
+            OverCapOwnershipContext()
+        );
+
+        var capExceeded = outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded>()
+            .Subject;
+        capExceeded.OwnershipTokenCount.Should().Be(OwnershipTokenLimitExceededException.OwnershipTokenLimit);
+        capExceeded.StrategyName.Should().Be(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    /// <summary>
+    /// The precedence carried since Phase 3 and now observable: a custom view whose basis resource cannot be
+    /// resolved is a configuration failure at a position ahead of OwnershipBased, which executes last among
+    /// the AND strategies. It must win over the cap terminal, or an over-cap token list would mask a
+    /// misconfigured view that a compliant token list would have reported.
+    /// </summary>
+    [Test]
+    public void It_reports_an_unresolved_custom_view_basis_ahead_of_the_read_single_token_cap()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            ResourceWithoutSecurableElements(),
+            NamespaceAuthorizationOperation.ReadSingle,
+            [
+                Strategy("MissingBasisWithCustomAuthorization", 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            OverCapOwnershipContext()
+        );
+
+        outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.SecurityConfigurationError>()
+            .Which.RelationshipClassification.SecurityConfigurationFailures.Should()
+            .Contain(failure =>
+                failure.FailureKind == RelationshipAuthorizationFailureKind.UnknownCustomViewBasisResource
+            );
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -1033,4 +1033,118 @@ public class Given_RelationalAuthorizationPlanner
 
         act.Should().Throw<ArgumentNullException>();
     }
+
+    // ── Out-of-scope boundaries, asserted rather than inferred from absence ─
+
+    /// <summary>
+    /// Descriptor ownership enforcement is out of scope for DMS-1060, so a descriptor configured with
+    /// OwnershipBased keeps its known-but-not-enabled 501 on every operation.
+    /// </summary>
+    /// <remarks>
+    /// The behavioral counterpart to the gate-predicate assertions above. Before ownership had a bucket of
+    /// its own this held only incidentally, because the descriptor guardrail rejects every non-namespace
+    /// strategy; splitting ownership out could have removed that with no failing test.
+    /// </remarks>
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    [TestCase(NamespaceAuthorizationOperation.ReadMany)]
+    public void It_keeps_descriptor_ownership_unsupported_for_every_operation(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor")),
+            DescriptorResource(),
+            operation,
+            [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
+            TwoPrefixContext()
+        );
+
+        var stillUnsupported = outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>()
+            .Subject;
+        stillUnsupported
+            .RelationshipClassification.KnownButNotEnabledStrategies.Select(static strategy =>
+                strategy.ConfiguredStrategy.StrategyName
+            )
+            .Should()
+            .Equal(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    /// <summary>
+    /// The descriptor boundary must not be reachable through the token cap either: an over-cap list on a
+    /// descriptor request keeps the 501 rather than becoming the cap's 500, because ownership is not
+    /// enforced there at all and so there is nothing for the cap to gate.
+    /// </summary>
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    [TestCase(NamespaceAuthorizationOperation.ReadMany)]
+    public void It_keeps_descriptor_ownership_unsupported_even_over_the_token_cap(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor")),
+            DescriptorResource(),
+            operation,
+            [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
+            OverCapOwnershipContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
+    /// <summary>
+    /// A descriptor 501 for ownership still carries the resolved custom views, so a missing or
+    /// non-conforming view keeps its own 500 instead of being masked by the 501. Ownership executes last
+    /// among the AND strategies whatever its configured position, so every view runs ahead of it.
+    /// </summary>
+    [Test]
+    public void It_carries_resolved_custom_views_on_a_descriptor_ownership_terminal()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
+            DescriptorResource(),
+            NamespaceAuthorizationOperation.ReadSingle,
+            [
+                Strategy("StudentWithCTECourseEnrollments", 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            TwoPrefixContext()
+        );
+
+        var stillUnsupported = outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>()
+            .Subject;
+        stillUnsupported
+            .RelationshipClassification.SupportedCustomViewStrategies.Should()
+            .ContainSingle()
+            .Which.ConfiguredStrategy.StrategyName.Should()
+            .Be("StudentWithCTECourseEnrollments");
+    }
+
+    /// <summary>
+    /// GET-many ownership filtering belongs to DMS-1410. An over-cap token list must not turn that 501 into
+    /// the cap's 500 — the strategy is not enforced for ReadMany, so the cap has nothing to gate.
+    /// </summary>
+    [Test]
+    public void It_keeps_read_many_ownership_unsupported_even_over_the_token_cap()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            ResourceWithoutSecurableElements(),
+            NamespaceAuthorizationOperation.ReadMany,
+            [
+                Strategy(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly, 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            OverCapOwnershipContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -813,4 +813,122 @@ public class Given_RelationalAuthorizationPlanner
         var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
         plan.NonNamespaceConfiguredStrategies.Should().Equal(rwedoo, rwedooi);
     }
+
+    // ── DMS-1060 ownership enablement gate ──────────────────────────────
+    //
+    // The gate withholds every operation in this step, so no plan outcome can distinguish an enforced
+    // combination from a withheld one. These assert the predicate directly; the behavioral assertions
+    // (a planned OwnershipCheck, and the token-cap terminal's precedence) belong to the commits that
+    // flip each operation on, because only those commits can observe them.
+
+    /// <summary>
+    /// Every operation is withheld at this point in the story. Each enforcement step adds its own operation
+    /// in the same commit that wires that operation's executor, so no commit exists in which a planned
+    /// ownership check has no executor.
+    /// </summary>
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    [TestCase(NamespaceAuthorizationOperation.ReadMany)]
+    public void It_withholds_ownership_enforcement_for_every_operation(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        RelationalAuthorizationPlanner
+            .EnforcesOwnershipChecks(operation, ResourceStorageKind.RelationalTables)
+            .Should()
+            .BeFalse();
+    }
+
+    /// <summary>
+    /// Descriptor storage is withheld permanently for this story. Before ownership had a bucket of its own,
+    /// descriptors were protected only incidentally — by the descriptor guardrail rejecting every
+    /// non-namespace strategy — so splitting ownership out would have removed that protection silently.
+    /// This is the named replacement.
+    /// </summary>
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    [TestCase(NamespaceAuthorizationOperation.ReadMany)]
+    public void It_withholds_ownership_enforcement_for_descriptor_storage(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        RelationalAuthorizationPlanner
+            .EnforcesOwnershipChecks(operation, ResourceStorageKind.SharedDescriptorTable)
+            .Should()
+            .BeFalse();
+    }
+
+    /// <summary>
+    /// The descriptor arm must not depend on the operation set: it has to keep withholding even once every
+    /// single-record operation has been flipped on for relational resources.
+    /// </summary>
+    [Test]
+    public void It_withholds_descriptor_ownership_enforcement_independently_of_the_operation_set()
+    {
+        foreach (var operation in Enum.GetValues<NamespaceAuthorizationOperation>())
+        {
+            RelationalAuthorizationPlanner
+                .EnforcesOwnershipChecks(operation, ResourceStorageKind.SharedDescriptorTable)
+                .Should()
+                .BeFalse($"descriptor storage must never enforce ownership in this story ({operation})");
+        }
+    }
+
+    /// <summary>
+    /// An over-cap ownership-token list must not produce the cap terminal while the operation is withheld:
+    /// the strategy is not enforced, so there is nothing for the cap to gate. It keeps its 501.
+    /// </summary>
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.ReadMany)]
+    public void It_does_not_report_the_token_cap_while_the_gate_withholds_the_operation(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            ResourceWithoutSecurableElements(),
+            operation,
+            [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
+            OverCapOwnershipContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
+    /// <summary>
+    /// A plan produced for a request with no ownership strategy carries no ownership check — the property
+    /// defaults to null rather than to an empty-but-present plan.
+    /// </summary>
+    [Test]
+    public void It_plans_no_ownership_check_when_ownership_is_not_configured()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            RootNamespaceResource(),
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0)],
+            TwoPrefixContext()
+        );
+
+        outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.Plan>()
+            .Which.OwnershipCheck.Should()
+            .BeNull();
+    }
+
+    private static RelationalAuthorizationContext OverCapOwnershipContext() =>
+        new(
+            [],
+            ["uri://ed-fi.org/"],
+            creatorOwnershipTokenId: null,
+            ownershipTokenIds:
+            [
+                .. Enumerable
+                    .Range(1, OwnershipTokenLimitExceededException.OwnershipTokenLimit)
+                    .Select(static value => (short)value),
+            ]
+        );
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -841,9 +841,9 @@ public class Given_RelationalAuthorizationPlanner
 
     // ── DMS-1060 ownership enablement gate ──────────────────────────────
     //
-    // ReadSingle is enforced; every other operation is still withheld. The predicate is asserted directly
-    // as well as through plan outcomes, because a withheld operation produces the same 501 whether the gate
-    // withheld it or the classifier never saw it, and only the predicate separates those.
+    // ReadSingle and Delete are enforced; Update and ReadMany are still withheld. The predicate is asserted
+    // directly as well as through plan outcomes, because a withheld operation produces the same 501 whether
+    // the gate withheld it or the classifier never saw it, and only the predicate separates those.
 
     /// <summary>
     /// The operations enforced so far, and only those. Each enforcement step adds its own operation in the

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -104,6 +104,42 @@ public class Given_RelationalAuthorizationPlanner
         );
     }
 
+    /// <summary>
+    /// A descriptor-storage resource whose namespace column resolves, so the namespace planner reaches its
+    /// no-prefixes terminal instead of stopping at <c>NoUsableRootColumn</c>. Descriptors carry no securable
+    /// element metadata; their Namespace column comes from the descriptor column contract.
+    /// </summary>
+    private static ConcreteResourceModel NamespaceableDescriptorResource()
+    {
+        var root = RootTable("SchoolTypeDescriptor", []);
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "SchoolTypeDescriptor"),
+            _edfiSchema,
+            ResourceStorageKind.SharedDescriptorTable,
+            root,
+            [root],
+            [],
+            []
+        );
+        return new ConcreteResourceModel(
+            ResourceKey(4, "SchoolTypeDescriptor"),
+            ResourceStorageKind.SharedDescriptorTable,
+            model,
+            new DescriptorMetadata(
+                new DescriptorColumnContract(
+                    Col("Namespace"),
+                    Col("CodeValue"),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                ),
+                DiscriminatorStrategy.ResourceKeyId
+            )
+        );
+    }
+
     private static MappingSet EmptyMappingSet(params ResourceKeyEntry[] resourceKeysInIdOrder) =>
         new(
             Key: new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
@@ -1241,5 +1277,124 @@ public class Given_RelationalAuthorizationPlanner
         );
 
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
+    /// <summary>
+    /// The descriptor ownership boundary must not be maskable by the namespace no-prefixes 403. Descriptor
+    /// ownership enforcement is out of scope for DMS-1060, so GET-by-id, the write verbs, and DELETE fail
+    /// closed with the known-but-not-enabled 501 even when <c>NamespaceBased</c> is configured alongside it
+    /// and the caller has no namespace prefixes.
+    /// </summary>
+    /// <remarks>
+    /// Without the descriptor arm the namespace terminal is reported first and the descriptor handlers turn
+    /// it into a namespace 403, which says the caller's prefixes refused the request rather than that
+    /// descriptor ownership is not implemented.
+    /// </remarks>
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    public void It_keeps_descriptor_ownership_unsupported_ahead_of_the_namespace_no_prefixes_terminal(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor")),
+            NamespaceableDescriptorResource(),
+            operation,
+            [
+                Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            EmptyPrefixContext()
+        );
+
+        var stillUnsupported = outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>()
+            .Subject;
+        stillUnsupported
+            .RelationshipClassification.KnownButNotEnabledStrategies.Select(static strategy =>
+                strategy.ConfiguredStrategy.StrategyName
+            )
+            .Should()
+            .Equal(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    /// <summary>
+    /// The same descriptor terminal still carries the resolved custom views, so a view configured ahead of
+    /// it keeps its own configuration failure rather than being masked by the 501.
+    /// </summary>
+    [Test]
+    public void It_carries_resolved_custom_views_on_a_descriptor_ownership_terminal_over_the_namespace_terminal()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor"), ResourceKey(3, "Student")),
+            NamespaceableDescriptorResource(),
+            NamespaceAuthorizationOperation.ReadSingle,
+            [
+                Strategy("StudentWithCTECourseEnrollments", 0),
+                Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 1),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 2),
+            ],
+            EmptyPrefixContext()
+        );
+
+        var stillUnsupported = outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>()
+            .Subject;
+        stillUnsupported
+            .RelationshipClassification.SupportedCustomViewStrategies.Should()
+            .ContainSingle()
+            .Which.ConfiguredStrategy.StrategyName.Should()
+            .Be("StudentWithCTECourseEnrollments");
+    }
+
+    /// <summary>
+    /// Descriptor GET-many is left exactly as it was. Ownership filtering for GET-many belongs to DMS-1410,
+    /// so the namespace no-prefixes 403 stays the reported terminal there — the descriptor arm covers only
+    /// the single-record operations the ownership gate would otherwise enforce.
+    /// </summary>
+    [Test]
+    public void It_keeps_the_namespace_no_prefixes_terminal_for_a_descriptor_read_many()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor")),
+            NamespaceableDescriptorResource(),
+            NamespaceAuthorizationOperation.ReadMany,
+            [
+                Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            EmptyPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.NoPrefixesConfigured>();
+    }
+
+    /// <summary>
+    /// Regular resources are left exactly as they were: ownership is enforced there, so the namespace
+    /// no-prefixes 403 still outranks it — Namespace-based executes ahead of Ownership-based among the AND
+    /// strategies. The descriptor arm must not generalize to relational storage.
+    /// </summary>
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    public void It_keeps_the_namespace_no_prefixes_terminal_for_a_regular_resource_with_ownership(
+        NamespaceAuthorizationOperation operation
+    )
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(1, "AcademicWeek")),
+            RootNamespaceResource(),
+            operation,
+            [
+                Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            EmptyPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.NoPrefixesConfigured>();
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -839,10 +839,9 @@ public class Given_RelationalAuthorizationPlanner
 
     // ── DMS-1060 ownership enablement gate ──────────────────────────────
     //
-    // The gate withholds every operation in this step, so no plan outcome can distinguish an enforced
-    // combination from a withheld one. These assert the predicate directly; the behavioral assertions
-    // (a planned OwnershipCheck, and the token-cap terminal's precedence) belong to the commits that
-    // flip each operation on, because only those commits can observe them.
+    // ReadSingle is enforced; every other operation is still withheld. The predicate is asserted directly
+    // as well as through plan outcomes, because a withheld operation produces the same 501 whether the gate
+    // withheld it or the classifier never saw it, and only the predicate separates those.
 
     /// <summary>
     /// ReadSingle is enforced from this commit on, and only ReadSingle. Each enforcement step adds its own

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -969,6 +969,30 @@ public class Given_RelationalAuthorizationPlanner
     }
 
     /// <summary>
+    /// The other direction of the same precedence, and the half no test held: a relationship configuration
+    /// failure executes in the OR group, after every AND strategy, so the ownership cap terminal displaces
+    /// it. Asserted through <c>Plan</c> rather than through the predicate, because the predicate is consulted
+    /// at two call sites and only a plan outcome says the live one honoured its answer.
+    /// </summary>
+    [Test]
+    public void It_reports_the_token_cap_ahead_of_a_relationship_configuration_failure()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            ResourceWithoutSecurableElements(),
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy("MadeUpStrategy", 0), Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1)],
+            OverCapOwnershipContext()
+        );
+
+        outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded>()
+            .Which.OwnershipTokenCount.Should()
+            .Be(OwnershipTokenLimitExceededException.OwnershipTokenLimit);
+    }
+
+    /// <summary>
     /// A plan produced for a request with no ownership strategy carries no ownership check — the property
     /// defaults to null rather than to an empty-but-present plan.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -931,4 +931,106 @@ public class Given_RelationalAuthorizationPlanner
                     .Select(static value => (short)value),
             ]
         );
+
+    // ── Ownership cap versus classifier security-configuration failures ─
+    //
+    // The classifier's SecurityConfigurationError bucket is not purely relationship failures: it also
+    // carries custom view-based strategy-resolution failures. Those are AND-strategy failures that
+    // execute ahead of Ownership-based, so the cap must not displace them. Asserted on the predicate
+    // because the enablement gate makes it unobservable through a plan outcome; the behavioral
+    // assertion belongs to the first gate-flip commit.
+
+    private static RelationshipAuthorizationFailureMetadata Failure(
+        RelationshipAuthorizationFailureKind failureKind
+    ) => new(failureKind, new QualifiedResourceName("Ed-Fi", "PlainResource"));
+
+    /// <summary>
+    /// The regression this pins: a custom-view configuration failure must keep its own 500 rather than
+    /// being replaced by the ownership token-cap terminal. Every custom view executes ahead of
+    /// Ownership-based among the AND strategies, whatever position CMS gave either.
+    /// </summary>
+    [TestCase(RelationshipAuthorizationFailureKind.UnknownCustomViewBasisResource)]
+    [TestCase(RelationshipAuthorizationFailureKind.NoCustomViewJoinPath)]
+    [TestCase(RelationshipAuthorizationFailureKind.MissingProposedCustomViewRootBinding)]
+    public void It_does_not_let_the_ownership_cap_displace_a_custom_view_configuration_failure(
+        RelationshipAuthorizationFailureKind failureKind
+    )
+    {
+        RelationalAuthorizationPlanner
+            .OwnershipCapOutranksClassifierFailure(ownershipCapExceeded: true, [Failure(failureKind)])
+            .Should()
+            .BeFalse();
+    }
+
+    /// <summary>
+    /// A relationship or otherwise generic failure does yield to the cap: the relationship OR group
+    /// executes after every AND strategy.
+    /// </summary>
+    [TestCase(RelationshipAuthorizationFailureKind.InvalidAuthorizationStrategy)]
+    [TestCase(RelationshipAuthorizationFailureKind.UnresolvedSecurableElement)]
+    [TestCase(RelationshipAuthorizationFailureKind.NoApplicableRootSubject)]
+    [TestCase(RelationshipAuthorizationFailureKind.MissingPeopleAuthViewAssociations)]
+    public void It_lets_the_ownership_cap_displace_a_relationship_configuration_failure(
+        RelationshipAuthorizationFailureKind failureKind
+    )
+    {
+        RelationalAuthorizationPlanner
+            .OwnershipCapOutranksClassifierFailure(ownershipCapExceeded: true, [Failure(failureKind)])
+            .Should()
+            .BeTrue();
+    }
+
+    /// <summary>
+    /// A single custom-view failure is enough to hold the cap back, even alongside relationship failures:
+    /// the earliest-executing failure is the one reported.
+    /// </summary>
+    [Test]
+    public void It_holds_the_cap_back_when_a_custom_view_failure_accompanies_relationship_failures()
+    {
+        RelationalAuthorizationPlanner
+            .OwnershipCapOutranksClassifierFailure(
+                ownershipCapExceeded: true,
+                [
+                    Failure(RelationshipAuthorizationFailureKind.InvalidAuthorizationStrategy),
+                    Failure(RelationshipAuthorizationFailureKind.UnknownCustomViewBasisResource),
+                ]
+            )
+            .Should()
+            .BeFalse();
+    }
+
+    /// <summary>
+    /// With no cap breach there is nothing to displace anything, whatever the failures say.
+    /// </summary>
+    [Test]
+    public void It_never_outranks_anything_when_the_cap_is_not_exceeded()
+    {
+        RelationalAuthorizationPlanner
+            .OwnershipCapOutranksClassifierFailure(
+                ownershipCapExceeded: false,
+                [Failure(RelationshipAuthorizationFailureKind.InvalidAuthorizationStrategy)]
+            )
+            .Should()
+            .BeFalse();
+    }
+
+    /// <summary>
+    /// An over-cap breach with no classifier failure at all leaves the cap free to be the terminal.
+    /// </summary>
+    [Test]
+    public void It_outranks_an_empty_failure_list_when_the_cap_is_exceeded()
+    {
+        RelationalAuthorizationPlanner
+            .OwnershipCapOutranksClassifierFailure(ownershipCapExceeded: true, [])
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    public void It_rejects_a_null_failure_list()
+    {
+        Action act = () => RelationalAuthorizationPlanner.OwnershipCapOutranksClassifierFailure(true, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -1029,6 +1029,71 @@ public class Given_RelationalAuthorizationPlanner
     }
 
     /// <summary>
+    /// A caller that resolves its target in-session — POST — cannot know at planning time whether the cap
+    /// applies, because a create never parameterizes the list. Asked to defer, the planner hands back the plan
+    /// with the ownership check in it instead of the cap terminal; the caller owes the failure only once the
+    /// target proves to exist.
+    /// </summary>
+    [Test]
+    public void It_hands_back_the_plan_when_the_token_cap_is_deferred_to_target_resolution()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            ResourceWithoutSecurableElements(),
+            NamespaceAuthorizationOperation.Update,
+            [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
+            OverCapOwnershipContext(),
+            OwnershipTokenCapHandling.DeferToTargetResolution
+        );
+
+        outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.Plan>()
+            .Which.OwnershipCheck.Should()
+            .Be(new OwnershipAuthorizationCheckSpec(0));
+    }
+
+    /// <summary>
+    /// Deferred, the cap is not a planning fact, so it displaces nothing: a relationship configuration failure
+    /// keeps its own 500 rather than yielding to a cap that a create would never have reached. The intentional
+    /// counterpart of <see cref="It_reports_the_token_cap_ahead_of_a_relationship_configuration_failure"/>,
+    /// and pinned again at the repository level for POST.
+    /// </summary>
+    [Test]
+    public void It_lets_a_relationship_configuration_failure_stand_when_the_token_cap_is_deferred()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            ResourceWithoutSecurableElements(),
+            NamespaceAuthorizationOperation.Update,
+            [Strategy("MadeUpStrategy", 0), Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1)],
+            OverCapOwnershipContext(),
+            OwnershipTokenCapHandling.DeferToTargetResolution
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.SecurityConfigurationError>();
+    }
+
+    /// <summary>
+    /// Deferral changes only how the cap is reported; it cannot open the descriptor boundary. A descriptor
+    /// write asked to defer keeps its 501, because ownership is not enforced there at all.
+    /// </summary>
+    [Test]
+    public void It_keeps_descriptor_ownership_unsupported_when_the_token_cap_is_deferred()
+    {
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(ResourceKey(4, "SchoolTypeDescriptor")),
+            DescriptorResource(),
+            NamespaceAuthorizationOperation.Update,
+            [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
+            OverCapOwnershipContext(),
+            OwnershipTokenCapHandling.DeferToTargetResolution
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
+    /// <summary>
     /// A plan produced for a request with no ownership strategy carries no ownership check — the property
     /// defaults to null rather than to an empty-but-present plan.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -238,6 +238,7 @@ public class Given_RelationalAuthorizationPlanner
     /// root namespace column, because its subject is the same document column for every resource.
     /// </summary>
     [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
     [TestCase(NamespaceAuthorizationOperation.Delete)]
     public void It_plans_ownership_configured_alone_for_an_enforced_operation(
         NamespaceAuthorizationOperation operation
@@ -384,24 +385,6 @@ public class Given_RelationalAuthorizationPlanner
         outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.SecurityConfigurationError>();
     }
 
-    /// <summary>
-    /// Update keeps the known-but-not-enabled 501 until Phase 6 wires the write path. This is the fail-closed
-    /// half of each flip: enabling one operation must not enable the others.
-    /// </summary>
-    [TestCase(NamespaceAuthorizationOperation.Update)]
-    public void It_returns_still_unsupported_for_update(NamespaceAuthorizationOperation operation)
-    {
-        var outcome = RelationalAuthorizationPlanner.Plan(
-            EmptyMappingSet(),
-            ResourceWithoutSecurableElements(),
-            operation,
-            [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
-            TwoPrefixContext()
-        );
-
-        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
-    }
-
     [TestCase(NamespaceAuthorizationOperation.ReadSingle, false)]
     [TestCase(NamespaceAuthorizationOperation.ReadSingle, true)]
     [TestCase(NamespaceAuthorizationOperation.Delete, false)]
@@ -510,8 +493,8 @@ public class Given_RelationalAuthorizationPlanner
 
     /// <summary>
     /// A still-unsupported outcome carries the strategies the relationship classifier could not support so
-    /// the 501 can name them. Uses Update, where ownership is still withheld; for ReadSingle it now plans
-    /// instead, which is asserted separately.
+    /// the 501 can name them. Uses ReadMany, the only operation that still withholds OwnershipBased: every
+    /// single-record operation now plans it instead, which is asserted separately.
     /// </summary>
     [Test]
     public void It_carries_the_non_namespace_strategies_on_a_still_unsupported_outcome()
@@ -522,7 +505,7 @@ public class Given_RelationalAuthorizationPlanner
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(),
             resource,
-            NamespaceAuthorizationOperation.Update,
+            NamespaceAuthorizationOperation.ReadMany,
             [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0), ownership],
             TwoPrefixContext()
         );
@@ -841,16 +824,17 @@ public class Given_RelationalAuthorizationPlanner
 
     // ── DMS-1060 ownership enablement gate ──────────────────────────────
     //
-    // ReadSingle and Delete are enforced; Update and ReadMany are still withheld. The predicate is asserted
-    // directly as well as through plan outcomes, because a withheld operation produces the same 501 whether
-    // the gate withheld it or the classifier never saw it, and only the predicate separates those.
+    // Every single-record operation is enforced; ReadMany is withheld for the whole story. The predicate is
+    // asserted directly as well as through plan outcomes, because a withheld operation produces the same 501
+    // whether the gate withheld it or the classifier never saw it, and only the predicate separates those.
 
     /// <summary>
-    /// The operations enforced so far, and only those. Each enforcement step adds its own operation in the
-    /// same commit that wires that operation's executor, so no commit exists in which a planned ownership
-    /// check has no executor.
+    /// Every single-record operation, and only those. Each enforcement step added its own operation in the
+    /// same commit that wired that operation's executor, so no commit existed in which a planned ownership
+    /// check had no executor.
     /// </summary>
     [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
     [TestCase(NamespaceAuthorizationOperation.Delete)]
     public void It_enforces_ownership_for_the_enabled_operations(NamespaceAuthorizationOperation operation)
     {
@@ -860,14 +844,18 @@ public class Given_RelationalAuthorizationPlanner
             .BeTrue();
     }
 
-    [TestCase(NamespaceAuthorizationOperation.Update)]
-    [TestCase(NamespaceAuthorizationOperation.ReadMany)]
-    public void It_withholds_ownership_enforcement_for_the_operations_still_out_of_scope(
-        NamespaceAuthorizationOperation operation
-    )
+    /// <summary>
+    /// ReadMany is the only operation left withheld, and permanently: GET-many ownership filtering is
+    /// DMS-1410's, and it is a page filter rather than a single-record check.
+    /// </summary>
+    [Test]
+    public void It_withholds_ownership_enforcement_for_read_many()
     {
         RelationalAuthorizationPlanner
-            .EnforcesOwnershipChecks(operation, ResourceStorageKind.RelationalTables)
+            .EnforcesOwnershipChecks(
+                NamespaceAuthorizationOperation.ReadMany,
+                ResourceStorageKind.RelationalTables
+            )
             .Should()
             .BeFalse();
     }
@@ -912,16 +900,13 @@ public class Given_RelationalAuthorizationPlanner
     /// An over-cap ownership-token list must not produce the cap terminal while the operation is withheld:
     /// the strategy is not enforced, so there is nothing for the cap to gate. It keeps its 501.
     /// </summary>
-    [TestCase(NamespaceAuthorizationOperation.Update)]
-    [TestCase(NamespaceAuthorizationOperation.ReadMany)]
-    public void It_does_not_report_the_token_cap_while_the_gate_withholds_the_operation(
-        NamespaceAuthorizationOperation operation
-    )
+    [Test]
+    public void It_does_not_report_the_token_cap_while_the_gate_withholds_read_many()
     {
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(),
             ResourceWithoutSecurableElements(),
-            operation,
+            NamespaceAuthorizationOperation.ReadMany,
             [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
             OverCapOwnershipContext()
         );
@@ -934,6 +919,7 @@ public class Given_RelationalAuthorizationPlanner
     /// an operator can see what to reduce, and never a token value.
     /// </summary>
     [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Update)]
     [TestCase(NamespaceAuthorizationOperation.Delete)]
     public void It_reports_the_token_cap_for_an_enforced_operation(NamespaceAuthorizationOperation operation)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -237,15 +237,18 @@ public class Given_RelationalAuthorizationPlanner
     /// OwnershipBased alone is a complete plan for ReadSingle. It needs neither a securable element nor a
     /// root namespace column, because its subject is the same document column for every resource.
     /// </summary>
-    [Test]
-    public void It_plans_ownership_configured_alone_for_read_single()
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    public void It_plans_ownership_configured_alone_for_an_enforced_operation(
+        NamespaceAuthorizationOperation operation
+    )
     {
         var resource = ResourceWithoutSecurableElements();
 
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(),
             resource,
-            NamespaceAuthorizationOperation.ReadSingle,
+            operation,
             [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
             TwoPrefixContext()
         );
@@ -382,12 +385,11 @@ public class Given_RelationalAuthorizationPlanner
     }
 
     /// <summary>
-    /// Update and Delete keep the known-but-not-enabled 501 until their own executors exist. This is the
-    /// fail-closed half of the ReadSingle flip: enabling one operation must not enable the others.
+    /// Update keeps the known-but-not-enabled 501 until Phase 6 wires the write path. This is the fail-closed
+    /// half of each flip: enabling one operation must not enable the others.
     /// </summary>
     [TestCase(NamespaceAuthorizationOperation.Update)]
-    [TestCase(NamespaceAuthorizationOperation.Delete)]
-    public void It_returns_still_unsupported_for_write_operations(NamespaceAuthorizationOperation operation)
+    public void It_returns_still_unsupported_for_update(NamespaceAuthorizationOperation operation)
     {
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(),
@@ -844,26 +846,23 @@ public class Given_RelationalAuthorizationPlanner
     // withheld it or the classifier never saw it, and only the predicate separates those.
 
     /// <summary>
-    /// ReadSingle is enforced from this commit on, and only ReadSingle. Each enforcement step adds its own
-    /// operation in the same commit that wires that operation's executor, so no commit exists in which a
-    /// planned ownership check has no executor.
+    /// The operations enforced so far, and only those. Each enforcement step adds its own operation in the
+    /// same commit that wires that operation's executor, so no commit exists in which a planned ownership
+    /// check has no executor.
     /// </summary>
-    [Test]
-    public void It_enforces_ownership_for_read_single()
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    public void It_enforces_ownership_for_the_enabled_operations(NamespaceAuthorizationOperation operation)
     {
         RelationalAuthorizationPlanner
-            .EnforcesOwnershipChecks(
-                NamespaceAuthorizationOperation.ReadSingle,
-                ResourceStorageKind.RelationalTables
-            )
+            .EnforcesOwnershipChecks(operation, ResourceStorageKind.RelationalTables)
             .Should()
             .BeTrue();
     }
 
     [TestCase(NamespaceAuthorizationOperation.Update)]
-    [TestCase(NamespaceAuthorizationOperation.Delete)]
     [TestCase(NamespaceAuthorizationOperation.ReadMany)]
-    public void It_withholds_ownership_enforcement_for_every_operation_but_read_single(
+    public void It_withholds_ownership_enforcement_for_the_operations_still_out_of_scope(
         NamespaceAuthorizationOperation operation
     )
     {
@@ -914,7 +913,6 @@ public class Given_RelationalAuthorizationPlanner
     /// the strategy is not enforced, so there is nothing for the cap to gate. It keeps its 501.
     /// </summary>
     [TestCase(NamespaceAuthorizationOperation.Update)]
-    [TestCase(NamespaceAuthorizationOperation.Delete)]
     [TestCase(NamespaceAuthorizationOperation.ReadMany)]
     public void It_does_not_report_the_token_cap_while_the_gate_withholds_the_operation(
         NamespaceAuthorizationOperation operation
@@ -932,16 +930,17 @@ public class Given_RelationalAuthorizationPlanner
     }
 
     /// <summary>
-    /// Now that ReadSingle is enforced, the cap terminal is reachable: it reports the configured token count
-    /// so an operator can see what to reduce, and never a token value.
+    /// The cap terminal is reachable for every enforced operation: it reports the configured token count so
+    /// an operator can see what to reduce, and never a token value.
     /// </summary>
-    [Test]
-    public void It_reports_the_token_cap_for_read_single()
+    [TestCase(NamespaceAuthorizationOperation.ReadSingle)]
+    [TestCase(NamespaceAuthorizationOperation.Delete)]
+    public void It_reports_the_token_cap_for_an_enforced_operation(NamespaceAuthorizationOperation operation)
     {
         var outcome = RelationalAuthorizationPlanner.Plan(
             EmptyMappingSet(),
             ResourceWithoutSecurableElements(),
-            NamespaceAuthorizationOperation.ReadSingle,
+            operation,
             [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
             OverCapOwnershipContext()
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationAuth1FailurePayload.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationAuth1FailurePayload.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Runtime failure kinds encoded in the compact AUTH1 ownership-authorization payload.
+/// </summary>
+/// <remarks>
+/// There is no "no ownership tokens configured" kind. A caller holding an empty ownership-token list still
+/// executes the stored-row check, so that the response can distinguish a stored null from a non-matching
+/// stored value rather than guessing before the row is read. There is likewise no cap-exceeded kind: the
+/// defensive token limit is a planner terminal reported before any statement is emitted.
+/// </remarks>
+public enum OwnershipAuthorizationAuth1FailureKind
+{
+    /// <summary>
+    /// The stored <c>CreatedByOwnershipTokenId</c> is non-null and matches none of the caller's tokens.
+    /// </summary>
+    OwnershipTokenMismatch,
+
+    /// <summary>The stored <c>CreatedByOwnershipTokenId</c> is null.</summary>
+    StoredOwnershipTokenUninitialized,
+
+    /// <summary>
+    /// The stored target row no longer exists. The row was deleted between the unlocked target lookup and
+    /// the ownership check, so the check has nothing to authorize. Read paths re-resolve the target and
+    /// surface the resulting 404; locked write/delete paths never observe this because the row is row-locked
+    /// before the check runs.
+    /// </summary>
+    StoredTargetMissing,
+}
+
+/// <summary>
+/// Provider-independent AUTH1 failure payload for the failed ownership authorization check.
+/// </summary>
+/// <remarks>
+/// Carries the <em>configured</em> strategy index rather than an emitted statement ordinal. Ownership emits
+/// exactly one check per operation, so an emitted ordinal would be a constant zero carrying no information,
+/// while the configured index identifies which configured strategy denied the request — which is what the
+/// AUTH1 design asks the index to do. The namespace and custom view-based codecs carry emitted ordinals
+/// because they emit several checks per request that share one provider exception.
+/// </remarks>
+public sealed record OwnershipAuthorizationAuth1FailurePayload
+{
+    public OwnershipAuthorizationAuth1FailurePayload(
+        int configuredStrategyIndex,
+        OwnershipAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        if (configuredStrategyIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(configuredStrategyIndex),
+                configuredStrategyIndex,
+                "Configured strategy index cannot be negative."
+            );
+        }
+
+        ConfiguredStrategyIndex = configuredStrategyIndex;
+        FailureKind = failureKind;
+    }
+
+    /// <summary>
+    /// Zero-based position of <c>OwnershipBased</c> in the CMS-configured strategy list for this request.
+    /// </summary>
+    public int ConfiguredStrategyIndex { get; init; }
+
+    public OwnershipAuthorizationAuth1FailureKind FailureKind { get; init; }
+}
+
+/// <summary>
+/// Encodes and parses the compact AUTH1 ownership-authorization payload (<c>own1|configuredIndex|kind</c>).
+/// </summary>
+/// <remarks>
+/// The payload shares the AUTH1 SqlState / message-prefix transport with the relationship, namespace and
+/// custom view-based codecs, but carries a distinct <c>own1</c> discriminator so a dispatcher can route each
+/// payload to the correct codec without any existing payload shape changing.
+/// </remarks>
+public static class OwnershipAuthorizationAuth1FailurePayloadCodec
+{
+    public const string ProviderFailureCode = "AUTH1";
+    public const string PayloadDiscriminator = "own1";
+
+    public static string Encode(OwnershipAuthorizationAuth1FailurePayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{PayloadDiscriminator}|{payload.ConfiguredStrategyIndex}|{EncodeFailureKind(payload.FailureKind)}"
+        );
+    }
+
+    public static bool TryParsePayload(
+        string payloadText,
+        out OwnershipAuthorizationAuth1FailurePayload? payload
+    )
+    {
+        payload = null;
+
+        if (string.IsNullOrWhiteSpace(payloadText))
+        {
+            return false;
+        }
+
+        var payloadSections = payloadText.Split('|');
+
+        if (
+            payloadSections.Length is not 3
+            || !string.Equals(payloadSections[0], PayloadDiscriminator, StringComparison.Ordinal)
+            || !TryParseNonNegativeInt(payloadSections[1], out var configuredStrategyIndex)
+            || !TryDecodeFailureKind(payloadSections[2], out var failureKind)
+        )
+        {
+            return false;
+        }
+
+        payload = new OwnershipAuthorizationAuth1FailurePayload(configuredStrategyIndex, failureKind);
+        return true;
+    }
+
+    private static bool TryParseNonNegativeInt(string text, out int value)
+    {
+        if (int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value) && value >= 0)
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static string EncodeFailureKind(OwnershipAuthorizationAuth1FailureKind failureKind) =>
+        failureKind switch
+        {
+            OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch => "m",
+            OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized => "u",
+            OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing => "s",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failureKind),
+                failureKind,
+                "Unsupported AUTH1 ownership failure kind."
+            ),
+        };
+
+    private static bool TryDecodeFailureKind(
+        string failureKindCode,
+        out OwnershipAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        switch (failureKindCode)
+        {
+            case "m":
+                failureKind = OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch;
+                return true;
+            case "u":
+                failureKind = OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized;
+                return true;
+            case "s":
+                failureKind = OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing;
+                return true;
+            default:
+                failureKind = OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch;
+                return false;
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationFailureMapper.cs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Why a decoded ownership AUTH1 payload could not be attributed to a planned check.
+/// </summary>
+/// <remarks>
+/// Both reasons are security-configuration problems, not client errors: the batch aborted with an ownership
+/// payload that the request's own plan cannot account for, so the only safe response is the
+/// <c>urn:ed-fi:api:system</c> 500. Reporting a 403 instead would attribute a denial to a strategy that was
+/// never planned.
+/// </remarks>
+public enum OwnershipAuthorizationAuth1UnmappableReason
+{
+    /// <summary>
+    /// The command carried no ownership check, so no ownership payload could legitimately have been raised.
+    /// </summary>
+    NoOwnershipCheckPlanned,
+
+    /// <summary>
+    /// The payload's configured strategy index is not the index the planned check was stamped with, so the
+    /// payload cannot be the one this request's check emitted.
+    /// </summary>
+    ConfiguredStrategyIndexMismatch,
+}
+
+/// <summary>
+/// The outcome of attributing a decoded ownership AUTH1 payload to the request's planned ownership check.
+/// </summary>
+/// <remarks>
+/// A single tri-state result rather than the sibling families' <c>TryMap</c> plus separate stale-target
+/// predicate. The three outcomes carry three different response obligations — a 403, a target re-resolution
+/// retry, and a 500 — and a caller that had to remember to consult a second predicate could silently turn a
+/// stale target into a 500. Returning one closed result makes every outcome a case the caller must handle.
+/// </remarks>
+public abstract record OwnershipAuthorizationAuth1MapResult
+{
+    private OwnershipAuthorizationAuth1MapResult() { }
+
+    /// <summary>The check denied the request: §2.13 or §2.14, a 403.</summary>
+    public sealed record Denied(OwnershipAuthorizationFailure Failure) : OwnershipAuthorizationAuth1MapResult;
+
+    /// <summary>
+    /// The stored target vanished between the unlocked lookup and the check. A retry signal that resolves to
+    /// a 404 on re-resolution, never a response of its own.
+    /// </summary>
+    public sealed record StaleStoredTarget : OwnershipAuthorizationAuth1MapResult;
+
+    /// <summary>The payload cannot be attributed to a planned check: a security-configuration 500.</summary>
+    public sealed record Unmappable(OwnershipAuthorizationAuth1UnmappableReason Reason)
+        : OwnershipAuthorizationAuth1MapResult;
+}
+
+/// <summary>
+/// Maps a decoded ownership AUTH1 payload back to a cross-boundary
+/// <see cref="OwnershipAuthorizationFailure"/>, or to the retry / security-configuration outcomes.
+/// </summary>
+/// <remarks>
+/// Attribution is an equality check, not a lookup. Ownership plans exactly one check per operation, so the
+/// payload's configured strategy index must equal the index that check was stamped with; anything else is a
+/// payload this request's plan cannot account for. The sibling families index into a list of emitted checks
+/// instead, because they emit several.
+/// </remarks>
+public static class OwnershipAuthorizationFailureMapper
+{
+    /// <param name="payload">The decoded <c>own1</c> payload.</param>
+    /// <param name="plannedConfiguredStrategyIndex">
+    /// The configured strategy index the request's single planned ownership check was stamped with, or
+    /// <see langword="null"/> when the request planned no ownership check at all.
+    /// </param>
+    public static OwnershipAuthorizationAuth1MapResult Map(
+        OwnershipAuthorizationAuth1FailurePayload payload,
+        int? plannedConfiguredStrategyIndex
+    )
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (plannedConfiguredStrategyIndex is not { } plannedIndex)
+        {
+            return new OwnershipAuthorizationAuth1MapResult.Unmappable(
+                OwnershipAuthorizationAuth1UnmappableReason.NoOwnershipCheckPlanned
+            );
+        }
+
+        if (payload.ConfiguredStrategyIndex != plannedIndex)
+        {
+            return new OwnershipAuthorizationAuth1MapResult.Unmappable(
+                OwnershipAuthorizationAuth1UnmappableReason.ConfiguredStrategyIndexMismatch
+            );
+        }
+
+        // Checked after attribution: a stale payload is only a trustworthy retry signal once it is known to
+        // have come from this request's own check.
+        if (payload.FailureKind is OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing)
+        {
+            return new OwnershipAuthorizationAuth1MapResult.StaleStoredTarget();
+        }
+
+        return new OwnershipAuthorizationAuth1MapResult.Denied(
+            new OwnershipAuthorizationFailure(
+                MapFailureKind(payload.FailureKind),
+                payload.ConfiguredStrategyIndex,
+                AuthorizationStrategyNameConstants.OwnershipBased
+            )
+        );
+    }
+
+    private static OwnershipAuthorizationFailureKind MapFailureKind(
+        OwnershipAuthorizationAuth1FailureKind failureKind
+    ) =>
+        failureKind switch
+        {
+            OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch =>
+                OwnershipAuthorizationFailureKind.OwnershipTokenMismatch,
+            OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized =>
+                OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized,
+            // StoredTargetMissing is answered above and has no cross-boundary failure representation.
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failureKind),
+                failureKind,
+                "Unsupported AUTH1 ownership failure kind."
+            ),
+        };
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationPlanner.cs
@@ -103,9 +103,9 @@ public static class OwnershipAuthorizationPlanner
             )
         )
         {
-            // Unreachable while the enablement gate withholds every other operation, and kept as a guard
-            // rather than a silent default: GET-many ownership filtering is a different shape of check
-            // (DMS-1410) and must not be served by this single-record plan.
+            // Unreachable through the planner, because the enablement gate never admits ReadMany, and kept
+            // as a guard rather than a silent default: GET-many ownership filtering is a different shape of
+            // check (DMS-1410) and must not be served by this single-record plan.
             throw new ArgumentOutOfRangeException(
                 nameof(operation),
                 operation,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationPlanner.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Security;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// The single planned ownership authorization check for a request.
+/// </summary>
+/// <param name="RawConfiguredIndex">
+/// Zero-based position of <c>OwnershipBased</c> in the CMS-configured strategy list. Carried into the
+/// emitted <c>own1</c> AUTH1 payload, so a denial identifies the configured strategy that produced it.
+/// </param>
+/// <param name="StrategyName">The configured strategy name — always <c>OwnershipBased</c>.</param>
+/// <remarks>
+/// <para>
+/// Deliberately thinner than <see cref="NamespaceAuthorizationCheckSpec"/>, which carries a value source, a
+/// root table, and a column. Ownership needs none of those: it evaluates only stored values, and its subject
+/// column is <c>dms.Document.CreatedByOwnershipTokenId</c> addressed by <c>DocumentId</c>, the same for every
+/// resource. There is no securable element to resolve and so nothing resource-specific to record.
+/// </para>
+/// <para>
+/// No emitted-ordinal field either. Ownership emits exactly one check, so an emitted ordinal would be a
+/// constant zero; the AUTH1 payload carries this configured index instead.
+/// </para>
+/// </remarks>
+public sealed record OwnershipAuthorizationCheckSpec(
+    int RawConfiguredIndex,
+    string StrategyName = AuthorizationStrategyNameConstants.OwnershipBased
+);
+
+/// <summary>
+/// Plans the ownership authorization check for a single-record CRUD operation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Returns the check directly rather than an outcome union. The namespace planner needs one because it can
+/// fail on inputs it inspects — no root-table Namespace column resolves, or the client has no prefixes.
+/// Ownership planning inspects neither the resource model nor the client's token list: the subject column is
+/// resource-independent, and an empty token list is a valid configuration that still executes the check so
+/// the response can distinguish a stored null (§2.14) from a non-matching stored value (§2.13). The one
+/// ownership failure that precedes execution — the defensive token limit — is a terminal on
+/// <see cref="RelationalAuthorizationPlanOutcome"/>, ranked against the other strategies' terminals, not an
+/// outcome of this planner.
+/// </para>
+/// <para>
+/// Callers must invoke this only for an operation and storage kind where ownership is enforced;
+/// <c>RelationalAuthorizationPlanner</c> owns that gate.
+/// </para>
+/// </remarks>
+public static class OwnershipAuthorizationPlanner
+{
+    /// <param name="operation">
+    /// The CRUD operation. <c>ReadSingle</c>, <c>Update</c> and <c>Delete</c> each plan one stored check;
+    /// <c>Update</c> covers both write verbs because a POST resolves to a create or an upsert-as-update only
+    /// in-session.
+    /// </param>
+    /// <param name="configuredOwnershipStrategies">
+    /// Every configured <c>OwnershipBased</c> strategy, which must be non-empty.
+    /// </param>
+    public static OwnershipAuthorizationCheckSpec Plan(
+        NamespaceAuthorizationOperation operation,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> configuredOwnershipStrategies
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configuredOwnershipStrategies);
+
+        if (configuredOwnershipStrategies.Count == 0)
+        {
+            throw new ArgumentException(
+                "Ownership authorization planning requires at least one configured OwnershipBased strategy.",
+                nameof(configuredOwnershipStrategies)
+            );
+        }
+
+        // A strategy that is not OwnershipBased reaching here means the caller's bucket split is wrong, which
+        // would silently authorize the wrong strategy's subject. Fail loudly instead.
+        var foreignStrategy = configuredOwnershipStrategies.FirstOrDefault(static strategy =>
+            !string.Equals(
+                strategy.StrategyName,
+                AuthorizationStrategyNameConstants.OwnershipBased,
+                StringComparison.Ordinal
+            )
+        );
+
+        if (foreignStrategy is not null)
+        {
+            throw new ArgumentException(
+                $"Ownership authorization planning received strategy '{foreignStrategy.StrategyName}', but only '{AuthorizationStrategyNameConstants.OwnershipBased}' is an ownership strategy.",
+                nameof(configuredOwnershipStrategies)
+            );
+        }
+
+        if (
+            operation
+            is not (
+                NamespaceAuthorizationOperation.ReadSingle
+                or NamespaceAuthorizationOperation.Update
+                or NamespaceAuthorizationOperation.Delete
+            )
+        )
+        {
+            // Unreachable while the enablement gate withholds every other operation, and kept as a guard
+            // rather than a silent default: GET-many ownership filtering is a different shape of check
+            // (DMS-1410) and must not be served by this single-record plan.
+            throw new ArgumentOutOfRangeException(
+                nameof(operation),
+                operation,
+                "Ownership authorization planning supports only single-record operations."
+            );
+        }
+
+        // The earliest configured occurrence, not the first list entry, so the result does not depend on
+        // caller ordering. Configuring OwnershipBased more than once cannot make one occurrence pass and
+        // another fail: the check reads one column against one token list, so it evaluates once however many
+        // times it is configured, and the position where it first executes is the earliest occurrence.
+        // Stamping a later one would let a custom view configured between them validate ahead of a terminal
+        // it actually follows.
+        var earliestConfiguredIndex = configuredOwnershipStrategies.Min(static strategy =>
+            strategy.RawConfiguredIndex
+        );
+
+        return new OwnershipAuthorizationCheckSpec(earliestConfiguredIndex);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipAuthorizationSqlCompiler.cs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Ddl;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Input specification for compiling the single-record ownership authorization SQL.
+/// </summary>
+/// <param name="Check">The planned ownership check. Exactly one per operation.</param>
+/// <param name="OwnershipTokenParameterization">Dialect-specific ownership-token parameterization.</param>
+/// <param name="DocumentIdParameterName">Bare parameter name for the stored row's DocumentId.</param>
+/// <param name="RowGuardPredicateSql">
+/// Optional raw predicate appended as a <c>WHERE</c> clause to the emitted check select. When it is false the
+/// check's result set is empty and none of its branches — the abort device included — evaluates, which is how
+/// a check co-batched behind a captured target stays vacuous for a write that resolved to a create. That is
+/// what makes a POST-create immune to ownership denial without needing a second command shape.
+/// </param>
+public sealed record OwnershipAuthorizationSqlSpec(
+    OwnershipAuthorizationCheckSpec Check,
+    OwnershipTokenParameterization OwnershipTokenParameterization,
+    string DocumentIdParameterName,
+    string? RowGuardPredicateSql = null
+);
+
+/// <summary>
+/// Compiled single-record ownership authorization SQL plan.
+/// </summary>
+/// <param name="AuthorizationSql">The compiled SQL command body.</param>
+/// <param name="ParametersInOrder">Deterministic parameter metadata in plan order.</param>
+public sealed record OwnershipAuthorizationSqlPlan(
+    string AuthorizationSql,
+    IReadOnlyList<QuerySqlParameter> ParametersInOrder
+);
+
+/// <summary>
+/// Compiles the single-record ownership authorization check as one <c>SELECT CASE</c> statement. A failure
+/// raises <c>AUTH1</c> with payload <c>own1|configuredIndex|kind</c> and aborts the rest of the command.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The subject is <c>dms.Document.CreatedByOwnershipTokenId</c> addressed by <c>DocumentId</c>, which is why
+/// this compiler needs no resource model: unlike the namespace and custom view-based checks, the ownership
+/// check's table and column are the same for every resource.
+/// </para>
+/// <para>
+/// The three failure branches exist so the response can distinguish §2.14 from §2.13 and a stale target from
+/// either. Their order matters: authorized first, then stored-null, then no-row, then mismatch as the
+/// fallthrough. Testing stored-null before no-row keeps a deleted row from being reported as an
+/// uninitialized token.
+/// </para>
+/// </remarks>
+public sealed class OwnershipAuthorizationSqlCompiler(SqlDialect dialect)
+{
+    private const string DocumentAlias = "d";
+
+    private static readonly DbTableName _documentTable = new(new DbSchemaName("dms"), "Document");
+    private static readonly DbColumnName _documentIdColumn = new("DocumentId");
+    private static readonly DbColumnName _ownershipTokenColumn = new("CreatedByOwnershipTokenId");
+
+    private readonly SqlDialect _dialect = dialect;
+    private readonly ISqlDialect _sqlDialect = SqlDialectFactory.Create(dialect);
+
+    public OwnershipAuthorizationSqlPlan Compile(OwnershipAuthorizationSqlSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        ArgumentNullException.ThrowIfNull(spec.Check);
+        ArgumentNullException.ThrowIfNull(spec.OwnershipTokenParameterization);
+        PlanSqlWriterExtensions.ValidateBareParameterName(
+            spec.DocumentIdParameterName,
+            nameof(spec.DocumentIdParameterName)
+        );
+
+        OwnershipTokenParameterizationValidator.ValidateOrThrow(
+            spec.OwnershipTokenParameterization,
+            _dialect,
+            nameof(OwnershipAuthorizationSqlSpec.OwnershipTokenParameterization),
+            "Single-record ownership authorization SQL"
+        );
+
+        var writer = new SqlWriter(_sqlDialect);
+
+        writer.AppendLine("SELECT CASE");
+
+        using (writer.Indent())
+        {
+            // Authorized: the row exists, carries a token, and that token is one of the caller's.
+            writer.Append("WHEN EXISTS (");
+            AppendStoredRowSelect(
+                writer,
+                spec,
+                predicateWriter =>
+                {
+                    OwnershipTokenSqlHelper.AppendIsNotNull(
+                        predicateWriter,
+                        DocumentAlias,
+                        _ownershipTokenColumn
+                    );
+                    predicateWriter.Append(" AND ");
+                    OwnershipTokenSqlHelper.AppendMembershipPredicate(
+                        predicateWriter,
+                        DocumentAlias,
+                        _ownershipTokenColumn,
+                        spec.OwnershipTokenParameterization
+                    );
+                }
+            );
+            writer.AppendLine(") THEN 1");
+
+            // Stored token is null → 'u' (§2.14). Checked before the no-row branch so a row that exists
+            // with an unassigned token is never reported as a missing target.
+            writer.Append("WHEN EXISTS (");
+            AppendStoredRowSelect(
+                writer,
+                spec,
+                predicateWriter =>
+                    OwnershipTokenSqlHelper.AppendIsNull(
+                        predicateWriter,
+                        DocumentAlias,
+                        _ownershipTokenColumn
+                    )
+            );
+            writer.Append(") THEN ");
+            AppendAuth1Throw(
+                writer,
+                spec.Check,
+                OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized
+            );
+            writer.AppendLine();
+
+            // No row for the target DocumentId → 's' (stale). The target was deleted between the unlocked
+            // lookup and this check. Read paths re-resolve the target and surface the resulting 404; locked
+            // write and delete paths row-lock the target first, so they never reach this branch.
+            writer.Append("WHEN NOT EXISTS (");
+            AppendStoredRowByDocumentId(writer, spec.DocumentIdParameterName);
+            writer.Append(") THEN ");
+            AppendAuth1Throw(writer, spec.Check, OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing);
+            writer.AppendLine();
+
+            // Otherwise → 'm' (§2.13). The row exists with a non-null token matching none of the caller's.
+            writer.Append("ELSE ");
+            AppendAuth1Throw(
+                writer,
+                spec.Check,
+                OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch
+            );
+            writer.AppendLine();
+        }
+
+        writer.Append("END");
+
+        if (spec.RowGuardPredicateSql is { } rowGuardPredicateSql)
+        {
+            writer.Append(" WHERE ");
+            writer.Append(rowGuardPredicateSql);
+        }
+
+        writer.AppendLine(";");
+
+        return new OwnershipAuthorizationSqlPlan(writer.ToString(), BuildParametersInOrder(spec));
+    }
+
+    private static void AppendStoredRowSelect(
+        SqlWriter writer,
+        OwnershipAuthorizationSqlSpec spec,
+        Action<SqlWriter> appendOwnershipPredicate
+    )
+    {
+        AppendStoredRowByDocumentId(writer, spec.DocumentIdParameterName);
+        writer.Append(" AND ");
+        appendOwnershipPredicate(writer);
+    }
+
+    private static void AppendStoredRowByDocumentId(SqlWriter writer, string documentIdParameterName)
+    {
+        writer.Append("SELECT 1 FROM ");
+        writer.AppendRelation(new SqlRelationRef.PhysicalTable(_documentTable));
+        writer.Append($" {DocumentAlias} WHERE {DocumentAlias}.");
+        writer.AppendQuoted(_documentIdColumn.Value);
+        writer.Append(" = ");
+        writer.AppendParameter(documentIdParameterName);
+    }
+
+    private void AppendAuth1Throw(
+        SqlWriter writer,
+        OwnershipAuthorizationCheckSpec check,
+        OwnershipAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        var payload = OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+            new OwnershipAuthorizationAuth1FailurePayload(check.RawConfiguredIndex, failureKind)
+        );
+
+        switch (_dialect)
+        {
+            case SqlDialect.Pgsql:
+                writer.AppendQuoted("dms");
+                writer.Append(".");
+                writer.AppendQuoted("throw_error");
+                writer.Append("('");
+                writer.Append(OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode);
+                writer.Append("', '");
+                writer.Append(payload);
+                writer.Append("')");
+                return;
+
+            case SqlDialect.Mssql:
+                writer.Append("CAST('");
+                writer.Append(OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode);
+                writer.Append(" - ");
+                writer.Append(payload);
+                writer.Append("' AS INT)");
+                return;
+
+            default:
+                throw new NotSupportedException(
+                    $"Single-record ownership authorization SQL does not support SQL dialect '{_dialect}'."
+                );
+        }
+    }
+
+    private static IReadOnlyList<QuerySqlParameter> BuildParametersInOrder(
+        OwnershipAuthorizationSqlSpec spec
+    ) =>
+        [
+            new QuerySqlParameter(QuerySqlParameterRole.Filter, spec.DocumentIdParameterName),
+            .. OwnershipTokenSqlHelper.BuildFilterParametersInOrder(spec.OwnershipTokenParameterization),
+        ];
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenLimitExceededException.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenLimitExceededException.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Thrown when an API client's ownership-token list reaches the defensive limit for <c>OwnershipBased</c>
+/// authorization. The repository layer maps this to a 500 Security Configuration Error so the client can
+/// diagnose the configuration limit without seeing an internal SQL error.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="NamespacePrefixLimitExceededException"/>, this limit is <strong>provider-independent</strong>.
+/// It applies on PostgreSQL, which binds the whole list as one array parameter and has no engine limit at
+/// these sizes, exactly as it applies on SQL Server, which binds one scalar parameter per token. The limit is
+/// a defensive bound on the configuration rather than an artifact of one dialect's parameter ceiling — that
+/// it also keeps the SQL Server <c>IN</c> chain under the engine's usable per-command parameter count is a
+/// convenience, not the reason.
+/// </para>
+/// <para>
+/// This backs up a limit enforced upstream rather than duplicating it.
+/// <c>ConfigurationServiceApplicationProvider.MaximumOwnershipTokenCount</c> already rejects a CMS response
+/// carrying more than 1,999 tokens, classifying it as malformed and mapping it to a 503 before the values
+/// reach <c>RelationalAuthorizationContext</c>. The two agree on the boundary and cannot both fire for one
+/// request: this exception is reachable only through an authorization context that bypassed that provider.
+/// Keep the two in step — 1,999 must remain a valid configuration that works end to end.
+/// </para>
+/// </remarks>
+public sealed class OwnershipTokenLimitExceededException : InvalidOperationException
+{
+    /// <summary>
+    /// The count at which ownership-token configuration fails closed, on every provider. CMS limits
+    /// assignments to one below this value.
+    /// </summary>
+    public const int OwnershipTokenLimit = 2000;
+
+    public OwnershipTokenLimitExceededException(int ownershipTokenCount)
+        : base(BuildMessage(ownershipTokenCount))
+    {
+        OwnershipTokenCount = ownershipTokenCount;
+    }
+
+    public int OwnershipTokenCount { get; }
+
+    private static string BuildMessage(int ownershipTokenCount) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"The API client has {ownershipTokenCount} ownership tokens, which reaches the supported limit of {OwnershipTokenLimit} for OwnershipBased authorization."
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterization.cs
@@ -57,14 +57,6 @@ public sealed record OwnershipTokenParameterization(
     /// untyped empty array.
     /// </summary>
     public bool MatchesNoToken => TokensInOrder.Count == 0;
-
-    /// <summary>
-    /// Evaluates in memory whether <paramref name="storedOwnershipTokenId"/> is one of the caller's tokens,
-    /// mirroring the emitted SQL membership predicate. A null stored token never matches, which is the
-    /// §2.14 case.
-    /// </summary>
-    public bool MatchesStoredToken(short? storedOwnershipTokenId) =>
-        storedOwnershipTokenId is { } storedToken && TokensInOrder.Contains(storedToken);
 }
 
 /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterization.cs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using EdFi.DataManagementService.Backend.External;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Dialect-specific runtime shape for the ownership-token list bound to the
+/// <c>dms.Document.CreatedByOwnershipTokenId</c> membership predicate.
+/// </summary>
+public enum OwnershipTokenParameterizationKind
+{
+    /// <summary>One PostgreSQL array parameter carrying every ownership token.</summary>
+    PgsqlArray,
+
+    /// <summary>One SQL Server scalar parameter per ownership token, joined by <c>IN</c> at the SQL site.</summary>
+    MssqlScalar,
+}
+
+public enum OwnershipTokenParameterizationFailureKind
+{
+    /// <summary>The token list reached the provider-independent defensive limit.</summary>
+    TokenCapExceeded,
+}
+
+/// <summary>
+/// Dialect-specific ownership-token parameterization.
+/// </summary>
+/// <param name="Kind">The emitted SQL/binding shape for the token list.</param>
+/// <param name="BaseParameterName">The logical base parameter name.</param>
+/// <param name="TokensInOrder">
+/// The caller's ownership tokens, deduplicated and ascending. These are the SQL-bound values. They are never
+/// rendered into a client response — an ownership denial discloses no token value.
+/// </param>
+/// <param name="ParameterNamesInOrder">Concrete SQL parameter names in deterministic binding order.</param>
+/// <remarks>
+/// An empty token list is a valid parameterization, not an error. A client configured for
+/// <c>OwnershipBased</c> with no tokens still executes the stored-row check so the response can distinguish a
+/// stored null (§2.14) from a non-matching stored value (§2.13); the compiler renders the membership
+/// predicate as a constant false in that case. This is why there is no minimum-count guard here, unlike
+/// <see cref="NamespacePrefixParameterization"/>, whose empty case is a §2.9 preflight denial instead.
+/// </remarks>
+public sealed record OwnershipTokenParameterization(
+    OwnershipTokenParameterizationKind Kind,
+    string BaseParameterName,
+    IReadOnlyList<short> TokensInOrder,
+    IReadOnlyList<string> ParameterNamesInOrder
+)
+{
+    /// <summary>
+    /// Whether the emitted membership predicate can ever match a row. False for an empty token list, which
+    /// the SQL compiler renders as a constant-false predicate rather than an empty <c>IN ()</c> or an
+    /// untyped empty array.
+    /// </summary>
+    public bool MatchesNoToken => TokensInOrder.Count == 0;
+
+    /// <summary>
+    /// Evaluates in memory whether <paramref name="storedOwnershipTokenId"/> is one of the caller's tokens,
+    /// mirroring the emitted SQL membership predicate. A null stored token never matches, which is the
+    /// §2.14 case.
+    /// </summary>
+    public bool MatchesStoredToken(short? storedOwnershipTokenId) =>
+        storedOwnershipTokenId is { } storedToken && TokensInOrder.Contains(storedToken);
+}
+
+/// <summary>
+/// Builds the ownership-token parameterization for a SQL dialect, failing closed at the defensive token
+/// limit on every provider.
+/// </summary>
+public static class OwnershipTokenParameterizationFactory
+{
+    public static OwnershipTokenParameterization Create(
+        SqlDialect dialect,
+        IReadOnlyList<short> ownershipTokenIds,
+        string baseParameterName
+    )
+    {
+        ArgumentNullException.ThrowIfNull(ownershipTokenIds);
+        PlanSqlWriterExtensions.ValidateBareParameterName(baseParameterName, nameof(baseParameterName));
+
+        // Guarded before deduplication, and deliberately so. A limit applied to the deduplicated count would
+        // be data-dependent: 2,500 configured tokens containing 600 duplicates would slip through, which is
+        // the opposite of what a defensive bound is for. The count that matters is what the client was
+        // configured with.
+        if (ownershipTokenIds.Count >= OwnershipTokenLimitExceededException.OwnershipTokenLimit)
+        {
+            throw new OwnershipTokenLimitExceededException(ownershipTokenIds.Count);
+        }
+
+        var tokens = ownershipTokenIds.Distinct().Order().ToArray();
+
+        return dialect switch
+        {
+            SqlDialect.Pgsql => new OwnershipTokenParameterization(
+                OwnershipTokenParameterizationKind.PgsqlArray,
+                baseParameterName,
+                tokens,
+                [baseParameterName]
+            ),
+            SqlDialect.Mssql => new OwnershipTokenParameterization(
+                OwnershipTokenParameterizationKind.MssqlScalar,
+                baseParameterName,
+                tokens,
+                [
+                    .. Enumerable
+                        .Range(0, tokens.Length)
+                        .Select(index => CreateScalarParameterName(baseParameterName, index)),
+                ]
+            ),
+            _ => throw new NotSupportedException(
+                $"Ownership token parameterization does not support SQL dialect '{dialect}'."
+            ),
+        };
+    }
+
+    public static bool TryCreate(
+        SqlDialect dialect,
+        IReadOnlyList<short> ownershipTokenIds,
+        string baseParameterName,
+        out OwnershipTokenParameterization parameterization,
+        out string securityConfigurationMessage,
+        out OwnershipTokenParameterizationFailureKind? failureKind
+    )
+    {
+        try
+        {
+            parameterization = Create(dialect, ownershipTokenIds, baseParameterName);
+            securityConfigurationMessage = string.Empty;
+            failureKind = null;
+            return true;
+        }
+        catch (OwnershipTokenLimitExceededException ex)
+        {
+            parameterization = null!;
+            securityConfigurationMessage =
+                OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(ex.OwnershipTokenCount);
+            failureKind = OwnershipTokenParameterizationFailureKind.TokenCapExceeded;
+            return false;
+        }
+    }
+
+    private static string CreateScalarParameterName(string baseParameterName, int index)
+    {
+        var parameterName = string.Create(CultureInfo.InvariantCulture, $"{baseParameterName}_{index}");
+
+        PlanSqlWriterExtensions.ValidateBareParameterName(parameterName, nameof(baseParameterName));
+        return parameterName;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterization.cs
@@ -21,12 +21,6 @@ public enum OwnershipTokenParameterizationKind
     MssqlScalar,
 }
 
-public enum OwnershipTokenParameterizationFailureKind
-{
-    /// <summary>The token list reached the provider-independent defensive limit.</summary>
-    TokenCapExceeded,
-}
-
 /// <summary>
 /// Dialect-specific ownership-token parameterization.
 /// </summary>
@@ -107,32 +101,6 @@ public static class OwnershipTokenParameterizationFactory
                 $"Ownership token parameterization does not support SQL dialect '{dialect}'."
             ),
         };
-    }
-
-    public static bool TryCreate(
-        SqlDialect dialect,
-        IReadOnlyList<short> ownershipTokenIds,
-        string baseParameterName,
-        out OwnershipTokenParameterization parameterization,
-        out string securityConfigurationMessage,
-        out OwnershipTokenParameterizationFailureKind? failureKind
-    )
-    {
-        try
-        {
-            parameterization = Create(dialect, ownershipTokenIds, baseParameterName);
-            securityConfigurationMessage = string.Empty;
-            failureKind = null;
-            return true;
-        }
-        catch (OwnershipTokenLimitExceededException ex)
-        {
-            parameterization = null!;
-            securityConfigurationMessage =
-                OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(ex.OwnershipTokenCount);
-            failureKind = OwnershipTokenParameterizationFailureKind.TokenCapExceeded;
-            return false;
-        }
     }
 
     private static string CreateScalarParameterName(string baseParameterName, int index)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterizationValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterizationValidator.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Validates that an <see cref="OwnershipTokenParameterization"/> matches the target SQL dialect and is
+/// internally consistent, so a compiler cannot, for example, accept a PostgreSQL array parameterization and
+/// emit <c>= ANY(...)</c> against SQL Server.
+/// </summary>
+internal static class OwnershipTokenParameterizationValidator
+{
+    public static void ValidateOrThrow(
+        OwnershipTokenParameterization ownershipTokenParameterization,
+        SqlDialect dialect,
+        string parameterizationName,
+        string unsupportedDialectMessagePrefix
+    )
+    {
+        ArgumentNullException.ThrowIfNull(ownershipTokenParameterization);
+        PlanSqlWriterExtensions.ValidateBareParameterName(
+            ownershipTokenParameterization.BaseParameterName,
+            $"{parameterizationName}.{nameof(OwnershipTokenParameterization.BaseParameterName)}"
+        );
+        ArgumentNullException.ThrowIfNull(ownershipTokenParameterization.TokensInOrder);
+        ArgumentNullException.ThrowIfNull(ownershipTokenParameterization.ParameterNamesInOrder);
+
+        // Deliberately no minimum-count guard: an empty token list is valid and renders a constant-false
+        // membership predicate, so that the stored-row check still runs and can tell §2.14 from §2.13.
+        if (
+            ownershipTokenParameterization.TokensInOrder.Count
+            >= OwnershipTokenLimitExceededException.OwnershipTokenLimit
+        )
+        {
+            throw new ArgumentException(
+                $"Ownership token parameterization carries {ownershipTokenParameterization.TokensInOrder.Count} tokens, which reaches the supported limit of {OwnershipTokenLimitExceededException.OwnershipTokenLimit}.",
+                nameof(ownershipTokenParameterization)
+            );
+        }
+
+        foreach (var parameterName in ownershipTokenParameterization.ParameterNamesInOrder)
+        {
+            PlanSqlWriterExtensions.ValidateBareParameterName(
+                parameterName,
+                $"{parameterizationName}.{nameof(OwnershipTokenParameterization.ParameterNamesInOrder)}"
+            );
+        }
+
+        ValidateMatchesDialect(ownershipTokenParameterization.Kind, dialect, unsupportedDialectMessagePrefix);
+        ValidateShape(ownershipTokenParameterization);
+    }
+
+    private static void ValidateMatchesDialect(
+        OwnershipTokenParameterizationKind kind,
+        SqlDialect dialect,
+        string unsupportedDialectMessagePrefix
+    )
+    {
+        switch (dialect)
+        {
+            case SqlDialect.Pgsql:
+                if (kind is not OwnershipTokenParameterizationKind.PgsqlArray)
+                {
+                    throw CreateDialectMismatchException(kind, dialect);
+                }
+
+                return;
+
+            case SqlDialect.Mssql:
+                if (kind is not OwnershipTokenParameterizationKind.MssqlScalar)
+                {
+                    throw CreateDialectMismatchException(kind, dialect);
+                }
+
+                return;
+
+            default:
+                throw new NotSupportedException(
+                    $"{unsupportedDialectMessagePrefix} does not support SQL dialect '{dialect}'."
+                );
+        }
+    }
+
+    private static void ValidateShape(OwnershipTokenParameterization ownershipTokenParameterization)
+    {
+        switch (ownershipTokenParameterization.Kind)
+        {
+            case OwnershipTokenParameterizationKind.PgsqlArray:
+                // Exactly the base name, even for an empty token list: the array parameter is still bound,
+                // carrying an empty array.
+                if (
+                    ownershipTokenParameterization.ParameterNamesInOrder.Count is not 1
+                    || !string.Equals(
+                        ownershipTokenParameterization.ParameterNamesInOrder[0],
+                        ownershipTokenParameterization.BaseParameterName,
+                        StringComparison.Ordinal
+                    )
+                )
+                {
+                    throw new ArgumentException(
+                        "PostgreSQL array ownership token parameterizations require exactly the base parameter name.",
+                        nameof(ownershipTokenParameterization)
+                    );
+                }
+
+                return;
+
+            case OwnershipTokenParameterizationKind.MssqlScalar:
+                if (
+                    ownershipTokenParameterization.ParameterNamesInOrder.Count
+                    != ownershipTokenParameterization.TokensInOrder.Count
+                )
+                {
+                    throw new ArgumentException(
+                        "SQL Server scalar ownership token parameterizations require one parameter name per token.",
+                        nameof(ownershipTokenParameterization)
+                    );
+                }
+
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(ownershipTokenParameterization),
+                    ownershipTokenParameterization.Kind,
+                    "Unsupported ownership token parameterization kind."
+                );
+        }
+    }
+
+    private static ArgumentException CreateDialectMismatchException(
+        OwnershipTokenParameterizationKind kind,
+        SqlDialect dialect
+    ) =>
+        new(
+            $"Ownership token parameterization kind '{kind}' is not supported by SQL dialect '{dialect}'.",
+            nameof(kind)
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterizationValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenParameterizationValidator.cs
@@ -90,8 +90,9 @@ internal static class OwnershipTokenParameterizationValidator
         switch (ownershipTokenParameterization.Kind)
         {
             case OwnershipTokenParameterizationKind.PgsqlArray:
-                // Exactly the base name, even for an empty token list: the array parameter is still bound,
-                // carrying an empty array.
+                // Exactly the base name, even for an empty token list. The shape is about what the
+                // parameterization declares, not what a given statement binds: an empty list renders a
+                // constant-false predicate and OwnershipTokenSqlHelper then binds no token parameter at all.
                 if (
                     ownershipTokenParameterization.ParameterNamesInOrder.Count is not 1
                     || !string.Equals(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenSqlHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/OwnershipTokenSqlHelper.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Ddl;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// SQL emission and parameter helpers for the ownership-token membership predicate. Centralizes the
+/// dialect split — PostgreSQL <c>col = ANY(@base)</c>, SQL Server <c>col IN (@base_0, @base_1, …)</c> — and
+/// the empty-token-list rendering, so a single-record compiler and any later page-query compiler cannot
+/// diverge on either.
+/// </summary>
+internal static class OwnershipTokenSqlHelper
+{
+    /// <summary>
+    /// The predicate emitted when the caller holds no ownership tokens. A constant false rather than an
+    /// empty <c>IN ()</c>, which is a syntax error on SQL Server, or an untyped empty array on PostgreSQL.
+    /// </summary>
+    private const string MatchesNothingPredicate = "1 = 0";
+
+    /// <summary>
+    /// Runtime parameter metadata for an ownership-token parameterization, in binding order.
+    /// </summary>
+    /// <remarks>
+    /// Empty for an empty token list, on both dialects. The emitted predicate is then a constant that
+    /// references no parameter, and a command must not declare a parameter its SQL never mentions —
+    /// co-batching rejects exactly that as a dangling parameter. This is why the decision lives here rather
+    /// than being read off <see cref="OwnershipTokenParameterization.ParameterNamesInOrder"/>, which
+    /// describes the parameterization's shape rather than what a given statement binds.
+    /// </remarks>
+    public static IReadOnlyList<QuerySqlParameter> BuildFilterParametersInOrder(
+        OwnershipTokenParameterization ownershipTokenParameterization
+    )
+    {
+        ArgumentNullException.ThrowIfNull(ownershipTokenParameterization);
+
+        if (ownershipTokenParameterization.MatchesNoToken)
+        {
+            return [];
+        }
+
+        return ownershipTokenParameterization.Kind switch
+        {
+            OwnershipTokenParameterizationKind.PgsqlArray =>
+            [
+                new QuerySqlParameter(
+                    QuerySqlParameterRole.Filter,
+                    ownershipTokenParameterization.BaseParameterName,
+                    QuerySqlParameterBinding.PgsqlArray
+                ),
+            ],
+            OwnershipTokenParameterizationKind.MssqlScalar =>
+            [
+                .. ownershipTokenParameterization.ParameterNamesInOrder.Select(
+                    static parameterName => new QuerySqlParameter(QuerySqlParameterRole.Filter, parameterName)
+                ),
+            ],
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(ownershipTokenParameterization),
+                ownershipTokenParameterization.Kind,
+                "Unsupported ownership token parameterization kind."
+            ),
+        };
+    }
+
+    /// <summary>
+    /// Appends the membership predicate for the stored ownership token against the caller's tokens. No outer
+    /// parentheses are added beyond the SQL Server list grouping — callers control bracketing.
+    /// </summary>
+    public static void AppendMembershipPredicate(
+        SqlWriter writer,
+        string tableAlias,
+        DbColumnName ownershipTokenColumn,
+        OwnershipTokenParameterization ownershipTokenParameterization
+    )
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(ownershipTokenParameterization);
+
+        if (ownershipTokenParameterization.MatchesNoToken)
+        {
+            writer.Append(MatchesNothingPredicate);
+            return;
+        }
+
+        switch (ownershipTokenParameterization.Kind)
+        {
+            case OwnershipTokenParameterizationKind.PgsqlArray:
+                AppendQualifiedColumn(writer, tableAlias, ownershipTokenColumn);
+                writer.Append(" = ANY(");
+                writer.AppendParameter(ownershipTokenParameterization.BaseParameterName);
+                writer.Append(")");
+                return;
+
+            case OwnershipTokenParameterizationKind.MssqlScalar:
+                AppendQualifiedColumn(writer, tableAlias, ownershipTokenColumn);
+                writer.Append(" IN (");
+                for (
+                    var parameterIndex = 0;
+                    parameterIndex < ownershipTokenParameterization.ParameterNamesInOrder.Count;
+                    parameterIndex++
+                )
+                {
+                    if (parameterIndex > 0)
+                    {
+                        writer.Append(", ");
+                    }
+
+                    writer.AppendParameter(
+                        ownershipTokenParameterization.ParameterNamesInOrder[parameterIndex]
+                    );
+                }
+                writer.Append(")");
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(ownershipTokenParameterization),
+                    ownershipTokenParameterization.Kind,
+                    "Unsupported ownership token parameterization kind."
+                );
+        }
+    }
+
+    public static void AppendIsNotNull(SqlWriter writer, string tableAlias, DbColumnName column)
+    {
+        AppendQualifiedColumn(writer, tableAlias, column);
+        writer.Append(" IS NOT NULL");
+    }
+
+    public static void AppendIsNull(SqlWriter writer, string tableAlias, DbColumnName column)
+    {
+        AppendQualifiedColumn(writer, tableAlias, column);
+        writer.Append(" IS NULL");
+    }
+
+    private static void AppendQualifiedColumn(SqlWriter writer, string tableAlias, DbColumnName column)
+    {
+        writer.Append($"{tableAlias}.").AppendQuoted(column.Value);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationAuth1Dispatcher.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationAuth1Dispatcher.cs
@@ -8,6 +8,23 @@ using EdFi.DataManagementService.Backend.External;
 namespace EdFi.DataManagementService.Backend.Plans;
 
 /// <summary>
+/// The AUTH1 payload families, one per leading discriminator the dispatcher knows.
+/// </summary>
+/// <remarks>
+/// The dispatcher is the single owner of the discriminator-to-family mapping. Callers that need to know
+/// which family a payload announced itself as — including one that announced a family whose codec could not
+/// then parse it — read it off the dispatch result rather than re-testing the raw prefix, so a family added
+/// here cannot be missed by a caller that never learned about it.
+/// </remarks>
+public enum RelationalAuthorizationAuth1PayloadFamily
+{
+    Relationship,
+    Namespace,
+    CustomView,
+    Ownership,
+}
+
+/// <summary>
 /// Result of dispatching an AUTH1 provider failure to the codec that owns its payload shape.
 /// </summary>
 public abstract record RelationalAuthorizationAuth1DispatchResult
@@ -26,7 +43,20 @@ public abstract record RelationalAuthorizationAuth1DispatchResult
     public sealed record Ownership(OwnershipAuthorizationAuth1FailurePayload Payload)
         : RelationalAuthorizationAuth1DispatchResult;
 
-    public sealed record InvalidPayload(string RawPayload) : RelationalAuthorizationAuth1DispatchResult;
+    /// <summary>
+    /// The payload could not be decoded into any family's shape.
+    /// </summary>
+    /// <param name="RawPayload">The undecodable payload text, as extracted from the provider failure.</param>
+    /// <param name="RecognizedFamily">
+    /// The family whose discriminator the payload leads with, or <see langword="null"/> when it leads with no
+    /// known discriminator at all. A non-null value says the payload announced itself as that family's even
+    /// though that family's codec could not parse it, which is what lets a mapper claim its own malformed
+    /// payload and decline another family's without re-testing the prefix itself.
+    /// </param>
+    public sealed record InvalidPayload(
+        string RawPayload,
+        RelationalAuthorizationAuth1PayloadFamily? RecognizedFamily
+    ) : RelationalAuthorizationAuth1DispatchResult;
 }
 
 /// <summary>
@@ -77,60 +107,93 @@ public static class RelationalAuthorizationAuth1Dispatcher
             return false;
         }
 
-        if (
-            payloadText.StartsWith(RelationshipDiscriminatorPrefix, StringComparison.Ordinal)
-            && RelationshipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
-                payloadText,
-                out var relationshipPayload
-            )
-            && relationshipPayload is not null
-        )
+        var recognizedFamily = RecognizeFamily(payloadText);
+
+        switch (recognizedFamily)
         {
-            result = new RelationalAuthorizationAuth1DispatchResult.Relationship(relationshipPayload);
-            return true;
+            case RelationalAuthorizationAuth1PayloadFamily.Relationship
+                when RelationshipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+                    payloadText,
+                    out var relationshipPayload
+                ) && relationshipPayload is not null:
+                result = new RelationalAuthorizationAuth1DispatchResult.Relationship(relationshipPayload);
+                return true;
+
+            case RelationalAuthorizationAuth1PayloadFamily.Namespace
+                when NamespaceAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+                    payloadText,
+                    out var namespacePayload
+                ) && namespacePayload is not null:
+                result = new RelationalAuthorizationAuth1DispatchResult.Namespace(namespacePayload);
+                return true;
+
+            case RelationalAuthorizationAuth1PayloadFamily.CustomView
+                when CustomViewAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+                    payloadText,
+                    out var customViewPayload
+                ) && customViewPayload is not null:
+                result = new RelationalAuthorizationAuth1DispatchResult.CustomView(customViewPayload);
+                return true;
+
+            case RelationalAuthorizationAuth1PayloadFamily.Ownership
+                when OwnershipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+                    payloadText,
+                    out var ownershipPayload
+                ) && ownershipPayload is not null:
+                result = new RelationalAuthorizationAuth1DispatchResult.Ownership(ownershipPayload);
+                return true;
+
+            default:
+                // Either no known discriminator, or a known one whose codec could not parse the rest. The
+                // recognized family rides along either way, so a mapper can tell its own malformed payload
+                // from another family's without re-testing the prefix.
+                result = new RelationalAuthorizationAuth1DispatchResult.InvalidPayload(
+                    payloadText,
+                    recognizedFamily
+                );
+                return true;
+        }
+    }
+
+    /// <summary>
+    /// The AUTH1 family whose discriminator <paramref name="payloadText"/> leads with, or
+    /// <see langword="null"/> when it leads with none of them.
+    /// </summary>
+    /// <remarks>
+    /// The single place any code decides which family a raw payload belongs to. Exposed so a mapper holding
+    /// an already-extracted payload can answer the same question without repeating the prefix constants; a
+    /// mapper holding a dispatch result reads
+    /// <see cref="RelationalAuthorizationAuth1DispatchResult.InvalidPayload.RecognizedFamily"/> instead.
+    /// <para>
+    /// The discriminators are mutually exclusive as anchored prefixes, so the arm order carries no meaning —
+    /// notably <c>own1|…</c> does not start with the relationship family's <c>1|</c>.
+    /// </para>
+    /// </remarks>
+    public static RelationalAuthorizationAuth1PayloadFamily? RecognizeFamily(string payloadText)
+    {
+        ArgumentNullException.ThrowIfNull(payloadText);
+
+        if (payloadText.StartsWith(RelationshipDiscriminatorPrefix, StringComparison.Ordinal))
+        {
+            return RelationalAuthorizationAuth1PayloadFamily.Relationship;
         }
 
-        if (
-            payloadText.StartsWith(NamespaceDiscriminatorPrefix, StringComparison.Ordinal)
-            && NamespaceAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
-                payloadText,
-                out var namespacePayload
-            )
-            && namespacePayload is not null
-        )
+        if (payloadText.StartsWith(NamespaceDiscriminatorPrefix, StringComparison.Ordinal))
         {
-            result = new RelationalAuthorizationAuth1DispatchResult.Namespace(namespacePayload);
-            return true;
+            return RelationalAuthorizationAuth1PayloadFamily.Namespace;
         }
 
-        if (
-            payloadText.StartsWith(CustomViewDiscriminatorPrefix, StringComparison.Ordinal)
-            && CustomViewAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
-                payloadText,
-                out var customViewPayload
-            )
-            && customViewPayload is not null
-        )
+        if (payloadText.StartsWith(CustomViewDiscriminatorPrefix, StringComparison.Ordinal))
         {
-            result = new RelationalAuthorizationAuth1DispatchResult.CustomView(customViewPayload);
-            return true;
+            return RelationalAuthorizationAuth1PayloadFamily.CustomView;
         }
 
-        if (
-            payloadText.StartsWith(OwnershipDiscriminatorPrefix, StringComparison.Ordinal)
-            && OwnershipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
-                payloadText,
-                out var ownershipPayload
-            )
-            && ownershipPayload is not null
-        )
+        if (payloadText.StartsWith(OwnershipDiscriminatorPrefix, StringComparison.Ordinal))
         {
-            result = new RelationalAuthorizationAuth1DispatchResult.Ownership(ownershipPayload);
-            return true;
+            return RelationalAuthorizationAuth1PayloadFamily.Ownership;
         }
 
-        result = new RelationalAuthorizationAuth1DispatchResult.InvalidPayload(payloadText);
-        return true;
+        return null;
     }
 
     private static bool TryExtractAuth1Payload(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationAuth1Dispatcher.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationAuth1Dispatcher.cs
@@ -23,16 +23,25 @@ public abstract record RelationalAuthorizationAuth1DispatchResult
     public sealed record CustomView(CustomViewAuthorizationAuth1FailurePayload Payload)
         : RelationalAuthorizationAuth1DispatchResult;
 
+    public sealed record Ownership(OwnershipAuthorizationAuth1FailurePayload Payload)
+        : RelationalAuthorizationAuth1DispatchResult;
+
     public sealed record InvalidPayload(string RawPayload) : RelationalAuthorizationAuth1DispatchResult;
 }
 
 /// <summary>
-/// Routes an AUTH1 provider failure to the relationship, namespace, or custom-view payload codec based on
-/// the payload's leading discriminator. Relationship payloads start with <c>1|</c>; namespace payloads start
-/// with <c>ns1|</c>; custom view-based payloads start with <c>cv1|</c>. Any other payload returns
+/// Routes an AUTH1 provider failure to the relationship, namespace, custom-view, or ownership payload codec
+/// based on the payload's leading discriminator. Relationship payloads start with <c>1|</c>; namespace
+/// payloads start with <c>ns1|</c>; custom view-based payloads start with <c>cv1|</c>; ownership payloads
+/// start with <c>own1|</c>. Any other payload returns
 /// <see cref="RelationalAuthorizationAuth1DispatchResult.InvalidPayload"/> so the caller can log and fall
 /// through to a generic security failure.
 /// </summary>
+/// <remarks>
+/// The discriminators are mutually exclusive as anchored prefixes, so arm order carries no meaning: notably
+/// <c>own1|…</c> does not start with the relationship family's <c>1|</c>, because a prefix match is anchored
+/// at the start of the payload.
+/// </remarks>
 public static class RelationalAuthorizationAuth1Dispatcher
 {
     private const string RelationshipDiscriminatorPrefix =
@@ -41,6 +50,8 @@ public static class RelationalAuthorizationAuth1Dispatcher
         NamespaceAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|";
     private const string CustomViewDiscriminatorPrefix =
         CustomViewAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|";
+    private const string OwnershipDiscriminatorPrefix =
+        OwnershipAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|";
 
     /// <summary>
     /// Attempts to extract and dispatch an AUTH1 payload from a provider exception.
@@ -105,6 +116,19 @@ public static class RelationalAuthorizationAuth1Dispatcher
             return true;
         }
 
+        if (
+            payloadText.StartsWith(OwnershipDiscriminatorPrefix, StringComparison.Ordinal)
+            && OwnershipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+                payloadText,
+                out var ownershipPayload
+            )
+            && ownershipPayload is not null
+        )
+        {
+            result = new RelationalAuthorizationAuth1DispatchResult.Ownership(ownershipPayload);
+            return true;
+        }
+
         result = new RelationalAuthorizationAuth1DispatchResult.InvalidPayload(payloadText);
         return true;
     }
@@ -116,9 +140,9 @@ public static class RelationalAuthorizationAuth1Dispatcher
         out string payloadText
     )
     {
-        // Both codecs share the same transport extraction logic (PG SqlState == "AUTH1", or MSSQL
+        // Every codec shares the same transport extraction logic (PG SqlState == "AUTH1", or MSSQL
         // message containing "AUTH1 - "). Use the relationship codec's extractor as the single source
-        // of truth so a future change to either codec cannot silently diverge from the other.
+        // of truth so a future change to any one codec cannot silently diverge from the others.
         return RelationshipAuthorizationAuth1FailurePayloadCodec.TryExtractProviderPayload(
             dialect,
             providerErrorCode,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -146,7 +146,9 @@ public abstract record RelationalAuthorizationPlanOutcome
 /// namespace terminals, because Namespace-based and custom view-based execute ahead of Ownership-based among the
 /// AND strategies; and ahead of every relationship terminal, because the relationship OR group executes after all
 /// AND strategies. That last part needs no index comparison, unlike the namespace-versus-relationship case: an
-/// ownership terminal outranks a relationship one whatever position CMS gave either.</item>
+/// ownership terminal outranks a relationship one whatever position CMS gave either. It does <em>not</em> outrank a
+/// custom-view configuration failure, which the classifier reports in the same bucket as relationship failures —
+/// see <c>OwnershipCapOutranksClassifierFailure</c>.</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.StillUnsupported"/> — the relationship classifier reports a
 /// known-but-not-enabled strategy in the non-namespace bucket (501 NotImplemented, fail closed).</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.Plan"/> — everything else.</item>
@@ -214,15 +216,22 @@ public static class RelationalAuthorizationPlanner
 
         var enforcesCustomViewChecks = EnforcesCustomViewChecks(operation);
 
-        // Evaluated here so both the relationship security-configuration arms below can yield to it.
-        // Ownership executes before the entire relationship OR group, so an ownership terminal outranks
-        // every relationship terminal regardless of configured position — no index comparison, unlike the
-        // namespace-versus-relationship case, where both are AND strategies ordered among themselves.
         var ownershipCapExceeded =
             ownershipStrategies.Count > 0
             && context.OwnershipTokenIds.Count >= OwnershipTokenLimitExceededException.OwnershipTokenLimit;
 
-        if (hasSecurityConfigurationError && !enforcesCustomViewChecks && !ownershipCapExceeded)
+        // Whether the ownership terminal may displace the classifier's security-configuration failure.
+        // Evaluated once here so both relationship security-configuration arms below consult one answer.
+        var ownershipCapOutranksClassifierFailure = OwnershipCapOutranksClassifierFailure(
+            ownershipCapExceeded,
+            relationshipClassification?.SecurityConfigurationFailures ?? []
+        );
+
+        if (
+            hasSecurityConfigurationError
+            && !enforcesCustomViewChecks
+            && !ownershipCapOutranksClassifierFailure
+        )
         {
             return new RelationalAuthorizationPlanOutcome.SecurityConfigurationError(
                 nonNamespaceStrategies,
@@ -252,9 +261,10 @@ public static class RelationalAuthorizationPlanner
                         relationshipClassification!.SecurityConfigurationFailures
                     );
 
-            // The ownership terminal also outranks this failure, and unconditionally: ownership executes
-            // before the whole relationship OR group whatever position CMS gave it.
-            if (!namespaceTerminalPrecedesFailure && !ownershipCapExceeded)
+            // The ownership terminal may also outrank this failure — but only when the failure is a
+            // relationship one. A custom-view configuration failure keeps its own response, because every
+            // custom view executes ahead of ownership among the AND strategies.
+            if (!namespaceTerminalPrecedesFailure && !ownershipCapOutranksClassifierFailure)
             {
                 return new RelationalAuthorizationPlanOutcome.SecurityConfigurationError(
                     nonNamespaceStrategies,
@@ -443,6 +453,59 @@ public static class RelationalAuthorizationPlanner
     /// </para>
     /// </remarks>
     private static readonly HashSet<NamespaceAuthorizationOperation> _ownershipEnforcedOperations = [];
+
+    /// <summary>
+    /// Whether the ownership token-cap terminal may displace the relationship classifier's
+    /// security-configuration failure.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The classifier's <c>SecurityConfigurationError</c> bucket is not purely relationship failures: it also
+    /// carries custom view-based strategy-resolution failures, such as a
+    /// <c>{BasisResource}With…</c> strategy whose basis resource does not exist
+    /// (<see cref="RelationshipAuthorizationFailureKind.UnknownCustomViewBasisResource"/>). Those are
+    /// AND-strategy failures. Every custom view executes ahead of Ownership-based among the AND strategies,
+    /// whatever position CMS gave either, so a custom-view configuration failure keeps its own response and
+    /// the ownership cap must yield to it — with no index comparison needed.
+    /// </para>
+    /// <para>
+    /// A purely relationship or otherwise generic failure does yield to the cap, because the relationship OR
+    /// group executes after every AND strategy. Both outcomes are a 500 with the same status and title, so
+    /// this choice decides which diagnostic an operator sees rather than whether the request is refused.
+    /// </para>
+    /// <para>
+    /// These are the classifier-level failures, which never become
+    /// <c>SupportedCustomViewAuthorizationStrategy</c> entries and so are never validated through the
+    /// resolved-custom-view path. That path is unaffected: a resolved view that turns out to be missing or
+    /// non-conforming is still probed and still keeps its own 500, because the terminals carry their
+    /// resolved views for validation.
+    /// </para>
+    /// <para>
+    /// Internal so the rule can be pinned directly while the enablement gate withholds every operation and
+    /// makes it unobservable through a plan outcome. The behavioral assertion belongs to the first gate-flip
+    /// commit, where it becomes reachable.
+    /// </para>
+    /// </remarks>
+    internal static bool OwnershipCapOutranksClassifierFailure(
+        bool ownershipCapExceeded,
+        IReadOnlyList<RelationshipAuthorizationFailureMetadata> securityConfigurationFailures
+    )
+    {
+        ArgumentNullException.ThrowIfNull(securityConfigurationFailures);
+
+        return ownershipCapExceeded && !securityConfigurationFailures.Any(IsCustomViewConfigurationFailure);
+    }
+
+    /// <summary>
+    /// Whether a classifier security-configuration failure is about a custom view rather than a relationship
+    /// strategy. Kept as a list of kinds rather than a name-convention test so a kind added later is a
+    /// compile-time decision here instead of silently defaulting to relationship precedence.
+    /// </summary>
+    private static bool IsCustomViewConfigurationFailure(RelationshipAuthorizationFailureMetadata failure) =>
+        failure.FailureKind
+            is RelationshipAuthorizationFailureKind.UnknownCustomViewBasisResource
+                or RelationshipAuthorizationFailureKind.NoCustomViewJoinPath
+                or RelationshipAuthorizationFailureKind.MissingProposedCustomViewRootBinding;
 
     /// <summary>
     /// Whether the caller for this operation executes the custom-view checks this planner hands back. When it

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -26,7 +26,50 @@ public abstract record RelationalAuthorizationPlanOutcome
         IReadOnlyList<NamespaceAuthorizationCheckSpec> NamespaceChecks,
         IReadOnlyList<ConfiguredAuthorizationStrategy> NonNamespaceConfiguredStrategies,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy> CustomViewStrategies
-    ) : RelationalAuthorizationPlanOutcome;
+    ) : RelationalAuthorizationPlanOutcome
+    {
+        /// <summary>
+        /// The planned ownership check, or <see langword="null"/> when <c>OwnershipBased</c> is not
+        /// configured or is not enforced for this operation and storage kind.
+        /// </summary>
+        /// <remarks>
+        /// An <c>init</c> property rather than a positional member so no existing construction site changes.
+        /// Singular, not a list: ownership plans exactly one check per operation, and repeated configuration
+        /// collapses to the earliest occurrence.
+        /// <para>
+        /// Null here does not mean "ownership is satisfied" — while the enablement gate withholds an
+        /// operation, a configured <c>OwnershipBased</c> stays in the non-namespace bucket and the request
+        /// never reaches a <c>Plan</c> at all, because the classifier reports it known-but-not-enabled. A
+        /// caller therefore cannot silently drop the check by ignoring this property.
+        /// </para>
+        /// </remarks>
+        public OwnershipAuthorizationCheckSpec? OwnershipCheck { get; init; }
+    }
+
+    /// <summary>
+    /// <c>OwnershipBased</c> is enforced and the client's ownership-token list reaches the defensive limit.
+    /// Maps to a 500 Security Configuration Error at planner/preflight time — no DB roundtrip is issued.
+    /// </summary>
+    /// <param name="OwnershipTokenCount">
+    /// The configured token count, as supplied and before deduplication. Reported so an operator can see
+    /// what to reduce; no token value is ever disclosed.
+    /// </param>
+    /// <param name="StrategyName">Always <c>OwnershipBased</c>.</param>
+    /// <remarks>
+    /// Ranked after both namespace terminals and ahead of every relationship terminal, because ownership is
+    /// an AND strategy that executes last among the AND strategies and before the relationship OR group.
+    /// <para>
+    /// <see cref="CustomViewStrategies"/> carries every resolved custom view rather than only those
+    /// configured before some index: ownership executes last among the AND strategies whatever position CMS
+    /// gave it, so every view runs ahead of this terminal and must be validated before it is reported.
+    /// </para>
+    /// </remarks>
+    public sealed record OwnershipTokenCapExceeded(int OwnershipTokenCount, string StrategyName)
+        : RelationalAuthorizationPlanOutcome
+    {
+        public IReadOnlyList<SupportedCustomViewAuthorizationStrategy> CustomViewStrategies { get; init; } =
+        [];
+    }
 
     /// <summary>
     /// <c>NamespaceBased</c> is configured but no securable element resolves to the resource's
@@ -98,18 +141,27 @@ public abstract record RelationalAuthorizationPlanOutcome
 /// and the client has no namespace prefixes (403, preflight). Namespace-based is AND-combined and executes
 /// ahead of relationship OR-combined strategies, so its 403 wins over a sibling
 /// known-but-not-enabled relationship strategy.</item>
+/// <item><see cref="RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded"/> — <c>OwnershipBased</c> is
+/// enforced and the client's ownership-token list reaches the defensive limit (500, preflight). Ranked after both
+/// namespace terminals, because Namespace-based and custom view-based execute ahead of Ownership-based among the
+/// AND strategies; and ahead of every relationship terminal, because the relationship OR group executes after all
+/// AND strategies. That last part needs no index comparison, unlike the namespace-versus-relationship case: an
+/// ownership terminal outranks a relationship one whatever position CMS gave either.</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.StillUnsupported"/> — the relationship classifier reports a
 /// known-but-not-enabled strategy in the non-namespace bucket (501 NotImplemented, fail closed).</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.Plan"/> — everything else.</item>
 /// </list>
 /// <para>
-/// <c>OwnershipBased</c> is known but not enabled for every operation, <c>ReadMany</c> included:
-/// DMS-1410 owns enabling it for <c>ReadMany</c>, while DMS-1060 owns write-side
-/// <c>CreatedByOwnershipTokenId</c> stamping.
-/// Until that required work lands, DMS-1062 never promotes it to a supported AND filter, so it always reaches
-/// its fail-closed 501 rather than filtering a page against
-/// ownership context this story cannot provision. A custom view configured ahead of that terminal is still
-/// validated first, so an earlier custom-view configuration failure keeps its own response.
+/// <c>OwnershipBased</c> is split into a bucket of its own, but only where
+/// <c>EnforcesOwnershipChecks</c> says the caller executes the check. Everywhere else it stays in the
+/// non-namespace bucket, so the classifier keeps reporting it known-but-not-enabled and the request keeps its
+/// fail-closed 501 — which is what stops an unenforced ownership strategy from being silently dropped. The
+/// gate currently withholds every operation; each enforcement step adds its own operation in the same commit
+/// that wires that operation's executor. <c>ReadMany</c> is withheld for the whole story (DMS-1410 owns
+/// GET-many ownership filtering, which is a page filter rather than a single-record check), and descriptor
+/// storage is withheld because descriptor ownership enforcement is out of this story's scope. A custom view
+/// configured ahead of any of these terminals is still validated first, so an earlier custom-view
+/// configuration failure keeps its own response.
 /// </para>
 /// </remarks>
 public static class RelationalAuthorizationPlanner
@@ -131,6 +183,20 @@ public static class RelationalAuthorizationPlanner
             configuredAuthorizationStrategies
         );
 
+        // Split OwnershipBased into its own bucket only where it is enforced. Where it is not, it stays in
+        // the non-namespace bucket so the classifier keeps reporting it known-but-not-enabled and the
+        // request keeps its existing 501. That is what makes an unenforced ownership strategy fail closed
+        // rather than be silently dropped, and it is why this split is conditional rather than
+        // unconditional like the namespace one.
+        var enforcesOwnershipChecks = EnforcesOwnershipChecks(operation, resource.StorageKind);
+
+        IReadOnlyList<ConfiguredAuthorizationStrategy> ownershipStrategies = [];
+
+        if (enforcesOwnershipChecks)
+        {
+            (ownershipStrategies, nonNamespaceStrategies) = SplitByOwnershipBased(nonNamespaceStrategies);
+        }
+
         // SecurityConfigurationError (500) and StillUnsupported (501) are detected by the existing
         // relationship classifier; invoke it only when the non-namespace bucket is non-empty.
         RelationshipAuthorizationClassification? relationshipClassification =
@@ -148,7 +214,15 @@ public static class RelationalAuthorizationPlanner
 
         var enforcesCustomViewChecks = EnforcesCustomViewChecks(operation);
 
-        if (hasSecurityConfigurationError && !enforcesCustomViewChecks)
+        // Evaluated here so both the relationship security-configuration arms below can yield to it.
+        // Ownership executes before the entire relationship OR group, so an ownership terminal outranks
+        // every relationship terminal regardless of configured position — no index comparison, unlike the
+        // namespace-versus-relationship case, where both are AND strategies ordered among themselves.
+        var ownershipCapExceeded =
+            ownershipStrategies.Count > 0
+            && context.OwnershipTokenIds.Count >= OwnershipTokenLimitExceededException.OwnershipTokenLimit;
+
+        if (hasSecurityConfigurationError && !enforcesCustomViewChecks && !ownershipCapExceeded)
         {
             return new RelationalAuthorizationPlanOutcome.SecurityConfigurationError(
                 nonNamespaceStrategies,
@@ -178,7 +252,9 @@ public static class RelationalAuthorizationPlanner
                         relationshipClassification!.SecurityConfigurationFailures
                     );
 
-            if (!namespaceTerminalPrecedesFailure)
+            // The ownership terminal also outranks this failure, and unconditionally: ownership executes
+            // before the whole relationship OR group whatever position CMS gave it.
+            if (!namespaceTerminalPrecedesFailure && !ownershipCapExceeded)
             {
                 return new RelationalAuthorizationPlanOutcome.SecurityConfigurationError(
                     nonNamespaceStrategies,
@@ -208,6 +284,25 @@ public static class RelationalAuthorizationPlanner
             return new RelationalAuthorizationPlanOutcome.NoPrefixesConfigured(
                 noPrefixes.StrategyName,
                 namespaceStrategy.RawConfiguredIndex
+            )
+            {
+                CustomViewStrategies = supportedCustomViewStrategies,
+            };
+        }
+
+        // Ranked here on purpose: after both namespace terminals, because Namespace-based and custom
+        // view-based execute ahead of Ownership-based among the AND strategies; and before every
+        // relationship terminal below, because the relationship OR group executes after all of them. The
+        // two relationship security-configuration arms above already yield to it.
+        //
+        // Every resolved custom view is carried for validation, not just those configured before some
+        // index, because ownership executes last among the AND strategies whatever position CMS gave it —
+        // so every view genuinely runs ahead of this terminal.
+        if (ownershipCapExceeded)
+        {
+            return new RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded(
+                context.OwnershipTokenIds.Count,
+                AuthorizationStrategyNameConstants.OwnershipBased
             )
             {
                 CustomViewStrategies = supportedCustomViewStrategies,
@@ -277,12 +372,77 @@ public static class RelationalAuthorizationPlanner
                 .Where(strategy => !customViewStrategyRawIndexes.Contains(strategy.RawConfiguredIndex))
                 .ToArray();
 
+        // Planned only where enforced, so the ownership bucket is empty for every operation and storage kind
+        // the gate withholds — and in those cases the strategy is still in the relationship bucket earning
+        // its known-but-not-enabled 501 above, so this null can never mean "dropped".
+        var ownershipCheck =
+            ownershipStrategies.Count == 0
+                ? null
+                : OwnershipAuthorizationPlanner.Plan(operation, ownershipStrategies);
+
         return new RelationalAuthorizationPlanOutcome.Plan(
             namespaceChecks,
             relationshipConfiguredStrategies,
             supportedCustomViewStrategies
-        );
+        )
+        {
+            OwnershipCheck = ownershipCheck,
+        };
     }
+
+    /// <summary>
+    /// Whether the caller for this operation and storage kind executes the ownership check this planner
+    /// would hand back. When it does not, <c>OwnershipBased</c> is left in the relationship bucket so the
+    /// classifier reports it known-but-not-enabled and the request fails closed with 501, exactly as it did
+    /// before ownership planning existed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Returns <see langword="false"/> for every operation at present. Each of the enforcement steps flips
+    /// exactly one operation on in the same commit that adds its execution, so no commit can exist in which
+    /// a planned ownership check has no executor.
+    /// </para>
+    /// <para>
+    /// <see cref="ResourceStorageKind.SharedDescriptorTable"/> is withheld permanently for this story.
+    /// Descriptor ownership enforcement is out of scope, and this named arm is what keeps that boundary
+    /// deliberate: before ownership had its own bucket, descriptors were protected only incidentally, by
+    /// <c>RelationalReadGuardrails.HasDescriptorUnsupportedNonNamespaceStrategies</c> catching every
+    /// non-namespace strategy. Splitting ownership out would have removed that protection silently.
+    /// Descriptor <em>stamping</em> is unaffected — it never consults configured strategies.
+    /// </para>
+    /// <para>
+    /// <see cref="NamespaceAuthorizationOperation.ReadMany"/> is withheld for the whole story: GET-many
+    /// ownership filtering is DMS-1410's, and it is a page filter rather than a single-record check.
+    /// </para>
+    /// <para>
+    /// Internal rather than private so its matrix can be pinned directly. While every operation is
+    /// withheld, no plan outcome can distinguish an enforced combination from a withheld one, and asserting
+    /// the gate through behavior alone would be impossible without a test-only switch — which would be a
+    /// worse thing to add than a visible predicate.
+    /// </para>
+    /// </remarks>
+    internal static bool EnforcesOwnershipChecks(
+        NamespaceAuthorizationOperation operation,
+        ResourceStorageKind storageKind
+    ) =>
+        storageKind is not ResourceStorageKind.SharedDescriptorTable
+        && _ownershipEnforcedOperations.Contains(operation);
+
+    /// <summary>
+    /// The operations whose callers execute the ownership check. Empty until each enforcement step adds its
+    /// own operation in the same commit that wires that operation's executor.
+    /// </summary>
+    /// <remarks>
+    /// A membership set rather than a per-operation switch, so an operation absent from it is withheld by
+    /// default: an operation added to the enum without an ownership executor keeps its 501 rather than
+    /// silently inheriting enforcement it does not implement.
+    /// <para>
+    /// <see cref="NamespaceAuthorizationOperation.ReadMany"/> must never be added here. GET-many ownership
+    /// filtering is DMS-1410's, and it is a page filter, not a single-record check —
+    /// <see cref="OwnershipAuthorizationPlanner"/> throws if it is ever asked to plan one.
+    /// </para>
+    /// </remarks>
+    private static readonly HashSet<NamespaceAuthorizationOperation> _ownershipEnforcedOperations = [];
 
     /// <summary>
     /// Whether the caller for this operation executes the custom-view checks this planner hands back. When it
@@ -359,5 +519,37 @@ public static class RelationalAuthorizationPlanner
         }
 
         return (namespaceStrategies, nonNamespaceStrategies);
+    }
+
+    /// <summary>
+    /// Splits <c>OwnershipBased</c> out of the non-namespace bucket, preserving configured order in both.
+    /// </summary>
+    private static (
+        IReadOnlyList<ConfiguredAuthorizationStrategy> Ownership,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> NonOwnership
+    ) SplitByOwnershipBased(IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies)
+    {
+        List<ConfiguredAuthorizationStrategy> ownershipStrategies = [];
+        List<ConfiguredAuthorizationStrategy> nonOwnershipStrategies = [];
+
+        foreach (var configuredStrategy in nonNamespaceConfiguredStrategies)
+        {
+            if (
+                string.Equals(
+                    configuredStrategy.StrategyName,
+                    AuthorizationStrategyNameConstants.OwnershipBased,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                ownershipStrategies.Add(configuredStrategy);
+            }
+            else
+            {
+                nonOwnershipStrategies.Add(configuredStrategy);
+            }
+        }
+
+        return (ownershipStrategies, nonOwnershipStrategies);
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -158,8 +158,8 @@ public abstract record RelationalAuthorizationPlanOutcome
 /// <c>EnforcesOwnershipChecks</c> says the caller executes the check. Everywhere else it stays in the
 /// non-namespace bucket, so the classifier keeps reporting it known-but-not-enabled and the request keeps its
 /// fail-closed 501 — which is what stops an unenforced ownership strategy from being silently dropped. The
-/// gate enforces <c>ReadSingle</c> and <c>Delete</c> and withholds the rest; each enforcement step adds its
-/// own operation in the same commit that wires that operation's executor. <c>ReadMany</c> is withheld for the whole story (DMS-1410 owns
+/// gate enforces every single-record operation and withholds <c>ReadMany</c>; each enforcement step added
+/// its own operation in the same commit that wired that operation's executor. <c>ReadMany</c> is withheld for the whole story (DMS-1410 owns
 /// GET-many ownership filtering, which is a page filter rather than a single-record check), and descriptor
 /// storage is withheld because descriptor ownership enforcement is out of this story's scope. A custom view
 /// configured ahead of any of these terminals is still validated first, so an earlier custom-view
@@ -408,10 +408,10 @@ public static class RelationalAuthorizationPlanner
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Returns <see langword="true"/> for <see cref="NamespaceAuthorizationOperation.ReadSingle"/> and
-    /// <see cref="NamespaceAuthorizationOperation.Delete"/>. Each enforcement step flips exactly one
-    /// operation on in the same commit that adds its execution, so no commit can exist in which a planned
-    /// ownership check has no executor.
+    /// Returns <see langword="true"/> for every single-record operation, and never for
+    /// <see cref="NamespaceAuthorizationOperation.ReadMany"/> or descriptor storage. Each enforcement step
+    /// flipped exactly one operation on in the same commit that added its execution, so no commit existed in
+    /// which a planned ownership check had no executor.
     /// </para>
     /// <para>
     /// <see cref="ResourceStorageKind.SharedDescriptorTable"/> is withheld permanently for this story.
@@ -456,9 +456,10 @@ public static class RelationalAuthorizationPlanner
     /// </remarks>
     private static readonly HashSet<NamespaceAuthorizationOperation> _ownershipEnforcedOperations =
     [
-        // ReadSingle and Delete. Update keeps the known-but-not-enabled 501 until Phase 6 wires the write
-        // path; ReadMany ownership filtering is DMS-1410's, not this ticket's.
+        // Every single-record operation. ReadMany is absent and must stay absent: GET-many ownership
+        // filtering is DMS-1410's, and it is a page filter rather than a single-record check.
         NamespaceAuthorizationOperation.ReadSingle,
+        NamespaceAuthorizationOperation.Update,
         NamespaceAuthorizationOperation.Delete,
     ];
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -158,8 +158,8 @@ public abstract record RelationalAuthorizationPlanOutcome
 /// <c>EnforcesOwnershipChecks</c> says the caller executes the check. Everywhere else it stays in the
 /// non-namespace bucket, so the classifier keeps reporting it known-but-not-enabled and the request keeps its
 /// fail-closed 501 — which is what stops an unenforced ownership strategy from being silently dropped. The
-/// gate currently withholds every operation; each enforcement step adds its own operation in the same commit
-/// that wires that operation's executor. <c>ReadMany</c> is withheld for the whole story (DMS-1410 owns
+/// gate enforces <c>ReadSingle</c> and withholds the rest; each enforcement step adds its own operation in
+/// the same commit that wires that operation's executor. <c>ReadMany</c> is withheld for the whole story (DMS-1410 owns
 /// GET-many ownership filtering, which is a page filter rather than a single-record check), and descriptor
 /// storage is withheld because descriptor ownership enforcement is out of this story's scope. A custom view
 /// configured ahead of any of these terminals is still validated first, so an earlier custom-view
@@ -425,10 +425,10 @@ public static class RelationalAuthorizationPlanner
     /// ownership filtering is DMS-1410's, and it is a page filter rather than a single-record check.
     /// </para>
     /// <para>
-    /// Internal rather than private so its matrix can be pinned directly. While every operation is
-    /// withheld, no plan outcome can distinguish an enforced combination from a withheld one, and asserting
-    /// the gate through behavior alone would be impossible without a test-only switch — which would be a
-    /// worse thing to add than a visible predicate.
+    /// Internal rather than private so its matrix can be pinned directly. A withheld operation returns the
+    /// same known-but-not-enabled 501 whether this gate withheld it or the classifier never recognized the
+    /// strategy, so a plan outcome alone cannot say which happened; only the predicate separates them, and
+    /// the alternative was a test-only switch, which would be a worse thing to add.
     /// </para>
     /// </remarks>
     internal static bool EnforcesOwnershipChecks(
@@ -487,9 +487,10 @@ public static class RelationalAuthorizationPlanner
     /// resolved views for validation.
     /// </para>
     /// <para>
-    /// Internal so the rule can be pinned directly while the enablement gate withholds every operation and
-    /// makes it unobservable through a plan outcome. The behavioral assertion belongs to the first gate-flip
-    /// commit, where it becomes reachable.
+    /// Internal so the rule can be pinned directly, which is how it was covered before any operation was
+    /// enforced and no plan outcome could reach it. It is now also asserted behaviorally through
+    /// <see cref="NamespaceAuthorizationOperation.ReadSingle"/>: an unresolved custom-view basis paired with
+    /// an over-cap ownership token list must report the custom-view failure, not the cap terminal.
     /// </para>
     /// </remarks>
     internal static bool OwnershipCapOutranksClassifierFailure(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -408,9 +408,9 @@ public static class RelationalAuthorizationPlanner
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Returns <see langword="false"/> for every operation at present. Each of the enforcement steps flips
-    /// exactly one operation on in the same commit that adds its execution, so no commit can exist in which
-    /// a planned ownership check has no executor.
+    /// Returns <see langword="true"/> for <see cref="NamespaceAuthorizationOperation.ReadSingle"/> only.
+    /// Each enforcement step flips exactly one operation on in the same commit that adds its execution, so
+    /// no commit can exist in which a planned ownership check has no executor.
     /// </para>
     /// <para>
     /// <see cref="ResourceStorageKind.SharedDescriptorTable"/> is withheld permanently for this story.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -158,8 +158,8 @@ public abstract record RelationalAuthorizationPlanOutcome
 /// <c>EnforcesOwnershipChecks</c> says the caller executes the check. Everywhere else it stays in the
 /// non-namespace bucket, so the classifier keeps reporting it known-but-not-enabled and the request keeps its
 /// fail-closed 501 — which is what stops an unenforced ownership strategy from being silently dropped. The
-/// gate enforces <c>ReadSingle</c> and withholds the rest; each enforcement step adds its own operation in
-/// the same commit that wires that operation's executor. <c>ReadMany</c> is withheld for the whole story (DMS-1410 owns
+/// gate enforces <c>ReadSingle</c> and <c>Delete</c> and withholds the rest; each enforcement step adds its
+/// own operation in the same commit that wires that operation's executor. <c>ReadMany</c> is withheld for the whole story (DMS-1410 owns
 /// GET-many ownership filtering, which is a page filter rather than a single-record check), and descriptor
 /// storage is withheld because descriptor ownership enforcement is out of this story's scope. A custom view
 /// configured ahead of any of these terminals is still validated first, so an earlier custom-view
@@ -408,9 +408,10 @@ public static class RelationalAuthorizationPlanner
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Returns <see langword="true"/> for <see cref="NamespaceAuthorizationOperation.ReadSingle"/> only.
-    /// Each enforcement step flips exactly one operation on in the same commit that adds its execution, so
-    /// no commit can exist in which a planned ownership check has no executor.
+    /// Returns <see langword="true"/> for <see cref="NamespaceAuthorizationOperation.ReadSingle"/> and
+    /// <see cref="NamespaceAuthorizationOperation.Delete"/>. Each enforcement step flips exactly one
+    /// operation on in the same commit that adds its execution, so no commit can exist in which a planned
+    /// ownership check has no executor.
     /// </para>
     /// <para>
     /// <see cref="ResourceStorageKind.SharedDescriptorTable"/> is withheld permanently for this story.
@@ -455,9 +456,10 @@ public static class RelationalAuthorizationPlanner
     /// </remarks>
     private static readonly HashSet<NamespaceAuthorizationOperation> _ownershipEnforcedOperations =
     [
-        // ReadSingle only. Update, Delete and ReadMany keep the known-but-not-enabled 501 until their own
-        // executors exist; ReadMany ownership filtering is DMS-1410's, not this ticket's.
+        // ReadSingle and Delete. Update keeps the known-but-not-enabled 501 until Phase 6 wires the write
+        // path; ReadMany ownership filtering is DMS-1410's, not this ticket's.
         NamespaceAuthorizationOperation.ReadSingle,
+        NamespaceAuthorizationOperation.Delete,
     ];
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -137,6 +137,12 @@ public abstract record RelationalAuthorizationPlanOutcome
 /// before the <c>NamespaceBased</c> index.</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.NoUsableRootColumn"/> — <c>NamespaceBased</c> is configured
 /// but no root-table column resolves (500).</item>
+/// <item><see cref="RelationalAuthorizationPlanOutcome.StillUnsupported"/> — descriptor storage configured with
+/// <c>OwnershipBased</c> on a single-record operation (501 NotImplemented, fail closed). The one place an
+/// unsupported strategy outranks a namespace terminal: descriptor ownership enforcement is out of this story's
+/// scope, so reporting the namespace 403 first would answer as though the caller's prefixes refused a check
+/// that was never enforced. Scoped to the operations the ownership gate would otherwise enforce, so descriptor
+/// <c>ReadMany</c> keeps its namespace terminal.</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.NoPrefixesConfigured"/> — <c>NamespaceBased</c> is configured
 /// and the client has no namespace prefixes (403, preflight). Namespace-based is AND-combined and executes
 /// ahead of relationship OR-combined strategies, so its 403 wins over a sibling
@@ -285,6 +291,33 @@ public static class RelationalAuthorizationPlanner
                 RawConfiguredIndex = namespaceStrategies[0].RawConfiguredIndex,
                 CustomViewStrategies = supportedCustomViewStrategies,
             };
+        }
+
+        // Descriptor ownership enforcement is out of this story's scope, so a descriptor configured with
+        // OwnershipBased must fail closed as known-but-not-enabled (501) on every single-record operation —
+        // GET-by-id, the write verbs, and DELETE. Ranked ahead of the namespace no-prefixes terminal on
+        // purpose, and it is the one place where an unimplemented strategy outranks a namespace terminal:
+        // that 403 is a runtime authorization answer for a strategy the caller does execute, so letting it
+        // win reports "your namespace prefixes refused this" for a descriptor whose ownership strategy was
+        // never enforced at all. The unimplemented strategy has to be the terminal, or the response says the
+        // request was authorized-and-refused rather than not-implemented.
+        //
+        // Ranked after NoUsableRootColumn, which stays ahead: that terminal means the descriptor's own
+        // namespace column is missing from the model, which is a genuine security-configuration fault (500)
+        // rather than a masked scope boundary.
+        //
+        // Scoped to the operations the ownership gate would otherwise enforce, so descriptor GET-many keeps
+        // its existing namespace terminal — GET-many ownership filtering is DMS-1410's.
+        if (DescriptorOwnershipUnsupported(resource.StorageKind, operation, nonNamespaceStrategies))
+        {
+            // relationshipClassification is non-null because the predicate requires OwnershipBased in the
+            // non-namespace bucket, so that bucket is non-empty. The classification is carried unchanged, so
+            // the resolved custom views ride along and a view configured ahead of this terminal keeps its own
+            // configuration failure exactly as it does on the other unsupported terminals below.
+            return new RelationalAuthorizationPlanOutcome.StillUnsupported(
+                nonNamespaceStrategies,
+                relationshipClassification!
+            );
         }
 
         if (namespaceOutcome is NamespaceAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes)
@@ -438,6 +471,41 @@ public static class RelationalAuthorizationPlanner
     ) =>
         storageKind is not ResourceStorageKind.SharedDescriptorTable
         && _ownershipEnforcedOperations.Contains(operation);
+
+    /// <summary>
+    /// Whether this request is a descriptor operation configured with <c>OwnershipBased</c> that the story
+    /// leaves unimplemented, and so must report the known-but-not-enabled 501 rather than any namespace
+    /// terminal that would otherwise be reported first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The complement of <see cref="EnforcesOwnershipChecks"/> for descriptor storage: that gate withholds
+    /// enforcement, and this predicate is what makes the withheld case visible early enough to keep its own
+    /// terminal. Without it the strategy still reaches the classifier and still earns its 501, but only when
+    /// no namespace terminal is reported first — and a client with no namespace prefixes reports one every
+    /// time, turning the descriptor scope boundary into a namespace 403.
+    /// </para>
+    /// <para>
+    /// Gated on the same operation set as the enforcement gate rather than on all operations, so
+    /// <see cref="NamespaceAuthorizationOperation.ReadMany"/> keeps its existing behavior: descriptor
+    /// GET-many ownership filtering is DMS-1410's and is staged separately.
+    /// </para>
+    /// <para>
+    /// Internal so the boundary can be pinned directly, for the same reason the enforcement gate is.
+    /// </para>
+    /// </remarks>
+    internal static bool DescriptorOwnershipUnsupported(
+        ResourceStorageKind storageKind,
+        NamespaceAuthorizationOperation operation,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies
+    )
+    {
+        ArgumentNullException.ThrowIfNull(nonNamespaceConfiguredStrategies);
+
+        return storageKind is ResourceStorageKind.SharedDescriptorTable
+            && _ownershipEnforcedOperations.Contains(operation)
+            && nonNamespaceConfiguredStrategies.Any(IsOwnershipBased);
+    }
 
     /// <summary>
     /// The operations whose callers execute the ownership check. Each enforcement step adds its own
@@ -607,13 +675,7 @@ public static class RelationalAuthorizationPlanner
 
         foreach (var configuredStrategy in nonNamespaceConfiguredStrategies)
         {
-            if (
-                string.Equals(
-                    configuredStrategy.StrategyName,
-                    AuthorizationStrategyNameConstants.OwnershipBased,
-                    StringComparison.Ordinal
-                )
-            )
+            if (IsOwnershipBased(configuredStrategy))
             {
                 ownershipStrategies.Add(configuredStrategy);
             }
@@ -625,4 +687,15 @@ public static class RelationalAuthorizationPlanner
 
         return (ownershipStrategies, nonOwnershipStrategies);
     }
+
+    /// <summary>
+    /// Whether a configured strategy is <c>OwnershipBased</c>. One definition so the ownership split and the
+    /// descriptor boundary can never drift apart on how the strategy is recognized.
+    /// </summary>
+    private static bool IsOwnershipBased(ConfiguredAuthorizationStrategy configuredStrategy) =>
+        string.Equals(
+            configuredStrategy.StrategyName,
+            AuthorizationStrategyNameConstants.OwnershipBased,
+            StringComparison.Ordinal
+        );
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -119,6 +119,30 @@ public abstract record RelationalAuthorizationPlanOutcome
 }
 
 /// <summary>
+/// How <see cref="RelationalAuthorizationPlanner.Plan"/> treats an enforced <c>OwnershipBased</c> token list
+/// that reaches the defensive limit.
+/// </summary>
+public enum OwnershipTokenCapHandling
+{
+    /// <summary>
+    /// Report <see cref="RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded"/> as a planner terminal.
+    /// The default, for every operation whose target is known to exist before planning — GET-by-id, PUT and
+    /// DELETE — so the failure is reported before any session opens and is ranked against the other terminals.
+    /// </summary>
+    FailAtPlanning,
+
+    /// <summary>
+    /// Plan as though the list were under the limit and leave the failure to the caller, who owes it only once
+    /// the target proves to exist. For POST: the check authorizes the stored token, so it is vacuous for a
+    /// create and the over-limit list is never parameterized for one, while a POST that resolves to an
+    /// upsert-as-update fails closed in the ownership slot — after the custom-view and namespace checks,
+    /// before the relationship check and before any DML. With the cap deferred it is not a planning fact, so
+    /// a relationship configuration failure keeps its own precedence rather than yielding to the cap.
+    /// </summary>
+    DeferToTargetResolution,
+}
+
+/// <summary>
 /// Higher-level relational authorization planner. Splits the configured strategy list into a
 /// namespace bucket and a non-namespace bucket, delegates namespace planning to
 /// <see cref="NamespaceAuthorizationPlanner"/>, and uses
@@ -154,7 +178,9 @@ public abstract record RelationalAuthorizationPlanOutcome
 /// AND strategies. That last part needs no index comparison, unlike the namespace-versus-relationship case: an
 /// ownership terminal outranks a relationship one whatever position CMS gave either. It does <em>not</em> outrank a
 /// custom-view configuration failure, which the classifier reports in the same bucket as relationship failures —
-/// see <c>OwnershipCapOutranksClassifierFailure</c>.</item>
+/// see <c>OwnershipCapOutranksClassifierFailure</c>. A caller that resolves its target in-session — POST — asks
+/// for <see cref="OwnershipTokenCapHandling.DeferToTargetResolution"/>, and this terminal is then never
+/// returned: the plan is handed back and the caller fails closed only once the target proves to exist.</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.StillUnsupported"/> — the relationship classifier reports a
 /// known-but-not-enabled strategy in the non-namespace bucket (501 NotImplemented, fail closed).</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.Plan"/> — everything else.</item>
@@ -179,7 +205,8 @@ public static class RelationalAuthorizationPlanner
         ConcreteResourceModel resource,
         NamespaceAuthorizationOperation operation,
         IReadOnlyList<ConfiguredAuthorizationStrategy> configuredAuthorizationStrategies,
-        RelationalAuthorizationContext context
+        RelationalAuthorizationContext context,
+        OwnershipTokenCapHandling ownershipTokenCapHandling = OwnershipTokenCapHandling.FailAtPlanning
     )
     {
         ArgumentNullException.ThrowIfNull(mappingSet);
@@ -222,8 +249,11 @@ public static class RelationalAuthorizationPlanner
 
         var enforcesCustomViewChecks = EnforcesCustomViewChecks(operation);
 
+        // Deferred, the cap is not a planning fact: a POST that creates never parameterizes the list, so the
+        // caller owes the failure only once the target proves to exist, and no terminal below may consult it.
         var ownershipCapExceeded =
-            ownershipStrategies.Count > 0
+            ownershipTokenCapHandling is OwnershipTokenCapHandling.FailAtPlanning
+            && ownershipStrategies.Count > 0
             && context.OwnershipTokenIds.Count >= OwnershipTokenLimitExceededException.OwnershipTokenLimit;
 
         // Whether the ownership terminal may displace the classifier's security-configuration failure.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -439,8 +439,9 @@ public static class RelationalAuthorizationPlanner
         && _ownershipEnforcedOperations.Contains(operation);
 
     /// <summary>
-    /// The operations whose callers execute the ownership check. Empty until each enforcement step adds its
-    /// own operation in the same commit that wires that operation's executor.
+    /// The operations whose callers execute the ownership check. Each enforcement step adds its own
+    /// operation in the same commit that wires that operation's executor, so no operation can be planned a
+    /// check nothing executes.
     /// </summary>
     /// <remarks>
     /// A membership set rather than a per-operation switch, so an operation absent from it is withheld by
@@ -452,7 +453,12 @@ public static class RelationalAuthorizationPlanner
     /// <see cref="OwnershipAuthorizationPlanner"/> throws if it is ever asked to plan one.
     /// </para>
     /// </remarks>
-    private static readonly HashSet<NamespaceAuthorizationOperation> _ownershipEnforcedOperations = [];
+    private static readonly HashSet<NamespaceAuthorizationOperation> _ownershipEnforcedOperations =
+    [
+        // ReadSingle only. Update, Delete and ReadMany keep the known-but-not-enabled 501 until their own
+        // executors exist; ReadMany ownership filtering is DMS-1410's, not this ticket's.
+        NamespaceAuthorizationOperation.ReadSingle,
+    ];
 
     /// <summary>
     /// Whether the ownership token-cap terminal may displace the relationship classifier's

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorWriteTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorWriteTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Globalization;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Postgresql;
@@ -745,6 +746,134 @@ public class Given_PostgresqlDescriptorWriteHandler
         var result = await handler.HandlePutAsync(putRequest);
 
         result.Should().BeOfType<UpdateResult.UpdateFailureImmutableIdentity>();
+    }
+
+    /// <summary>
+    /// Descriptor creates use their own inline insert SQL rather than the shared document-row builder, so the
+    /// stamp needs live-provider coverage of its own. Unit tests inspect the emitted statement; only a real
+    /// engine proves the column round-trips.
+    /// </summary>
+    [Test]
+    public async Task It_stamps_the_creator_ownership_token_on_a_descriptor_create()
+    {
+        var handler = ResolveHandler();
+        var request = CreatePostRequest(
+            _database.Fixture.SchoolTypeDescriptorResource,
+            """
+            {
+                "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+                "codeValue": "OwnershipStamped",
+                "shortDescription": "Ownership Stamped"
+            }
+            """
+        ) with
+        {
+            RelationalAuthorizationContext = new RelationalAuthorizationContext(
+                [],
+                [],
+                creatorOwnershipTokenId: 42,
+                ownershipTokenIds: []
+            ),
+        };
+
+        var result = await handler.HandlePostAsync(request);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync(request.DocumentUuid)).Should().Be((short)42);
+    }
+
+    [Test]
+    public async Task It_stamps_null_on_a_descriptor_create_when_the_client_has_no_creator_token()
+    {
+        var handler = ResolveHandler();
+        var request = CreatePostRequest(
+            _database.Fixture.SchoolTypeDescriptorResource,
+            """
+            {
+                "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+                "codeValue": "OwnershipUnstamped",
+                "shortDescription": "Ownership Unstamped"
+            }
+            """
+        ) with
+        {
+            RelationalAuthorizationContext = new RelationalAuthorizationContext(
+                [],
+                [],
+                creatorOwnershipTokenId: null,
+                ownershipTokenIds: [7]
+            ),
+        };
+
+        var result = await handler.HandlePostAsync(request);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync(request.DocumentUuid)).Should().BeNull();
+    }
+
+    /// <summary>
+    /// A descriptor upsert-as-update must leave the stored token alone, even though its request carries a
+    /// different creator token that a create would have stamped.
+    /// </summary>
+    [Test]
+    public async Task It_leaves_the_stored_token_unchanged_on_a_descriptor_post_as_update()
+    {
+        var handler = ResolveHandler();
+        var resource = _database.Fixture.SchoolTypeDescriptorResource;
+        const string CreateBody = """
+            {
+                "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+                "codeValue": "OwnershipUpsert",
+                "shortDescription": "Ownership Upsert"
+            }
+            """;
+        const string UpsertBody = """
+            {
+                "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+                "codeValue": "OwnershipUpsert",
+                "shortDescription": "Ownership Upsert Changed"
+            }
+            """;
+
+        var createRequest = CreatePostRequest(resource, CreateBody) with
+        {
+            RelationalAuthorizationContext = new RelationalAuthorizationContext(
+                [],
+                [],
+                creatorOwnershipTokenId: 42,
+                ownershipTokenIds: []
+            ),
+        };
+        (await handler.HandlePostAsync(createRequest)).Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var upsertRequest = CreatePostRequest(resource, UpsertBody) with
+        {
+            RelationalAuthorizationContext = new RelationalAuthorizationContext(
+                [],
+                [],
+                creatorOwnershipTokenId: 7,
+                ownershipTokenIds: []
+            ),
+        };
+        (await handler.HandlePostAsync(upsertRequest)).Should().BeOfType<UpsertResult.UpdateSuccess>();
+
+        (await ReadStoredOwnershipTokenAsync(createRequest.DocumentUuid)).Should().Be((short)42);
+    }
+
+    private async Task<short?> ReadStoredOwnershipTokenAsync(DocumentUuid documentUuid)
+    {
+        await using var dataSource = Npgsql.NpgsqlDataSource.Create(_database.ConnectionString);
+        await using var connection = await dataSource.OpenConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT "CreatedByOwnershipTokenId"
+            FROM dms."Document"
+            WHERE "DocumentUuid" = @documentUuid;
+            """;
+        command.Parameters.AddWithValue("@documentUuid", documentUuid.Value);
+
+        var value = await command.ExecuteScalarAsync();
+        return value is null or DBNull ? null : Convert.ToInt16(value, CultureInfo.InvariantCulture);
     }
 
     // ── Helper methods ──────────────────────────────────────────────────

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalDeleteAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalDeleteAuthorizationTests.cs
@@ -622,8 +622,14 @@ public class Given_A_Postgresql_Relational_Delete_Authorization_With_A_Synthetic
         );
     }
 
+    /// <summary>
+    /// OwnershipBased is the only strategy in the relationship classifier's known-but-not-enabled set, so
+    /// once Delete is enforced this composition plans instead of returning a 501. These rows were seeded
+    /// without an ownership token, which is auth.md 2.14 — and the row assertions below are the point: a
+    /// denial must leave the row exactly where it was.
+    /// </summary>
     [Test]
-    public async Task It_returns_501_and_security_configuration_failures_before_deleting()
+    public async Task It_denies_and_reports_security_configuration_failures_before_deleting()
     {
         var knownUnsupportedSeed = _authorizationRootChildSeeds[7];
 
@@ -639,13 +645,11 @@ public class Given_A_Postgresql_Relational_Delete_Authorization_With_A_Synthetic
             RelationshipAuthorizationCrudTestSupport.EdOrgOnlyPlusKnownUnsupportedStrategyNames
         );
 
-        var notImplemented = knownUnsupportedResult
+        knownUnsupportedResult
             .Should()
-            .BeOfType<DeleteResult.DeleteFailureNotImplemented>()
-            .Subject;
-        notImplemented
-            .FailureMessage.Should()
-            .Contain(RelationshipAuthorizationCrudTestSupport.OwnershipBased);
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
         var securityConfiguration = securityConfigurationResult
             .Should()
             .BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalGetByIdAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalGetByIdAuthorizationTests.cs
@@ -47,7 +47,12 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
         AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
         AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
     ];
-    private static readonly IReadOnlyList<string> _normalPlusKnownUnsupportedStrategy =
+
+    /// <summary>
+    /// OwnershipBased is enforced for GET-by-id and withheld everywhere else, so this composition plans
+    /// rather than returning the known-but-not-enabled 501 that the write and query routes still return.
+    /// </summary>
+    private static readonly IReadOnlyList<string> _normalPlusOwnershipStrategy =
     [
         AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
         AuthorizationStrategyNameConstants.OwnershipBased,
@@ -526,16 +531,22 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
         _context.AssertNoHydration();
     }
 
+    /// <summary>
+    /// OwnershipBased composed with a supported relationship strategy. It is an AND filter running before the
+    /// relationship OR group, so it decides first: these rows were seeded without an ownership token, which
+    /// is auth.md 2.14 and stops the read before hydration even though the relationship claim would have
+    /// authorized it.
+    /// </summary>
     [Test]
-    public async Task It_returns_501_for_known_but_not_enabled_mixed_strategies()
+    public async Task It_denies_an_unstamped_row_for_ownership_composed_with_a_relationship_strategy()
     {
-        var result = await GetRootChildAsync(
-            _authorizationRootChildSeeds[0],
-            _normalPlusKnownUnsupportedStrategy
-        );
+        var result = await GetRootChildAsync(_authorizationRootChildSeeds[0], _normalPlusOwnershipStrategy);
 
-        var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
         _context.AssertNoHydration();
     }
 
@@ -547,7 +558,7 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
             RelationshipAuthorizationCrudTestSupport.ChildOnlyEdOrgResourceName,
             _authorizationChildOnlySeed.DocumentUuid,
             [ClaimEducationOrganizationId],
-            _normalPlusKnownUnsupportedStrategy
+            _normalPlusOwnershipStrategy
         );
 
         var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalOwnershipStampingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalOwnershipStampingTests.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Globalization;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Postgresql;
 using EdFi.DataManagementService.Backend.Tests.Common;
 using EdFi.DataManagementService.Backend.Tests.Integration.Common;
@@ -14,6 +15,7 @@ using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -35,7 +37,8 @@ namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 /// leaves the stored token alone rather than merely omitting it from a statement the unit tests inspected.
 /// </para>
 /// <para>
-/// Stamping only — this suite asserts nothing about ownership enforcement, which is not yet wired.
+/// Stamping first, then enforcement: the same seeded row proves both, because what a create stamps is
+/// exactly what a later GET-by-id has to authorize against.
 /// </para>
 /// </remarks>
 [TestFixture]
@@ -149,6 +152,165 @@ public class Given_A_Postgresql_Relational_Write_With_Ownership_Stamping
         await ExecuteUpdateAsync(CreatorToken);
 
         (await ReadStoredOwnershipTokenAsync()).Should().BeNull();
+    }
+
+    // ----- Enforcement -----------------------------------------------------
+    // These execute the compiled ownership SQL against the real engine. Only a live provider can prove the
+    // SELECT CASE parses, the membership predicate binds smallint to smallint, and the AUTH1 abort device
+    // raises an error the dispatcher and mapper decode back into a response. The stamping tests above put a
+    // known token on the row, so each arm is reached by choosing which tokens the reader holds.
+
+    /// <summary>
+    /// The stored token is one of the reader's, so the read is authorized and the document is served.
+    /// </summary>
+    [Test]
+    public async Task It_authorizes_a_get_by_id_whose_stored_token_the_reader_holds()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync([OtherToken, CreatorToken]);
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+    }
+
+    /// <summary>
+    /// The stored token is not one of the reader's: auth.md 2.13. The row exists and is readable by its own
+    /// owner, so only the membership predicate can be denying it.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_get_by_id_whose_stored_token_the_reader_does_not_hold()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync([OtherToken]);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+    }
+
+    /// <summary>
+    /// A reader holding no tokens at all still runs the check rather than being short-circuited, so the
+    /// constant-false membership predicate has to be valid SQL on this engine. The row carries a token, so
+    /// this is a mismatch rather than the uninitialized case.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_get_by_id_for_a_reader_holding_no_tokens()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync([]);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+    }
+
+    /// <summary>
+    /// The stored token is null: auth.md 2.14, a different response type from 2.13 because the document can
+    /// never be reached by any client rather than merely not by this one. Reached by creating through a
+    /// client that has no creator token, which is exactly how such a row arises in practice.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_get_by_id_whose_stored_token_was_never_assigned()
+    {
+        await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        var result = await ExecuteOwnershipGetByIdAsync([CreatorToken]);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+    }
+
+    /// <summary>
+    /// The configured position travels through the emitted payload and back, so a denial is attributed to
+    /// the position OwnershipBased actually holds rather than to a normalized zero.
+    /// </summary>
+    [Test]
+    public async Task It_reports_the_configured_strategy_index_a_denial_came_from()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync(
+            [OtherToken],
+            strategyNames:
+            [
+                AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
+                AuthorizationStrategyNameConstants.OwnershipBased,
+            ]
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureOwnershipNotAuthorized>().Subject;
+        failure.OwnershipFailure.ConfiguredStrategyIndex.Should().Be(1);
+        failure.OwnershipFailure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    /// <summary>
+    /// The provider-independent defensive limit, reported before any statement is emitted. Proves the cap
+    /// terminal reaches the response on a live engine rather than the over-limit parameter list reaching the
+    /// SQL boundary.
+    /// </summary>
+    [Test]
+    public async Task It_fails_closed_for_a_get_by_id_with_an_over_cap_ownership_token_list()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipGetByIdAsync([
+            .. Enumerable
+                .Range(1, OwnershipTokenLimitExceededException.OwnershipTokenLimit)
+                .Select(static tokenId => (short)tokenId),
+        ]);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("2,000");
+    }
+
+    private async Task<GetResult> ExecuteOwnershipGetByIdAsync(
+        IReadOnlyList<short> ownershipTokenIds,
+        IReadOnlyList<string>? strategyNames = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.GetDocumentById(
+            new IntegrationRelationalGetRequest(
+                DocumentUuid: SchoolDocumentUuid,
+                ResourceInfo: SchoolResourceInfo,
+                MappingSet: _mappingSet,
+                AuthorizationStrategyEvaluators:
+                [
+                    .. (strategyNames ?? [AuthorizationStrategyNameConstants.OwnershipBased]).Select(
+                        static strategyName => new AuthorizationStrategyEvaluator(
+                            strategyName,
+                            [],
+                            FilterOperator.And
+                        )
+                    ),
+                ],
+                TraceId: new TraceId("pg-ownership-enforcement-get")
+            )
+            {
+                AuthorizationContext = new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    creatorOwnershipTokenId: null,
+                    ownershipTokenIds
+                ),
+            }
+        );
     }
 
     private async Task<UpsertResult> ExecuteCreateAsync(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalOwnershipStampingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalOwnershipStampingTests.cs
@@ -432,6 +432,180 @@ public class Given_A_Postgresql_Relational_Write_With_Ownership_Stamping
         );
     }
 
+    // ----- Write enforcement -----------------------------------------------
+
+    /// <summary>
+    /// The live half of the D1 proof, moved here from 6.2 because a POST create cannot plan an ownership
+    /// check until the Update gate is open. <c>OwnershipBased</c> is configured and the caller holds no
+    /// tokens at all — the configuration most likely to deny if the carrier row guard were missing — and the
+    /// create still succeeds and still stamps.
+    /// </summary>
+    [Test]
+    public async Task It_creates_and_stamps_with_ownership_configured_and_no_tokens()
+    {
+        var createResult = await ExecuteOwnershipCreateAsync(CreatorToken, ownershipTokenIds: []);
+
+        createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A POST that resolves to an upsert-as-update is denied for a foreign token, and the stored row is
+    /// unchanged — including the token, which a denied write must never rewrite.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_post_as_update_for_a_foreign_token_and_leaves_the_row_unmodified()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipCreateAsync(
+            CreatorToken,
+            ownershipTokenIds: [OtherToken],
+            requestBody: UpdateRequestBody()
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    [Test]
+    public async Task It_denies_a_put_for_a_foreign_token_and_leaves_the_row_unmodified()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipUpdateAsync([OtherToken]);
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// An owner may update, and the stored token survives it. The write carries its own creator token, which
+    /// a create would have stamped, so this also proves the update path still does not rewrite it.
+    /// </summary>
+    [Test]
+    public async Task It_authorizes_a_put_for_an_owner_and_preserves_the_stored_token()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipUpdateAsync([OtherToken, CreatorToken]);
+
+        result.Should().BeOfType<UpdateResult.UpdateSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A document created without a token cannot be updated by anyone: auth.md 2.14.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_put_whose_stored_ownership_token_was_never_assigned()
+    {
+        await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        var result = await ExecuteOwnershipUpdateAsync([CreatorToken]);
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        (await ReadStoredOwnershipTokenAsync()).Should().BeNull();
+    }
+
+    /// <summary>
+    /// The denial outranks a stale If-Match, as on the delete path: telling a non-owner its etag is stale
+    /// would disclose that the row changed.
+    /// </summary>
+    [Test]
+    public async Task It_reports_an_ownership_put_denial_over_a_stale_if_match()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipUpdateAsync([OtherToken], ifMatch: "\"stale-etag\"");
+
+        result.Should().BeOfType<UpdateResult.UpdateFailureOwnershipNotAuthorized>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    private async Task<UpsertResult> ExecuteOwnershipCreateAsync(
+        short? creatorOwnershipTokenId,
+        IReadOnlyList<short> ownershipTokenIds,
+        JsonNode? requestBody = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.UpsertDocument(
+            new UpsertRequest(
+                ResourceInfo: SchoolResourceInfo,
+                DocumentInfo: CreateSchoolDocumentInfo(),
+                MappingSet: _mappingSet,
+                EdfiDoc: requestBody ?? CreateRequestBody(),
+                Headers: [],
+                TraceId: new TraceId("ownership-enforcement-post"),
+                DocumentUuid: SchoolDocumentUuid
+            )
+            {
+                AuthorizationContext = new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    creatorOwnershipTokenId,
+                    ownershipTokenIds
+                ),
+                AuthorizationStrategyEvaluators = OwnershipStrategyEvaluators,
+            }
+        );
+    }
+
+    private async Task<UpdateResult> ExecuteOwnershipUpdateAsync(
+        IReadOnlyList<short> ownershipTokenIds,
+        string? ifMatch = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.UpdateDocumentById(
+            new UpdateRequest(
+                ResourceInfo: SchoolResourceInfo,
+                DocumentInfo: CreateSchoolDocumentInfo(),
+                MappingSet: _mappingSet,
+                EdfiDoc: UpdateRequestBody(),
+                Headers: ifMatch is null ? [] : new Dictionary<string, string> { ["If-Match"] = ifMatch },
+                TraceId: new TraceId("ownership-enforcement-put"),
+                DocumentUuid: SchoolDocumentUuid
+            )
+            {
+                AuthorizationContext = new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    // A PUT carries a creator token too; a create would stamp it, an update must not.
+                    creatorOwnershipTokenId: OtherToken,
+                    ownershipTokenIds
+                ),
+                AuthorizationStrategyEvaluators = OwnershipStrategyEvaluators,
+            }
+        );
+    }
+
+    private static AuthorizationStrategyEvaluator[] OwnershipStrategyEvaluators =>
+        [
+            new AuthorizationStrategyEvaluator(
+                AuthorizationStrategyNameConstants.OwnershipBased,
+                [],
+                FilterOperator.And
+            ),
+        ];
+
     private async Task<UpsertResult> ExecuteCreateAsync(
         short? creatorOwnershipTokenId,
         JsonNode? requestBody = null

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalOwnershipStampingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalOwnershipStampingTests.cs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Postgresql;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+using static EdFi.DataManagementService.Backend.Tests.Common.NoProfileUpdateSemanticsScenarios;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Live-provider coverage for <c>dms.Document.CreatedByOwnershipTokenId</c> stamping on PostgreSQL.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The unit tests assert the emitted SQL and parameter binding; only a live provider can prove the column
+/// actually round-trips. Two things specifically need a real engine: that a nullable <c>smallint</c> parameter
+/// declared as <see cref="DbType.Int16"/> binds for both a value and a null, and that an update genuinely
+/// leaves the stored token alone rather than merely omitting it from a statement the unit tests inspected.
+/// </para>
+/// <para>
+/// Stamping only — this suite asserts nothing about ownership enforcement, which is not yet wired.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+[Category("Authorization")]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Postgresql_Relational_Write_With_Ownership_Stamping
+{
+    private const short CreatorToken = 42;
+    private const short OtherToken = 7;
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(FixtureRelativePath);
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await _database.ResetAsync();
+        _serviceProvider = CreateServiceProvider();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public async Task It_stamps_the_creator_ownership_token_on_a_create()
+    {
+        var createResult = await ExecuteCreateAsync(CreatorToken);
+
+        createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A client with no creator token stamps null. This is the case the declared parameter type exists for: a
+    /// null reaches the driver as <c>DBNull</c>, which carries no type of its own.
+    /// </summary>
+    [Test]
+    public async Task It_stamps_null_when_the_client_has_no_creator_token()
+    {
+        var createResult = await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().BeNull();
+    }
+
+    [Test]
+    public async Task It_leaves_the_stored_token_unchanged_on_a_put()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var updateResult = await ExecuteUpdateAsync(OtherToken);
+
+        updateResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A POST that resolves to an upsert-as-update must also leave the stored token alone, even though its
+    /// request carries a creator token that a create would have stamped.
+    /// </summary>
+    [Test]
+    public async Task It_leaves_the_stored_token_unchanged_on_a_post_as_update()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var upsertResult = await ExecuteCreateAsync(OtherToken, UpdateRequestBody());
+
+        upsertResult.Should().BeOfType<UpsertResult.UpdateSuccess>();
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A document stamped null stays null through an update by a client that does have a creator token — an
+    /// unstamped document is permanently unreachable through ownership authorization, and an update must not
+    /// quietly repair it.
+    /// </summary>
+    [Test]
+    public async Task It_leaves_a_null_stored_token_null_on_a_put()
+    {
+        await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        await ExecuteUpdateAsync(CreatorToken);
+
+        (await ReadStoredOwnershipTokenAsync()).Should().BeNull();
+    }
+
+    private async Task<UpsertResult> ExecuteCreateAsync(
+        short? creatorOwnershipTokenId,
+        JsonNode? requestBody = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.UpsertDocument(
+            new UpsertRequest(
+                ResourceInfo: SchoolResourceInfo,
+                DocumentInfo: CreateSchoolDocumentInfo(),
+                MappingSet: _mappingSet,
+                EdfiDoc: requestBody ?? CreateRequestBody(),
+                Headers: [],
+                TraceId: new TraceId("pg-ownership-stamping-post"),
+                DocumentUuid: SchoolDocumentUuid
+            )
+            {
+                AuthorizationContext = CreateAuthorizationContext(creatorOwnershipTokenId),
+            }
+        );
+    }
+
+    private async Task<UpdateResult> ExecuteUpdateAsync(short? creatorOwnershipTokenId)
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.UpdateDocumentById(
+            new UpdateRequest(
+                ResourceInfo: SchoolResourceInfo,
+                DocumentInfo: CreateSchoolDocumentInfo(),
+                MappingSet: _mappingSet,
+                EdfiDoc: UpdateRequestBody(),
+                Headers: [],
+                TraceId: new TraceId("pg-ownership-stamping-put"),
+                DocumentUuid: SchoolDocumentUuid
+            )
+            {
+                AuthorizationContext = CreateAuthorizationContext(creatorOwnershipTokenId),
+            }
+        );
+    }
+
+    private static RelationalAuthorizationContext CreateAuthorizationContext(
+        short? creatorOwnershipTokenId
+    ) => new([], [], creatorOwnershipTokenId, []);
+
+    private IServiceScope CreateScopeForDatabase()
+    {
+        var scope = _serviceProvider.CreateScope();
+
+        scope
+            .ServiceProvider.GetRequiredService<IDataStoreSelection>()
+            .SetSelectedDataStore(
+                new DataStore(
+                    Id: 1,
+                    DataStoreType: "test",
+                    Name: "PostgresqlRelationalOwnershipStamping",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        return scope;
+    }
+
+    private async Task<short?> ReadStoredOwnershipTokenAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT "CreatedByOwnershipTokenId"
+            FROM "dms"."Document"
+            WHERE "DocumentUuid" = @documentUuid;
+            """,
+            new NpgsqlParameter("documentUuid", SchoolDocumentUuid.Value)
+        );
+
+        if (rows.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected exactly one document row for '{SchoolDocumentUuid.Value}', but found {rows.Count}."
+            );
+        }
+
+        var value = rows[0]["CreatedByOwnershipTokenId"];
+        return value is null or DBNull ? null : Convert.ToInt16(value, CultureInfo.InvariantCulture);
+    }
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = new();
+
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<NpgsqlDataSourceCache>();
+        services.AddScoped<IDataStoreSelection, DataStoreSelection>();
+        services.AddScoped<NpgsqlDataSourceProvider>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddPostgresqlBackendIntegrationTestServices();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalOwnershipStampingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalOwnershipStampingTests.cs
@@ -277,6 +277,125 @@ public class Given_A_Postgresql_Relational_Write_With_Ownership_Stamping
             .Contain("2,000");
     }
 
+    // ----- Delete enforcement ----------------------------------------------
+
+    /// <summary>
+    /// An owner may delete. Proves the co-batched ownership statement authorizes and the deletes in the same
+    /// command still run, rather than the check aborting a batch that carried them.
+    /// </summary>
+    [Test]
+    public async Task It_deletes_a_document_whose_stored_token_the_reader_holds()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipDeleteAsync([OtherToken, CreatorToken]);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        (await CountStoredDocumentsAsync()).Should().Be(0);
+    }
+
+    /// <summary>
+    /// A non-owner may not, and the row survives. The deletes rode the same command the ownership statement
+    /// aborted, so the abort rolled them back — this is the assertion that a denial cannot destroy data.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_delete_whose_stored_token_the_reader_does_not_hold_and_leaves_the_row()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipDeleteAsync([OtherToken]);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        (await CountStoredDocumentsAsync()).Should().Be(1);
+        (await ReadStoredOwnershipTokenAsync()).Should().Be(CreatorToken);
+    }
+
+    /// <summary>
+    /// A document created without a token can be deleted by nobody: auth.md 2.14, and the row stays.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_delete_whose_stored_ownership_token_was_never_assigned()
+    {
+        await ExecuteCreateAsync(creatorOwnershipTokenId: null);
+
+        var result = await ExecuteOwnershipDeleteAsync([CreatorToken]);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        (await CountStoredDocumentsAsync()).Should().Be(1);
+    }
+
+    /// <summary>
+    /// The denial outranks a stale If-Match. Telling a non-owner its etag is stale would disclose that the
+    /// row changed, so the ownership decision is the one reported.
+    /// </summary>
+    [Test]
+    public async Task It_reports_an_ownership_delete_denial_over_a_stale_if_match()
+    {
+        await ExecuteCreateAsync(CreatorToken);
+
+        var result = await ExecuteOwnershipDeleteAsync([OtherToken], ifMatch: "\"stale-etag\"");
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>();
+        (await CountStoredDocumentsAsync()).Should().Be(1);
+    }
+
+    private async Task<DeleteResult> ExecuteOwnershipDeleteAsync(
+        IReadOnlyList<short> ownershipTokenIds,
+        string? ifMatch = null
+    )
+    {
+        using var scope = CreateScopeForDatabase();
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+
+        return await repository.DeleteDocumentById(
+            new DeleteRequest(
+                DocumentUuid: SchoolDocumentUuid,
+                ResourceInfo: SchoolResourceInfo,
+                TraceId: new TraceId("ownership-enforcement-delete"),
+                Headers: ifMatch is null ? [] : new Dictionary<string, string> { ["If-Match"] = ifMatch },
+                MappingSet: _mappingSet
+            )
+            {
+                AuthorizationContext = new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    creatorOwnershipTokenId: null,
+                    ownershipTokenIds
+                ),
+                AuthorizationStrategyEvaluators =
+                [
+                    new AuthorizationStrategyEvaluator(
+                        AuthorizationStrategyNameConstants.OwnershipBased,
+                        [],
+                        FilterOperator.And
+                    ),
+                ],
+            }
+        );
+    }
+
+    private async Task<int> CountStoredDocumentsAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT COUNT(*) AS "DocumentCount"
+            FROM "dms"."Document"
+            WHERE "DocumentUuid" = @documentUuid;
+            """,
+            new NpgsqlParameter("documentUuid", SchoolDocumentUuid.Value)
+        );
+
+        return Convert.ToInt32(rows[0]["DocumentCount"], CultureInfo.InvariantCulture);
+    }
+
     private async Task<GetResult> ExecuteOwnershipGetByIdAsync(
         IReadOnlyList<short> ownershipTokenIds,
         IReadOnlyList<string>? strategyNames = null

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalPostAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalPostAuthorizationTests.cs
@@ -520,6 +520,40 @@ public class Given_A_Postgresql_RelationalPost_Create_Authorization_With_A_Synth
         await AssertNoPeopleCreateSideEffectsAsync(seed);
     }
 
+    /// <summary>
+    /// Ownership AND-composes ahead of the relationship OR group, so when both are configured and the
+    /// caller holds no EducationOrganization claims at all, the ownership denial is what a POST resolving
+    /// to upsert-as-update reports. Preflight cannot short-circuit the relationship NoClaims here: nothing
+    /// has read the stored token yet. The row was created without one, which is auth.md 2.14, and the row
+    /// assertions are the other half of the point — a denial must leave it exactly where it was.
+    /// </summary>
+    [Test]
+    public async Task It_reports_a_post_as_update_ownership_denial_over_a_relationship_no_claims_denial()
+    {
+        var seed = CreateRootChildSeed(
+            "cccccccc-0000-0000-0000-000000000701",
+            701,
+            "ownership-over-relationship-no-claims",
+            100,
+            []
+        );
+
+        (await PostRootChildAsync(seed)).Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var result = await _context.UpsertAuthorizationRootChildAsync(
+            seed,
+            [],
+            RelationshipAuthorizationCrudTestSupport.EdOrgOnlyPlusKnownUnsupportedStrategyNames
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        await AssertPersistedRowsAsync(seed);
+    }
+
     private async Task<UpsertResult> PostRootChildAsync(
         AuthorizationRootChildSeed seed,
         IReadOnlyList<string>? strategyNames = null,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
@@ -114,7 +114,7 @@ public class Given_The_Composite_Relational_Delete_Command
     {
         var session = CreateSession(
             dialect,
-            DeleteReader(rootDeleteOrdinal: 2, deleted: true, namespaceCheckCount: 1)
+            DeleteReader(rootDeleteOrdinal: 2, deleted: true, authorizationResultSetCount: 1)
         );
         var request = CreateRequest(dialect) with
         {
@@ -144,7 +144,7 @@ public class Given_The_Composite_Relational_Delete_Command
             DeleteReader(
                 rootDeleteOrdinal: 3,
                 deleted: true,
-                namespaceCheckCount: 1,
+                authorizationResultSetCount: 1,
                 includeRelationshipRow: true
             )
         );
@@ -219,7 +219,7 @@ public class Given_The_Composite_Relational_Delete_Command
     {
         var session = CreateSession(
             dialect,
-            DeleteReader(rootDeleteOrdinal: 2, deleted: true, namespaceCheckCount: 1)
+            DeleteReader(rootDeleteOrdinal: 2, deleted: true, authorizationResultSetCount: 1)
         );
         var request = CreateRequest(dialect) with
         {
@@ -296,7 +296,7 @@ public class Given_The_Composite_Relational_Delete_Command
     {
         var session = CreateSession(
             SqlDialect.Pgsql,
-            DeleteReader(rootDeleteOrdinal: 3, deleted: true, namespaceCheckCount: 2)
+            DeleteReader(rootDeleteOrdinal: 3, deleted: true, authorizationResultSetCount: 2)
         );
         var request = CreateRequest(SqlDialect.Pgsql) with
         {
@@ -322,7 +322,7 @@ public class Given_The_Composite_Relational_Delete_Command
         // its view may be validated only once that check has passed, and the deletes wait for both.
         var session = CreateSession(
             SqlDialect.Pgsql,
-            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            CaptureOnlyReader(captured: true, authorizationResultSetCount: 1),
             NamespaceCheckReader(checkCount: 1),
             SegmentDeleteReader(deleted: true)
         );
@@ -379,7 +379,7 @@ public class Given_The_Composite_Relational_Delete_Command
         // after follows as a segment, and the deletes wait for that segment.
         var session = CreateSession(
             SqlDialect.Pgsql,
-            CaptureOnlyReader(captured: true, namespaceCheckCount: 2),
+            CaptureOnlyReader(captured: true, authorizationResultSetCount: 2),
             NamespaceCheckReader(checkCount: 1),
             SegmentDeleteReader(deleted: true)
         );
@@ -484,7 +484,7 @@ public class Given_The_Composite_Relational_Delete_Command
         // never be enforced on this delete.
         var session = CreateSession(
             SqlDialect.Pgsql,
-            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            CaptureOnlyReader(captured: true, authorizationResultSetCount: 1),
             NamespaceCheckReader(checkCount: 1),
             new FakeDbException("AUTH1", "AUTH1")
         );
@@ -532,7 +532,7 @@ public class Given_The_Composite_Relational_Delete_Command
         // the relationship check is never issued at all.
         var session = CreateSession(
             SqlDialect.Pgsql,
-            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            CaptureOnlyReader(captured: true, authorizationResultSetCount: 1),
             new FakeDbException("AUTH1", "AUTH1")
         );
         var request = CreateRequest(SqlDialect.Pgsql) with
@@ -636,7 +636,7 @@ public class Given_The_Composite_Relational_Delete_Command
         // One result set for the namespace check and one for the ownership check, then the two deletes.
         var session = CreateSession(
             dialect,
-            DeleteReader(rootDeleteOrdinal: 3, deleted: true, namespaceCheckCount: 2)
+            DeleteReader(rootDeleteOrdinal: 3, deleted: true, authorizationResultSetCount: 2)
         );
         var request = CreateRequest(dialect) with
         {
@@ -750,7 +750,7 @@ public class Given_The_Composite_Relational_Delete_Command
     {
         var session = CreateSession(
             SqlDialect.Pgsql,
-            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            CaptureOnlyReader(captured: true, authorizationResultSetCount: 1),
             // The custom-view segment, then the ownership segment, then the withheld deletes.
             NamespaceCheckReader(checkCount: 1),
             NamespaceCheckReader(checkCount: 1),
@@ -1074,7 +1074,7 @@ public class Given_The_Composite_Relational_Delete_Command
     {
         var session = CreateSession(
             SqlDialect.Mssql,
-            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            CaptureOnlyReader(captured: true, authorizationResultSetCount: 1),
             RelationshipRowReader(),
             SegmentDeleteReader(deleted: true)
         );
@@ -1509,7 +1509,7 @@ public class Given_The_Composite_Relational_Delete_Command
     /// </summary>
     private static ScriptedDbDataReader CaptureOnlyReader(
         bool captured,
-        int namespaceCheckCount = 0,
+        int authorizationResultSetCount = 0,
         bool includeRelationshipRow = false
     )
     {
@@ -1530,7 +1530,7 @@ public class Given_The_Composite_Relational_Delete_Command
             ["DocumentId", "ContentVersion", "DocumentUuid", "CapturedToken"],
         ];
 
-        for (var check = 0; check < namespaceCheckCount; check++)
+        for (var resultSet = 0; resultSet < authorizationResultSetCount; resultSet++)
         {
             resultSets.Add([
                 [1],
@@ -1598,15 +1598,20 @@ public class Given_The_Composite_Relational_Delete_Command
         );
 
     /// <summary>
-    /// The composite command's declared result-set stream: the capture row, one row set per namespace check,
-    /// the relationship row when one is co-batched, the root delete's sentinel echoing its own ordinal, and
-    /// the <c>dms.Document</c> delete's returned id.
+    /// The composite command's declared result-set stream: the capture row, one row set per co-batched
+    /// authorization statement, the relationship row when one is co-batched, the root delete's sentinel
+    /// echoing its own ordinal, and the <c>dms.Document</c> delete's returned id.
     /// </summary>
+    /// <param name="authorizationResultSetCount">
+    /// How many single-row authorization statements the command carries. Namespace and ownership checks emit
+    /// the same shape, so one counter serves both — a command with a namespace check and an ownership check
+    /// declares two.
+    /// </param>
     private static ScriptedDbDataReader DeleteReader(
         int rootDeleteOrdinal,
         bool deleted,
         bool captured = true,
-        int namespaceCheckCount = 0,
+        int authorizationResultSetCount = 0,
         bool includeRelationshipRow = false
     )
     {
@@ -1628,7 +1633,7 @@ public class Given_The_Composite_Relational_Delete_Command
             ["DocumentId", "ContentVersion", "DocumentUuid", "CapturedToken"],
         ];
 
-        for (var check = 0; check < namespaceCheckCount; check++)
+        for (var resultSet = 0; resultSet < authorizationResultSetCount; resultSet++)
         {
             resultSets.Add([
                 [1],

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalDeleteCommandTests.cs
@@ -620,6 +620,248 @@ public class Given_The_Composite_Relational_Delete_Command
         validationExecutor.ExecutedCommands.Should().BeEmpty();
     }
 
+    // ----- Ownership --------------------------------------------------------
+
+    /// <summary>
+    /// The production call-site order, which the helper-level fixture cannot prove: the ownership statement
+    /// lands after the namespace one and before both deletes. Statement order is precedence order because
+    /// the command aborts at its first AUTH1, so a denial ahead of the deletes is what keeps the row.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public async Task It_emits_the_ownership_statement_after_namespace_and_before_both_deletes(
+        SqlDialect dialect
+    )
+    {
+        // One result set for the namespace check and one for the ownership check, then the two deletes.
+        var session = CreateSession(
+            dialect,
+            DeleteReader(rootDeleteOrdinal: 3, deleted: true, namespaceCheckCount: 2)
+        );
+        var request = CreateRequest(dialect) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(dialect),
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(dialect),
+        };
+
+        var result = await CreateSut().ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        var commandText = session.Commands.Should().ContainSingle().Subject.CommandText;
+        // Not NamespaceCheckMarker: the ownership statement is also a SELECT CASE, so that marker matches
+        // whichever check came first and the comparison below would hold either way. The prefix parameter is
+        // emitted only by the namespace check.
+        var namespaceIndex = commandText.IndexOf("namespacePrefixes", StringComparison.Ordinal);
+        var ownershipIndex = commandText.IndexOf(OwnershipCheckMarker(dialect), StringComparison.Ordinal);
+        namespaceIndex.Should().BePositive();
+        ownershipIndex.Should().BePositive();
+        namespaceIndex.Should().BeLessThan(ownershipIndex);
+        ownershipIndex.Should().BeLessThan(IndexOfRootDelete(session, dialect));
+        ownershipIndex.Should().BeLessThan(IndexOfDocumentDelete(session, dialect));
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public async Task It_denies_a_delete_on_an_ownership_token_mismatch_and_leaves_the_row(SqlDialect dialect)
+    {
+        var session = CreateSession(dialect, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(dialect) with
+        {
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(dialect),
+        };
+
+        var result = await CreateSut(
+                new StubProviderFailureExtractor("AUTH1", OwnershipDenialPayload(dialect))
+            )
+            .ExecuteAsync(request, session);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        // The deletes rode the same command, so the abort rolled them back with it: the row survives.
+        session.Commands.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// An uninitialized stored token is auth.md 2.14 and reaches the caller as its own failure kind, not
+    /// collapsed into the 2.13 mismatch the sibling test covers.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_delete_whose_stored_ownership_token_was_never_assigned()
+    {
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(SqlDialect.Pgsql),
+        };
+
+        var result = await CreateSut(
+                new StubProviderFailureExtractor(
+                    "AUTH1",
+                    OwnershipDenialPayload(
+                        SqlDialect.Pgsql,
+                        OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized
+                    )
+                )
+            )
+            .ExecuteAsync(request, session);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+    }
+
+    /// <summary>
+    /// A namespace denial still wins over an ownership one. Both statements ride the command and the command
+    /// aborts at the first, so the emitted order is what decides — which is why the ownership statement is
+    /// appended after the namespace one rather than at its configured position.
+    /// </summary>
+    [Test]
+    public async Task It_reports_a_namespace_denial_over_an_ownership_check_configured_before_it()
+    {
+        var session = CreateSession(SqlDialect.Pgsql, new FakeDbException("AUTH1", "AUTH1"));
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+            // Configured ahead of NamespaceBased, and still executed after it.
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(
+                SqlDialect.Pgsql,
+                rawConfiguredIndex: 0
+            ),
+        };
+
+        var result = await CreateSut(new StubProviderFailureExtractor("AUTH1", NamespaceDenialPayload()))
+            .ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>();
+    }
+
+    /// <summary>
+    /// When a check configured ahead of ownership owes an ordered segment, ownership must not ride the
+    /// opening command either — it executes after that check — and the deletes must be withheld so nothing
+    /// is removed before the ownership decision.
+    /// </summary>
+    [Test]
+    public async Task It_withholds_the_deletes_when_ownership_must_run_as_a_segment()
+    {
+        var session = CreateSession(
+            SqlDialect.Pgsql,
+            CaptureOnlyReader(captured: true, namespaceCheckCount: 1),
+            // The custom-view segment, then the ownership segment, then the withheld deletes.
+            NamespaceCheckReader(checkCount: 1),
+            NamespaceCheckReader(checkCount: 1),
+            SegmentDeleteReader(deleted: true)
+        );
+        var request = CreateRequest(SqlDialect.Pgsql) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(SqlDialect.Pgsql),
+            // A view configured after NamespaceBased always takes a segment, which pushes ownership out too.
+            CustomViewAuthorization = CreateStoredCustomViewAuthorization(("SchoolWithALateTag", 1)),
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(SqlDialect.Pgsql),
+        };
+
+        var result = await CreateSut().ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        session.Commands.Should().HaveCount(4);
+        // The opening command carries the namespace check but neither the ownership statement nor the deletes.
+        session
+            .Commands[0]
+            .CommandText.Should()
+            .Contain("namespacePrefixes")
+            .And.NotContain(OwnershipCheckMarker(SqlDialect.Pgsql))
+            .And.NotContain("DELETE FROM");
+        session.Commands[1].CommandText.Should().Contain("SchoolWithALateTag");
+        // Ownership runs after the custom-view segment and before the deletes.
+        session.Commands[2].CommandText.Should().Contain(OwnershipCheckMarker(SqlDialect.Pgsql));
+        session.Commands[3].CommandText.Should().Contain("DELETE FROM");
+    }
+
+    /// <summary>
+    /// The case the sibling test cannot reach: ownership alone does not fit the command's parameter budget,
+    /// with no custom-view segment owed. The deletes must still be withheld, or the row would be removed by
+    /// the opening command before the ownership check that runs afterwards could deny it.
+    /// </summary>
+    [Test]
+    public async Task It_withholds_the_deletes_when_only_ownership_does_not_fit_the_command()
+    {
+        var session = CreateSession(
+            SqlDialect.Mssql,
+            CaptureOnlyReader(captured: true),
+            // The ownership segment, then the withheld deletes.
+            NamespaceCheckReader(checkCount: 1),
+            SegmentDeleteReader(deleted: true)
+        );
+        var request = CreateRequest(SqlDialect.Mssql) with
+        {
+            // SQL Server binds one scalar per token, so three tokens cannot fit beside the capture's own
+            // parameter in a two-slot budget.
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(
+                SqlDialect.Mssql,
+                ownershipTokenIds: [3, 5, 7]
+            ),
+        };
+
+        var result = await CreateSut(
+                commandBudget: new RelationalCommandBudget(
+                    MaxParametersPerCommand: 2,
+                    MaxRowsPerStatement: 1000
+                )
+            )
+            .ExecuteAsync(request, session);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        session.Commands.Should().HaveCount(3);
+        session
+            .Commands[0]
+            .CommandText.Should()
+            .NotContain(OwnershipCheckMarker(SqlDialect.Mssql))
+            .And.NotContain("DELETE FROM");
+        session.Commands[1].CommandText.Should().Contain(OwnershipCheckMarker(SqlDialect.Mssql));
+        session.Commands[2].CommandText.Should().Contain("DELETE FROM");
+    }
+
+    private static RelationalOwnershipAuthorization CreateStoredOwnershipAuthorization(
+        SqlDialect dialect,
+        int rawConfiguredIndex = 1,
+        IReadOnlyList<short>? ownershipTokenIds = null
+    ) =>
+        new(
+            new OwnershipAuthorizationCheckSpec(rawConfiguredIndex),
+            OwnershipTokenParameterizationFactory.Create(
+                dialect,
+                ownershipTokenIds ?? [11],
+                "ownershipTokenIds"
+            )
+        );
+
+    /// <summary>
+    /// The ownership check's emitted shape, which no other delete statement produces: only it reads
+    /// CreatedByOwnershipTokenId.
+    /// </summary>
+    private static string OwnershipCheckMarker(SqlDialect dialect) =>
+        dialect is SqlDialect.Pgsql ? "\"CreatedByOwnershipTokenId\"" : "[CreatedByOwnershipTokenId]";
+
+    private static string OwnershipDenialPayload(
+        SqlDialect dialect,
+        OwnershipAuthorizationAuth1FailureKind failureKind =
+            OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch,
+        int configuredStrategyIndex = 1
+    )
+    {
+        var payload = OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+            new OwnershipAuthorizationAuth1FailurePayload(configuredStrategyIndex, failureKind)
+        );
+
+        return dialect is SqlDialect.Mssql
+            ? $"{OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode} - {payload}"
+            : payload;
+    }
+
     private static string NamespaceDenialPayload() =>
         NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
             new NamespaceAuthorizationAuth1FailurePayload(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteDmlCommandTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteDmlCommandTests.cs
@@ -52,6 +52,69 @@ public class Given_The_Composite_Relational_Write_Second_Command_In_Dml_Mode
         resolution.PersistResult!.ContentVersion.Should().Be(77L);
     }
 
+    /// <summary>
+    /// The co-batched create stamps <c>CreatedByOwnershipTokenId</c> from the client's creator token, the same
+    /// value the ordered-segment path binds. The composite statement rewriter renames parameters, so the
+    /// assertion matches on the allocator-stamped name rather than the builder's.
+    /// </summary>
+    [Test]
+    public async Task It_stamps_the_creator_ownership_token_on_the_co_batched_document_insert()
+    {
+        var request = CreateCreatedTargetRequest() with { CreatorOwnershipTokenId = 42 };
+        var session = new ScriptedWriteSession(
+            CreateReader(Scalar(900L), Sentinel(1), PersistObservation(1L))
+        );
+
+        await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateNewRootMergeResult(request),
+                RelationalWriteSecondCommandMode.Dml,
+                session
+            );
+
+        var command = session.Commands.Should().ContainSingle().Subject;
+        command.CommandText.Should().Contain("\"CreatedByOwnershipTokenId\"");
+        command
+            .Parameters.Should()
+            .ContainSingle(parameter =>
+                parameter.Name.Contains("createdByOwnershipTokenId", StringComparison.OrdinalIgnoreCase)
+            )
+            .Which.Value.Should()
+            .Be((short)42);
+    }
+
+    /// <summary>
+    /// An existing-target write must leave the stored ownership token alone, and it does so because no
+    /// statement it emits mentions the column — not because of a runtime guard.
+    /// </summary>
+    [Test]
+    public async Task It_never_writes_the_ownership_column_for_an_existing_target()
+    {
+        var request = CreateExistingTargetRequest() with { CreatorOwnershipTokenId = 42 };
+        var session = new ScriptedWriteSession(CreateReader(Sentinel(0), PersistObservation(77L)));
+
+        await CreateSut()
+            .ResolveAsync(
+                request,
+                CreateChangedRootMergeResult(request),
+                RelationalWriteSecondCommandMode.Dml,
+                session
+            );
+
+        session
+            .Commands.Should()
+            .OnlyContain(command =>
+                !command.CommandText.Contains("CreatedByOwnershipTokenId", StringComparison.Ordinal)
+            );
+        session
+            .Commands.SelectMany(static command => command.Parameters)
+            .Should()
+            .NotContain(parameter =>
+                parameter.Name.Contains("createdByOwnershipTokenId", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
     [Test]
     public async Task It_co_batches_the_document_insert_with_the_rows_it_makes_room_for()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
@@ -1082,30 +1082,64 @@ public class Given_The_Composite_Relational_Write_First_Phase
     /// path, as a namespace non-fit already does. That path executes and validates every check in configured
     /// order, so ownership still runs after the namespace check and before the relationship one.
     /// </summary>
-    [Test]
-    public async Task It_falls_back_to_ordered_segments_when_the_ownership_tokens_do_not_fit()
+    /// <remarks>
+    /// SQL Server-shaped deliberately, and asserted at both token counts against one budget. PostgreSQL
+    /// binds any token count as a single array parameter, so a PostgreSQL fallback could only ever be caused
+    /// by something other than the token list — the capture's own parameters, say — which would make this
+    /// test pass while proving nothing. Here the token count is the only thing that differs between the two
+    /// cases.
+    /// </remarks>
+    [TestCase(2, true)]
+    [TestCase(6, false)]
+    public async Task It_co_batches_ownership_only_while_its_scalar_tokens_fit_the_budget(
+        int ownershipTokenCount,
+        bool expectsCoBatch
+    )
     {
         var target = new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value);
-        var input = CreateInput(RelationalWriteOperationKind.Put) with
+        var input = CreateInput(RelationalWriteOperationKind.Put, dialect: SqlDialect.Mssql) with
         {
-            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(ownershipTokenIds: [3, 5, 7]),
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(
+                dialect: SqlDialect.Mssql,
+                ownershipTokenIds:
+                [
+                    .. Enumerable.Range(1, ownershipTokenCount).Select(static tokenId => (short)tokenId),
+                ]
+            ),
         };
-        var session = new ScriptedWriteSession(
-            CreateCaptureReader(target),
-            // The ownership segment authorizes, then hydration runs.
-            CreateReader(CreateAuthorizationTable()),
-            CreateReader(CreateDocumentMetadataTable(target, 44L), CreateRootTable(target))
-        );
+        var session = expectsCoBatch
+            ? new ScriptedWriteSession(
+                CreateReader(
+                    CreateCaptureTable(target),
+                    CreateAuthorizationTable(),
+                    CreateDocumentMetadataTable(target, 44L),
+                    CreateRootTable(target)
+                )
+            )
+            : new ScriptedWriteSession(
+                CreateCaptureReader(target),
+                // The ownership segment authorizes, then hydration runs.
+                CreateReader(CreateAuthorizationTable()),
+                CreateReader(CreateDocumentMetadataTable(target, 44L), CreateRootTable(target))
+            );
 
         var resolution = await CreateSut(
                 commandBudget: new RelationalCommandBudget(
-                    MaxParametersPerCommand: 2,
+                    MaxParametersPerCommand: 4,
                     MaxRowsPerStatement: 1000
                 )
             )
             .ResolveAsync(input, session);
 
         resolution.ImmediateResult.Should().BeNull();
+
+        if (expectsCoBatch)
+        {
+            session.Commands.Should().ContainSingle();
+            session.Commands[0].CommandText.Should().Contain("CreatedByOwnershipTokenId");
+            return;
+        }
+
         session.Commands.Count.Should().BeGreaterThan(1);
         session.Commands[0].CommandText.Should().NotContain("CreatedByOwnershipTokenId");
         session
@@ -1116,12 +1150,13 @@ public class Given_The_Composite_Relational_Write_First_Phase
 
     private static RelationalOwnershipAuthorization CreateStoredOwnershipAuthorization(
         int rawConfiguredIndex = 1,
-        IReadOnlyList<short>? ownershipTokenIds = null
+        IReadOnlyList<short>? ownershipTokenIds = null,
+        SqlDialect dialect = SqlDialect.Pgsql
     ) =>
         new(
             new OwnershipAuthorizationCheckSpec(rawConfiguredIndex),
             OwnershipTokenParameterizationFactory.Create(
-                SqlDialect.Pgsql,
+                dialect,
                 ownershipTokenIds ?? [11],
                 "ownershipTokenIds"
             )

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
@@ -1027,6 +1027,71 @@ public class Given_The_Composite_Relational_Write_First_Phase
     }
 
     /// <summary>
+    /// The failure a POST deferred from preflight is owed only to an upsert-as-update, and in the ownership
+    /// slot: after the namespace segment, before the relationship check and the hydration, so no DML follows.
+    /// The request takes the ordered-segments path, which is what keeps the relationship statement and the
+    /// hydration from riding ahead of the failure inside one composite command.
+    /// </summary>
+    [Test]
+    public async Task It_returns_the_deferred_ownership_failure_for_an_existing_post_target_after_the_namespace_segment()
+    {
+        var deferred = RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
+            RelationalWriteOperationKind.Post,
+            ["ownership token cap"]
+        );
+        var target = new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value);
+        var input = CreateInput(RelationalWriteOperationKind.Post) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            DeferredStoredOwnershipFailureResult = deferred,
+        };
+        var session = new ScriptedWriteSession(
+            CreateCaptureReader(target),
+            CreateReader(CreateAuthorizationTable())
+        );
+
+        var resolution = await CreateSut().ResolveAsync(input, session);
+
+        resolution.ImmediateResult.Should().BeSameAs(deferred);
+        resolution.Outcome.Should().BeNull();
+        // Capture, then the namespace segment, then the deferred failure in the ownership slot: no
+        // relationship, reference or hydration command follows it.
+        session.Commands.Should().HaveCount(2);
+        session.Commands[1].CommandText.Should().Contain("namespacePrefixes");
+        session
+            .Commands.Should()
+            .NotContain(command => command.CommandText.Contains("CreatedByOwnershipTokenId"));
+    }
+
+    /// <summary>
+    /// A create never sees the deferred failure: ownership never denies a create, and the over-limit list was
+    /// never parameterized for one, so the write proceeds with no ownership statement or parameter at all.
+    /// </summary>
+    [Test]
+    public async Task It_ignores_the_deferred_ownership_failure_for_a_post_create()
+    {
+        var deferred = RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
+            RelationalWriteOperationKind.Post,
+            ["ownership token cap"]
+        );
+        var input = CreateInput(RelationalWriteOperationKind.Post, includeReadPlan: false) with
+        {
+            DeferredStoredOwnershipFailureResult = deferred,
+        };
+        var session = new ScriptedWriteSession(CreateCaptureReader(target: null));
+
+        var resolution = await CreateSut().ResolveAsync(input, session);
+
+        resolution.ImmediateResult.Should().BeNull();
+        resolution
+            .Outcome!.ExecutionRequest.TargetContext.Should()
+            .BeOfType<RelationalWriteTargetContext.CreateNew>();
+        var commandText = session.Commands.Should().ContainSingle().Subject.CommandText;
+        commandText.Should().NotContain("CreatedByOwnershipTokenId");
+        commandText.Should().NotContain("ownershipTokenIds");
+    }
+
+    /// <summary>
     /// An ownership denial on the co-batched command maps to the operation's own ownership failure rather
     /// than a generic write failure, for both verbs.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CompositeRelationalWriteFirstPhaseTests.cs
@@ -942,6 +942,191 @@ public class Given_The_Composite_Relational_Write_First_Phase
             new JsonPath("$.schoolReference")
         );
 
+    // ----- Ownership --------------------------------------------------------
+
+    /// <summary>
+    /// The ownership statement lands after the namespace one, matching auth.md: ownership is the last AND
+    /// filter. Statement order is precedence order because the command aborts at its first AUTH1; the
+    /// relative order against the relationship statement is asserted by the composite append fixture.
+    /// </summary>
+    [TestCase(RelationalWriteOperationKind.Post)]
+    [TestCase(RelationalWriteOperationKind.Put)]
+    public async Task It_emits_the_ownership_statement_after_namespace_and_before_hydration(
+        RelationalWriteOperationKind operationKind
+    )
+    {
+        var target = new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value);
+        var input = CreateInput(operationKind) with
+        {
+            StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(),
+        };
+        var session = new ScriptedWriteSession(
+            CreateReader(
+                CreateCaptureTable(target),
+                // One row set for the namespace check, one for the ownership check.
+                CreateAuthorizationTable(),
+                CreateAuthorizationTable(),
+                CreateDocumentMetadataTable(target, 44L),
+                CreateRootTable(target)
+            )
+        );
+
+        await CreateSut().ResolveAsync(input, session);
+
+        var commandText = session.Commands.Should().ContainSingle().Subject.CommandText;
+        // The prefix parameter is emitted only by the namespace check; both checks are SELECT CASE, so a
+        // shared marker would make this comparison hold either way.
+        var namespaceIndex = commandText.IndexOf("namespacePrefixes", StringComparison.Ordinal);
+        var ownershipIndex = commandText.IndexOf("CreatedByOwnershipTokenId", StringComparison.Ordinal);
+        namespaceIndex.Should().BePositive();
+        ownershipIndex.Should().BePositive();
+        namespaceIndex.Should().BeLessThan(ownershipIndex);
+        // Hydration follows both checks, which is what puts the ownership decision ahead of reading the row
+        // it authorizes.
+        ownershipIndex
+            .Should()
+            .BeLessThan(commandText.LastIndexOf("ContentVersion", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// This is the assertion that pins D1: a POST that resolves to a create is never denied by ownership.
+    /// The statement carries the carrier's row guard, so with no captured target it produces no rows and
+    /// none of its branches — the AUTH1 abort device included — evaluates. Asserted with the caller holding
+    /// zero ownership tokens, which is the configuration most likely to deny if the guard were missing.
+    /// </summary>
+    [Test]
+    public async Task It_keeps_the_ownership_statement_vacuous_for_a_create_with_no_tokens()
+    {
+        var input = CreateInput(RelationalWriteOperationKind.Post, includeReadPlan: false) with
+        {
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(ownershipTokenIds: []),
+        };
+        var session = new ScriptedWriteSession(
+            CreateReader(CreateCaptureTable(target: null), CreateAuthorizationTable())
+        );
+
+        var resolution = await CreateSut().ResolveAsync(input, session);
+
+        resolution.ImmediateResult.Should().BeNull();
+        resolution
+            .Outcome!.ExecutionRequest.TargetContext.Should()
+            .BeOfType<RelationalWriteTargetContext.CreateNew>();
+        var commandText = session.Commands.Should().ContainSingle().Subject.CommandText;
+        // The check is present and guarded: an empty token list renders a constant-false membership
+        // predicate, and the row guard is what stops the statement producing a row to abort on.
+        commandText.Should().Contain("CreatedByOwnershipTokenId");
+        commandText.Should().Contain("1 = 0");
+        commandText
+            .Should()
+            .Contain(
+                IRelationalCompositeCommandDialect
+                    .Create(SqlDialect.Pgsql)
+                    .Carrier.CapturedTargetPresentPredicate
+            );
+    }
+
+    /// <summary>
+    /// An ownership denial on the co-batched command maps to the operation's own ownership failure rather
+    /// than a generic write failure, for both verbs.
+    /// </summary>
+    [TestCase(RelationalWriteOperationKind.Post)]
+    [TestCase(RelationalWriteOperationKind.Put)]
+    public async Task It_maps_a_co_batched_ownership_denial_to_the_operations_ownership_failure(
+        RelationalWriteOperationKind operationKind
+    )
+    {
+        var input = CreateInput(operationKind) with
+        {
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(rawConfiguredIndex: 1),
+        };
+        var extractor = new TestProviderFailureExtractor(
+            OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+            OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+                new OwnershipAuthorizationAuth1FailurePayload(
+                    1,
+                    OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch
+                )
+            )
+        );
+        var session = new ScriptedWriteSession(new FakeDbException("ownership denial"));
+
+        var resolution = await CreateSut(providerFailureExtractor: extractor).ResolveAsync(input, session);
+
+        var immediate = resolution.ImmediateResult.Should().NotBeNull().And.Subject;
+
+        if (operationKind is RelationalWriteOperationKind.Post)
+        {
+            immediate
+                .Should()
+                .BeOfType<RelationalWriteExecutorResult.Upsert>()
+                .Which.Result.Should()
+                .BeOfType<UpsertResult.UpsertFailureOwnershipNotAuthorized>()
+                .Which.OwnershipFailure.ConfiguredStrategyIndex.Should()
+                .Be(1);
+        }
+        else
+        {
+            immediate
+                .Should()
+                .BeOfType<RelationalWriteExecutorResult.Update>()
+                .Which.Result.Should()
+                .BeOfType<UpdateResult.UpdateFailureOwnershipNotAuthorized>()
+                .Which.OwnershipFailure.ConfiguredStrategyIndex.Should()
+                .Be(1);
+        }
+    }
+
+    /// <summary>
+    /// A token list that does not fit the command's budget sends the whole request to the ordered-segments
+    /// path, as a namespace non-fit already does. That path executes and validates every check in configured
+    /// order, so ownership still runs after the namespace check and before the relationship one.
+    /// </summary>
+    [Test]
+    public async Task It_falls_back_to_ordered_segments_when_the_ownership_tokens_do_not_fit()
+    {
+        var target = new CapturedTarget(345L, 44L, ExistingDocumentUuid.Value);
+        var input = CreateInput(RelationalWriteOperationKind.Put) with
+        {
+            StoredOwnershipAuthorization = CreateStoredOwnershipAuthorization(ownershipTokenIds: [3, 5, 7]),
+        };
+        var session = new ScriptedWriteSession(
+            CreateCaptureReader(target),
+            // The ownership segment authorizes, then hydration runs.
+            CreateReader(CreateAuthorizationTable()),
+            CreateReader(CreateDocumentMetadataTable(target, 44L), CreateRootTable(target))
+        );
+
+        var resolution = await CreateSut(
+                commandBudget: new RelationalCommandBudget(
+                    MaxParametersPerCommand: 2,
+                    MaxRowsPerStatement: 1000
+                )
+            )
+            .ResolveAsync(input, session);
+
+        resolution.ImmediateResult.Should().BeNull();
+        session.Commands.Count.Should().BeGreaterThan(1);
+        session.Commands[0].CommandText.Should().NotContain("CreatedByOwnershipTokenId");
+        session
+            .Commands.Skip(1)
+            .Should()
+            .Contain(command => command.CommandText.Contains("CreatedByOwnershipTokenId"));
+    }
+
+    private static RelationalOwnershipAuthorization CreateStoredOwnershipAuthorization(
+        int rawConfiguredIndex = 1,
+        IReadOnlyList<short>? ownershipTokenIds = null
+    ) =>
+        new(
+            new OwnershipAuthorizationCheckSpec(rawConfiguredIndex),
+            OwnershipTokenParameterizationFactory.Create(
+                SqlDialect.Pgsql,
+                ownershipTokenIds ?? [11],
+                "ownershipTokenIds"
+            )
+        );
+
     private static DbDataReader CreateCompositeReader(
         CapturedTarget? target,
         bool includeMetadata = true,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
@@ -103,19 +103,24 @@ public class Given_AnAuth1PayloadFromAnotherFamily
     }
 
     /// <summary>
-    /// The same yield has to hold for an <c>own1|</c> payload the ownership codec cannot parse. Nothing in
-    /// it can be decoded, so only its discriminator says whose it is — and it is the ownership mapper, not
-    /// this one, that owns the diagnostic for it.
+    /// The same yield has to hold for a payload another family's codec cannot parse. Nothing in it can be
+    /// decoded, so only its discriminator says whose it is — and the discriminator names the statement that
+    /// raised the abort, so that family's mapper owns the diagnostic rather than this one.
     /// </summary>
     /// <remarks>
-    /// The mappers used to re-test the raw prefix themselves to decide this. They now read the family the
-    /// dispatcher recognized, so this pins the malformed case that distinguishes the two: a raw-prefix test
-    /// and a recognized-family test agree on well-formed payloads and can only diverge here.
+    /// The regression this pins is narrower than the well-formed case above and outlived it: the yield used
+    /// to be written for <c>own1</c> alone, so a malformed <c>cv1</c> or <c>1|</c> payload was still filed as
+    /// <c>NamespaceInvalidAuth1Payload</c>. The composite classifier reaches the namespace arm before the
+    /// relationship one, so that stole the diagnostic from its owner on any command carrying a namespace
+    /// statement beside a custom-view or relationship one.
     /// </remarks>
     [TestCase("own1|0")]
     [TestCase("own1|0|x")]
     [TestCase("own1|-1|m")]
-    public void It_should_not_be_reported_as_namespace_invalid_metadata_when_malformed_but_ownership_prefixed(
+    [TestCase("cv1|0")]
+    [TestCase("cv1|0|x")]
+    [TestCase("1|0|1|not-a-subject-failure")]
+    public void It_should_not_be_reported_as_namespace_invalid_metadata_when_malformed_but_prefixed_with_another_family(
         string payloadText
     )
     {
@@ -162,6 +167,55 @@ public class Given_AnAuth1PayloadFromAnotherFamily
                 diagnostic.ProviderOrPlannerFailureKind
                 == AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuth1Payload
             );
+    }
+
+    /// <summary>
+    /// A <c>cv1|</c>-prefixed payload the custom-view codec cannot parse is still this family's to report.
+    /// Only a custom-view statement emits that prefix, so no other family may answer for it — and declining
+    /// it left it to the namespace catch-all on a co-batched command, and to nothing at all on the
+    /// standalone executor, whose catch filters call straight into this predicate.
+    /// </summary>
+    [TestCase("cv1|0")]
+    [TestCase("cv1|0|x")]
+    [TestCase("cv1||n")]
+    [TestCase("cv1|-1|n")]
+    public void It_should_be_claimed_as_an_unmappable_custom_view_payload_when_malformed(string payloadText)
+    {
+        CustomViewAuthorizationProviderFailureMapper
+            .IsUnmappableCustomViewPayload(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                []
+            )
+            .Should()
+            .BeTrue(payloadText);
+    }
+
+    /// <summary>
+    /// The claim stays narrow: a malformed payload of any other family, and one with no known discriminator
+    /// at all, are still not this family's to report.
+    /// </summary>
+    [TestCase("own1|0")]
+    [TestCase("own1|0|x")]
+    [TestCase("ns1|0")]
+    [TestCase("ns1|0|x")]
+    [TestCase("1|0|1|not-a-subject-failure")]
+    [TestCase("garbage-with-no-discriminator")]
+    [TestCase("v2|0|x")]
+    public void It_should_not_be_claimed_as_an_unmappable_custom_view_payload_when_not_custom_view_prefixed(
+        string payloadText
+    )
+    {
+        CustomViewAuthorizationProviderFailureMapper
+            .IsUnmappableCustomViewPayload(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                []
+            )
+            .Should()
+            .BeFalse(payloadText);
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
@@ -102,6 +102,98 @@ public class Given_AnAuth1PayloadFromAnotherFamily
         diagnostics.Should().BeNull();
     }
 
+    /// <summary>
+    /// The same yield has to hold for an <c>own1|</c> payload the ownership codec cannot parse. Nothing in
+    /// it can be decoded, so only its discriminator says whose it is — and it is the ownership mapper, not
+    /// this one, that owns the diagnostic for it.
+    /// </summary>
+    /// <remarks>
+    /// The mappers used to re-test the raw prefix themselves to decide this. They now read the family the
+    /// dispatcher recognized, so this pins the malformed case that distinguishes the two: a raw-prefix test
+    /// and a recognized-family test agree on well-formed payloads and can only diverge here.
+    /// </remarks>
+    [TestCase("own1|0")]
+    [TestCase("own1|0|x")]
+    [TestCase("own1|-1|m")]
+    public void It_should_not_be_reported_as_namespace_invalid_metadata_when_malformed_but_ownership_prefixed(
+        string payloadText
+    )
+    {
+        var built =
+            NamespaceAuthorizationProviderFailureMapper.TryBuildInvalidAuthorizationFailureDiagnostics(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                NamespaceValueSources,
+                NamespaceChecks,
+                out var diagnostics
+            );
+
+        built.Should().BeFalse(payloadText);
+        diagnostics.Should().BeNull(payloadText);
+    }
+
+    /// <summary>
+    /// The yield must stay narrow in the other direction too. A payload the dispatcher recognizes no family
+    /// for belongs to nobody, so the namespace mapper keeps claiming it — that is what stops an undecodable
+    /// payload from falling through every mapper into generic database-failure handling.
+    /// </summary>
+    [TestCase("garbage-with-no-discriminator")]
+    [TestCase("v2|0|x")]
+    public void It_should_still_report_namespace_invalid_payload_for_an_unknown_discriminator(
+        string payloadText
+    )
+    {
+        var built =
+            NamespaceAuthorizationProviderFailureMapper.TryBuildInvalidAuthorizationFailureDiagnostics(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                NamespaceValueSources,
+                NamespaceChecks,
+                out var diagnostics
+            );
+
+        built.Should().BeTrue(payloadText);
+        diagnostics
+            .Should()
+            .NotBeNull()
+            .And.Contain(diagnostic =>
+                diagnostic.ProviderOrPlannerFailureKind
+                == AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuth1Payload
+            );
+    }
+
+    /// <summary>
+    /// A malformed payload of a family the relationship mapper is consulted ahead of still yields with no
+    /// diagnostic, exactly as its well-formed payload does. The relationship mapper reports an undecodable
+    /// payload as its own parse failure, so claiming another family's malformed payload here would convert
+    /// that family's 403 into a relationship 500.
+    /// </summary>
+    [TestCase("ns1|0")]
+    [TestCase("ns1|0|x")]
+    [TestCase("cv1|0")]
+    [TestCase("cv1|0|x")]
+    [TestCase("own1|0")]
+    [TestCase("own1|0|x")]
+    public void It_should_not_be_claimed_as_a_relationship_diagnostic_when_malformed(string payloadText)
+    {
+        var mapped = RelationshipAuthorizationProviderFailureMapper.TryMapRelationshipAuthorizationFailure(
+            SqlDialect.Pgsql,
+            new FakeDbException(payloadText, "AUTH1"),
+            new StubProviderFailureExtractor("AUTH1", payloadText),
+            expectedEmittedAuth1Index: 0,
+            [],
+            [],
+            out var relationshipFailure,
+            out var invalidFailureDiagnostic
+        );
+
+        mapped.Should().BeFalse(payloadText);
+        relationshipFailure.Should().BeNull(payloadText);
+        invalidFailureDiagnostic.Should().BeNull(payloadText);
+    }
+
     [TestCase("cv1|0|n")]
     [TestCase("cv1|0|u")]
     [TestCase("ns1|0|m")]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
@@ -38,6 +38,9 @@ public class Given_AnAuth1PayloadFromAnotherFamily
     [TestCase("cv1|0|u")]
     [TestCase("cv1|1|r")]
     [TestCase("cv1|0|s")]
+    [TestCase("own1|0|m")]
+    [TestCase("own1|1|u")]
+    [TestCase("own1|0|s")]
     public void It_should_not_be_claimed_as_a_namespace_authorization_failure(string payloadText)
     {
         var mapped = NamespaceAuthorizationProviderFailureMapper.TryMapNamespaceAuthorizationFailure(
@@ -56,27 +59,35 @@ public class Given_AnAuth1PayloadFromAnotherFamily
     [Test]
     public void It_should_not_be_claimed_as_a_namespace_stale_stored_target()
     {
-        // The custom-view stale code is also 's'. Reading it as a namespace stale target would turn a
-        // custom-view retry signal into a namespace one, silently retrying against the wrong plan.
-        NamespaceAuthorizationProviderFailureMapper
-            .IsStaleStoredTargetFailure(
-                SqlDialect.Pgsql,
-                new FakeDbException("cv1|0|s", "AUTH1"),
-                new StubProviderFailureExtractor("AUTH1", "cv1|0|s"),
-                NamespaceValueSources
-            )
-            .Should()
-            .BeFalse();
+        // Every family's stale code is 's'. Reading another family's as a namespace stale target would turn
+        // its retry signal into a namespace one, silently retrying against the wrong plan.
+        foreach (var payloadText in new[] { "cv1|0|s", "own1|0|s" })
+        {
+            NamespaceAuthorizationProviderFailureMapper
+                .IsStaleStoredTargetFailure(
+                    SqlDialect.Pgsql,
+                    new FakeDbException(payloadText, "AUTH1"),
+                    new StubProviderFailureExtractor("AUTH1", payloadText),
+                    NamespaceValueSources
+                )
+                .Should()
+                .BeFalse(payloadText);
+        }
     }
 
     [TestCase("cv1|0|n")]
     [TestCase("cv1|0|u")]
     [TestCase("cv1|0|s")]
+    [TestCase("own1|0|m")]
+    [TestCase("own1|1|u")]
+    [TestCase("own1|0|s")]
     public void It_should_not_be_reported_as_namespace_invalid_authorization_metadata(string payloadText)
     {
         // The regression this pins: the diagnostics switch used to route every unrecognized dispatch result
         // through a catch-all that claimed it as namespace invalid-authorization metadata, which would have
-        // turned a custom-view 403 into a namespace 500 as soon as one command carried both.
+        // turned a custom-view 403 into a namespace 500 as soon as one command carried both. The ownership
+        // cases pin the same thing for the family added by DMS-1060, whose statements co-batch with the
+        // namespace statement on every write and delete path.
         var built =
             NamespaceAuthorizationProviderFailureMapper.TryBuildInvalidAuthorizationFailureDiagnostics(
                 SqlDialect.Pgsql,
@@ -94,6 +105,8 @@ public class Given_AnAuth1PayloadFromAnotherFamily
     [TestCase("cv1|0|n")]
     [TestCase("cv1|0|u")]
     [TestCase("ns1|0|m")]
+    [TestCase("own1|0|m")]
+    [TestCase("own1|1|u")]
     public void It_should_not_be_claimed_as_a_relationship_authorization_failure_or_diagnostic(
         string payloadText
     )
@@ -114,6 +127,38 @@ public class Given_AnAuth1PayloadFromAnotherFamily
         // No diagnostic either: a diagnostic makes callers report their own invalid-payload 500, which is
         // exactly the misclassification being prevented.
         invalidFailureDiagnostic.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The custom-view mapper is safe by construction — it only claims a <c>CustomView</c> dispatch result —
+    /// but the contract is pinned so a future refactor toward a catch-all cannot reintroduce the
+    /// cross-family misclassification the rest of this fixture exists to prevent.
+    /// </summary>
+    [TestCase("own1|0|m")]
+    [TestCase("own1|1|u")]
+    [TestCase("own1|0|s")]
+    public void It_should_not_be_claimed_as_a_custom_view_authorization_problem(string payloadText)
+    {
+        CustomViewAuthorizationProviderFailureMapper
+            .IsUnmappableCustomViewPayload(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                []
+            )
+            .Should()
+            .BeFalse(payloadText);
+
+        // Recognized by the dispatcher, so it is not an unrecognized provider failure the custom-view mapper
+        // would attribute to a missing or revoked auth view.
+        CustomViewAuthorizationProviderFailureMapper
+            .IsUnrecognizedProviderFailure(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText)
+            )
+            .Should()
+            .BeFalse(payloadText);
     }
 
     [TestCase("garbage-with-no-discriminator")]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/CustomViewAuthorizationPayloadFamilyIsolationTests.cs
@@ -186,6 +186,101 @@ public class Given_AnAuth1PayloadFromAnotherFamily
         invalidFailureDiagnostic.Should().NotBeNull();
     }
 
+    /// <summary>
+    /// The full co-batch matrix for the ownership family. A single command carries namespace, custom-view,
+    /// relationship and ownership statements, and only one of them can raise the abort — so no other family
+    /// may convert an ownership payload into a denial of its own, whatever the payload says.
+    /// </summary>
+    /// <remarks>
+    /// Covers every variant an ownership statement can produce: the two denials (§2.13 and §2.14), the
+    /// stale-target retry signal, a configured-strategy index that matches no planned check, and two
+    /// malformed payload shapes. None of these mappers is given an ownership plan, so this is also the
+    /// "no planned ownership check" case.
+    /// <para>
+    /// These assertions are about the <em>403</em> paths, which is where a misattribution would be a
+    /// security-relevant wrong answer. Which family reports the 500 <em>diagnostic</em> for a malformed
+    /// ownership payload is settled separately, when the ownership provider-failure mapper joins the
+    /// composite classifier.
+    /// </para>
+    /// </remarks>
+    [TestCase("own1|0|m")]
+    [TestCase("own1|0|u")]
+    [TestCase("own1|0|s")]
+    [TestCase("own1|9|m")]
+    [TestCase("own1|0|x")]
+    [TestCase("own1|0")]
+    public void It_should_never_be_turned_into_another_familys_authorization_denial(string payloadText)
+    {
+        NamespaceAuthorizationProviderFailureMapper
+            .TryMapNamespaceAuthorizationFailure(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                NamespaceValueSources,
+                ["uri://ed-fi.org"],
+                out var namespaceFailure
+            )
+            .Should()
+            .BeFalse(payloadText);
+        namespaceFailure.Should().BeNull(payloadText);
+
+        RelationshipAuthorizationProviderFailureMapper
+            .TryMapRelationshipAuthorizationFailure(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                expectedEmittedAuth1Index: 0,
+                [],
+                [],
+                out var relationshipFailure,
+                out _
+            )
+            .Should()
+            .BeFalse(payloadText);
+        relationshipFailure.Should().BeNull(payloadText);
+
+        CustomViewAuthorizationProviderFailureMapper
+            .IsUnmappableCustomViewPayload(
+                SqlDialect.Pgsql,
+                new FakeDbException(payloadText, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", payloadText),
+                []
+            )
+            .Should()
+            .BeFalse(payloadText);
+    }
+
+    /// <summary>
+    /// A well-formed ownership payload must not be read as any other family's stale-target retry signal:
+    /// every family encodes stale as <c>s</c>, and retrying against the wrong plan would re-run a check the
+    /// abort never came from.
+    /// </summary>
+    [Test]
+    public void It_should_never_be_read_as_another_familys_stale_stored_target()
+    {
+        const string OwnershipStalePayload = "own1|0|s";
+
+        NamespaceAuthorizationProviderFailureMapper
+            .IsStaleStoredTargetFailure(
+                SqlDialect.Pgsql,
+                new FakeDbException(OwnershipStalePayload, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", OwnershipStalePayload),
+                NamespaceValueSources
+            )
+            .Should()
+            .BeFalse();
+
+        CustomViewAuthorizationProviderFailureMapper
+            .IsStaleStoredTargetFailure(
+                SqlDialect.Pgsql,
+                new FakeDbException(OwnershipStalePayload, "AUTH1"),
+                new StubProviderFailureExtractor("AUTH1", OwnershipStalePayload),
+                []
+            )
+            .Should()
+            .BeFalse();
+    }
+
     [Test]
     public void It_should_still_let_the_namespace_mapper_claim_its_own_payload()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
@@ -1014,6 +1014,41 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
         return count;
     }
 
+    /// <summary>
+    /// Descriptor ownership enforcement is out of scope for DMS-1060, so a descriptor GET-by-id configured
+    /// with OwnershipBased fails closed with 501 even when NamespaceBased is configured alongside it and the
+    /// client has no namespace prefixes. Reporting the namespace 403 first would answer as though the
+    /// caller's prefixes refused a check that was never enforced.
+    /// </summary>
+    [Test]
+    public async Task It_returns_not_implemented_for_descriptor_get_by_id_with_ownership_when_the_client_has_no_prefixes()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: [],
+                authorizationStrategies:
+                [
+                    NamespaceStrategy(),
+                    new AuthorizationStrategyEvaluator(
+                        AuthorizationStrategyNameConstants.OwnershipBased,
+                        [],
+                        FilterOperator.And
+                    ),
+                ]
+            )
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNotImplemented>()
+            .Which.FailureMessage.Should()
+            .Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        commandExecutor.Commands.Should().BeEmpty();
+    }
+
     private static DescriptorGetByIdRequest CreateGetByIdRequest(
         IReadOnlyList<string> namespacePrefixes,
         AuthorizationStrategyEvaluator authorizationStrategy,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -1837,6 +1837,75 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
         request.RelationalAuthorizationContext.NamespacePrefixes.Should().BeEmpty();
     }
 
+    /// <summary>
+    /// Descriptor ownership enforcement is out of scope for DMS-1060, so a descriptor write configured with
+    /// OwnershipBased fails closed with 501 even when NamespaceBased is configured alongside it and the
+    /// client has no namespace prefixes. Reporting the namespace 403 first would answer as though the
+    /// caller's prefixes refused a check that was never enforced.
+    /// </summary>
+    [Test]
+    public async Task It_returns_not_implemented_for_descriptor_post_with_ownership_when_the_client_has_no_prefixes()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: [],
+                authorizationStrategies:
+                [
+                    NamespaceStrategy(),
+                    UnsupportedStrategy(AuthorizationStrategyNameConstants.OwnershipBased),
+                ]
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureNotImplemented>();
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_not_implemented_for_descriptor_put_with_ownership_when_the_client_has_no_prefixes()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandlePutAsync(
+            CreatePutRequest(
+                namespacePrefixes: [],
+                authorizationStrategies:
+                [
+                    NamespaceStrategy(),
+                    UnsupportedStrategy(AuthorizationStrategyNameConstants.OwnershipBased),
+                ]
+            )
+        );
+
+        result.Should().BeOfType<UpdateResult.UpdateFailureNotImplemented>();
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_not_implemented_for_descriptor_delete_with_ownership_when_the_client_has_no_prefixes()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: [],
+                authorizationStrategies:
+                [
+                    NamespaceStrategy(),
+                    UnsupportedStrategy(AuthorizationStrategyNameConstants.OwnershipBased),
+                ]
+            )
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNotImplemented>();
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
     private static System.Text.Json.Nodes.JsonNode CreateDescriptorRequestBody(
         string @namespace,
         string codeValue

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -287,6 +287,131 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
         sessionFactory.Session.CommitCallCount.Should().Be(1);
     }
 
+    /// <summary>
+    /// A descriptor create stamps <c>CreatedByOwnershipTokenId</c> exactly as a regular-resource create does.
+    /// Ownership <em>enforcement</em> for descriptors remains a 501 for this ticket, but stamping is
+    /// unconditional and does not wait for it: an unstamped descriptor could never be reached by ownership
+    /// authorization once it is enabled.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql, "\"CreatedByOwnershipTokenId\"")]
+    [TestCase(SqlDialect.Mssql, "[CreatedByOwnershipTokenId]")]
+    public async Task It_stamps_the_creator_ownership_token_on_a_descriptor_create(
+        SqlDialect dialect,
+        string quotedColumn
+    )
+    {
+        var sessionFactory = await InsertDescriptorWithOwnershipContextAsync(
+            dialect,
+            new RelationalAuthorizationContext(
+                [],
+                ["uri://ed-fi.org/"],
+                creatorOwnershipTokenId: 42,
+                ownershipTokenIds: []
+            )
+        );
+
+        var insert = DescriptorDocumentInsert(sessionFactory, quotedColumn);
+        insert
+            .Parameters.Should()
+            .ContainSingle(parameter => parameter.Name == "@createdByOwnershipTokenId")
+            .Which.Value.Should()
+            .Be((short)42);
+    }
+
+    [TestCase(SqlDialect.Pgsql, "\"CreatedByOwnershipTokenId\"")]
+    [TestCase(SqlDialect.Mssql, "[CreatedByOwnershipTokenId]")]
+    public async Task It_stamps_null_on_a_descriptor_create_when_the_client_has_no_creator_token(
+        SqlDialect dialect,
+        string quotedColumn
+    )
+    {
+        var sessionFactory = await InsertDescriptorWithOwnershipContextAsync(
+            dialect,
+            new RelationalAuthorizationContext(
+                [],
+                ["uri://ed-fi.org/"],
+                creatorOwnershipTokenId: null,
+                ownershipTokenIds: [7]
+            )
+        );
+
+        var insert = DescriptorDocumentInsert(sessionFactory, quotedColumn);
+        insert
+            .Parameters.Should()
+            .ContainSingle(parameter => parameter.Name == "@createdByOwnershipTokenId")
+            .Which.Value.Should()
+            .BeNull();
+    }
+
+    /// <summary>
+    /// The SQL Server insert captures the insert-time <c>ContentVersion</c> through
+    /// <c>OUTPUT ... INTO</c>, and that capture must keep working with the added column — an added column is
+    /// exactly the kind of change that would silently break an <c>OUTPUT</c> clause's column list if the two
+    /// were coupled.
+    /// </summary>
+    [Test]
+    public async Task It_keeps_the_sql_server_content_version_capture_alongside_the_ownership_column()
+    {
+        var sessionFactory = await InsertDescriptorWithOwnershipContextAsync(
+            SqlDialect.Mssql,
+            new RelationalAuthorizationContext(
+                [],
+                ["uri://ed-fi.org/"],
+                creatorOwnershipTokenId: 42,
+                ownershipTokenIds: []
+            )
+        );
+
+        var insert = DescriptorDocumentInsert(sessionFactory, "[CreatedByOwnershipTokenId]");
+        insert
+            .CommandText.Should()
+            .Contain("OUTPUT INSERTED.[ContentVersion] INTO @insertedContentVersion ([ContentVersion])");
+    }
+
+    private static async Task<RecordingNamespaceWriteSessionFactory> InsertDescriptorWithOwnershipContextAsync(
+        SqlDialect dialect,
+        RelationalAuthorizationContext authorizationContext
+    )
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(dialect);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateContentVersionRow()]);
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var request = new DescriptorWriteRequest(
+            CreateMappingSet(dialect),
+            _descriptorResource,
+            CreateDescriptorRequestBody("uri://ed-fi.org/SchoolTypeDescriptor", "Charter"),
+            _documentUuid,
+            new ReferentialId(Guid.Parse("11111111-2222-3333-4444-555555555555")),
+            new TraceId("descriptor-post-ownership-stamp"),
+            [NamespaceStrategy()],
+            authorizationContext
+        );
+
+        var result = await sut.HandlePostAsync(request);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        return sessionFactory;
+    }
+
+    private static RelationalCommand DescriptorDocumentInsert(
+        RecordingNamespaceWriteSessionFactory sessionFactory,
+        string quotedOwnershipColumn
+    ) =>
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .ContainSingle(command =>
+                command.CommandText.Contains(quotedOwnershipColumn, StringComparison.Ordinal)
+            )
+            .Subject;
+
     [Test]
     public async Task It_returns_namespace_403_not_precondition_failed_when_descriptor_post_create_under_stale_if_match_has_a_proposed_namespace_denial()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/OwnershipAuthorizationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/OwnershipAuthorizationExecutorTests.cs
@@ -1,0 +1,552 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipAuthorizationExecutor
+{
+    [Test]
+    public async Task It_authorizes_and_binds_postgresql_tokens_as_one_short_array()
+    {
+        var commandExecutor = OwnershipAuthTestDoubles.CleanRun(SqlDialect.Pgsql);
+        var sut = new OwnershipAuthorizationExecutor(commandExecutor);
+
+        var result = await sut.ExecuteAsync(
+            OwnershipAuthTestDoubles.Request(SqlDialect.Pgsql, documentId: 345L, ownershipTokenIds: [3, 5, 7])
+        );
+
+        result.Should().BeOfType<OwnershipAuthorizationExecutionResult.Authorized>();
+        commandExecutor.Commands.Should().ContainSingle();
+        commandExecutor
+            .Commands[0]
+            .Parameters.Select(static parameter => parameter.Name)
+            .Should()
+            .Equal("@documentId", "@ownershipTokenIds");
+        commandExecutor.Commands[0].Parameters[0].Value.Should().Be(345L);
+        // A short[], not the long[] the relationship claim-EdOrg array path binds: Npgsql infers smallint[]
+        // from it, so = ANY(...) compares smallint to smallint and the index on the ownership column holds.
+        commandExecutor
+            .Commands[0]
+            .Parameters[1]
+            .Value.Should()
+            .BeOfType<short[]>()
+            .Which.Should()
+            .Equal((short)3, (short)5, (short)7);
+    }
+
+    [Test]
+    public async Task It_binds_sql_server_tokens_as_one_smallint_scalar_per_token()
+    {
+        var commandExecutor = OwnershipAuthTestDoubles.CleanRun(SqlDialect.Mssql);
+        var sut = new OwnershipAuthorizationExecutor(commandExecutor);
+
+        var result = await sut.ExecuteAsync(
+            OwnershipAuthTestDoubles.Request(SqlDialect.Mssql, documentId: 346L, ownershipTokenIds: [7, 3, 3])
+        );
+
+        result.Should().BeOfType<OwnershipAuthorizationExecutionResult.Authorized>();
+        commandExecutor
+            .Commands[0]
+            .Parameters.Select(static parameter => parameter.Name)
+            .Should()
+            .Equal("@documentId", "@ownershipTokenIds_0", "@ownershipTokenIds_1");
+        // Deduplicated and ascending, and each value is a short so the provider infers smallint rather than
+        // widening the comparison against the smallint ownership column.
+        commandExecutor.Commands[0].Parameters[1].Value.Should().BeOfType<short>().And.Be((short)3);
+        commandExecutor.Commands[0].Parameters[2].Value.Should().BeOfType<short>().And.Be((short)7);
+    }
+
+    /// <summary>
+    /// A client with no ownership tokens still runs the check — that is what keeps §2.14 distinguishable
+    /// from §2.13 — but binds only the document id. Binding an empty token parameter would leave the command
+    /// declaring a parameter the constant-false predicate never references.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public async Task It_binds_no_token_parameter_when_the_client_holds_no_tokens(SqlDialect dialect)
+    {
+        var commandExecutor = OwnershipAuthTestDoubles.CleanRun(dialect);
+        var sut = new OwnershipAuthorizationExecutor(commandExecutor);
+
+        var result = await sut.ExecuteAsync(
+            OwnershipAuthTestDoubles.Request(dialect, documentId: 347L, ownershipTokenIds: [])
+        );
+
+        result.Should().BeOfType<OwnershipAuthorizationExecutionResult.Authorized>();
+        commandExecutor
+            .Commands[0]
+            .Parameters.Select(static parameter => parameter.Name)
+            .Should()
+            .Equal("@documentId");
+        commandExecutor.Commands[0].CommandText.Should().Contain("1 = 0");
+    }
+
+    [Test]
+    public async Task It_maps_a_postgresql_mismatch_payload_to_an_ownership_denial()
+    {
+        var sut = OwnershipAuthTestDoubles.FailingExecutor(
+            SqlDialect.Pgsql,
+            OwnershipAuthTestDoubles.EncodePayload(
+                1,
+                OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            OwnershipAuthTestDoubles.Request(SqlDialect.Pgsql, rawConfiguredIndex: 1)
+        );
+
+        var failure = result
+            .Should()
+            .BeOfType<OwnershipAuthorizationExecutionResult.NotAuthorized>()
+            .Which.Failure;
+        failure.FailureKind.Should().Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        failure.ConfiguredStrategyIndex.Should().Be(1);
+        failure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    /// <summary>
+    /// The SQL Server transport differs — the payload arrives inside the provider message rather than as a
+    /// SqlState — so both are proven, and the uninitialized kind maps to its own §2.14 failure rather than
+    /// collapsing into the mismatch case.
+    /// </summary>
+    [Test]
+    public async Task It_maps_a_sql_server_uninitialized_payload_to_an_ownership_denial()
+    {
+        var sut = OwnershipAuthTestDoubles.FailingExecutor(
+            SqlDialect.Mssql,
+            OwnershipAuthTestDoubles.EncodePayload(
+                0,
+                OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized
+            )
+        );
+
+        var result = await sut.ExecuteAsync(OwnershipAuthTestDoubles.Request(SqlDialect.Mssql));
+
+        result
+            .Should()
+            .BeOfType<OwnershipAuthorizationExecutionResult.NotAuthorized>()
+            .Which.Failure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public async Task It_maps_a_stale_target_payload_to_a_stale_target_result(SqlDialect dialect)
+    {
+        var sut = OwnershipAuthTestDoubles.FailingExecutor(
+            dialect,
+            OwnershipAuthTestDoubles.EncodePayload(
+                0,
+                OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing
+            )
+        );
+
+        var result = await sut.ExecuteAsync(OwnershipAuthTestDoubles.Request(dialect));
+
+        result.Should().BeOfType<OwnershipAuthorizationExecutionResult.StaleTarget>();
+    }
+
+    /// <summary>
+    /// A payload whose configured index is not the planned check's cannot have come from this request's
+    /// check, so it fails closed as a security-configuration 500 and is never reported as a denial. Doing
+    /// otherwise would attribute a 403 to a configured position that did not deny the request.
+    /// </summary>
+    [Test]
+    public async Task It_maps_a_configured_index_mismatch_to_a_security_configuration_failure()
+    {
+        var sut = OwnershipAuthTestDoubles.FailingExecutor(
+            SqlDialect.Pgsql,
+            OwnershipAuthTestDoubles.EncodePayload(
+                2,
+                OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            OwnershipAuthTestDoubles.Request(SqlDialect.Pgsql, rawConfiguredIndex: 1)
+        );
+
+        result.Should().NotBeOfType<OwnershipAuthorizationExecutionResult.NotAuthorized>();
+        var invalid = result
+            .Should()
+            .BeOfType<OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure>()
+            .Which;
+        invalid
+            .FailureMessage.Should()
+            .Be(OwnershipAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata);
+        invalid
+            .Diagnostics.Should()
+            .ContainSingle()
+            .Which.Should()
+            .BeEquivalentTo(
+                new SecurityConfigurationFailureDiagnostic(
+                    ProviderOrPlannerFailureKind: AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed,
+                    ConfiguredStrategyNames: [AuthorizationStrategyNameConstants.OwnershipBased],
+                    ConfiguredStrategyIndexes: [1]
+                )
+            );
+    }
+
+    /// <summary>
+    /// An <c>own1|</c>-prefixed payload that cannot be decoded is still ours: the ownership check is the only
+    /// thing that emits that discriminator, so no other family may answer for it. It fails closed as a
+    /// security-configuration 500 because nothing decodable remains to attribute a denial with.
+    /// </summary>
+    [TestCase("own1|")]
+    [TestCase("own1|x|m")]
+    [TestCase("own1|0|zzz")]
+    [TestCase("own1|-1|m")]
+    [TestCase("own1|0|m|extra")]
+    public async Task It_claims_a_malformed_ownership_payload_as_a_security_configuration_failure(
+        string malformedPayload
+    )
+    {
+        var sut = OwnershipAuthTestDoubles.FailingExecutor(SqlDialect.Pgsql, malformedPayload);
+
+        var result = await sut.ExecuteAsync(OwnershipAuthTestDoubles.Request(SqlDialect.Pgsql));
+
+        result
+            .Should()
+            .BeOfType<OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure>()
+            .Which.Diagnostics.Should()
+            .ContainSingle()
+            .Which.ProviderOrPlannerFailureKind.Should()
+            .Be(AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed);
+    }
+
+    /// <summary>
+    /// A payload belonging to another AUTH1 family is not this executor's to answer, so the provider
+    /// exception propagates for the family that owns the discriminator to classify. The relationship case is
+    /// the one that matters most: its <c>1|</c> discriminator is a substring of <c>own1|</c>, and only
+    /// because the dispatcher anchors the match at the start of the payload do the two stay distinct.
+    /// </summary>
+    [Test]
+    public async Task It_does_not_claim_a_payload_from_another_authorization_family()
+    {
+        string[] foreignPayloads =
+        [
+            RelationshipAuthorizationAuth1FailurePayloadCodec.Encode(
+                new RelationshipAuthorizationAuth1FailurePayload(
+                    0,
+                    [
+                        new RelationshipAuthorizationAuth1SubjectFailure(
+                            0,
+                            0,
+                            RelationshipAuthorizationAuth1SubjectFailureKind.NoRelationship
+                        ),
+                    ]
+                )
+            ),
+            NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+                new NamespaceAuthorizationAuth1FailurePayload(
+                    0,
+                    NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+                )
+            ),
+            CustomViewAuthorizationAuth1FailurePayloadCodec.Encode(
+                new CustomViewAuthorizationAuth1FailurePayload(
+                    0,
+                    CustomViewAuthorizationAuth1FailureKind.NoMatchingCustomViewRow
+                )
+            ),
+            // Undecodable and not ours either: the discriminator decides, so this must not be claimed
+            // simply because nothing else could parse it.
+            "zzz|0|m",
+        ];
+
+        foreach (var foreignPayload in foreignPayloads)
+        {
+            var sut = OwnershipAuthTestDoubles.FailingExecutor(SqlDialect.Pgsql, foreignPayload);
+
+            Func<Task> act = () => sut.ExecuteAsync(OwnershipAuthTestDoubles.Request(SqlDialect.Pgsql));
+
+            await act.Should()
+                .ThrowAsync<OwnershipAuthStubDbException>(
+                    $"payload '{foreignPayload}' belongs to another family"
+                );
+        }
+    }
+
+    [Test]
+    public async Task It_does_not_claim_a_provider_failure_that_carries_no_auth1_payload()
+    {
+        var commandExecutor = new OwnershipAuthRecordingCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new OwnershipAuthStubDbException(
+                "duplicate key value violates unique constraint"
+            )
+        );
+        var sut = new OwnershipAuthorizationExecutor(
+            commandExecutor,
+            new OwnershipAuthStubProviderFailureExtractor(
+                "23505",
+                "duplicate key value violates unique constraint"
+            )
+        );
+
+        Func<Task> act = () => sut.ExecuteAsync(OwnershipAuthTestDoubles.Request(SqlDialect.Pgsql));
+
+        await act.Should().ThrowAsync<OwnershipAuthStubDbException>();
+    }
+
+    [Test]
+    public async Task It_rejects_a_null_request()
+    {
+        var sut = new OwnershipAuthorizationExecutor(OwnershipAuthTestDoubles.CleanRun(SqlDialect.Pgsql));
+
+        Func<Task> act = () => sut.ExecuteAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipAuthorizationProviderFailureMapper
+{
+    /// <summary>
+    /// An ownership payload raised against a request that planned no ownership check at all. The executor
+    /// cannot reach this — it always carries a check — but a co-batched caller can pass no planned index, and
+    /// the payload must then fail closed as a 500 rather than be attributed to a strategy the plan never had.
+    /// </summary>
+    [Test]
+    public void It_maps_an_ownership_payload_with_no_planned_check_to_a_security_configuration_failure()
+    {
+        var mapped = Map(
+            OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch,
+            plannedConfiguredStrategyIndex: null
+        );
+
+        var invalid = mapped
+            .Should()
+            .BeOfType<OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure>()
+            .Which;
+        invalid
+            .Diagnostics.Should()
+            .ContainSingle()
+            .Which.Should()
+            .BeEquivalentTo(
+                new SecurityConfigurationFailureDiagnostic(
+                    ProviderOrPlannerFailureKind: AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed,
+                    ConfiguredStrategyNames: [AuthorizationStrategyNameConstants.OwnershipBased],
+                    // No planned index to report, so none is claimed.
+                    ConfiguredStrategyIndexes: []
+                )
+            );
+    }
+
+    /// <summary>
+    /// A stale-target payload with no planned check reports its own diagnostic kind: the retry path emitted
+    /// a check the plan does not contain, which is a different fault from a payload whose index is not ours.
+    /// </summary>
+    [Test]
+    public void It_reports_a_stale_target_payload_with_no_planned_check_under_its_own_diagnostic_kind()
+    {
+        var mapped = Map(
+            OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing,
+            plannedConfiguredStrategyIndex: null
+        );
+
+        mapped
+            .Should()
+            .BeOfType<OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure>()
+            .Which.Diagnostics.Should()
+            .ContainSingle()
+            .Which.ProviderOrPlannerFailureKind.Should()
+            .Be(AuthorizationSecurityConfigurationDiagnostics.OwnershipInvalidStaleTargetPayload);
+    }
+
+    /// <summary>
+    /// A namespace payload arriving while no ownership check was planned is refused rather than reported as
+    /// an ownership security-configuration failure. Without this, consulting ownership first on a co-batched
+    /// command would convert every namespace denial into an ownership 500.
+    /// </summary>
+    [Test]
+    public void It_refuses_a_foreign_payload_even_when_no_ownership_check_was_planned()
+    {
+        var claimed = OwnershipAuthorizationProviderFailureMapper.TryMapOwnershipAuthorizationFailure(
+            SqlDialect.Pgsql,
+            new OwnershipAuthStubDbException("PostgreSQL provider exception"),
+            new OwnershipAuthStubProviderFailureExtractor(
+                OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+                    new NamespaceAuthorizationAuth1FailurePayload(
+                        0,
+                        NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+                    )
+                )
+            ),
+            plannedConfiguredStrategyIndex: null,
+            out var result
+        );
+
+        claimed.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    private static OwnershipAuthorizationExecutionResult Map(
+        OwnershipAuthorizationAuth1FailureKind failureKind,
+        int? plannedConfiguredStrategyIndex
+    )
+    {
+        var claimed = OwnershipAuthorizationProviderFailureMapper.TryMapOwnershipAuthorizationFailure(
+            SqlDialect.Pgsql,
+            new OwnershipAuthStubDbException("PostgreSQL provider exception"),
+            new OwnershipAuthStubProviderFailureExtractor(
+                OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                OwnershipAuthTestDoubles.EncodePayload(0, failureKind)
+            ),
+            plannedConfiguredStrategyIndex,
+            out var result
+        );
+
+        claimed.Should().BeTrue();
+        return result!;
+    }
+}
+
+internal static class OwnershipAuthTestDoubles
+{
+    public static string EncodePayload(
+        int configuredStrategyIndex,
+        OwnershipAuthorizationAuth1FailureKind failureKind
+    ) =>
+        OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+            new OwnershipAuthorizationAuth1FailurePayload(configuredStrategyIndex, failureKind)
+        );
+
+    public static OwnershipAuthRecordingCommandExecutor CleanRun(SqlDialect dialect) =>
+        new(dialect, [new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()])]);
+
+    public static OwnershipAuthorizationExecutor FailingExecutor(SqlDialect dialect, string payloadText) =>
+        new(
+            new OwnershipAuthRecordingCommandExecutor(
+                dialect,
+                exceptionToThrow: new OwnershipAuthStubDbException("provider exception")
+            ),
+            new OwnershipAuthStubProviderFailureExtractor(
+                OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                BuildProviderMessage(dialect, payloadText)
+            )
+        );
+
+    public static OwnershipAuthorizationExecutionRequest Request(
+        SqlDialect dialect,
+        long documentId = 100L,
+        short[]? ownershipTokenIds = null,
+        int rawConfiguredIndex = 0
+    ) =>
+        new(
+            CreateMappingSet(dialect),
+            documentId,
+            new OwnershipAuthorizationCheckSpec(rawConfiguredIndex),
+            OwnershipTokenParameterizationFactory.Create(
+                dialect,
+                ownershipTokenIds ?? [11],
+                "ownershipTokenIds"
+            )
+        );
+
+    /// <remarks>
+    /// PostgreSQL carries the payload as the SqlState with the payload as the message; SQL Server has no
+    /// custom SqlState and carries it inside the message as <c>AUTH1 - payload</c>. Building the message
+    /// per dialect is what makes the dialect-specific transport, not just the codec, part of the test.
+    /// </remarks>
+    private static string BuildProviderMessage(SqlDialect dialect, string payloadText) =>
+        dialect is SqlDialect.Mssql
+            ? $"{OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode} - {payloadText}"
+            : payloadText;
+
+    private static MappingSet CreateMappingSet(SqlDialect dialect) =>
+        new(
+            new MappingSetKey("schema-hash", dialect, "v1"),
+            new DerivedRelationalModelSet(
+                new EffectiveSchemaInfo("5.2.0", "v1", "schema-hash", 1, [], [], []),
+                dialect,
+                [],
+                [],
+                [],
+                [],
+                [],
+                []
+            ),
+            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>(),
+            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            ResourceKeyIdByResource: new Dictionary<QualifiedResourceName, short>(),
+            ResourceKeyById: new Dictionary<short, ResourceKeyEntry>(),
+            SecurableElementColumnPathsByResource: new Dictionary<
+                QualifiedResourceName,
+                IReadOnlyList<ResolvedSecurableElementPath>
+            >()
+        );
+}
+
+internal sealed class OwnershipAuthStubDbException(string message) : DbException(message);
+
+internal sealed class OwnershipAuthStubProviderFailureExtractor(
+    string? providerErrorCode,
+    string providerMessage
+) : IRelationshipAuthorizationProviderFailureExtractor
+{
+    public RelationshipAuthorizationProviderFailure Extract(DbException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        return new RelationshipAuthorizationProviderFailure(providerErrorCode, providerMessage);
+    }
+}
+
+internal sealed class OwnershipAuthRecordingCommandExecutor(
+    SqlDialect dialect,
+    IReadOnlyList<InMemoryRelationalCommandExecution>? executions = null,
+    DbException? exceptionToThrow = null
+) : IRelationalCommandExecutor
+{
+    private readonly Queue<InMemoryRelationalCommandExecution> _executions = new(executions ?? []);
+    private readonly DbException? _exceptionToThrow = exceptionToThrow;
+
+    public SqlDialect Dialect { get; } = dialect;
+
+    public List<RelationalCommand> Commands { get; } = [];
+
+    public async Task<TResult> ExecuteReaderAsync<TResult>(
+        RelationalCommand command,
+        Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(readAsync);
+
+        Commands.Add(command);
+
+        if (_exceptionToThrow is not null)
+        {
+            throw _exceptionToThrow;
+        }
+
+        if (!_executions.TryDequeue(out var execution))
+        {
+            throw new AssertionException(
+                "No in-memory ownership authorization execution was configured for this call."
+            );
+        }
+
+        await using var reader = new InMemoryRelationalCommandReader(execution.ResultSets);
+        return await readAsync(reader, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/OwnershipAuthorizationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/OwnershipAuthorizationExecutorTests.cs
@@ -522,6 +522,27 @@ public class Given_OwnershipAuthorizationCommandParameterBuilder
     }
 }
 
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipTokenParameterValueBinder
+{
+    /// <summary>
+    /// The binder's only production caller already requires a parameterization, so a null here is a
+    /// programming error, not a request to bind nothing. The case that legitimately binds nothing is a
+    /// non-null parameterization with no tokens, pinned by
+    /// Given_OwnershipAuthorizationExecutor.It_binds_no_token_parameter_when_the_client_holds_no_tokens.
+    /// </summary>
+    [Test]
+    public void It_rejects_a_null_parameterization()
+    {
+        Dictionary<string, object?> parameterValues = new(StringComparer.Ordinal);
+
+        Action act = () => OwnershipTokenParameterValueBinder.Bind(parameterValues, null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("ownershipTokenParameterization");
+    }
+}
+
 internal static class OwnershipAuthTestDoubles
 {
     public static string EncodePayload(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/OwnershipAuthorizationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/OwnershipAuthorizationExecutorTests.cs
@@ -419,6 +419,109 @@ public class Given_OwnershipAuthorizationProviderFailureMapper
     }
 }
 
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipAuthorizationCommandParameterBuilder
+{
+    private static readonly QuerySqlParameter _arrayParameter = new(
+        QuerySqlParameterRole.Filter,
+        "ownershipTokenIds",
+        QuerySqlParameterBinding.PgsqlArray
+    );
+
+    /// <summary>
+    /// The PostgreSQL array parameter is materialized as a short[] from any short list, not only from an
+    /// array, so the element type rather than the container is what the guard is about.
+    /// </summary>
+    [Test]
+    public void It_materializes_a_short_list_into_a_short_array()
+    {
+        var parameter = OwnershipAuthorizationCommandParameterBuilder.BuildParameter(
+            _arrayParameter,
+            new List<short> { 3, 5 }
+        );
+
+        parameter.Name.Should().Be("@ownershipTokenIds");
+        parameter.Value.Should().BeOfType<short[]>().Which.Should().Equal((short)3, (short)5);
+    }
+
+    /// <summary>
+    /// A wider or unrelated element type is refused rather than converted. Every one of these would still
+    /// return correct rows once bound, which is exactly why the guard has to be explicit: a long or int list
+    /// would widen the comparison against the smallint ownership column and quietly cost the index on it.
+    /// </summary>
+    [Test]
+    public void It_rejects_a_pgsql_array_value_that_is_not_a_short_list()
+    {
+        object?[] rejectedValues =
+        [
+            new long[] { 3, 5 },
+            new int[] { 3, 5 },
+            new string[] { "3", "5" },
+            new List<int> { 3, 5 },
+            (short)3,
+            null,
+        ];
+
+        foreach (var rejectedValue in rejectedValues)
+        {
+            Action act = () =>
+                OwnershipAuthorizationCommandParameterBuilder.BuildParameter(_arrayParameter, rejectedValue);
+
+            act.Should()
+                .Throw<InvalidOperationException>(
+                    $"'{rejectedValue?.GetType().Name ?? "null"}' is not an IReadOnlyList<short>"
+                )
+                .WithMessage("*ownershipTokenIds*IReadOnlyList<short>*");
+        }
+    }
+
+    /// <summary>
+    /// A scalar passes its value through untouched: the document id is a long and the SQL Server token
+    /// scalars are shorts, and neither is reshaped here.
+    /// </summary>
+    [Test]
+    public void It_passes_a_scalar_value_through_untouched()
+    {
+        OwnershipAuthorizationCommandParameterBuilder
+            .BuildParameter(new QuerySqlParameter(QuerySqlParameterRole.Filter, "documentId"), 345L)
+            .Value.Should()
+            .Be(345L);
+        OwnershipAuthorizationCommandParameterBuilder
+            .BuildParameter(
+                new QuerySqlParameter(QuerySqlParameterRole.Filter, "ownershipTokenIds_0"),
+                (short)3
+            )
+            .Value.Should()
+            .BeOfType<short>()
+            .And.Be((short)3);
+    }
+
+    [Test]
+    public void It_rejects_an_unsupported_binding_kind()
+    {
+        Action act = () =>
+            OwnershipAuthorizationCommandParameterBuilder.BuildParameter(
+                new QuerySqlParameter(
+                    QuerySqlParameterRole.Filter,
+                    "ownershipTokenIds",
+                    QuerySqlParameterBinding.CreateMssqlStructured("dms.OwnershipTokenIdList", "Id")
+                ),
+                new List<short> { 3 }
+            );
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void It_rejects_a_null_parameter()
+    {
+        Action act = () => OwnershipAuthorizationCommandParameterBuilder.BuildParameter(null!, null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}
+
 internal static class OwnershipAuthTestDoubles
 {
     public static string EncodePayload(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/OwnershipTokenParameterizationPreflightTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/OwnershipTokenParameterizationPreflightTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// The preflight is defence in depth behind the planner's own token-cap terminal: it converts the
+/// parameterization factory's throw into a clean security-configuration result so a caller that skipped the
+/// planner still fails closed instead of emitting an over-limit parameter list or letting the exception
+/// escape as a generic failure.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_OwnershipTokenParameterizationPreflight
+{
+    private const int Limit = OwnershipTokenLimitExceededException.OwnershipTokenLimit;
+
+    private static IReadOnlyList<short> Tokens(int count) =>
+        [.. Enumerable.Range(1, count).Select(static value => (short)value)];
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_creates_a_parameterization_below_the_limit(SqlDialect dialect)
+    {
+        var created = OwnershipTokenParameterizationPreflight.TryCreate(
+            dialect,
+            [3, 7],
+            out var parameterization,
+            out var securityConfigurationMessage,
+            out var diagnostics
+        );
+
+        created.Should().BeTrue();
+        parameterization.Should().NotBeNull();
+        parameterization.TokensInOrder.Should().Equal((short)3, (short)7);
+        securityConfigurationMessage.Should().BeEmpty();
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_creates_a_parameterization_for_an_empty_token_list(SqlDialect dialect)
+    {
+        var created = OwnershipTokenParameterizationPreflight.TryCreate(
+            dialect,
+            [],
+            out var parameterization,
+            out _,
+            out var diagnostics
+        );
+
+        created.Should().BeTrue();
+        parameterization.MatchesNoToken.Should().BeTrue();
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_accepts_one_token_below_the_limit_on_every_provider(SqlDialect dialect)
+    {
+        OwnershipTokenParameterizationPreflight
+            .TryCreate(dialect, Tokens(Limit - 1), out _, out _, out _)
+            .Should()
+            .BeTrue();
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_fails_closed_at_the_limit_on_every_provider(SqlDialect dialect)
+    {
+        var created = OwnershipTokenParameterizationPreflight.TryCreate(
+            dialect,
+            Tokens(Limit),
+            out var parameterization,
+            out var securityConfigurationMessage,
+            out var diagnostics
+        );
+
+        created.Should().BeFalse();
+        parameterization.Should().BeNull();
+        securityConfigurationMessage
+            .Should()
+            .Be(OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(Limit));
+
+        var diagnostic = diagnostics.Should().ContainSingle().Subject;
+        diagnostic
+            .ProviderOrPlannerFailureKind.Should()
+            .Be(AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded);
+        diagnostic.ConfiguredStrategyNames.Should().Equal(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    /// <summary>
+    /// The cap reads the configured count, so a list whose duplicates would bring it under the limit still
+    /// fails closed.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_fails_closed_before_deduplication_on_every_provider(SqlDialect dialect)
+    {
+        List<short> withDuplicates = [.. Tokens(1400), .. Tokens(1200)];
+
+        OwnershipTokenParameterizationPreflight
+            .TryCreate(dialect, withDuplicates, out _, out var securityConfigurationMessage, out _)
+            .Should()
+            .BeFalse();
+
+        securityConfigurationMessage
+            .Should()
+            .Be(OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(2600));
+    }
+
+    /// <summary>
+    /// A public failure response must never disclose ownership-token values. The count is safe — it tells an
+    /// operator what to fix — but the tokens identify other clients' data partitions.
+    /// </summary>
+    [Test]
+    public void It_reports_no_ownership_token_value_in_the_failure_message_or_diagnostics()
+    {
+        const short DistinctiveToken = 31337;
+        List<short> tokens = [.. Tokens(Limit - 1), DistinctiveToken];
+
+        OwnershipTokenParameterizationPreflight.TryCreate(
+            SqlDialect.Mssql,
+            tokens,
+            out _,
+            out var securityConfigurationMessage,
+            out var diagnostics
+        );
+
+        securityConfigurationMessage.Should().NotContain("31337");
+        diagnostics.Should().ContainSingle();
+        diagnostics[0].PhysicalPath.Should().BeNull();
+        diagnostics[0].ResourceFullName.Should().BeNull();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteOrchestrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteOrchestrationTests.cs
@@ -71,6 +71,7 @@ public class Given_No_Profile_Relational_Post
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
             A.Fake<INamespaceAuthorizationExecutor>(),
             A.Fake<ICustomViewAuthorizationExecutor>(),
+            A.Fake<IOwnershipAuthorizationExecutor>(),
             A.Fake<IRelationalCommandExecutor>(),
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -163,6 +164,7 @@ public class Given_No_Profile_Relational_Put
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
             A.Fake<INamespaceAuthorizationExecutor>(),
             A.Fake<ICustomViewAuthorizationExecutor>(),
+            A.Fake<IOwnershipAuthorizationExecutor>(),
             A.Fake<IRelationalCommandExecutor>(),
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -255,6 +257,7 @@ public class Given_A_Profiled_Relational_Post
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
             A.Fake<INamespaceAuthorizationExecutor>(),
             A.Fake<ICustomViewAuthorizationExecutor>(),
+            A.Fake<IOwnershipAuthorizationExecutor>(),
             A.Fake<IRelationalCommandExecutor>(),
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -356,6 +359,7 @@ public class Given_A_Profiled_Relational_Put
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
             A.Fake<INamespaceAuthorizationExecutor>(),
             A.Fake<ICustomViewAuthorizationExecutor>(),
+            A.Fake<IOwnershipAuthorizationExecutor>(),
             A.Fake<IRelationalCommandExecutor>(),
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ReferenceResolverServiceCollectionExtensionsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ReferenceResolverServiceCollectionExtensionsTests.cs
@@ -87,6 +87,8 @@ public class Given_ReferenceResolver_Service_Collection_Extensions
             scope.ServiceProvider.GetRequiredService<IRelationalReadTargetLookupService>();
         var singleRecordRelationshipAuthorizationExecutor =
             scope.ServiceProvider.GetRequiredService<ISingleRecordRelationshipAuthorizationExecutor>();
+        var ownershipAuthorizationExecutor =
+            scope.ServiceProvider.GetRequiredService<IOwnershipAuthorizationExecutor>();
         var relationshipAuthorizationProviderFailureExtractor =
             scope.ServiceProvider.GetRequiredService<IRelationshipAuthorizationProviderFailureExtractor>();
         var documentCacheReadAccelerationCoordinator =
@@ -127,6 +129,10 @@ public class Given_ReferenceResolver_Service_Collection_Extensions
             .Subject;
 
         commandExecutor.Should().BeOfType<TestRelationalCommandExecutor>();
+        // Registered so the repository's own resolution cannot fail once the ReadSingle gate opens: an
+        // unregistered executor would surface as a container error on the first ownership-configured read
+        // rather than at composition time.
+        ownershipAuthorizationExecutor.Should().BeOfType<OwnershipAuthorizationExecutor>();
         parameterConfigurator.Should().BeOfType<DefaultRelationalParameterConfigurator>();
         writeSessionFactory.Should().BeOfType<TestRelationalWriteSessionFactory>();
         documentHydrator.Should().BeOfType<TestDocumentHydrator>();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCompositeStoredOwnershipAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCompositeStoredOwnershipAuthorizationTests.cs
@@ -68,7 +68,21 @@ public class Given_The_Composite_Stored_Ownership_Authorization
             .Should()
             .BeTrue();
 
+        RelationalCompositeStoredAuthorization
+            .TryAppendRelationship(
+                builder,
+                builder.Carrier,
+                mappingSet,
+                RelationalCompositeStoredAuthorization.Classify(CreateAuthorizedRelationship(dialect)),
+                emittedAuth1Index: 0,
+                DefaultRelationalParameterConfigurator.Instance,
+                out var relationshipPlan
+            )
+            .Should()
+            .BeTrue();
+
         ownershipPlan.Should().NotBeNull();
+        relationshipPlan.Disposition.Should().Be(StoredRelationshipDisposition.Emitted);
         builder
             .Seal()
             .StatementsInOrder.Select(static statement => statement.Label)
@@ -76,7 +90,8 @@ public class Given_The_Composite_Stored_Ownership_Authorization
             .ContainInOrder(
                 RelationalCompositeStoredAuthorization.CustomViewLabel,
                 RelationalCompositeStoredAuthorization.NamespaceLabel,
-                RelationalCompositeStoredAuthorization.OwnershipLabel
+                RelationalCompositeStoredAuthorization.OwnershipLabel,
+                RelationalCompositeStoredAuthorization.RelationshipLabel
             );
     }
 
@@ -490,6 +505,54 @@ public class Given_The_Composite_Stored_Ownership_Authorization
             ],
             NamespacePrefixParameterizationFactory.Create(dialect, ["uri://ed-fi.org/"], "namespacePrefixes")
         );
+
+    /// <remarks>
+    /// One stored EdOrg subject, which is the smallest shape that emits a co-batchable relationship
+    /// statement. A PostgreSQL/SQL Server scalar claim parameterization keeps the disposition Emitted rather
+    /// than Standalone, which a table-valued parameter would force.
+    /// </remarks>
+    private static RelationshipAuthorizationResult.Authorized CreateAuthorizedRelationship(SqlDialect dialect)
+    {
+        var rootTable = new DbTableName(new DbSchemaName("edfi"), "School");
+        var resource = new QualifiedResourceName("Ed-Fi", "School");
+
+        return new RelationshipAuthorizationResult.Authorized(
+            [
+                new RelationshipAuthorizationCheckSpec(
+                    new ConfiguredAuthorizationStrategy(
+                        AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+                        RawConfiguredIndex: 2
+                    ),
+                    RelationshipLocalOrder: 0,
+                    RelationshipAuthorizationHierarchyDirection.Normal,
+                    RelationshipAuthorizationValueSource.Stored,
+                    [
+                        new RelationshipAuthorizationSubject(
+                            resource,
+                            rootTable,
+                            new DbColumnName("SchoolId"),
+                            RelationshipAuthorizationAuthObject.CreateEdOrgHierarchy(
+                                RelationshipAuthorizationHierarchyDirection.Normal
+                            ),
+                            [
+                                new RelationshipAuthorizationSubjectContributor(
+                                    SecurableElementKind.EducationOrganization,
+                                    "$.schoolId",
+                                    "SchoolId"
+                                ),
+                            ]
+                        ),
+                    ],
+                    new RelationshipAuthorizationCheckTarget.Stored(rootTable, new DbColumnName("DocumentId"))
+                ),
+            ],
+            AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
+                dialect,
+                [255901L],
+                RelationalAuthorizationParameterNameConstants.ClaimEducationOrganizationIds
+            )
+        );
+    }
 
     private static MappingSet CreateMappingSet(SqlDialect dialect)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCompositeStoredOwnershipAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCompositeStoredOwnershipAuthorizationTests.cs
@@ -1,0 +1,519 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.Composite;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// Owns how the stored ownership check joins a composite command: where its statement lands relative to the
+/// other stored checks, what happens when it does not fit the command's parameter budget, and which family
+/// claims a provider failure the command aborted with.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_The_Composite_Stored_Ownership_Authorization
+{
+    // The allocator issues statement-scoped names, and the builder refuses a parameter it did not issue, so
+    // the capture predicate has to reference the allocated name.
+    private const string TargetPredicate = "d.\"DocumentUuid\" = @documentUuid_s0";
+    private const string CustomViewStrategyName = "SchoolWithCompositeOwnershipTest";
+
+    /// <summary>
+    /// Statement order is precedence order, because the command aborts at its first AUTH1. auth.md puts the
+    /// custom views and NamespaceBased ahead of OwnershipBased, and OwnershipBased ahead of the relationship
+    /// OR group, so the emitted order has to be exactly this.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_emits_ownership_after_the_and_filters_and_before_the_relationship_check(SqlDialect dialect)
+    {
+        var builder = CreateBuilderWithCapture(dialect);
+        var mappingSet = CreateMappingSet(dialect);
+
+        RelationalCompositeStoredAuthorization.AppendCustomViewRun(
+            builder,
+            builder.Carrier,
+            mappingSet,
+            CreateCustomViewChecks()
+        );
+        RelationalCompositeStoredAuthorization
+            .TryAppendNamespace(
+                builder,
+                builder.Carrier,
+                mappingSet,
+                CreateNamespaceAuthorization(dialect),
+                out _
+            )
+            .Should()
+            .BeTrue();
+        RelationalCompositeStoredAuthorization
+            .TryAppendOwnership(
+                builder,
+                builder.Carrier,
+                mappingSet,
+                CreateOwnershipAuthorization(dialect),
+                out var ownershipPlan
+            )
+            .Should()
+            .BeTrue();
+
+        ownershipPlan.Should().NotBeNull();
+        builder
+            .Seal()
+            .StatementsInOrder.Select(static statement => statement.Label)
+            .Should()
+            .ContainInOrder(
+                RelationalCompositeStoredAuthorization.CustomViewLabel,
+                RelationalCompositeStoredAuthorization.NamespaceLabel,
+                RelationalCompositeStoredAuthorization.OwnershipLabel
+            );
+    }
+
+    /// <summary>
+    /// The check carries the carrier's row guard, which is what makes it vacuous when the capture observed
+    /// no target — the property a create relies on to never be denied by ownership.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_guards_the_emitted_ownership_statement_with_the_captured_target_predicate(
+        SqlDialect dialect
+    )
+    {
+        var builder = CreateBuilderWithCapture(dialect);
+
+        RelationalCompositeStoredAuthorization
+            .TryAppendOwnership(
+                builder,
+                builder.Carrier,
+                CreateMappingSet(dialect),
+                CreateOwnershipAuthorization(dialect),
+                out _
+            )
+            .Should()
+            .BeTrue();
+
+        var statement = builder
+            .Seal()
+            .StatementsInOrder.Single(static statement =>
+                statement.Label == RelationalCompositeStoredAuthorization.OwnershipLabel
+            );
+        statement.Sql.Should().Contain(builder.Carrier.CapturedTargetPresentPredicate);
+        // The DocumentId parameter is substituted away by the carrier expression, so the statement binds
+        // only its ownership tokens.
+        statement
+            .Parameters.Should()
+            .OnlyContain(parameter =>
+                !parameter.Name.Contains("documentId", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_appends_nothing_when_no_ownership_check_was_planned(SqlDialect dialect)
+    {
+        var builder = CreateBuilderWithCapture(dialect);
+        var statementsBefore = builder.StatementCount;
+
+        RelationalCompositeStoredAuthorization
+            .TryAppendOwnership(builder, builder.Carrier, CreateMappingSet(dialect), null, out var plan)
+            .Should()
+            .BeTrue();
+
+        plan.Should().BeNull();
+        builder.StatementCount.Should().Be(statementsBefore);
+    }
+
+    /// <summary>
+    /// A token list that does not fit the remaining budget reports false rather than throwing, so the caller
+    /// can run ownership as an ordered segment. That degradation is safe here and not for a custom-view run:
+    /// every other AND filter precedes ownership either way, so a segment after the command keeps the order.
+    /// </summary>
+    [Test]
+    public void It_reports_a_non_fit_rather_than_throwing()
+    {
+        // SQL Server binds one scalar per token. The capture statement's own parameter already occupies the
+        // single available slot, so no token scalar can fit.
+        var builder = CreateBuilderWithCapture(
+            SqlDialect.Mssql,
+            new RelationalCommandBudget(MaxParametersPerCommand: 1, MaxRowsPerStatement: 1000)
+        );
+
+        RelationalCompositeStoredAuthorization
+            .TryAppendOwnership(
+                builder,
+                builder.Carrier,
+                CreateMappingSet(SqlDialect.Mssql),
+                CreateOwnershipAuthorization(SqlDialect.Mssql, [3, 5, 7]),
+                out var plan
+            )
+            .Should()
+            .BeFalse();
+
+        plan.Should().BeNull();
+        builder
+            .Seal()
+            .StatementsInOrder.Should()
+            .NotContain(statement =>
+                statement.Label == RelationalCompositeStoredAuthorization.OwnershipLabel
+            );
+    }
+
+    // ----- Denial classification --------------------------------------------
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_classifies_an_ownership_mismatch_payload_as_an_ownership_denial(SqlDialect dialect)
+    {
+        var denial = Classify(
+            dialect,
+            OwnershipPayload(1, OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch),
+            ownershipPlan: new StoredOwnershipStatementPlan(new OwnershipAuthorizationCheckSpec(1))
+        );
+
+        denial
+            .Should()
+            .BeOfType<StoredAuthorizationDenial.OwnershipNotAuthorized>()
+            .Which.Failure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+    }
+
+    [Test]
+    public void It_classifies_an_uninitialized_stored_token_payload_as_its_own_denial_kind()
+    {
+        var denial = Classify(
+            SqlDialect.Pgsql,
+            OwnershipPayload(0, OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized),
+            ownershipPlan: new StoredOwnershipStatementPlan(new OwnershipAuthorizationCheckSpec(0))
+        );
+
+        denial
+            .Should()
+            .BeOfType<StoredAuthorizationDenial.OwnershipNotAuthorized>()
+            .Which.Failure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+    }
+
+    /// <summary>
+    /// Unreachable for a locked write or delete, which row-locks the target before the check, so it is
+    /// classified as the shared stale-target denial the caller already maps to its own conflict outcome
+    /// rather than being reported as an ownership 403 for a row that is gone.
+    /// </summary>
+    [Test]
+    public void It_classifies_a_stale_target_payload_as_the_shared_stale_target_denial()
+    {
+        var denial = Classify(
+            SqlDialect.Pgsql,
+            OwnershipPayload(0, OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing),
+            ownershipPlan: new StoredOwnershipStatementPlan(new OwnershipAuthorizationCheckSpec(0))
+        );
+
+        denial.Should().BeOfType<StoredAuthorizationDenial.StaleTarget>();
+    }
+
+    /// <summary>
+    /// The gap this step exists to close. A malformed own1 payload is claimed by ownership rather than
+    /// reported as a namespace invalid-metadata failure, even on a command carrying both families' checks.
+    /// Both outcomes are a 500, so only the diagnostic distinguishes them — which is exactly what an
+    /// operator would use to find the defect.
+    /// </summary>
+    [TestCase("own1|")]
+    [TestCase("own1|x|m")]
+    [TestCase("own1|0|zzz")]
+    public void It_attributes_a_malformed_ownership_payload_to_ownership_not_namespace(
+        string malformedPayload
+    )
+    {
+        var dialect = SqlDialect.Pgsql;
+        var denial = Classify(
+            dialect,
+            malformedPayload,
+            namespacePlan: new StoredNamespaceStatementPlan(
+                CreateNamespaceAuthorization(dialect).Checks,
+                CreateNamespaceAuthorization(dialect).NamespacePrefixParameterization
+            ),
+            ownershipPlan: new StoredOwnershipStatementPlan(new OwnershipAuthorizationCheckSpec(0))
+        );
+
+        denial
+            .Should()
+            .BeOfType<StoredAuthorizationDenial.SecurityConfiguration>()
+            .Which.Diagnostics.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Match<SecurityConfigurationFailureDiagnostic>(diagnostic =>
+                diagnostic.ProviderOrPlannerFailureKind
+                    == AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed
+                && diagnostic.ConfiguredStrategyNames.Contains(
+                    AuthorizationStrategyNameConstants.OwnershipBased
+                )
+            );
+    }
+
+    /// <summary>
+    /// The same malformed payload with no ownership check planned. It still cannot be namespace's — only
+    /// ownership emits own1 — so it fails closed under ownership's diagnostic rather than being filed
+    /// against NamespaceBased.
+    /// </summary>
+    [Test]
+    public void It_attributes_a_malformed_ownership_payload_to_ownership_even_with_no_ownership_plan()
+    {
+        var dialect = SqlDialect.Pgsql;
+        var namespaceAuthorization = CreateNamespaceAuthorization(dialect);
+
+        var denial = Classify(
+            dialect,
+            "own1|x|m",
+            namespacePlan: new StoredNamespaceStatementPlan(
+                namespaceAuthorization.Checks,
+                namespaceAuthorization.NamespacePrefixParameterization
+            ),
+            ownershipPlan: null
+        );
+
+        denial
+            .Should()
+            .BeOfType<StoredAuthorizationDenial.SecurityConfiguration>()
+            .Which.Diagnostics.Should()
+            .ContainSingle()
+            .Which.ProviderOrPlannerFailureKind.Should()
+            .Be(AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed);
+    }
+
+    /// <summary>
+    /// Consulting ownership first must not let it claim another family's payload. A namespace mismatch stays
+    /// a namespace denial with an ownership plan present.
+    /// </summary>
+    [Test]
+    public void It_leaves_a_namespace_payload_to_namespace_even_with_an_ownership_plan()
+    {
+        var dialect = SqlDialect.Pgsql;
+        var namespaceAuthorization = CreateNamespaceAuthorization(dialect);
+
+        var denial = Classify(
+            dialect,
+            NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+                new NamespaceAuthorizationAuth1FailurePayload(
+                    0,
+                    NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+                )
+            ),
+            namespacePlan: new StoredNamespaceStatementPlan(
+                namespaceAuthorization.Checks,
+                namespaceAuthorization.NamespacePrefixParameterization
+            ),
+            ownershipPlan: new StoredOwnershipStatementPlan(new OwnershipAuthorizationCheckSpec(0))
+        );
+
+        denial.Should().BeOfType<StoredAuthorizationDenial.NamespaceNotAuthorized>();
+    }
+
+    /// <summary>
+    /// A payload with no recognizable discriminator keeps its existing home. Ownership declines it, so the
+    /// namespace catch-all still reports it and the diagnostic is not lost to a family that yielded.
+    /// </summary>
+    [Test]
+    public void It_leaves_a_payload_no_family_owns_to_the_namespace_catch_all()
+    {
+        var dialect = SqlDialect.Pgsql;
+        var namespaceAuthorization = CreateNamespaceAuthorization(dialect);
+
+        var denial = Classify(
+            dialect,
+            "zzz|0|m",
+            namespacePlan: new StoredNamespaceStatementPlan(
+                namespaceAuthorization.Checks,
+                namespaceAuthorization.NamespacePrefixParameterization
+            ),
+            ownershipPlan: new StoredOwnershipStatementPlan(new OwnershipAuthorizationCheckSpec(0))
+        );
+
+        denial
+            .Should()
+            .BeOfType<StoredAuthorizationDenial.SecurityConfiguration>()
+            .Which.Diagnostics.Should()
+            .ContainSingle()
+            .Which.ProviderOrPlannerFailureKind.Should()
+            .Be(AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuth1Payload);
+    }
+
+    [Test]
+    public void It_ignores_a_provider_failure_that_carries_no_auth1_payload()
+    {
+        Classify(
+                SqlDialect.Pgsql,
+                providerMessage: "duplicate key value violates unique constraint",
+                providerErrorCode: "23505",
+                ownershipPlan: new StoredOwnershipStatementPlan(new OwnershipAuthorizationCheckSpec(0))
+            )
+            .Should()
+            .BeNull();
+    }
+
+    // ----- Helpers ----------------------------------------------------------
+
+    private static StoredAuthorizationDenial? Classify(
+        SqlDialect dialect,
+        string providerMessage,
+        string? providerErrorCode = null,
+        StoredNamespaceStatementPlan? namespacePlan = null,
+        StoredOwnershipStatementPlan? ownershipPlan = null
+    ) =>
+        RelationalCompositeStoredAuthorization.TryClassifyDenial(
+            dialect,
+            new StoredAuthorizationStubDbException("provider exception"),
+            namespacePlan,
+            relationshipPlan: null,
+            emittedAuth1Index: 0,
+            new StoredAuthorizationStubProviderFailureExtractor(
+                providerErrorCode ?? OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                BuildProviderMessage(dialect, providerMessage, providerErrorCode)
+            ),
+            NullLogger.Instance,
+            customViewPlan: null,
+            ownershipPlan
+        );
+
+    /// <remarks>
+    /// PostgreSQL carries the payload as the message with AUTH1 as the SqlState; SQL Server has no custom
+    /// SqlState and carries it inside the message. A non-AUTH1 failure is passed through untouched.
+    /// </remarks>
+    private static string BuildProviderMessage(
+        SqlDialect dialect,
+        string providerMessage,
+        string? providerErrorCode
+    )
+    {
+        if (providerErrorCode is not null)
+        {
+            return providerMessage;
+        }
+
+        return dialect is SqlDialect.Mssql
+            ? $"{OwnershipAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode} - {providerMessage}"
+            : providerMessage;
+    }
+
+    private static string OwnershipPayload(
+        int configuredStrategyIndex,
+        OwnershipAuthorizationAuth1FailureKind failureKind
+    ) =>
+        OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+            new OwnershipAuthorizationAuth1FailurePayload(configuredStrategyIndex, failureKind)
+        );
+
+    private static RelationalCompositeCommandBuilder CreateBuilderWithCapture(
+        SqlDialect dialect,
+        RelationalCommandBudget? budget = null
+    )
+    {
+        var builder = new RelationalCompositeCommandBuilder(
+            IRelationalCompositeCommandDialect.Create(dialect),
+            budget
+        );
+        builder.AppendCaptureTarget(
+            TargetPredicate,
+            [
+                new RelationalParameter(
+                    builder.Allocator.AllocateStatementScoped("documentUuid", 0),
+                    Guid.NewGuid()
+                ),
+            ]
+        );
+
+        return builder;
+    }
+
+    /// <remarks>
+    /// A stored self-basis custom view, so the fixture needs no reference model. Its emitted statement binds
+    /// only the DocumentId the carrier substitutes away, which is what lets a run co-batch with no budget
+    /// fallback at all.
+    /// </remarks>
+    private static IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CreateCustomViewChecks() =>
+        [
+            new SingleRecordCustomViewAuthorizationCheckSpec(
+                new ConfiguredAuthorizationStrategy(CustomViewStrategyName, 0),
+                0,
+                CustomViewAuthorizationCheckValueSource.Stored,
+                new DbTableName(new DbSchemaName("auth"), CustomViewStrategyName),
+                new DbColumnName("DocumentId"),
+                [
+                    new ColumnPathStep(
+                        new DbTableName(new DbSchemaName("edfi"), "School"),
+                        new DbColumnName("DocumentId"),
+                        null,
+                        null
+                    ),
+                ],
+                new CustomViewAuthorizationCheckTarget.Stored(
+                    new DbTableName(new DbSchemaName("edfi"), "School"),
+                    new DbColumnName("DocumentId")
+                ),
+                new QualifiedResourceName("Ed-Fi", "School"),
+                [$"{CustomViewStrategyName}Element"],
+                $"You may need a {CustomViewStrategyName} hint."
+            ),
+        ];
+
+    private static RelationalOwnershipAuthorization CreateOwnershipAuthorization(
+        SqlDialect dialect,
+        IReadOnlyList<short>? ownershipTokenIds = null
+    ) =>
+        new(
+            new OwnershipAuthorizationCheckSpec(0),
+            OwnershipTokenParameterizationFactory.Create(
+                dialect,
+                ownershipTokenIds ?? [11],
+                "ownershipTokenIds"
+            )
+        );
+
+    private static RelationalWriteNamespaceAuthorization CreateNamespaceAuthorization(SqlDialect dialect) =>
+        new(
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Stored,
+                    new DbTableName(new DbSchemaName("edfi"), "School"),
+                    new DbColumnName("Name")
+                ),
+            ],
+            NamespacePrefixParameterizationFactory.Create(dialect, ["uri://ed-fi.org/"], "namespacePrefixes")
+        );
+
+    private static MappingSet CreateMappingSet(SqlDialect dialect)
+    {
+        var rootPlan = Given_Default_Relational_Write_Executor.CreateRootPlan();
+
+        return Given_Default_Relational_Write_Executor.CreateMappingSet(
+            Given_Default_Relational_Write_Executor.CreateRelationalResourceModel(rootPlan.TableModel),
+            [rootPlan],
+            dialect
+        );
+    }
+
+    private sealed class StoredAuthorizationStubDbException(string message) : DbException(message);
+
+    private sealed class StoredAuthorizationStubProviderFailureExtractor(
+        string? providerErrorCode,
+        string providerMessage
+    ) : IRelationshipAuthorizationProviderFailureExtractor
+    {
+        public RelationshipAuthorizationProviderFailure Extract(DbException exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            return new RelationshipAuthorizationProviderFailure(providerErrorCode, providerMessage);
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCompositeStoredOwnershipAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCompositeStoredOwnershipAuthorizationTests.cs
@@ -362,6 +362,39 @@ public class Given_The_Composite_Stored_Ownership_Authorization
             .Be(AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuth1Payload);
     }
 
+    /// <summary>
+    /// A namespace plan must not answer for a malformed payload another family's statement raised. The
+    /// namespace arm is reached before the relationship one, so claiming these filed a custom-view or
+    /// relationship defect under <c>NamespaceBased</c>.
+    /// </summary>
+    /// <remarks>
+    /// Asserts <see langword="null"/> — no family claims it — because this fixture's classifier helper
+    /// supplies neither a custom-view nor a relationship plan, and building either takes a fixture larger
+    /// than this regression is worth. That is precisely the assertion that matters here: the steal is gone,
+    /// and <c>TryClassifyDenial</c> returning null leaves the caller's own database-failure handling
+    /// authoritative. The owning mappers are covered directly in
+    /// <c>Given_AnAuth1PayloadFromAnotherFamily</c>.
+    /// </remarks>
+    [TestCase("cv1|0")]
+    [TestCase("cv1|0|x")]
+    [TestCase("1|0|1|not-a-subject-failure")]
+    public void It_does_not_let_a_namespace_plan_claim_another_familys_malformed_payload(string payloadText)
+    {
+        var dialect = SqlDialect.Pgsql;
+        var namespaceAuthorization = CreateNamespaceAuthorization(dialect);
+
+        var denial = Classify(
+            dialect,
+            payloadText,
+            namespacePlan: new StoredNamespaceStatementPlan(
+                namespaceAuthorization.Checks,
+                namespaceAuthorization.NamespacePrefixParameterization
+            )
+        );
+
+        denial.Should().BeNull(payloadText);
+    }
+
     [Test]
     public void It_ignores_a_provider_failure_that_carries_no_auth1_payload()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentRowCommandBuilderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentRowCommandBuilderTests.cs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// The <c>dms.Document</c> insert statement, which is the single place
+/// <c>CreatedByOwnershipTokenId</c> is stamped for regular resources — both the co-batched write path and
+/// the ordered-segment one build their insert here.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_RelationalDocumentRowCommandBuilder
+{
+    private const string OwnershipTokenParameterName = "@createdByOwnershipTokenId";
+
+    private static readonly DocumentUuid _documentUuid = new(
+        Guid.Parse("11111111-2222-3333-4444-555555555555")
+    );
+
+    private static RelationalCommand Insert(SqlDialect dialect, short? createdByOwnershipTokenId) =>
+        RelationalDocumentRowCommandBuilder.BuildInsertCommand(
+            dialect,
+            _documentUuid,
+            resourceKeyId: 7,
+            createdByOwnershipTokenId
+        );
+
+    [TestCase(SqlDialect.Pgsql, "\"CreatedByOwnershipTokenId\"")]
+    [TestCase(SqlDialect.Mssql, "[CreatedByOwnershipTokenId]")]
+    public void It_emits_the_ownership_column_in_the_insert(SqlDialect dialect, string quotedColumn)
+    {
+        Insert(dialect, 42).CommandText.Should().Contain(quotedColumn);
+    }
+
+    /// <summary>
+    /// The column is emitted for a null token too, so each dialect has exactly one statement text. A
+    /// conditional column list would double statement-text cardinality and cost plan reuse on both engines.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_emits_one_statement_text_whether_or_not_the_client_has_a_creator_token(SqlDialect dialect)
+    {
+        Insert(dialect, 42).CommandText.Should().Be(Insert(dialect, null).CommandText);
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_binds_the_creator_ownership_token(SqlDialect dialect)
+    {
+        Parameter(Insert(dialect, 42)).Value.Should().Be((short)42);
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_binds_null_when_the_client_has_no_creator_token(SqlDialect dialect)
+    {
+        Parameter(Insert(dialect, null)).Value.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The parameter declares <c>smallint</c> rather than relying on provider inference. A null value reaches
+    /// the driver as <c>DBNull</c>, which carries no type: PostgreSQL would have to infer one from the insert
+    /// target and SQL Server would default to a string type and rely on an implicit conversion. Declaring the
+    /// type makes the null and non-null cases bind identically on both engines.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_declares_the_ownership_parameter_as_smallint(SqlDialect dialect)
+    {
+        foreach (short? token in new short?[] { 42, null })
+        {
+            var parameter = Parameter(Insert(dialect, token));
+            parameter.ConfigureParameter.Should().NotBeNull();
+
+            using var probe = new ProbeDbParameter();
+            parameter.ConfigureParameter!(probe);
+
+            probe.DbType.Should().Be(DbType.Int16);
+        }
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_binds_exactly_three_parameters(SqlDialect dialect)
+    {
+        Insert(dialect, 42)
+            .Parameters.Select(static parameter => parameter.Name)
+            .Should()
+            .BeEquivalentTo("@documentUuid", "@resourceKeyId", OwnershipTokenParameterName);
+    }
+
+    [Test]
+    public void It_rejects_an_unsupported_dialect()
+    {
+        Action act = () => Insert((SqlDialect)999, 42);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// The subquery a later statement uses to re-derive the created DocumentId is unaffected by the added
+    /// column, so a create's downstream statements still resolve their root id.
+    /// </summary>
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public void It_leaves_the_document_id_subquery_free_of_the_ownership_column(SqlDialect dialect)
+    {
+        RelationalDocumentRowCommandBuilder
+            .BuildDocumentIdSubquery(dialect, "@documentUuid")
+            .Should()
+            .NotContain("CreatedByOwnershipTokenId");
+    }
+
+    private static RelationalParameter Parameter(RelationalCommand command) =>
+        command.Parameters.Single(parameter => parameter.Name == OwnershipTokenParameterName);
+
+    /// <summary>
+    /// A minimal <see cref="DbParameter"/> so the provider-agnostic configuration callback can be observed
+    /// without a real provider command.
+    /// </summary>
+    private sealed class ProbeDbParameter : DbParameter, IDisposable
+    {
+        public override DbType DbType { get; set; }
+        public override ParameterDirection Direction { get; set; }
+        public override bool IsNullable { get; set; }
+
+        [AllowNull]
+        public override string ParameterName { get; set; } = string.Empty;
+
+        [AllowNull]
+        public override string SourceColumn { get; set; } = string.Empty;
+
+        public override bool SourceColumnNullMapping { get; set; }
+        public override object? Value { get; set; }
+        public override int Size { get; set; }
+
+        public override void ResetDbType() => DbType = default;
+
+        public void Dispose() { }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.Partitions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.Partitions.cs
@@ -472,6 +472,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -1810,6 +1810,40 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_validates_a_read_acceleration_get_by_id_custom_view_configured_before_a_namespace_no_prefixes_terminal()
+    {
+        // The same terminal as the plain-path sibling above, reached through the read-acceleration entry
+        // point instead. That path used to return the terminal's result without probing the views ahead of
+        // it, so a missing or non-conforming view lost its own 500 depending on nothing but which entry
+        // point served the read. It matters most for the terminals carrying every configured view, such as
+        // the ownership token cap.
+        var readAccelerationCoordinator = new RecordingReadAccelerationCoordinator();
+        UseReadAccelerationCoordinator(readAccelerationCoordinator);
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var getRequest = CreateGetRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa0a")),
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: []
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        readAccelerationCoordinator.GetByIdAttempts.Should().Be(1);
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+    }
+
+    [Test]
     public async Task It_does_not_validate_a_get_by_id_custom_view_configured_after_a_namespace_no_prefixes_terminal()
     {
         // The run would have aborted at the namespace position, so a view configured after it never executes

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -3233,6 +3233,184 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     /// <summary>
+    /// The authorized path, which the denial tests cannot reach: ownership authorizes, and only then does
+    /// the relationship OR group run. Ownership is an AND filter and the relationship group follows every
+    /// AND filter, so a reorder that moved the relationship group ahead of ownership would let a document
+    /// the caller does not own reach the relationship boundary — and, if that boundary authorized it, be
+    /// served.
+    /// </summary>
+    [Test]
+    public async Task It_runs_the_relationship_group_after_ownership_authorizes_a_get_by_id()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccc19"));
+        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ],
+            claimEducationOrganizationIds: [255901L],
+            ownershipTokenIds: [11]
+        );
+        var hydratedPage = CreateHydratedPage(
+            readPlan,
+            CreateDocumentMetadataRow(documentUuid, 345L, 91L),
+            (345L, "Lincoln High")
+        );
+        var order = 0;
+        var ownershipOrder = 0;
+        var relationshipOrder = 0;
+        var hydrationOrder = 0;
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                )
+            );
+        A.CallTo(() =>
+                _ownershipAuthorizationExecutor.ExecuteAsync(
+                    A<OwnershipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(() => ownershipOrder = ++order)
+            .Returns(
+                Task.FromResult<OwnershipAuthorizationExecutionResult>(
+                    new OwnershipAuthorizationExecutionResult.Authorized()
+                )
+            );
+        A.CallTo(() =>
+                _singleRecordRelationshipAuthorizationExecutor.ExecuteAsync(
+                    A<SingleRecordRelationshipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(() => relationshipOrder = ++order)
+            .Returns(
+                Task.FromResult<SingleRecordRelationshipAuthorizationExecutionResult>(
+                    new SingleRecordRelationshipAuthorizationExecutionResult.Authorized(91L)
+                )
+            );
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    new PageKeysetSpec.Single(345L),
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(() => hydrationOrder = ++order)
+            .Returns(hydratedPage);
+        A.CallTo(() => _readMaterializer.Materialize(A<RelationalReadMaterializationRequest>._))
+            .Returns(JsonNode.Parse("""{"id":"authorized"}""")!);
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+        ownershipOrder.Should().Be(1);
+        relationshipOrder.Should().Be(2);
+        hydrationOrder.Should().Be(3);
+    }
+
+    /// <summary>
+    /// Ownership joins the stored AND-filter read boundary. It reads the stored row and reports no content
+    /// version, so its decision is only valid for the version that drove the attempt; when the relationship
+    /// boundary then observes a different version, a mutation interleaved and the whole authorization
+    /// sequence must re-run rather than serve a representation ownership never validated.
+    /// </summary>
+    /// <remarks>
+    /// Ownership is deliberately the only stored AND filter configured here. With no namespace or custom
+    /// view check present, the anchoring step runs only because ownership is counted among them, so this
+    /// test fails if ownership is ever dropped from that condition.
+    /// </remarks>
+    [Test]
+    public async Task It_retries_when_ownership_authorized_a_version_the_relationship_boundary_did_not_observe()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccc20"));
+        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ],
+            claimEducationOrganizationIds: [255901L],
+            ownershipTokenIds: [11]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .ReturnsNextFromSequence(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                ),
+                new RelationalReadTargetLookupResult.NotFound()
+            );
+        GivenOwnershipAuthorizationReturns(new OwnershipAuthorizationExecutionResult.Authorized());
+        // The relationship boundary observed content version 92 while the ownership check authorized the
+        // row at 91, so the two decisions describe different rows.
+        A.CallTo(() =>
+                _singleRecordRelationshipAuthorizationExecutor.ExecuteAsync(
+                    A<SingleRecordRelationshipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                Task.FromResult<SingleRecordRelationshipAuthorizationExecutionResult>(
+                    new SingleRecordRelationshipAuthorizationExecutionResult.Authorized(92L)
+                )
+            );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        // The retry re-resolves the target, which is gone, so the read ends as a 404 rather than serving a
+        // representation no check validated.
+        result.Should().BeOfType<GetResult.GetFailureNotExists>();
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .MustHaveHappenedTwiceExactly();
+        AssertGetByIdHydrationWasNotAttempted();
+    }
+
+    /// <summary>
     /// The same denial through the read-acceleration entry point. Both GET-by-id paths run their own
     /// preflight and their own per-attempt authorization, so a check wired into one is not wired into the
     /// other by construction.
@@ -6800,8 +6978,9 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     public async Task It_fails_closed_when_a_custom_view_is_composed_with_OwnershipBased()
     {
         // DMS-1410 owns GET-many OwnershipBased support. Even alongside a resolved custom view and a
-        // relationship strategy, GET-many must fail closed rather than emit an ownership filter:
-        // DMS-1060 has not stamped CreatedByOwnershipTokenId yet, so a filter would silently drop every row.
+        // relationship strategy, GET-many must fail closed rather than emit an ownership filter: DMS-1060
+        // ships the stamping and the single-record check, not the page filter, which is a different shape of
+        // query and not this ticket's to emit.
         var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
         var queryRequest = CreateQueryRequest(
             mappingSet,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -9767,6 +9767,46 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         ownership.OwnershipTokenParameterization.TokensInOrder.Should().Equal((short)11);
     }
 
+    /// <summary>
+    /// Ownership is the last AND filter ahead of the relationship OR group, so a relationship NoClaims
+    /// cannot be reported at preflight while an ownership check is still planned. A POST resolving to
+    /// upsert-as-update has a stored token nothing has read yet, and short-circuiting here would report the
+    /// relationship denial in place of the ownership one auth.md gives precedence to.
+    /// </summary>
+    [Test]
+    public async Task It_defers_a_post_relationship_no_claims_denial_when_an_ownership_check_is_still_planned()
+    {
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post no claims with ownership"));
+        // Empty claim EducationOrganizationIds make the relationship strategy resolve to NoClaims; the
+        // ownership tokens keep an ownership check planned alongside it.
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], [], null, [11]));
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        var executorInput = _capturedExecutorRequests.Should().ContainSingle().Subject;
+        executorInput.StoredOwnershipAuthorization.Should().NotBeNull();
+        executorInput
+            .StoredOwnershipAuthorization!.OwnershipTokenParameterization.TokensInOrder.Should()
+            .Equal((short)11);
+        executorInput
+            .ProposedRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.NoClaims>();
+    }
+
     [Test]
     public async Task It_plans_a_custom_view_alongside_relationship_authorization_for_a_post()
     {
@@ -11049,6 +11089,52 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         var ownership = executorInput.StoredOwnershipAuthorization!;
         ownership.Check.RawConfiguredIndex.Should().Be(1);
         ownership.OwnershipTokenParameterization.TokensInOrder.Should().Equal((short)11);
+    }
+
+    /// <summary>
+    /// The PUT counterpart of the POST deferral, and the asymmetry is deliberate. A stored-slot NoClaims
+    /// routes the write down the ordered-segments path, where the ownership segment already runs ahead of
+    /// the stored relationship boundary — so the ownership denial wins from the stored slot, without the
+    /// merge the proposed slot would run before reporting it. What has to hold is that the ownership plan
+    /// still reaches the executor.
+    /// </summary>
+    [Test]
+    public async Task It_keeps_a_put_relationship_no_claims_denial_in_the_stored_slot_behind_a_planned_ownership_check()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa12"));
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateSuccess(documentUuid, ComposedWriteResultEtag)
+            )
+        );
+        var updateRequest = A.Fake<IUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Put no claims with ownership"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => updateRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], [], null, [11]));
+
+        await _sut.UpdateDocumentById(updateRequest);
+
+        var putExecutorInput = _capturedExecutorRequests.Should().ContainSingle().Subject;
+        putExecutorInput
+            .StoredRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.NoClaims>();
+        putExecutorInput.ProposedRelationshipAuthorization.Should().BeNull();
+        putExecutorInput.StoredOwnershipAuthorization.Should().NotBeNull();
+        putExecutorInput
+            .StoredOwnershipAuthorization!.OwnershipTokenParameterization.TokensInOrder.Should()
+            .Equal((short)11);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -9729,7 +9729,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_post_not_implemented_for_known_but_not_enabled_relationship_authorization_before_target_lookup()
+    public async Task It_plans_post_ownership_alongside_a_supported_relationship_strategy()
     {
         var documentUuid = new DocumentUuid(Guid.NewGuid());
         var requestBody = CreateRequestBody("Roosevelt High");
@@ -9753,19 +9753,18 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ]);
         A.CallTo(() => upsertRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901]));
+            .Returns(new RelationalAuthorizationContext([255901], [], null, [11]));
 
-        var result = await _sut.UpsertDocument(upsertRequest);
+        await _sut.UpsertDocument(upsertRequest);
 
-        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureNotImplemented>().Subject;
-        failure.Reason.Should().Be(UpsertFailureNotImplementedReason.StrategyNotEnabled);
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
-        AssertSupportedRelationshipStrategyNames(failure.FailureMessage);
-        _capturedExecutorRequests.Should().BeEmpty();
-        A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
-            .MustNotHaveHappened();
-        A.CallTo(() => _referenceResolver.ResolveAsync(A<ReferenceResolverRequest>._, A<CancellationToken>._))
-            .MustNotHaveHappened();
+        // OwnershipBased is the only strategy in the relationship classifier's known-but-not-enabled set, so
+        // once Update is enforced this composition plans instead of returning a 501, and the executor
+        // receives the planned check with the caller's tokens.
+        var executorInput = _capturedExecutorRequests.Should().ContainSingle().Subject;
+        executorInput.StoredOwnershipAuthorization.Should().NotBeNull();
+        var ownership = executorInput.StoredOwnershipAuthorization!;
+        ownership.Check.RawConfiguredIndex.Should().Be(1);
+        ownership.OwnershipTokenParameterization.TokensInOrder.Should().Equal((short)11);
     }
 
     [Test]
@@ -9913,40 +9912,14 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_validates_a_post_custom_view_when_an_unsupported_strategy_stops_before_planning()
+    public async Task It_validates_a_put_custom_view_when_an_unknown_strategy_stops_before_planning()
     {
-        // OwnershipBased makes the strategy-level outcome StillUnsupported, which enters the relationship
-        // bucket before any custom view has been planned. The view still AND-composes ahead of that 501, so
-        // the bucket has to plan and validate it rather than reporting the terminal over an unchecked view.
-        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
-        var upsertRequest = A.Fake<IUpsertRequest>();
-        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
-        A.CallTo(() => upsertRequest.MappingSet)
-            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
-        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
-        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
-        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post unsupported strategy"));
-        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
-            .Returns([
-                CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
-            ]);
-        A.CallTo(() => upsertRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901]));
-
-        var result = await _sut.UpsertDocument(upsertRequest);
-
-        result.Should().BeOfType<UpsertResult.UpsertFailureNotImplemented>();
-        capturedValidationSql
-            .Should()
-            .ContainSingle()
-            .Which.Should()
-            .Contain("SchoolWithCustomAuthorization");
-    }
-
-    [Test]
-    public async Task It_validates_a_put_custom_view_when_an_unsupported_strategy_stops_before_planning()
-    {
+        // The PUT counterpart of the POST unknown-strategy case above. An unknown strategy makes the
+        // strategy-level outcome SecurityConfigurationError, which enters the relationship bucket with
+        // nothing planned, and the view AND-composes ahead of that 500 so the bucket owes its validation.
+        // OwnershipBased used to give this test its own StillUnsupported trigger; it is enforced for every
+        // single-record operation now, so an unknown strategy is the remaining way to reach the bucket
+        // unplanned.
         var capturedValidationSql = GivenCustomViewValidationIsRecorded();
         var updateRequest = A.Fake<IUpdateRequest>();
         A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
@@ -9954,18 +9927,18 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
         A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
         A.CallTo(() => updateRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
-        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Put unsupported strategy"));
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Put unknown strategy"));
         A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
             .Returns([
                 CreateAuthorizationStrategyEvaluator("SchoolWithCustomAuthorization"),
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+                CreateAuthorizationStrategyEvaluator("AnUnknownAuthorizationStrategy"),
             ]);
         A.CallTo(() => updateRequest.AuthorizationContext)
             .Returns(new RelationalAuthorizationContext([255901]));
 
         var result = await _sut.UpdateDocumentById(updateRequest);
 
-        result.Should().BeOfType<UpdateResult.UpdateFailureNotImplemented>();
+        result.Should().BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>();
         capturedValidationSql
             .Should()
             .ContainSingle()
@@ -10137,7 +10110,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_post_security_configuration_failure_before_known_but_not_enabled_result()
+    public async Task It_returns_post_security_configuration_failure_for_an_unknown_strategy()
     {
         var upsertRequest = A.Fake<IUpsertRequest>();
         A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
@@ -10156,8 +10129,14 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         var result = await _sut.UpsertDocument(upsertRequest);
 
         var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
-        failure.Errors.Should().Contain(error => error.Contains("Relational POST authorization metadata"));
-        failure.Errors.Should().Contain(error => error.Contains("CustomAuthorizationStrategy"));
+        // OwnershipBased no longer contributes a known-but-not-enabled failure to this bucket — it is
+        // enforced for every single-record operation — so the unknown strategy's own 500 is what remains.
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("Could not find authorization strategy implementations")
+            .And.Contain("CustomAuthorizationStrategy");
         _capturedExecutorRequests.Should().BeEmpty();
         A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
             .MustNotHaveHappened();
@@ -11025,8 +11004,18 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_put_not_implemented_for_known_but_not_enabled_relationship_authorization_before_target_lookup()
+    public async Task It_plans_put_ownership_alongside_a_supported_relationship_strategy()
     {
+        // The shared fake write executor answers with an upsert result, which the PUT projector rejects, so
+        // this test scripts an update result the way the other PUT cases in this fixture do.
+        GivenWriteExecutorCaptures(
+            new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateSuccess(
+                    new DocumentUuid(Guid.Parse("bbbbbbbb-1111-2222-3333-aaaaaaaaaa11")),
+                    ComposedWriteResultEtag
+                )
+            )
+        );
         var documentUuid = new DocumentUuid(Guid.NewGuid());
         var requestBody = CreateRequestBody("Roosevelt High");
         var documentInfo = CreateDocumentInfo();
@@ -11049,21 +11038,21 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ]);
         A.CallTo(() => updateRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901]));
+            .Returns(new RelationalAuthorizationContext([255901], [], null, [11]));
 
-        var result = await _sut.UpdateDocumentById(updateRequest);
+        await _sut.UpdateDocumentById(updateRequest);
 
-        var failure = result.Should().BeOfType<UpdateResult.UpdateFailureNotImplemented>().Subject;
-        failure.Reason.Should().Be(UpdateFailureNotImplementedReason.StrategyNotEnabled);
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
-        AssertSupportedRelationshipStrategyNames(failure.FailureMessage);
-        _capturedExecutorRequests.Should().BeEmpty();
-        A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
-            .MustNotHaveHappened();
+        // The PUT twin of the POST case above: enforced, so planned rather than 501, and the executor
+        // receives the planned check.
+        var executorInput = _capturedExecutorRequests.Should().ContainSingle().Subject;
+        executorInput.StoredOwnershipAuthorization.Should().NotBeNull();
+        var ownership = executorInput.StoredOwnershipAuthorization!;
+        ownership.Check.RawConfiguredIndex.Should().Be(1);
+        ownership.OwnershipTokenParameterization.TokensInOrder.Should().Equal((short)11);
     }
 
     [Test]
-    public async Task It_returns_put_security_configuration_failure_before_known_but_not_enabled_result()
+    public async Task It_returns_put_security_configuration_failure_for_an_unknown_strategy()
     {
         var updateRequest = A.Fake<IUpdateRequest>();
         A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
@@ -11082,8 +11071,14 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         var result = await _sut.UpdateDocumentById(updateRequest);
 
         var failure = result.Should().BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>().Subject;
-        failure.Errors.Should().Contain(error => error.Contains("Relational PUT authorization metadata"));
-        failure.Errors.Should().Contain(error => error.Contains("CustomAuthorizationStrategy"));
+        // OwnershipBased no longer contributes a known-but-not-enabled failure to this bucket — it is
+        // enforced for every single-record operation — so the unknown strategy's own 500 is what remains.
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("Could not find authorization strategy implementations")
+            .And.Contain("CustomAuthorizationStrategy");
         _capturedExecutorRequests.Should().BeEmpty();
         A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
             .MustNotHaveHappened();
@@ -14008,16 +14003,6 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
                 )
             )
             .MustNotHaveHappened();
-
-    private static void AssertSupportedRelationshipStrategyNames(string message)
-    {
-        foreach (
-            var expectedStrategyName in RelationshipAuthorizationStrategyCatalog.SupportedRelationshipStrategyNames
-        )
-        {
-            message.Should().Contain(expectedStrategyName);
-        }
-    }
 
     private static IGetRequest CreateGetRequest(
         DocumentUuid documentUuid,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -12809,10 +12809,23 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_not_implemented_before_delete_target_lookup_when_authorization_includes_a_still_unsupported_strategy()
+    public async Task It_denies_a_delete_on_an_ownership_token_mismatch_and_rolls_back()
     {
+        // OwnershipBased is the only strategy in the relationship classifier's known-but-not-enabled set, so
+        // once Delete is enforced this composition plans instead of returning a 501. Ownership is an AND
+        // filter running before the relationship OR group, so its denial ends the delete — and the deletes
+        // rode the same aborted command, so the row survives the rollback.
         var documentUuid = new DocumentUuid(Guid.NewGuid());
-        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
+        var mappingSet = AsMssql(CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteAuth1Failure(
+            OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+                new OwnershipAuthorizationAuth1FailurePayload(
+                    1,
+                    OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch
+                )
+            )
+        );
 
         var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
         A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
@@ -12823,19 +12836,118 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ]);
         A.CallTo(() => deleteRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901L]));
+            .Returns(new RelationalAuthorizationContext([255901L], [], null, [11]));
 
         var result = await _sut.DeleteDocumentById(deleteRequest);
 
-        result.Should().BeOfType<DeleteResult.DeleteFailureNotImplemented>();
-        var failure = result.As<DeleteResult.DeleteFailureNotImplemented>();
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
-        AssertSupportedRelationshipStrategyNames(failure.FailureMessage);
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>().Subject;
+        failure
+            .OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        failure.OwnershipFailure.ConfiguredStrategyIndex.Should().Be(1);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    /// <summary>
+    /// An uninitialized stored token is auth.md 2.14 and reaches the caller as its own failure kind.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_delete_whose_stored_ownership_token_was_never_assigned()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = AsMssql(CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteAuth1Failure(
+            OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+                new OwnershipAuthorizationAuth1FailurePayload(
+                    0,
+                    OwnershipAuthorizationAuth1FailureKind.StoredOwnershipTokenUninitialized
+                )
+            )
+        );
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], [], null, [11]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    /// <summary>
+    /// The ownership denial outranks a specific-tag If-Match mismatch. The check rides the opening command,
+    /// which the precondition comparison follows, so a caller who does not own the row learns that rather
+    /// than being told its etag is stale — which would disclose that the row changed.
+    /// </summary>
+    [Test]
+    public async Task It_reports_an_ownership_denial_over_an_if_match_mismatch()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = AsMssql(CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteAuth1Failure(
+            OwnershipAuthorizationAuth1FailurePayloadCodec.Encode(
+                new OwnershipAuthorizationAuth1FailurePayload(
+                    0,
+                    OwnershipAuthorizationAuth1FailureKind.OwnershipTokenMismatch
+                )
+            )
+        );
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.WritePrecondition)
+            .Returns(new WritePrecondition.IfMatch("\"stale-ownership-etag\""));
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], [], null, [11]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureOwnershipNotAuthorized>();
+    }
+
+    /// <summary>
+    /// The ownership token cap is a planner terminal, so it is reported before the write session opens and
+    /// the target is never locked.
+    /// </summary>
+    [Test]
+    public async Task It_fails_closed_for_a_delete_with_an_over_cap_ownership_token_list()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], [], null, OverCapOwnershipTokenIds()));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("2,000");
         _writeSessionFactory.CreateAsyncCallCount.Should().Be(0);
-        _currentEtagPreconditionChecker.CallCount.Should().Be(0);
-        A.CallTo(_commandExecutor)
-            .WithReturnType<Task<SingleRecordRelationshipAuthorizationExecutionResult>>()
-            .MustNotHaveHappened();
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -1343,8 +1343,11 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_not_implemented_before_get_by_id_target_lookup_when_authorization_includes_known_out_of_scope_strategies()
+    public async Task It_composes_get_by_id_ownership_with_a_supported_relationship_strategy()
     {
+        // OwnershipBased is the only strategy in the relationship classifier's known-but-not-enabled set, so
+        // once ReadSingle is enforced this composition plans instead of returning a 501. Ownership is an AND
+        // filter and runs before the relationship OR group; a denial there ends the read.
         var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-2222-3333-4444-cfcfcfcfcfcf"));
         var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
         var getRequest = CreateGetRequest(
@@ -1358,26 +1361,40 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
                 ),
                 CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ],
-            claimEducationOrganizationIds: [255901L]
+            claimEducationOrganizationIds: [255901L],
+            ownershipTokenIds: [11]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                )
+            );
+        GivenOwnershipAuthorizationReturns(
+            new OwnershipAuthorizationExecutionResult.NotAuthorized(
+                CreateOwnershipFailure(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch, 1)
+            )
         );
 
         var result = await _sut.GetDocumentById(getRequest);
 
-        var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
-        AssertSupportedRelationshipStrategyNames(failure.FailureMessage);
-        // OwnershipBased keeps its known-but-not-enabled 501 while the ReadSingle gate is closed, and the
-        // wired executor is not reached on the way to it.
-        AssertOwnershipAuthorizationWasNotExecuted();
-        A.CallTo(() =>
-                _readTargetLookupService.ResolveForGetByIdAsync(
-                    A<MappingSet>._,
-                    A<QualifiedResourceName>._,
-                    A<DocumentUuid>._,
-                    A<CancellationToken>._
-                )
-            )
-            .MustNotHaveHappened();
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.ConfiguredStrategyIndex.Should()
+            .Be(1);
+        // The relationship OR group follows the AND filters, so an ownership denial stops the read before it.
         A.CallTo(() =>
                 _singleRecordRelationshipAuthorizationExecutor.ExecuteAsync(
                     A<SingleRecordRelationshipAuthorizationExecutionRequest>._,
@@ -1385,15 +1402,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
                 )
             )
             .MustNotHaveHappened();
-        A.CallTo(() =>
-                _documentHydrator.HydrateAsync(
-                    A<ResourceReadPlan>._,
-                    A<PageKeysetSpec>._,
-                    A<HydrationExecutionOptions>._,
-                    A<CancellationToken>._
-                )
-            )
-            .MustNotHaveHappened();
+        AssertGetByIdHydrationWasNotAttempted();
     }
 
     [Test]
@@ -1996,10 +2005,10 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_validates_a_get_by_id_custom_view_configured_before_an_ownership_based_terminal()
+    public async Task It_validates_a_get_by_id_custom_view_configured_before_an_ownership_token_cap_terminal()
     {
         // OwnershipBased executes last per auth.md regardless of configured position, so every resolved view
-        // runs before its 501.
+        // runs before its terminal. The cap is a planner terminal, reported before any target lookup.
         var capturedValidationSql = GivenCustomViewValidationIsRecorded();
         var getRequest = CreateGetRequest(
             new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa03")),
@@ -2010,16 +2019,51 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
                 CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ],
-            namespacePrefixes: ["uri://ed-fi.org/"]
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            ownershipTokenIds: OverCapOwnershipTokenIds()
         );
 
         var result = await _sut.GetDocumentById(getRequest);
 
-        result
-            .Should()
-            .BeOfType<GetResult.GetFailureNotImplemented>()
-            .Which.FailureMessage.Should()
-            .Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;
+        // The configured count is reportable; a token value never is.
+        failure.Errors.Should().ContainSingle().Which.Should().Contain("2,000");
+        capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    A<MappingSet>._,
+                    A<QualifiedResourceName>._,
+                    A<DocumentUuid>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// A view configured after OwnershipBased still runs before the cap terminal. Ownership executes last
+    /// among the AND strategies whatever position it holds, so no configured view can follow it.
+    /// </summary>
+    [Test]
+    public async Task It_validates_a_get_by_id_custom_view_configured_after_ownership_before_the_cap_terminal()
+    {
+        var capturedValidationSql = GivenCustomViewValidationIsRecorded();
+        var getRequest = CreateGetRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa0b")),
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            ownershipTokenIds: OverCapOwnershipTokenIds()
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>();
         capturedValidationSql.Should().ContainSingle().Which.Should().Contain(CustomViewStrategyName);
     }
 
@@ -2058,6 +2102,76 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             ReadableSecurableElements: ["School"],
             Hint: "You may need a School with A Tag."
         );
+
+    private void GivenOwnershipAuthorizationReturns(OwnershipAuthorizationExecutionResult result) =>
+        A.CallTo(() =>
+                _ownershipAuthorizationExecutor.ExecuteAsync(
+                    A<OwnershipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(Task.FromResult(result));
+
+    /// <summary>
+    /// A GET-by-id request whose target resolves, with the given strategies configured and the given
+    /// ownership tokens held by the caller.
+    /// </summary>
+    private IGetRequest GivenAResolvableOwnershipGetByIdTarget(
+        DocumentUuid documentUuid,
+        MappingSet mappingSet,
+        AuthorizationStrategyEvaluator[] authorizationStrategyEvaluators,
+        IReadOnlyList<short>? ownershipTokenIds = null
+    )
+    {
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators: authorizationStrategyEvaluators,
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            ownershipTokenIds: ownershipTokenIds ?? [11]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                new RelationalReadTargetLookupResult.ExistingDocument(
+                    345L,
+                    documentUuid,
+                    91L,
+                    _readTargetContentLastModifiedAt
+                )
+            );
+
+        return getRequest;
+    }
+
+    private void AssertGetByIdHydrationWasNotAttempted() =>
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+
+    /// <summary>
+    /// One more ownership token than the defensive limit allows, so the planner reports the cap terminal.
+    /// </summary>
+    private static IReadOnlyList<short> OverCapOwnershipTokenIds() =>
+        [
+            .. Enumerable
+                .Range(1, OwnershipTokenLimitExceededException.OwnershipTokenLimit)
+                .Select(static tokenId => (short)tokenId),
+        ];
 
     private void GivenCustomViewAuthorizationReturns(CustomViewAuthorizationExecutionResult result) =>
         A.CallTo(() =>
@@ -3049,10 +3163,187 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             .MustNotHaveHappened();
     }
 
-    [Test]
-    public async Task It_fails_closed_when_ownership_is_configured_alongside_namespace()
+    /// <summary>
+    /// Ownership runs after NamespaceBased even when configured before it. auth.md places OwnershipBased
+    /// last among the AND strategies whatever position it holds, which is the one place configured order and
+    /// execution order diverge on purpose.
+    /// </summary>
+    [TestCase(0)]
+    [TestCase(1)]
+    public async Task It_runs_get_by_id_ownership_after_namespace_whichever_order_they_are_configured_in(
+        int ownershipConfiguredIndex
+    )
     {
         var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccccc"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        AuthorizationStrategyEvaluator[] evaluators =
+            ownershipConfiguredIndex == 0
+                ?
+                [
+                    CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+                    CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                ]
+                :
+                [
+                    CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                    CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+                ];
+        var getRequest = GivenAResolvableOwnershipGetByIdTarget(documentUuid, mappingSet, evaluators);
+
+        var order = 0;
+        var namespaceOrder = 0;
+        var ownershipOrder = 0;
+
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(() => namespaceOrder = ++order)
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.Authorized()
+                )
+            );
+        A.CallTo(() =>
+                _ownershipAuthorizationExecutor.ExecuteAsync(
+                    A<OwnershipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(() => ownershipOrder = ++order)
+            .Returns(
+                Task.FromResult<OwnershipAuthorizationExecutionResult>(
+                    new OwnershipAuthorizationExecutionResult.NotAuthorized(
+                        CreateOwnershipFailure(
+                            OwnershipAuthorizationFailureKind.OwnershipTokenMismatch,
+                            ownershipConfiguredIndex
+                        )
+                    )
+                )
+            );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureOwnershipNotAuthorized>();
+        namespaceOrder.Should().Be(1);
+        ownershipOrder.Should().Be(2);
+        AssertGetByIdHydrationWasNotAttempted();
+    }
+
+    /// <summary>
+    /// The same denial through the read-acceleration entry point. Both GET-by-id paths run their own
+    /// preflight and their own per-attempt authorization, so a check wired into one is not wired into the
+    /// other by construction.
+    /// </summary>
+    [Test]
+    public async Task It_denies_a_read_acceleration_get_by_id_on_an_ownership_token_mismatch()
+    {
+        var readAccelerationCoordinator = new RecordingReadAccelerationCoordinator();
+        UseReadAccelerationCoordinator(readAccelerationCoordinator);
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccc18"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = GivenAResolvableOwnershipGetByIdTarget(
+            documentUuid,
+            mappingSet,
+            [CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased)]
+        );
+        GivenOwnershipAuthorizationReturns(
+            new OwnershipAuthorizationExecutionResult.NotAuthorized(
+                CreateOwnershipFailure(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch, 0)
+            )
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        readAccelerationCoordinator.GetByIdAttempts.Should().Be(1);
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch);
+        AssertGetByIdHydrationWasNotAttempted();
+    }
+
+    /// <summary>
+    /// The stored ownership token is null, which is auth.md 2.14 rather than 2.13: the document can never be
+    /// reached by any client, so the response type differs even though both are a 403.
+    /// </summary>
+    [Test]
+    public async Task It_returns_the_uninitialized_ownership_failure_for_a_get_by_id_stored_null_token()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccc14"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = GivenAResolvableOwnershipGetByIdTarget(
+            documentUuid,
+            mappingSet,
+            [CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased)]
+        );
+        GivenOwnershipAuthorizationReturns(
+            new OwnershipAuthorizationExecutionResult.NotAuthorized(
+                CreateOwnershipFailure(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized, 0)
+            )
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureOwnershipNotAuthorized>()
+            .Which.OwnershipFailure.FailureKind.Should()
+            .Be(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized);
+        AssertGetByIdHydrationWasNotAttempted();
+    }
+
+    /// <summary>
+    /// An ownership AUTH1 payload the request's plan cannot account for is a security-configuration 500, not
+    /// a denial attributed to a strategy that did not deny the request.
+    /// </summary>
+    [Test]
+    public async Task It_returns_a_get_by_id_security_configuration_failure_for_an_unattributable_ownership_payload()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccc15"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = GivenAResolvableOwnershipGetByIdTarget(
+            documentUuid,
+            mappingSet,
+            [CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased)]
+        );
+        GivenOwnershipAuthorizationReturns(
+            new OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure(
+                OwnershipAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata,
+                AuthorizationSecurityConfigurationDiagnostics.ForOwnershipAuthorizationAuth1(
+                    AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed,
+                    0
+                )
+            )
+        );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(OwnershipAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata);
+        failure
+            .Diagnostics.Should()
+            .ContainSingle()
+            .Which.ProviderOrPlannerFailureKind.Should()
+            .Be(AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed);
+        AssertGetByIdHydrationWasNotAttempted();
+    }
+
+    /// <summary>
+    /// A target deleted between the unlocked lookup and the ownership check must surface as a 404 on
+    /// re-resolution, never as an ownership denial for a row that no longer exists.
+    /// </summary>
+    [Test]
+    public async Task It_retries_and_returns_not_found_when_the_get_by_id_ownership_target_is_stale()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccc16"));
         var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
         var getRequest = CreateGetRequest(
             documentUuid,
@@ -3060,10 +3351,10 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _schoolResourceInfo,
             authorizationStrategyEvaluators:
             [
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
                 CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ],
-            namespacePrefixes: ["uri://ed-fi.org/"]
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            ownershipTokenIds: [11]
         );
 
         A.CallTo(() =>
@@ -3074,35 +3365,85 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
                     A<CancellationToken>._
                 )
             )
-            .Returns(
+            .ReturnsNextFromSequence(
                 new RelationalReadTargetLookupResult.ExistingDocument(
                     345L,
                     documentUuid,
                     91L,
                     _readTargetContentLastModifiedAt
-                )
+                ),
+                new RelationalReadTargetLookupResult.NotFound()
             );
+        GivenOwnershipAuthorizationReturns(new OwnershipAuthorizationExecutionResult.StaleTarget());
 
         var result = await _sut.GetDocumentById(getRequest);
 
-        var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        result.Should().BeOfType<GetResult.GetFailureNotExists>();
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .MustHaveHappenedTwiceExactly();
+        AssertGetByIdHydrationWasNotAttempted();
+    }
+
+    /// <summary>
+    /// The ownership check receives the resolved target and the caller's tokens, and its request carries the
+    /// planned configured index so a denial can be attributed to the right configured position.
+    /// </summary>
+    [Test]
+    public async Task It_passes_the_resolved_target_and_the_caller_tokens_to_the_get_by_id_ownership_check()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccc17"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = GivenAResolvableOwnershipGetByIdTarget(
+            documentUuid,
+            mappingSet,
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ],
+            ownershipTokenIds: [7, 3, 3]
+        );
+        OwnershipAuthorizationExecutionRequest capturedRequest = null!;
+
         A.CallTo(() =>
                 _namespaceAuthorizationExecutor.ExecuteAsync(
                     A<NamespaceAuthorizationExecutionRequest>._,
                     A<CancellationToken>._
                 )
             )
-            .MustNotHaveHappened();
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.Authorized()
+                )
+            );
         A.CallTo(() =>
-                _documentHydrator.HydrateAsync(
-                    A<ResourceReadPlan>._,
-                    A<PageKeysetSpec>._,
-                    A<HydrationExecutionOptions>._,
+                _ownershipAuthorizationExecutor.ExecuteAsync(
+                    A<OwnershipAuthorizationExecutionRequest>._,
                     A<CancellationToken>._
                 )
             )
-            .MustNotHaveHappened();
+            .Invokes(call => capturedRequest = call.GetArgument<OwnershipAuthorizationExecutionRequest>(0)!)
+            .Returns(
+                Task.FromResult<OwnershipAuthorizationExecutionResult>(
+                    new OwnershipAuthorizationExecutionResult.NotAuthorized(
+                        CreateOwnershipFailure(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch, 1)
+                    )
+                )
+            );
+
+        await _sut.GetDocumentById(getRequest);
+
+        capturedRequest.MappingSet.Should().BeSameAs(mappingSet);
+        capturedRequest.DocumentId.Should().Be(345L);
+        capturedRequest.Check.RawConfiguredIndex.Should().Be(1);
+        // Deduplicated and ascending, so the emitted parameter order is deterministic.
+        capturedRequest.OwnershipTokenParameterization.TokensInOrder.Should().Equal((short)3, (short)7);
     }
 
     [Test]
@@ -13395,7 +13736,8 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         ReadableProfileProjectionContext? readableProfileProjectionContext = null,
         AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null,
         IReadOnlyList<long>? claimEducationOrganizationIds = null,
-        IReadOnlyList<string>? namespacePrefixes = null
+        IReadOnlyList<string>? namespacePrefixes = null,
+        IReadOnlyList<short>? ownershipTokenIds = null
     )
     {
         var getRequest = A.Fake<IGetRequest>();
@@ -13418,12 +13760,19 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             .Returns(
                 new RelationalAuthorizationContext(
                     claimEducationOrganizationIds ?? [],
-                    namespacePrefixes ?? []
+                    namespacePrefixes ?? [],
+                    creatorOwnershipTokenId: null,
+                    ownershipTokenIds ?? []
                 )
             );
 
         return getRequest;
     }
+
+    private static OwnershipAuthorizationFailure CreateOwnershipFailure(
+        OwnershipAuthorizationFailureKind failureKind,
+        int configuredStrategyIndex
+    ) => new(failureKind, configuredStrategyIndex, AuthorizationStrategyNameConstants.OwnershipBased);
 
     private static RelationshipAuthorizationFailure CreateRelationshipFailure() =>
         new(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -95,6 +95,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         null!;
     private INamespaceAuthorizationExecutor _namespaceAuthorizationExecutor = null!;
     private ICustomViewAuthorizationExecutor _customViewAuthorizationExecutor = null!;
+    private IOwnershipAuthorizationExecutor _ownershipAuthorizationExecutor = null!;
     private RelationalWriteExecutorInput _capturedExecutorRequest = null!;
     private List<RelationalWriteExecutorInput> _capturedExecutorRequests = null!;
 
@@ -122,6 +123,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>();
         _namespaceAuthorizationExecutor = A.Fake<INamespaceAuthorizationExecutor>();
         _customViewAuthorizationExecutor = A.Fake<ICustomViewAuthorizationExecutor>();
+        _ownershipAuthorizationExecutor = A.Fake<IOwnershipAuthorizationExecutor>();
         _capturedExecutorRequests = [];
         A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
             .Invokes(call =>
@@ -180,6 +182,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -205,6 +208,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -232,6 +236,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: readAccelerationCoordinator
         );
@@ -729,6 +734,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -1118,6 +1124,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         result.Should().BeOfType<GetResult.GetSuccess>();
         authorizationOrder.Should().Be(1);
         hydrationOrder.Should().Be(2);
+        AssertOwnershipAuthorizationWasNotExecuted();
         capturedAuthorizationRequest.MappingSet.Should().BeSameAs(mappingSet);
         capturedAuthorizationRequest.DocumentId.Should().Be(345L);
         capturedAuthorizationRequest.EmittedAuth1Index.Should().Be(0);
@@ -1359,6 +1366,9 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
         failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
         AssertSupportedRelationshipStrategyNames(failure.FailureMessage);
+        // OwnershipBased keeps its known-but-not-enabled 501 while the ReadSingle gate is closed, and the
+        // wired executor is not reached on the way to it.
+        AssertOwnershipAuthorizationWasNotExecuted();
         A.CallTo(() =>
                 _readTargetLookupService.ResolveForGetByIdAsync(
                     A<MappingSet>._,
@@ -4665,6 +4675,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -4837,6 +4848,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -4911,6 +4923,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11313,6 +11326,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11370,6 +11384,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11412,6 +11427,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11469,6 +11485,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11525,6 +11542,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11591,6 +11609,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11692,6 +11711,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11755,6 +11775,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -11795,6 +11816,7 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             _singleRecordRelationshipAuthorizationExecutor,
             _namespaceAuthorizationExecutor,
             _customViewAuthorizationExecutor,
+            _ownershipAuthorizationExecutor,
             _commandExecutor,
             readAccelerationCoordinator: PassthroughDocumentCacheReadAccelerationCoordinator.Instance
         );
@@ -13306,6 +13328,20 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             return ValueTask.CompletedTask;
         }
     }
+
+    /// <summary>
+    /// Asserts no ownership authorization round trip was made. While the ReadSingle enablement gate is
+    /// closed no operation plans an ownership check, so the wiring must stay inert: an unconditional call
+    /// here would be an extra command per read and, once the gate opens, a check running out of order.
+    /// </summary>
+    private void AssertOwnershipAuthorizationWasNotExecuted() =>
+        A.CallTo(() =>
+                _ownershipAuthorizationExecutor.ExecuteAsync(
+                    A<OwnershipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
 
     private static void AssertSupportedRelationshipStrategyNames(string message)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -9937,6 +9937,128 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
             .BeOfType<RelationshipAuthorizationResult.NoClaims>();
     }
 
+    /// <summary>
+    /// A POST cannot know at preflight whether it will create or update, and a create never parameterizes the
+    /// ownership-token list, so an over-limit list must not stop it before the session opens. The planner's
+    /// cap is deferred: the executor receives no ownership parameterization at all, the creator token for the
+    /// create branch, and the security-configuration failure it owes only if the target proves to exist.
+    /// </summary>
+    [Test]
+    public async Task It_defers_a_post_ownership_token_cap_to_target_resolution()
+    {
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post over the ownership cap"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(
+                new RelationalAuthorizationContext(
+                    [],
+                    [],
+                    creatorOwnershipTokenId: 42,
+                    ownershipTokenIds: OverCapOwnershipTokenIds()
+                )
+            );
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        var executorInput = _capturedExecutorRequests.Should().ContainSingle().Subject;
+        executorInput.StoredOwnershipAuthorization.Should().BeNull();
+        executorInput.CreatorOwnershipTokenId.Should().Be((short)42);
+        var deferredFailure = executorInput
+            .DeferredStoredOwnershipFailureResult.Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>()
+            .Subject;
+        // The configured count is reportable; a token value never is.
+        deferredFailure.Errors.Should().ContainSingle().Which.Should().Contain("2,000");
+        deferredFailure
+            .Diagnostics.Should()
+            .ContainSingle()
+            .Which.ProviderOrPlannerFailureKind.Should()
+            .Be(AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded);
+    }
+
+    /// <summary>
+    /// Intentional precedence for the one POST double failure the deferral changes. An unrecognized strategy
+    /// is a relationship configuration failure the classifier reports at preflight; with the cap deferred the
+    /// planner has no cap to rank ahead of it, so that 500 is reported before the target is resolved and the
+    /// executor is never reached. A create would never have reached the cap and the planner cannot know the
+    /// branch, so unlike GET-by-id, PUT and DELETE — where the cap terminal displaces this failure — a POST
+    /// reports the configuration failure it can already prove.
+    /// </summary>
+    [Test]
+    public async Task It_reports_a_post_relationship_configuration_failure_ahead_of_a_deferred_ownership_token_cap()
+    {
+        var upsertRequest = A.Fake<IUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Post unknown strategy over cap"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator("AnUnknownAuthorizationStrategy"),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], [], null, OverCapOwnershipTokenIds()));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().NotContain(error => error.Contains("2,000"));
+        failure
+            .Diagnostics.Should()
+            .NotContain(diagnostic =>
+                diagnostic.ProviderOrPlannerFailureKind
+                == AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded
+            );
+        _capturedExecutorRequests.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The deferral is POST's alone. A PUT's target must already exist, so its ownership check is never
+    /// vacuous, and the cap stays a planner terminal reported before the executor is reached.
+    /// </summary>
+    [Test]
+    public async Task It_keeps_the_put_ownership_token_cap_as_a_preflight_terminal()
+    {
+        var updateRequest = A.Fake<IUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Put over the ownership cap"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]);
+        A.CallTo(() => updateRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], [], null, OverCapOwnershipTokenIds()));
+
+        var result = await _sut.UpdateDocumentById(updateRequest);
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("2,000");
+        _capturedExecutorRequests.Should().BeEmpty();
+    }
+
     [Test]
     public async Task It_plans_a_custom_view_alongside_relationship_authorization_for_a_post()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -9038,6 +9038,129 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
         _capturedExecutorRequest.TraceId.Should().Be(traceId);
     }
 
+    /// <summary>
+    /// A POST forwards the API client's creator ownership token to the executor, which stamps it onto
+    /// <c>dms.Document</c> if the write resolves to a create.
+    /// </summary>
+    [Test]
+    public async Task It_forwards_the_creator_ownership_token_for_a_post()
+    {
+        var upsertRequest = CreateOwnershipStampingUpsertRequest(
+            new RelationalAuthorizationContext([], [], creatorOwnershipTokenId: 42, ownershipTokenIds: [])
+        );
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        _capturedExecutorRequest.CreatorOwnershipTokenId.Should().Be((short)42);
+    }
+
+    /// <summary>
+    /// A client with no creator token stamps null rather than failing: an unstamped document is a valid
+    /// outcome, and one that ownership authorization can never later grant access to.
+    /// </summary>
+    [Test]
+    public async Task It_forwards_a_null_creator_ownership_token_when_the_client_has_none()
+    {
+        var upsertRequest = CreateOwnershipStampingUpsertRequest(
+            new RelationalAuthorizationContext([], [], creatorOwnershipTokenId: null, ownershipTokenIds: [7])
+        );
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        _capturedExecutorRequest.CreatorOwnershipTokenId.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Forwarded regardless of the resource's configured strategies. Stamping is unconditional, which is what
+    /// lets a claim set later enforce ownership over data written before it was configured.
+    /// </summary>
+    [Test]
+    public async Task It_forwards_the_creator_ownership_token_for_a_post_with_no_ownership_strategy_configured()
+    {
+        var upsertRequest = CreateOwnershipStampingUpsertRequest(
+            new RelationalAuthorizationContext([], [], creatorOwnershipTokenId: 9, ownershipTokenIds: []),
+            [
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired
+                ),
+            ]
+        );
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        _capturedExecutorRequest.CreatorOwnershipTokenId.Should().Be((short)9);
+    }
+
+    /// <summary>
+    /// A PUT never creates, so it forwards no creator token at all. Combined with the write path emitting no
+    /// statement that mentions the column, this is what makes "a PUT cannot change the stored ownership
+    /// token" true at the source rather than only downstream.
+    /// </summary>
+    [Test]
+    public async Task It_forwards_no_creator_ownership_token_for_a_put()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateSupportedMappingSet(_schoolResourceInfo);
+
+        // The shared setup scripts an upsert result, which the PUT projector rejects; script an update one
+        // so the request reaches the executor and its captured input can be inspected.
+        A.CallTo(() => _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorInput>._, A<CancellationToken>._))
+            .Invokes(call =>
+            {
+                _capturedExecutorRequest = call.GetArgument<RelationalWriteExecutorInput>(0)!;
+                _capturedExecutorRequests.Add(_capturedExecutorRequest);
+            })
+            .Returns(
+                Task.FromResult<RelationalWriteExecutorResult>(
+                    new RelationalWriteExecutorResult.Update(
+                        new UpdateResult.UpdateSuccess(documentUuid, ComposedWriteResultEtag)
+                    )
+                )
+            );
+
+        var updateRequest = A.Fake<IUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet).Returns(mappingSet);
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Roosevelt High"));
+        A.CallTo(() => updateRequest.TraceId).Returns(new TraceId("put-ownership-stamp"));
+        A.CallTo(() => updateRequest.AuthorizationContext)
+            .Returns(
+                new RelationalAuthorizationContext([], [], creatorOwnershipTokenId: 42, ownershipTokenIds: [])
+            );
+
+        await _sut.UpdateDocumentById(updateRequest);
+
+        _capturedExecutorRequest.OperationKind.Should().Be(RelationalWriteOperationKind.Put);
+        _capturedExecutorRequest.CreatorOwnershipTokenId.Should().BeNull();
+    }
+
+    private static IUpsertRequest CreateOwnershipStampingUpsertRequest(
+        RelationalAuthorizationContext authorizationContext,
+        AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null
+    )
+    {
+        var mappingSet = CreateSupportedMappingSet(_schoolResourceInfo);
+        var upsertRequest = A.Fake<IUpsertRequest>();
+
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet).Returns(mappingSet);
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Roosevelt High"));
+        A.CallTo(() => upsertRequest.TraceId).Returns(new TraceId("post-ownership-stamp"));
+        A.CallTo(() => upsertRequest.AuthorizationContext).Returns(authorizationContext);
+
+        if (authorizationStrategyEvaluators is not null)
+        {
+            A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+                .Returns(authorizationStrategyEvaluators);
+        }
+
+        return upsertRequest;
+    }
+
     [Test]
     public async Task It_returns_post_not_implemented_for_known_but_not_enabled_relationship_authorization_before_target_lookup()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -3233,6 +3233,87 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     /// <summary>
+    /// The caller's cancellation token has to reach every GET-by-id AND-filter executor. All three support
+    /// cancellation, so a dropped token means an abandoned request keeps its connection busy running
+    /// authorization SQL for a response nobody will read.
+    /// </summary>
+    /// <remarks>
+    /// A token from a live source rather than <see cref="CancellationToken.None"/>: the defect this pins was
+    /// the chain calling these executors with defaulted tokens, and a default token compares equal to
+    /// <c>None</c>, so only a distinguishable token can fail when it is dropped. All three executors are
+    /// asserted in one test because they are reached through one call chain, and the ownership one is the
+    /// last link — the chain has to stay threaded end to end for it to observe the token.
+    /// </remarks>
+    [Test]
+    public async Task It_passes_the_caller_cancellation_token_to_every_get_by_id_and_filter_executor()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccc21"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = GivenAResolvableOwnershipGetByIdTarget(
+            documentUuid,
+            mappingSet,
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ]
+        );
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        CancellationToken observedNamespaceToken = default;
+        CancellationToken observedCustomViewToken = default;
+        CancellationToken observedOwnershipToken = default;
+
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call => observedNamespaceToken = call.GetArgument<CancellationToken>(1))
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.Authorized()
+                )
+            );
+        A.CallTo(() =>
+                _customViewAuthorizationExecutor.ExecuteAsync(
+                    A<CustomViewAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call => observedCustomViewToken = call.GetArgument<CancellationToken>(1))
+            .Returns(
+                Task.FromResult<CustomViewAuthorizationExecutionResult>(
+                    new CustomViewAuthorizationExecutionResult.Authorized()
+                )
+            );
+        A.CallTo(() =>
+                _ownershipAuthorizationExecutor.ExecuteAsync(
+                    A<OwnershipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call => observedOwnershipToken = call.GetArgument<CancellationToken>(1))
+            .Returns(
+                Task.FromResult<OwnershipAuthorizationExecutionResult>(
+                    new OwnershipAuthorizationExecutionResult.NotAuthorized(
+                        CreateOwnershipFailure(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch, 2)
+                    )
+                )
+            );
+
+        var result = await _sut.GetDocumentById(getRequest, cancellationToken);
+
+        result.Should().BeOfType<GetResult.GetFailureOwnershipNotAuthorized>();
+        observedOwnershipToken.Should().Be(cancellationToken);
+        observedNamespaceToken.Should().Be(cancellationToken);
+        observedCustomViewToken.Should().Be(cancellationToken);
+    }
+
+    /// <summary>
     /// The authorized path, which the denial tests cannot reach: ownership authorizes, and only then does
     /// the relationship OR group run. Ownership is an AND filter and the relationship group follows every
     /// AND filter, so a reorder that moved the relationship group ahead of ownership would let a document

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -2041,6 +2041,55 @@ public partial class Given_RelationalDocumentStoreRepositoryTests
     }
 
     /// <summary>
+    /// The caller's cancellation token has to reach the custom-view validation a GET-by-id terminal runs.
+    /// A terminal has already decided to refuse the request, so this is DB work whose result only feeds a
+    /// response that may never be read — dropping the token leaves an abandoned request holding a
+    /// connection to validate views for it.
+    /// </summary>
+    /// <remarks>
+    /// The ownership token cap is the terminal used here because it carries every resolved view rather than
+    /// only those configured before some index, so it is the terminal most likely to run this validation.
+    /// A token from a live source, not <see cref="CancellationToken.None"/>: a dropped token binds to
+    /// <c>None</c>, so only a distinguishable one can fail when it is dropped.
+    /// </remarks>
+    [Test]
+    public async Task It_passes_the_caller_cancellation_token_to_get_by_id_terminal_custom_view_validation()
+    {
+        CancellationToken observedValidationToken = default;
+
+        A.CallTo(() =>
+                _commandExecutor.ExecuteReaderAsync(
+                    A<RelationalCommand>._,
+                    A<Func<IRelationalCommandReader, CancellationToken, Task<bool>>>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call => observedValidationToken = call.GetArgument<CancellationToken>(2))
+            .Returns(Task.FromResult(true));
+
+        var getRequest = CreateGetRequest(
+            new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaa22")),
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            _schoolResourceInfo,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(CustomViewStrategyName),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            ownershipTokenIds: OverCapOwnershipTokenIds()
+        );
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        var result = await _sut.GetDocumentById(getRequest, cancellationToken);
+
+        result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>();
+        observedValidationToken.Should().Be(cancellationToken);
+    }
+
+    /// <summary>
     /// A view configured after OwnershipBased still runs before the cap terminal. Ownership executes last
     /// among the AND strategies whatever position it holds, so no configured view can follow it.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteNoProfilePersisterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteNoProfilePersisterTests.cs
@@ -43,6 +43,73 @@ public class Given_Relational_Write_No_Profile_Persister
     }
 
     [Test]
+    public async Task It_stamps_the_creator_ownership_token_on_the_created_document()
+    {
+        var rootPlan = CreateRootPlan();
+        var writePlan = CreateWritePlan([rootPlan]);
+        var request = CreateRequest(writePlan, RelationalWriteOperationKind.Post) with
+        {
+            CreatorOwnershipTokenId = 42,
+        };
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [],
+                    [CreateRow(FlattenedWriteValue.UnresolvedRootDocumentId.Instance, 255901, "Lincoln High")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
+        var writeSession = new RecordingRelationalWriteSession([
+            new CommandResponse(ScalarResult: 910L),
+            new CommandResponse(),
+            new CommandResponse(ScalarResult: 77L),
+        ]);
+
+        await _sut.PersistAsync(request, mergeResult, writeSession);
+
+        writeSession.Commands[0].CommandText.Should().Contain("\"CreatedByOwnershipTokenId\"");
+        GetParameterValue(writeSession.Commands[0], "@createdByOwnershipTokenId").Should().Be((short)42);
+    }
+
+    /// <summary>
+    /// A write that resolved to an existing target must leave the stored ownership token alone. Nothing this
+    /// path issues may mention the column: that, rather than a guard, is what preserves the token across a
+    /// PUT and an upsert-as-update.
+    /// </summary>
+    [Test]
+    public async Task It_never_writes_the_ownership_column_for_an_existing_target()
+    {
+        var rootPlan = CreateRootPlan();
+        var writePlan = CreateWritePlan([rootPlan]);
+        var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put) with
+        {
+            CreatorOwnershipTokenId = 42,
+        };
+        var mergeResult = new RelationalWriteMergeResult(
+            [new RelationalWriteMergedTableState(rootPlan, [], [CreateRow(345L, 255901, "Lincoln High")])],
+            supportsGuardedNoOp: true
+        );
+        var writeSession = new RecordingRelationalWriteSession([
+            new CommandResponse(),
+            new CommandResponse(ScalarResult: 77L),
+        ]);
+
+        await _sut.PersistAsync(request, mergeResult, writeSession);
+
+        writeSession
+            .Commands.Should()
+            .OnlyContain(command =>
+                !command.CommandText.Contains("CreatedByOwnershipTokenId", StringComparison.Ordinal)
+            );
+        writeSession
+            .Commands.SelectMany(static command => command.Parameters)
+            .Should()
+            .NotContain(parameter => parameter.Name == "@createdByOwnershipTokenId");
+    }
+
+    [Test]
     public async Task It_inserts_document_root_and_root_extension_rows_for_create_requests()
     {
         var rootPlan = CreateRootPlan();
@@ -89,6 +156,9 @@ public class Given_Relational_Write_No_Profile_Persister
             .Should()
             .Be(Guid.Parse("cccccccc-1111-2222-3333-dddddddddddd"));
         GetParameterValue(writeSession.Commands[0], "@resourceKeyId").Should().Be((short)1);
+        // Stamped on every create, whether or not the resource uses OwnershipBased. Null here because this
+        // request carries no creator token.
+        GetParameterValue(writeSession.Commands[0], "@createdByOwnershipTokenId").Should().BeNull();
 
         writeSession.Commands[1].CommandText.Should().Be(rootPlan.InsertSql);
         GetParameterValue(writeSession.Commands[1], "@DocumentId").Should().Be(910L);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/AuthorizationSecurityConfigurationDiagnostics.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/AuthorizationSecurityConfigurationDiagnostics.cs
@@ -33,6 +33,11 @@ internal static class AuthorizationSecurityConfigurationDiagnostics
         "CustomViewAuthorization.Auth1.PayloadMappingFailed";
     public const string CustomViewProposedValueExtractionInvalid =
         "CustomViewAuthorization.ProposedValueExtractionInvalid";
+    public const string OwnershipTokenCapExceeded = "OwnershipAuthorization.TokenCapExceeded";
+    public const string OwnershipAuth1PayloadMappingFailed =
+        "OwnershipAuthorization.Auth1.PayloadMappingFailed";
+    public const string OwnershipInvalidStaleTargetPayload =
+        "OwnershipAuthorization.Auth1.InvalidStaleTargetPayload";
 
     public static SecurityConfigurationFailureDiagnostic[] ForNamespacePrefixParameterization(
         string providerOrPlannerFailureKind
@@ -53,6 +58,51 @@ internal static class AuthorizationSecurityConfigurationDiagnostics
                 ProviderOrPlannerFailureKind: providerOrPlannerFailureKind,
                 ConfiguredStrategyNames: [AuthorizationStrategyNameConstants.NamespaceBased],
                 PhysicalPath: FormatNamespacePhysicalPath(checks)
+            ),
+        ];
+
+    /// <summary>
+    /// Diagnostics for an ownership-token parameterization failure — today only the provider-independent
+    /// defensive token limit.
+    /// </summary>
+    /// <remarks>
+    /// No physical path is reported: the ownership check addresses <c>dms.Document</c> by <c>DocumentId</c>
+    /// regardless of resource, so there is no resource-specific column to name. No token value is reported
+    /// either; the message carries only a count.
+    /// </remarks>
+    public static SecurityConfigurationFailureDiagnostic[] ForOwnershipTokenParameterization(
+        string providerOrPlannerFailureKind
+    ) =>
+        [
+            new SecurityConfigurationFailureDiagnostic(
+                ProviderOrPlannerFailureKind: providerOrPlannerFailureKind,
+                ConfiguredStrategyNames: [AuthorizationStrategyNameConstants.OwnershipBased]
+            ),
+        ];
+
+    /// <summary>
+    /// Diagnostics for an ownership AUTH1 payload that could not be attributed to the request's planned
+    /// ownership check.
+    /// </summary>
+    /// <param name="providerOrPlannerFailureKind">
+    /// <see cref="OwnershipAuth1PayloadMappingFailed"/> for an unparseable payload or a configured-index
+    /// mismatch, or <see cref="OwnershipInvalidStaleTargetPayload"/> for a stale-target payload on a path
+    /// that planned no stored ownership check.
+    /// </param>
+    /// <param name="configuredStrategyIndex">
+    /// The configured index the request's planned ownership check carried, or <see langword="null"/> when no
+    /// ownership check was planned. Reported so an operator can see which configured position the request
+    /// expected, against the index the payload actually carried.
+    /// </param>
+    public static SecurityConfigurationFailureDiagnostic[] ForOwnershipAuthorizationAuth1(
+        string providerOrPlannerFailureKind,
+        int? configuredStrategyIndex
+    ) =>
+        [
+            new SecurityConfigurationFailureDiagnostic(
+                ProviderOrPlannerFailureKind: providerOrPlannerFailureKind,
+                ConfiguredStrategyNames: [AuthorizationStrategyNameConstants.OwnershipBased],
+                ConfiguredStrategyIndexes: configuredStrategyIndex is { } index ? [index] : []
             ),
         ];
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/CustomViewAuthorizationProviderFailureMapper.cs
@@ -69,10 +69,18 @@ internal static class CustomViewAuthorizationProviderFailureMapper
 
     /// <summary>
     /// Whether <paramref name="exception"/> carries a custom-view AUTH1 payload that this family owns but
-    /// cannot turn into a response — an out-of-range index, or a kind the indexed check's value source cannot
-    /// produce. Such a payload is a security-configuration defect, not a denial, so the caller reports 500
-    /// rather than inventing a 403.
+    /// cannot turn into a response — undecodable outright, an out-of-range index, or a kind the indexed
+    /// check's value source cannot produce. Such a payload is a security-configuration defect, not a denial,
+    /// so the caller reports 500 rather than inventing a 403.
     /// </summary>
+    /// <remarks>
+    /// The undecodable case is claimed by discriminator alone. A <c>cv1|</c>-prefixed payload the codec
+    /// cannot parse still announces which statement raised the abort, and only a custom-view statement emits
+    /// that prefix, so no other family may answer for it — while nothing inside it can be trusted to
+    /// attribute a denial. Declining it here left it to the namespace mapper's catch-all on a co-batched
+    /// command, and to no one at all on the standalone executor, where it escaped as an unhandled provider
+    /// exception past every catch filter.
+    /// </remarks>
     public static bool IsUnmappableCustomViewPayload(
         SqlDialect dialect,
         DbException exception,
@@ -84,13 +92,38 @@ internal static class CustomViewAuthorizationProviderFailureMapper
         ArgumentNullException.ThrowIfNull(providerFailureExtractor);
         ArgumentNullException.ThrowIfNull(plannedChecks);
 
-        if (!TryDispatchCustomViewPayload(dialect, exception, providerFailureExtractor, out var payload))
+        var providerFailure = providerFailureExtractor.Extract(exception);
+
+        if (
+            !RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+                dialect,
+                providerFailure.ErrorCode,
+                providerFailure.Message,
+                out var dispatchResult
+            )
+        )
         {
             return false;
         }
 
-        return payload is not null
-            && !CustomViewAuthorizationFailureMapper.IsStaleStoredTargetFailure(payload, plannedChecks)
+        if (
+            dispatchResult is RelationalAuthorizationAuth1DispatchResult.InvalidPayload
+            {
+                RecognizedFamily: RelationalAuthorizationAuth1PayloadFamily.CustomView
+            }
+        )
+        {
+            return true;
+        }
+
+        if (dispatchResult is not RelationalAuthorizationAuth1DispatchResult.CustomView customViewResult)
+        {
+            return false;
+        }
+
+        var payload = customViewResult.Payload;
+
+        return !CustomViewAuthorizationFailureMapper.IsStaleStoredTargetFailure(payload, plannedChecks)
             && !CustomViewAuthorizationFailureMapper.TryMapAuth1Failure(payload, plannedChecks, out _);
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using EdFi.DataManagementService.Backend.Etag;
@@ -2627,19 +2628,27 @@ internal sealed class DescriptorWriteHandler(
             request.TraceId.Value
         );
 
+        // Stamped on every descriptor create, exactly as it is for a regular resource, and independently of
+        // whether descriptor ownership enforcement is available: stamping never consults configured
+        // strategies. Descriptor requests configured with OwnershipBased still fail closed with a 501 before
+        // reaching here, so a stamped descriptor row is only ever produced by a request this handler accepts.
+        var createdByOwnershipTokenId = request.RelationalAuthorizationContext.CreatorOwnershipTokenId;
+
         var command = request.MappingSet.Key.Dialect switch
         {
             SqlDialect.Pgsql => BuildPostgresqlInsertCommand(
                 body,
                 documentUuid,
                 resourceKeyId,
-                request.ReferentialId!.Value
+                request.ReferentialId!.Value,
+                createdByOwnershipTokenId
             ),
             SqlDialect.Mssql => BuildMssqlInsertCommand(
                 body,
                 documentUuid,
                 resourceKeyId,
-                request.ReferentialId!.Value
+                request.ReferentialId!.Value,
+                createdByOwnershipTokenId
             ),
             _ => throw new NotSupportedException(
                 $"Descriptor write does not support SQL dialect '{request.MappingSet.Key.Dialect}'."
@@ -3473,15 +3482,16 @@ internal sealed class DescriptorWriteHandler(
         ExtractedDescriptorBody body,
         DocumentUuid documentUuid,
         short resourceKeyId,
-        ReferentialId referentialId
+        ReferentialId referentialId,
+        short? createdByOwnershipTokenId
     )
     {
         // The data-modifying CTE performs the insert graph, then a separate statement reads the inserted
         // document and projection work row so PostgreSQL observes trigger side effects in this transaction.
         const string Sql = """
             WITH new_doc AS (
-                INSERT INTO dms."Document" ("DocumentUuid", "ResourceKeyId")
-                VALUES (@documentUuid, @resourceKeyId)
+                INSERT INTO dms."Document" ("DocumentUuid", "ResourceKeyId", "CreatedByOwnershipTokenId")
+                VALUES (@documentUuid, @resourceKeyId, @createdByOwnershipTokenId)
                 RETURNING "DocumentId"
             )
             , new_descriptor AS (
@@ -3521,7 +3531,7 @@ internal sealed class DescriptorWriteHandler(
 
         return new RelationalCommand(
             Sql,
-            BuildInsertParameters(body, documentUuid, resourceKeyId, referentialId)
+            BuildInsertParameters(body, documentUuid, resourceKeyId, referentialId, createdByOwnershipTokenId)
         );
     }
 
@@ -3529,7 +3539,8 @@ internal sealed class DescriptorWriteHandler(
         ExtractedDescriptorBody body,
         DocumentUuid documentUuid,
         short resourceKeyId,
-        ReferentialId referentialId
+        ReferentialId referentialId,
+        short? createdByOwnershipTokenId
     )
     {
         // Capture the insert-time ContentVersion into a table variable via OUTPUT ... INTO, run every
@@ -3543,9 +3554,9 @@ internal sealed class DescriptorWriteHandler(
             DECLARE @newDocumentId BIGINT;
             DECLARE @insertedContentVersion TABLE ([ContentVersion] BIGINT);
 
-            INSERT INTO [dms].[Document] ([DocumentUuid], [ResourceKeyId])
+            INSERT INTO [dms].[Document] ([DocumentUuid], [ResourceKeyId], [CreatedByOwnershipTokenId])
             OUTPUT INSERTED.[ContentVersion] INTO @insertedContentVersion ([ContentVersion])
-            VALUES (@documentUuid, @resourceKeyId);
+            VALUES (@documentUuid, @resourceKeyId, @createdByOwnershipTokenId);
 
             SET @newDocumentId = SCOPE_IDENTITY();
 
@@ -3580,7 +3591,7 @@ internal sealed class DescriptorWriteHandler(
 
         return new RelationalCommand(
             Sql,
-            BuildInsertParameters(body, documentUuid, resourceKeyId, referentialId)
+            BuildInsertParameters(body, documentUuid, resourceKeyId, referentialId, createdByOwnershipTokenId)
         );
     }
 
@@ -4008,17 +4019,31 @@ internal sealed class DescriptorWriteHandler(
 
     // ── Parameter builders ───────────────────────────────────────────────
 
+    /// <param name="createdByOwnershipTokenId">
+    /// The API client's <c>CreatorOwnershipTokenId</c>, or <see langword="null"/> when it has none. Bound
+    /// either way so each dialect keeps one insert statement text, and typed explicitly for the same reason
+    /// the regular-resource insert types it: a null reaches the driver as <c>DBNull</c>, which carries no
+    /// type of its own.
+    /// </param>
     private static List<RelationalParameter> BuildInsertParameters(
         ExtractedDescriptorBody body,
         DocumentUuid documentUuid,
         short resourceKeyId,
-        ReferentialId referentialId
+        ReferentialId referentialId,
+        short? createdByOwnershipTokenId
     )
     {
         var parameters = BuildInsertFieldParameters(body);
         parameters.Add(new RelationalParameter("@documentUuid", documentUuid.Value));
         parameters.Add(new RelationalParameter("@resourceKeyId", resourceKeyId));
         parameters.Add(new RelationalParameter("@referentialId", referentialId.Value));
+        parameters.Add(
+            new RelationalParameter(
+                "@createdByOwnershipTokenId",
+                createdByOwnershipTokenId,
+                static parameter => parameter.DbType = DbType.Int16
+            )
+        );
         AddEnqueueOutcomeParameters(parameters);
         return parameters;
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
@@ -124,6 +124,7 @@ internal static class NamespaceAuthorizationProviderFailureMapper
             // it does not recognize.
             RelationalAuthorizationAuth1DispatchResult.Relationship => string.Empty,
             RelationalAuthorizationAuth1DispatchResult.CustomView => string.Empty,
+            RelationalAuthorizationAuth1DispatchResult.Ownership => string.Empty,
             _ => AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuthorizationMetadata,
         };
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
@@ -110,13 +110,17 @@ internal static class NamespaceAuthorizationProviderFailureMapper
 
         string providerOrPlannerFailureKind = dispatchResult switch
         {
-            // An undecodable payload that announces itself as another family's is not ours to report, even
+            // An undecodable payload the dispatcher recognized as ownership's is not ours to report, even
             // though nothing in it can be decoded. Only ownership emits own1, so its malformed payloads are
             // its own to diagnose; without this, consulting namespace first on a command carrying both
-            // would file an ownership defect under NamespaceBased. Anything with no recognizable
-            // discriminator is still claimed below, which keeps the diagnostic for a payload no family owns.
-            RelationalAuthorizationAuth1DispatchResult.InvalidPayload { RawPayload: var rawPayload }
-                when IsForeignInvalidPayload(rawPayload) => string.Empty,
+            // would file an ownership defect under NamespaceBased. Anything else — no recognizable
+            // discriminator, or a malformed relationship or custom-view payload whose own mapper has
+            // already declined it by the time this one is consulted — is still claimed below, which keeps
+            // the diagnostic for a payload no family owns.
+            RelationalAuthorizationAuth1DispatchResult.InvalidPayload
+            {
+                RecognizedFamily: RelationalAuthorizationAuth1PayloadFamily.Ownership
+            } => string.Empty,
             RelationalAuthorizationAuth1DispatchResult.InvalidPayload =>
                 AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuth1Payload,
             RelationalAuthorizationAuth1DispatchResult.Namespace { Payload: var payload }
@@ -177,20 +181,6 @@ internal static class NamespaceAuthorizationProviderFailureMapper
 
         return false;
     }
-
-    /// <remarks>
-    /// Every AUTH1 family that owns a discriminator has to be listed here, exactly as
-    /// <c>RelationshipAuthorizationProviderFailureMapper.IsForeignAuthorizationPayload</c> lists them: an
-    /// omission does not fail a build, it silently misattributes the omitted family's malformed payloads.
-    /// The relationship and custom view-based families are absent on purpose — this mapper is consulted
-    /// after theirs, so an undecodable payload of theirs has already been declined by the codec that owns
-    /// it, and claiming it here is the existing behavior for a payload nobody owns.
-    /// </remarks>
-    private static bool IsForeignInvalidPayload(string rawPayload) =>
-        rawPayload.StartsWith(
-            OwnershipAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
-            StringComparison.Ordinal
-        );
 
     private static bool IsInvalidStaleStoredTargetPayload(
         NamespaceAuthorizationAuth1FailurePayload payload,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
@@ -110,6 +110,13 @@ internal static class NamespaceAuthorizationProviderFailureMapper
 
         string providerOrPlannerFailureKind = dispatchResult switch
         {
+            // An undecodable payload that announces itself as another family's is not ours to report, even
+            // though nothing in it can be decoded. Only ownership emits own1, so its malformed payloads are
+            // its own to diagnose; without this, consulting namespace first on a command carrying both
+            // would file an ownership defect under NamespaceBased. Anything with no recognizable
+            // discriminator is still claimed below, which keeps the diagnostic for a payload no family owns.
+            RelationalAuthorizationAuth1DispatchResult.InvalidPayload { RawPayload: var rawPayload }
+                when IsForeignInvalidPayload(rawPayload) => string.Empty,
             RelationalAuthorizationAuth1DispatchResult.InvalidPayload =>
                 AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuth1Payload,
             RelationalAuthorizationAuth1DispatchResult.Namespace { Payload: var payload }
@@ -170,6 +177,20 @@ internal static class NamespaceAuthorizationProviderFailureMapper
 
         return false;
     }
+
+    /// <remarks>
+    /// Every AUTH1 family that owns a discriminator has to be listed here, exactly as
+    /// <c>RelationshipAuthorizationProviderFailureMapper.IsForeignAuthorizationPayload</c> lists them: an
+    /// omission does not fail a build, it silently misattributes the omitted family's malformed payloads.
+    /// The relationship and custom view-based families are absent on purpose — this mapper is consulted
+    /// after theirs, so an undecodable payload of theirs has already been declined by the codec that owns
+    /// it, and claiming it here is the existing behavior for a payload nobody owns.
+    /// </remarks>
+    private static bool IsForeignInvalidPayload(string rawPayload) =>
+        rawPayload.StartsWith(
+            OwnershipAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
+            StringComparison.Ordinal
+        );
 
     private static bool IsInvalidStaleStoredTargetPayload(
         NamespaceAuthorizationAuth1FailurePayload payload,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
@@ -110,17 +110,25 @@ internal static class NamespaceAuthorizationProviderFailureMapper
 
         string providerOrPlannerFailureKind = dispatchResult switch
         {
-            // An undecodable payload the dispatcher recognized as ownership's is not ours to report, even
-            // though nothing in it can be decoded. Only ownership emits own1, so its malformed payloads are
-            // its own to diagnose; without this, consulting namespace first on a command carrying both
-            // would file an ownership defect under NamespaceBased. Anything else — no recognizable
-            // discriminator, or a malformed relationship or custom-view payload whose own mapper has
-            // already declined it by the time this one is consulted — is still claimed below, which keeps
-            // the diagnostic for a payload no family owns.
+            // An undecodable payload the dispatcher recognized as another family's is not ours to report,
+            // even though nothing in it can be decoded. Its discriminator is the only trustworthy thing
+            // left in it, and it names the family whose statement raised the abort — so that family's
+            // mapper owns the diagnostic. Without this, a command carrying a namespace statement beside a
+            // custom-view, relationship, or ownership one files that family's defect under NamespaceBased:
+            // the composite classifier reaches this arm before the relationship one, so a malformed
+            // relationship or custom-view payload never gets back to its owner.
+            //
+            // Written as "any recognized family that is not ours" rather than as a list of the three
+            // foreign families on purpose. A list would have to be extended whenever a family is added,
+            // and an omission does not fail a build — it silently misattributes that family's malformed
+            // payloads, which is the defect this arm exists to prevent.
             RelationalAuthorizationAuth1DispatchResult.InvalidPayload
             {
-                RecognizedFamily: RelationalAuthorizationAuth1PayloadFamily.Ownership
+                RecognizedFamily: not null and not RelationalAuthorizationAuth1PayloadFamily.Namespace
             } => string.Empty,
+            // A malformed namespace payload, or one leading with no known discriminator at all. Both are
+            // ours: the first by its own discriminator, the second because no family owns it, and dropping
+            // it would lose the diagnostic entirely rather than route it somewhere better.
             RelationalAuthorizationAuth1DispatchResult.InvalidPayload =>
                 AuthorizationSecurityConfigurationDiagnostics.NamespaceInvalidAuth1Payload,
             RelationalAuthorizationAuth1DispatchResult.Namespace { Payload: var payload }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationCommandParameterBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationCommandParameterBuilder.cs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Binds runtime parameter values for single-record ownership authorization commands. Distinct from both
+/// sibling builders: ownership tokens bind as a PostgreSQL <c>short[]</c> array (or SQL Server
+/// <c>smallint</c> scalars), never as the namespace builder's <c>string[]</c> prefix patterns and never as
+/// the relationship builder's long-only claim-EdOrg array path.
+/// </summary>
+internal static class OwnershipAuthorizationCommandParameterBuilder
+{
+    public static void AddParameterValues(
+        IDictionary<string, object?> parameterValues,
+        OwnershipTokenParameterization ownershipTokenParameterization,
+        long documentId
+    )
+    {
+        ArgumentNullException.ThrowIfNull(parameterValues);
+        ArgumentNullException.ThrowIfNull(ownershipTokenParameterization);
+
+        parameterValues[OwnershipAuthorizationSqlSpecDefaults.DocumentIdParameterName] = documentId;
+
+        OwnershipTokenParameterValueBinder.Bind(parameterValues, ownershipTokenParameterization);
+    }
+
+    public static RelationalParameter BuildParameter(QuerySqlParameter parameter, object? value)
+    {
+        ArgumentNullException.ThrowIfNull(parameter);
+
+        return parameter.Binding.Kind switch
+        {
+            QuerySqlParameterBindingKind.Scalar => new RelationalParameter(
+                $"@{parameter.ParameterName}",
+                value
+            ),
+            QuerySqlParameterBindingKind.PgsqlArray => new RelationalParameter(
+                $"@{parameter.ParameterName}",
+                RequireShortList(value, parameter.ParameterName).ToArray()
+            ),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(parameter),
+                parameter.Binding.Kind,
+                "Unsupported ownership authorization parameter binding kind."
+            ),
+        };
+    }
+
+    /// <remarks>
+    /// The list type is checked rather than assumed. A <c>long</c> or <c>int</c> list would still bind and
+    /// still return correct rows, but it would widen the comparison against the <c>smallint</c> ownership
+    /// column and silently cost the index on it, so the wrong element type fails loudly here instead.
+    /// </remarks>
+    private static IReadOnlyList<short> RequireShortList(object? value, string parameterName)
+    {
+        if (value is IReadOnlyList<short> ownershipTokenIds)
+        {
+            return ownershipTokenIds;
+        }
+
+        throw new InvalidOperationException(
+            $"Ownership authorization array parameter '{parameterName}' requires an IReadOnlyList<short> runtime value."
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationExecutor.cs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <param name="DocumentId">The stored root document's surrogate id, the check's only subject.</param>
+/// <param name="Check">
+/// The single planned ownership check. Ownership emits exactly one check per operation, so this is a value
+/// rather than the sibling families' list.
+/// </param>
+public sealed record OwnershipAuthorizationExecutionRequest(
+    MappingSet MappingSet,
+    long DocumentId,
+    OwnershipAuthorizationCheckSpec Check,
+    OwnershipTokenParameterization OwnershipTokenParameterization
+);
+
+public abstract record OwnershipAuthorizationExecutionResult
+{
+    private OwnershipAuthorizationExecutionResult() { }
+
+    public sealed record Authorized : OwnershipAuthorizationExecutionResult;
+
+    /// <summary>A §2.13 or §2.14 denial, a 403.</summary>
+    public sealed record NotAuthorized(OwnershipAuthorizationFailure Failure)
+        : OwnershipAuthorizationExecutionResult;
+
+    public sealed record InvalidAuthorizationFailure(
+        string FailureMessage,
+        SecurityConfigurationFailureDiagnostic[]? Diagnostics = null
+    ) : OwnershipAuthorizationExecutionResult;
+
+    /// <summary>
+    /// The stored target row no longer exists: it was deleted between the unlocked target lookup and this
+    /// check. Read callers re-resolve the target and surface the resulting 404; locked write and delete
+    /// callers never observe this because they row-lock the target before the check.
+    /// </summary>
+    public sealed record StaleTarget : OwnershipAuthorizationExecutionResult;
+}
+
+public interface IOwnershipAuthorizationExecutor
+{
+    Task<OwnershipAuthorizationExecutionResult> ExecuteAsync(
+        OwnershipAuthorizationExecutionRequest request,
+        CancellationToken cancellationToken = default
+    );
+}
+
+/// <summary>
+/// Executes the single-record ownership authorization SQL. The SQL emits one <c>SELECT CASE … END;</c>
+/// whose authorized arm yields <c>1</c> and whose three failure arms raise AUTH1 with an
+/// <c>own1|configuredIndex|kind</c> payload, aborting the command. A clean run authorizes the record.
+/// </summary>
+/// <remarks>
+/// One command, one statement, unlike the namespace executor which co-batches a stored and a proposed check.
+/// Ownership has exactly one value source — the stored token — so there is never a second check to batch
+/// with. The reader still drains every result set, which costs nothing here and keeps the shape identical
+/// should a caller ever hand this executor a co-batched plan.
+/// </remarks>
+internal sealed class OwnershipAuthorizationExecutor(
+    IRelationalCommandExecutor commandExecutor,
+    IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
+) : IOwnershipAuthorizationExecutor
+{
+    private readonly IRelationalCommandExecutor _commandExecutor =
+        commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
+    private readonly IRelationshipAuthorizationProviderFailureExtractor _providerFailureExtractor =
+        providerFailureExtractor ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance;
+
+    public async Task<OwnershipAuthorizationExecutionResult> ExecuteAsync(
+        OwnershipAuthorizationExecutionRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Check);
+
+        var dialect = request.MappingSet.Key.Dialect;
+        var sqlPlan = new OwnershipAuthorizationSqlCompiler(dialect).Compile(
+            new OwnershipAuthorizationSqlSpec(
+                request.Check,
+                request.OwnershipTokenParameterization,
+                OwnershipAuthorizationSqlSpecDefaults.DocumentIdParameterName
+            )
+        );
+
+        try
+        {
+            return await _commandExecutor
+                .ExecuteReaderAsync(
+                    BuildCommand(sqlPlan, request),
+                    ReadAuthorizedResultAsync,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        catch (DbException ex)
+            when (OwnershipAuthorizationProviderFailureMapper.TryMapOwnershipAuthorizationFailure(
+                    dialect,
+                    ex,
+                    _providerFailureExtractor,
+                    request.Check.RawConfiguredIndex,
+                    out var mappedResult
+                )
+            )
+        {
+            // Every ownership AUTH1 outcome — denial, stale target, or unattributable payload — is decided
+            // by the mapper, so this executor holds no second copy of that classification.
+            return mappedResult!;
+        }
+    }
+
+    /// <summary>
+    /// Builds the executable command for a compiled plan. Internal so composite emission can reuse the
+    /// exact standalone command — SQL and parameter binding — rather than duplicating either.
+    /// </summary>
+    internal static RelationalCommand BuildCommand(
+        OwnershipAuthorizationSqlPlan sqlPlan,
+        OwnershipAuthorizationExecutionRequest request
+    )
+    {
+        ArgumentNullException.ThrowIfNull(sqlPlan);
+        ArgumentNullException.ThrowIfNull(request);
+
+        Dictionary<string, object?> valuesByParameterName = new(StringComparer.Ordinal);
+
+        OwnershipAuthorizationCommandParameterBuilder.AddParameterValues(
+            valuesByParameterName,
+            request.OwnershipTokenParameterization,
+            request.DocumentId
+        );
+
+        return new RelationalCommand(
+            sqlPlan.AuthorizationSql,
+            [
+                .. sqlPlan.ParametersInOrder.Select(parameter =>
+                    OwnershipAuthorizationCommandParameterBuilder.BuildParameter(
+                        parameter,
+                        valuesByParameterName[parameter.ParameterName]
+                    )
+                ),
+            ]
+        );
+    }
+
+    private static async Task<OwnershipAuthorizationExecutionResult> ReadAuthorizedResultAsync(
+        IRelationalCommandReader reader,
+        CancellationToken cancellationToken
+    )
+    {
+        // Drain every result set so each statement executes and any AUTH1 failure surfaces as a
+        // DbException. A clean run means the authorized arm matched: every other arm raises.
+        var hasMoreResultSets = true;
+        while (hasMoreResultSets)
+        {
+            hasMoreResultSets = await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return new OwnershipAuthorizationExecutionResult.Authorized();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationProviderFailureMapper.cs
@@ -18,10 +18,12 @@ namespace EdFi.DataManagementService.Backend;
 /// <remarks>
 /// <para>
 /// This mapper claims an AUTH1 failure only when the payload belongs to the <c>own1</c> family, including
-/// the case where an <c>own1|</c>-prefixed payload is malformed and so cannot be decoded at all. Deciding
-/// that by the payload's own discriminator, rather than by which statements the command happened to carry,
-/// is what makes the mapper safe to consult from a co-batched path: it can never claim another family's
-/// malformed payload, and another family can never legitimately claim ours.
+/// the case where an <c>own1|</c>-prefixed payload is malformed and so cannot be decoded at all — the
+/// dispatcher reports that as <see cref="RelationalAuthorizationAuth1DispatchResult.InvalidPayload"/>
+/// carrying <see cref="RelationalAuthorizationAuth1PayloadFamily.Ownership"/>. Deciding that by the
+/// payload's own discriminator, rather than by which statements the command happened to carry, is what
+/// makes the mapper safe to consult from a co-batched path: it can never claim another family's malformed
+/// payload, and another family can never legitimately claim ours.
 /// </para>
 /// <para>
 /// The reverse direction is closed too, and independently: <c>NamespaceAuthorizationProviderFailureMapper</c>
@@ -81,9 +83,12 @@ internal static class OwnershipAuthorizationProviderFailureMapper
                 return true;
 
             // An undecodable payload that still announces itself as ours. The check emitted it, so no other
-            // family may answer for it, but nothing in it can be trusted to attribute a denial.
-            case RelationalAuthorizationAuth1DispatchResult.InvalidPayload { RawPayload: var rawPayload }
-                when IsOwnershipFamilyPayload(rawPayload):
+            // family may answer for it, but nothing in it can be trusted to attribute a denial. The
+            // dispatcher decides whose it is; this mapper never re-tests the discriminator itself.
+            case RelationalAuthorizationAuth1DispatchResult.InvalidPayload
+            {
+                RecognizedFamily: RelationalAuthorizationAuth1PayloadFamily.Ownership
+            }:
                 result = BuildInvalidAuthorizationFailure(
                     AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed,
                     plannedConfiguredStrategyIndex
@@ -148,11 +153,5 @@ internal static class OwnershipAuthorizationProviderFailureMapper
                 providerOrPlannerFailureKind,
                 plannedConfiguredStrategyIndex
             )
-        );
-
-    private static bool IsOwnershipFamilyPayload(string rawPayload) =>
-        rawPayload.StartsWith(
-            OwnershipAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
-            StringComparison.Ordinal
         );
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationProviderFailureMapper.cs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Maps a provider <see cref="DbException"/> carrying an ownership AUTH1 payload
+/// (<c>own1|configuredIndex|kind</c>) to the execution result it obliges. Routes through the shared
+/// <see cref="RelationalAuthorizationAuth1Dispatcher"/> so a relationship <c>1|…</c>, namespace <c>ns1|…</c>
+/// or custom-view <c>cv1|…</c> payload is never mistaken for an ownership failure.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mapper claims an AUTH1 failure only when the payload belongs to the <c>own1</c> family, including
+/// the case where an <c>own1|</c>-prefixed payload is malformed and so cannot be decoded at all. Deciding
+/// that by the payload's own discriminator, rather than by which statements the command happened to carry,
+/// is what makes the mapper safe to consult from a co-batched path: it can never claim another family's
+/// malformed payload, and another family can never legitimately claim ours.
+/// </para>
+/// <para>
+/// The reverse direction is not yet closed. <c>NamespaceAuthorizationProviderFailureMapper</c> still reports
+/// every undecodable AUTH1 payload — an <c>own1|</c>-prefixed one included — as a namespace invalid-payload
+/// diagnostic, so on a command where both families are co-batched the namespace mapper must not be consulted
+/// ahead of this one. Both outcomes are a 500 and only the diagnostic differs; closing it is Phase 5.1's
+/// work, when co-batching first makes the two reachable from one command.
+/// </para>
+/// </remarks>
+internal static class OwnershipAuthorizationProviderFailureMapper
+{
+    /// <param name="plannedConfiguredStrategyIndex">
+    /// The configured strategy index the request's single planned ownership check was stamped with, or
+    /// <see langword="null"/> when the request planned no ownership check. A payload arriving against a
+    /// request that planned none is still claimed here — it can have come from no other family — and fails
+    /// closed as a security-configuration failure.
+    /// </param>
+    /// <param name="result">
+    /// The obliged execution result: a denial, a stale-target retry signal, or a security-configuration
+    /// failure. Never <c>Authorized</c>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when <paramref name="exception"/> carries an ownership AUTH1 payload;
+    /// <see langword="false"/> when it carries no AUTH1 payload at all, or one belonging to another family,
+    /// in which case the exception is not this mapper's to answer.
+    /// </returns>
+    public static bool TryMapOwnershipAuthorizationFailure(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        int? plannedConfiguredStrategyIndex,
+        out OwnershipAuthorizationExecutionResult? result
+    )
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(providerFailureExtractor);
+
+        result = null;
+        var providerFailure = providerFailureExtractor.Extract(exception);
+
+        if (
+            !RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+                dialect,
+                providerFailure.ErrorCode,
+                providerFailure.Message,
+                out var dispatchResult
+            )
+        )
+        {
+            return false;
+        }
+
+        switch (dispatchResult)
+        {
+            case RelationalAuthorizationAuth1DispatchResult.Ownership { Payload: var payload }:
+                result = MapDecodedPayload(payload, plannedConfiguredStrategyIndex);
+                return true;
+
+            // An undecodable payload that still announces itself as ours. The check emitted it, so no other
+            // family may answer for it, but nothing in it can be trusted to attribute a denial.
+            case RelationalAuthorizationAuth1DispatchResult.InvalidPayload { RawPayload: var rawPayload }
+                when IsOwnershipFamilyPayload(rawPayload):
+                result = BuildInvalidAuthorizationFailure(
+                    AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed,
+                    plannedConfiguredStrategyIndex
+                );
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static OwnershipAuthorizationExecutionResult MapDecodedPayload(
+        OwnershipAuthorizationAuth1FailurePayload payload,
+        int? plannedConfiguredStrategyIndex
+    ) =>
+        OwnershipAuthorizationFailureMapper.Map(payload, plannedConfiguredStrategyIndex) switch
+        {
+            OwnershipAuthorizationAuth1MapResult.Denied denied =>
+                new OwnershipAuthorizationExecutionResult.NotAuthorized(denied.Failure),
+            OwnershipAuthorizationAuth1MapResult.StaleStoredTarget =>
+                new OwnershipAuthorizationExecutionResult.StaleTarget(),
+            OwnershipAuthorizationAuth1MapResult.Unmappable unmappable => BuildInvalidAuthorizationFailure(
+                MapUnmappableToDiagnosticKind(unmappable.Reason, payload.FailureKind),
+                plannedConfiguredStrategyIndex
+            ),
+            var unrecognized => throw new InvalidOperationException(
+                $"Unsupported ownership AUTH1 map result '{unrecognized.GetType().Name}'."
+            ),
+        };
+
+    /// <remarks>
+    /// A stale-target payload raised against a request that planned no ownership check at all gets its own
+    /// diagnostic kind: it is the one unmappable shape that reports the retry path emitting a check the plan
+    /// does not contain, which is a different fault from a payload whose index simply is not ours.
+    /// </remarks>
+    private static string MapUnmappableToDiagnosticKind(
+        OwnershipAuthorizationAuth1UnmappableReason reason,
+        OwnershipAuthorizationAuth1FailureKind failureKind
+    ) =>
+        reason switch
+        {
+            OwnershipAuthorizationAuth1UnmappableReason.NoOwnershipCheckPlanned => failureKind
+            is OwnershipAuthorizationAuth1FailureKind.StoredTargetMissing
+                ? AuthorizationSecurityConfigurationDiagnostics.OwnershipInvalidStaleTargetPayload
+                : AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed,
+            OwnershipAuthorizationAuth1UnmappableReason.ConfiguredStrategyIndexMismatch =>
+                AuthorizationSecurityConfigurationDiagnostics.OwnershipAuth1PayloadMappingFailed,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(reason),
+                reason,
+                "Unsupported ownership AUTH1 unmappable reason."
+            ),
+        };
+
+    private static OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure BuildInvalidAuthorizationFailure(
+        string providerOrPlannerFailureKind,
+        int? plannedConfiguredStrategyIndex
+    ) =>
+        new(
+            OwnershipAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata,
+            AuthorizationSecurityConfigurationDiagnostics.ForOwnershipAuthorizationAuth1(
+                providerOrPlannerFailureKind,
+                plannedConfiguredStrategyIndex
+            )
+        );
+
+    private static bool IsOwnershipFamilyPayload(string rawPayload) =>
+        rawPayload.StartsWith(
+            OwnershipAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
+            StringComparison.Ordinal
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipAuthorizationProviderFailureMapper.cs
@@ -24,11 +24,11 @@ namespace EdFi.DataManagementService.Backend;
 /// malformed payload, and another family can never legitimately claim ours.
 /// </para>
 /// <para>
-/// The reverse direction is not yet closed. <c>NamespaceAuthorizationProviderFailureMapper</c> still reports
-/// every undecodable AUTH1 payload — an <c>own1|</c>-prefixed one included — as a namespace invalid-payload
-/// diagnostic, so on a command where both families are co-batched the namespace mapper must not be consulted
-/// ahead of this one. Both outcomes are a 500 and only the diagnostic differs; closing it is Phase 5.1's
-/// work, when co-batching first makes the two reachable from one command.
+/// The reverse direction is closed too, and independently: <c>NamespaceAuthorizationProviderFailureMapper</c>
+/// yields on an <c>own1|</c>-prefixed undecodable payload rather than claiming every payload it cannot
+/// identify, and <c>RelationalCompositeStoredAuthorization.TryClassifyDenial</c> consults this mapper ahead
+/// of it. Either guard alone attributes a malformed ownership payload correctly; both exist so that removing
+/// one does not silently file an ownership defect under <c>NamespaceBased</c>.
 /// </para>
 /// </remarks>
 internal static class OwnershipAuthorizationProviderFailureMapper

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterValueBinder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterValueBinder.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Binds runtime ownership-token parameter values into a planner parameter-value dictionary. PostgreSQL
+/// stores the whole token list under the base parameter name; SQL Server stores each token under its
+/// allocated scalar parameter name in declaration order.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bound values are <see cref="short"/> — ownership tokens are <c>smallint</c> — never the
+/// <see cref="long"/> shape the relationship claim-EdOrg array path binds. On PostgreSQL that means the
+/// array parameter is a <c>short[]</c>, from which Npgsql infers <c>smallint[]</c>, so
+/// <c>= ANY(@ownershipTokenIds)</c> compares <c>smallint</c> to <c>smallint</c>. Binding a wider type would
+/// force the provider to widen <c>dms.Document.CreatedByOwnershipTokenId</c> for the comparison and give up
+/// the index on it.
+/// </para>
+/// <para>
+/// No explicit <c>DbType</c> is declared, unlike the nullable create-stamping parameter. Every bound token
+/// is a non-null <see cref="short"/>, so both providers infer <c>smallint</c> from the runtime value; the
+/// stamping parameter needs the declaration only because a null binds as <see cref="DBNull"/>, which
+/// carries no type of its own.
+/// </para>
+/// </remarks>
+internal static class OwnershipTokenParameterValueBinder
+{
+    public static void Bind(
+        IDictionary<string, object?> parameterValues,
+        OwnershipTokenParameterization? ownershipTokenParameterization
+    )
+    {
+        ArgumentNullException.ThrowIfNull(parameterValues);
+
+        if (ownershipTokenParameterization is null)
+        {
+            return;
+        }
+
+        if (ownershipTokenParameterization.MatchesNoToken)
+        {
+            // An empty token list renders the membership predicate as a constant false, which references no
+            // parameter. Binding a value here would leave the command declaring a parameter its SQL never
+            // mentions — rejected by RelationalCompositeStatementRewriter as a dangling parameter.
+            return;
+        }
+
+        switch (ownershipTokenParameterization.Kind)
+        {
+            case OwnershipTokenParameterizationKind.PgsqlArray:
+                parameterValues[ownershipTokenParameterization.BaseParameterName] =
+                    ownershipTokenParameterization.TokensInOrder;
+                return;
+
+            case OwnershipTokenParameterizationKind.MssqlScalar:
+                for (
+                    var parameterIndex = 0;
+                    parameterIndex < ownershipTokenParameterization.ParameterNamesInOrder.Count;
+                    parameterIndex++
+                )
+                {
+                    parameterValues[ownershipTokenParameterization.ParameterNamesInOrder[parameterIndex]] =
+                        ownershipTokenParameterization.TokensInOrder[parameterIndex];
+                }
+
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(ownershipTokenParameterization),
+                    ownershipTokenParameterization.Kind,
+                    "Unsupported ownership token parameterization kind."
+                );
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterValueBinder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterValueBinder.cs
@@ -32,15 +32,11 @@ internal static class OwnershipTokenParameterValueBinder
 {
     public static void Bind(
         IDictionary<string, object?> parameterValues,
-        OwnershipTokenParameterization? ownershipTokenParameterization
+        OwnershipTokenParameterization ownershipTokenParameterization
     )
     {
         ArgumentNullException.ThrowIfNull(parameterValues);
-
-        if (ownershipTokenParameterization is null)
-        {
-            return;
-        }
+        ArgumentNullException.ThrowIfNull(ownershipTokenParameterization);
 
         if (ownershipTokenParameterization.MatchesNoToken)
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterizationPreflight.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterizationPreflight.cs
@@ -14,11 +14,14 @@ namespace EdFi.DataManagementService.Backend;
 /// into the security-configuration message and diagnostics a caller wraps in its own result type.
 /// </summary>
 /// <remarks>
-/// Defence in depth rather than the primary gate. The planner returns its own token-cap terminal, which is
-/// what gives the failure correct precedence among the other authorization terminals, so a request that
-/// reaches this preflight is already known to be under the limit. This layer exists so that a caller which
-/// somehow skipped the planner still fails closed with a clean 500 instead of emitting an over-limit
-/// parameter list at the SQL boundary or letting the factory's exception escape as a generic failure.
+/// Defence in depth on GET-by-id, PUT and DELETE, and the gate on POST. On the first three the planner
+/// returns its own token-cap terminal, which is what gives the failure correct precedence among the other
+/// authorization terminals, so a request that reaches this preflight is already known to be under the limit;
+/// this layer exists so that a caller which somehow skipped the planner still fails closed with a clean 500
+/// instead of emitting an over-limit parameter list at the SQL boundary or letting the factory's exception
+/// escape as a generic failure. POST defers the planner's cap to target resolution, so this is where its
+/// over-limit list is caught, and the failure reported here is carried into the write session to be returned
+/// only if the target proves to exist.
 /// </remarks>
 internal static class OwnershipTokenParameterizationPreflight
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterizationPreflight.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterizationPreflight.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Builds the ownership-token parameterization for a request, converting the factory's defensive-limit throw
+/// into the security-configuration message and diagnostics a caller wraps in its own result type.
+/// </summary>
+/// <remarks>
+/// Defence in depth rather than the primary gate. The planner returns its own token-cap terminal, which is
+/// what gives the failure correct precedence among the other authorization terminals, so a request that
+/// reaches this preflight is already known to be under the limit. This layer exists so that a caller which
+/// somehow skipped the planner still fails closed with a clean 500 instead of emitting an over-limit
+/// parameter list at the SQL boundary or letting the factory's exception escape as a generic failure.
+/// </remarks>
+internal static class OwnershipTokenParameterizationPreflight
+{
+    /// <returns>
+    /// <see langword="true"/> with <paramref name="parameterization"/> populated on success;
+    /// <see langword="false"/> with <paramref name="securityConfigurationMessage"/> and
+    /// <paramref name="securityConfigurationDiagnostics"/> set when the token list reaches the defensive
+    /// limit.
+    /// </returns>
+    public static bool TryCreate(
+        SqlDialect dialect,
+        IReadOnlyList<short> ownershipTokenIds,
+        out OwnershipTokenParameterization parameterization,
+        out string securityConfigurationMessage,
+        out SecurityConfigurationFailureDiagnostic[] securityConfigurationDiagnostics
+    )
+    {
+        if (
+            OwnershipTokenParameterizationFactory.TryCreate(
+                dialect,
+                ownershipTokenIds,
+                OwnershipAuthorizationSqlSpecDefaults.OwnershipTokenIdsParameterName,
+                out parameterization,
+                out securityConfigurationMessage,
+                out OwnershipTokenParameterizationFailureKind? failureKind
+            )
+        )
+        {
+            securityConfigurationDiagnostics = [];
+            return true;
+        }
+
+        string diagnosticFailureKind = failureKind switch
+        {
+            OwnershipTokenParameterizationFailureKind.TokenCapExceeded =>
+                AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded,
+            _ => throw new InvalidOperationException(
+                $"Unsupported ownership token parameterization failure kind '{failureKind}'."
+            ),
+        };
+
+        securityConfigurationDiagnostics =
+            AuthorizationSecurityConfigurationDiagnostics.ForOwnershipTokenParameterization(
+                diagnosticFailureKind
+            );
+        return false;
+    }
+}
+
+/// <summary>
+/// Parameter names the ownership authorization SQL binds. Declared here rather than on the compiler so the
+/// preflight, the compiler, and the command parameter builder cannot drift apart.
+/// </summary>
+internal static class OwnershipAuthorizationSqlSpecDefaults
+{
+    public const string DocumentIdParameterName = "documentId";
+    public const string OwnershipTokenIdsParameterName = "ownershipTokenIds";
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterizationPreflight.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/OwnershipTokenParameterizationPreflight.cs
@@ -36,35 +36,28 @@ internal static class OwnershipTokenParameterizationPreflight
         out SecurityConfigurationFailureDiagnostic[] securityConfigurationDiagnostics
     )
     {
-        if (
-            OwnershipTokenParameterizationFactory.TryCreate(
+        try
+        {
+            parameterization = OwnershipTokenParameterizationFactory.Create(
                 dialect,
                 ownershipTokenIds,
-                OwnershipAuthorizationSqlSpecDefaults.OwnershipTokenIdsParameterName,
-                out parameterization,
-                out securityConfigurationMessage,
-                out OwnershipTokenParameterizationFailureKind? failureKind
-            )
-        )
-        {
+                OwnershipAuthorizationSqlSpecDefaults.OwnershipTokenIdsParameterName
+            );
+            securityConfigurationMessage = string.Empty;
             securityConfigurationDiagnostics = [];
             return true;
         }
-
-        string diagnosticFailureKind = failureKind switch
+        catch (OwnershipTokenLimitExceededException ex)
         {
-            OwnershipTokenParameterizationFailureKind.TokenCapExceeded =>
-                AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded,
-            _ => throw new InvalidOperationException(
-                $"Unsupported ownership token parameterization failure kind '{failureKind}'."
-            ),
-        };
-
-        securityConfigurationDiagnostics =
-            AuthorizationSecurityConfigurationDiagnostics.ForOwnershipTokenParameterization(
-                diagnosticFailureKind
-            );
-        return false;
+            parameterization = null!;
+            securityConfigurationMessage =
+                OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(ex.OwnershipTokenCount);
+            securityConfigurationDiagnostics =
+                AuthorizationSecurityConfigurationDiagnostics.ForOwnershipTokenParameterization(
+                    AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded
+                );
+            return false;
+        }
     }
 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -281,6 +281,9 @@ public static class ReferenceResolverServiceCollectionExtensions
             ServiceDescriptor.Scoped<INamespaceAuthorizationExecutor, NamespaceAuthorizationExecutor>()
         );
         services.TryAdd(
+            ServiceDescriptor.Scoped<IOwnershipAuthorizationExecutor, OwnershipAuthorizationExecutor>()
+        );
+        services.TryAdd(
             ServiceDescriptor.Scoped<ICustomViewAuthorizationExecutor>(
                 static serviceProvider => new CustomViewAuthorizationExecutor(
                     serviceProvider.GetRequiredService<IRelationalCommandExecutor>(),

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCompositeStoredAuthorization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCompositeStoredAuthorization.cs
@@ -403,7 +403,7 @@ internal static class RelationalCompositeStoredAuthorization
             return true;
         }
 
-        var command = BuildOwnershipCommand(mappingSet, ownershipAuthorization, carrier);
+        var command = BuildCoBatchedOwnershipCommand(mappingSet, ownershipAuthorization, carrier);
 
         if (
             !builder.Fits(
@@ -444,24 +444,29 @@ internal static class RelationalCompositeStoredAuthorization
     }
 
     /// <summary>
-    /// Builds the stored ownership command, carrying the carrier's row guard so the check is vacuous when
-    /// the capture observed no target. Internal so an ordered-segment caller runs the identical statement.
+    /// Builds the co-batched stored ownership command, carrying the carrier's row guard so the check is
+    /// vacuous when the capture observed no target.
     /// </summary>
-    public static RelationalCommand BuildOwnershipCommand(
+    /// <remarks>
+    /// Private, and the carrier is required, because the command it produces is only safe co-batched. Its
+    /// <c>DocumentId</c> is bound to a placeholder that <see cref="TryAppendOwnership"/> rewrites into the
+    /// carrier's captured-id expression before execution — the same placeholder the namespace and
+    /// relationship builders bind — so executing it as its own command would authorize document id 0. An
+    /// ordered-segment caller runs <see cref="OwnershipAuthorizationExecutor"/> against the observed target
+    /// id instead, exactly as the namespace and custom-view segments do.
+    /// </remarks>
+    private static RelationalCommand BuildCoBatchedOwnershipCommand(
         MappingSet mappingSet,
         RelationalOwnershipAuthorization ownershipAuthorization,
-        IRelationalCompositeTargetCarrier? carrier = null
+        IRelationalCompositeTargetCarrier carrier
     )
     {
-        ArgumentNullException.ThrowIfNull(mappingSet);
-        ArgumentNullException.ThrowIfNull(ownershipAuthorization);
-
         var sqlPlan = new OwnershipAuthorizationSqlCompiler(mappingSet.Key.Dialect).Compile(
             new OwnershipAuthorizationSqlSpec(
                 ownershipAuthorization.Check,
                 ownershipAuthorization.OwnershipTokenParameterization,
                 OwnershipAuthorizationSqlSpecDefaults.DocumentIdParameterName,
-                RowGuardPredicateSql: carrier?.CapturedTargetPresentPredicate
+                RowGuardPredicateSql: carrier.CapturedTargetPresentPredicate
             )
         );
 
@@ -469,6 +474,7 @@ internal static class RelationalCompositeStoredAuthorization
             sqlPlan,
             new OwnershipAuthorizationExecutionRequest(
                 mappingSet,
+                // Rewritten to the carrier's captured-id expression by the caller; never executed as bound.
                 DocumentId: 0L,
                 ownershipAuthorization.Check,
                 ownershipAuthorization.OwnershipTokenParameterization

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCompositeStoredAuthorization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCompositeStoredAuthorization.cs
@@ -108,21 +108,22 @@ internal abstract record StoredAuthorizationDenial
 }
 
 /// <summary>
-/// Co-batches the stored namespace and stored relationship <c>AUTH1</c> checks against a captured target,
-/// and classifies the provider failure a denial raises.
+/// Co-batches the stored custom view-based, namespace, ownership, and relationship <c>AUTH1</c> checks
+/// against a captured target, and classifies the provider failure a denial raises.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Statement order is precedence order: a command aborts at its first <c>AUTH1</c>, so emitting namespace
-/// before relationship is what makes a namespace denial win. Every write verb that authorizes stored values
-/// against a locked target shares this one implementation, so that precedence — and the failure
-/// classification the caller renders — cannot drift between the write executor's first phase and the delete
-/// command.
+/// Statement order is precedence order: a command aborts at its first <c>AUTH1</c>, so emitting the custom
+/// views and namespace before ownership, and ownership before relationship, is what decides which denial
+/// wins. Every write verb that authorizes stored values against a locked target shares this one
+/// implementation, so that precedence — and the failure classification the caller renders — cannot drift
+/// between the write executor's first phase and the delete command.
 /// </para>
 /// <para>
-/// Both checks are written to be vacuous when the capture observed nothing: the namespace checks carry the
-/// carrier's row guard, and the relationship check's own target CTE yields no row. A command must serve both
-/// branches, because choosing per branch would require knowing the target before the command runs.
+/// Every check is written to be vacuous when the capture observed nothing: the custom-view, namespace and
+/// ownership checks carry the carrier's row guard, and the relationship check's own target CTE yields no
+/// row. A command must serve both branches, because choosing per branch would require knowing the target
+/// before the command runs.
 /// </para>
 /// </remarks>
 internal static class RelationalCompositeStoredAuthorization
@@ -611,8 +612,8 @@ internal static class RelationalCompositeStoredAuthorization
         int emittedAuth1Index,
         IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
         ILogger logger,
-        StoredCustomViewStatementPlan? customViewPlan = null,
-        StoredOwnershipStatementPlan? ownershipPlan = null
+        StoredCustomViewStatementPlan? customViewPlan,
+        StoredOwnershipStatementPlan? ownershipPlan
     )
     {
         ArgumentNullException.ThrowIfNull(exception);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCompositeStoredAuthorization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCompositeStoredAuthorization.cs
@@ -66,6 +66,14 @@ internal sealed record StoredCustomViewStatementPlan(
     IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> PlannedChecks
 );
 
+/// <summary>What an emitted stored ownership check needs in order to map its provider failure back.</summary>
+/// <remarks>
+/// Only the planned check, because attribution is an equality test against its configured index rather than
+/// a lookup into a list: ownership emits exactly one check per operation. The caller's ownership tokens are
+/// deliberately absent — no ownership response discloses a token value, so nothing downstream needs them.
+/// </remarks>
+internal sealed record StoredOwnershipStatementPlan(OwnershipAuthorizationCheckSpec Check);
+
 /// <summary>The stored relationship check's decoded success row.</summary>
 internal sealed record StoredRelationshipAuthorizationRow(int AuthorizationResult, long ContentVersion);
 
@@ -85,6 +93,9 @@ internal abstract record StoredAuthorizationDenial
         : StoredAuthorizationDenial;
 
     public sealed record CustomViewNotAuthorized(CustomViewAuthorizationFailure Failure)
+        : StoredAuthorizationDenial;
+
+    public sealed record OwnershipNotAuthorized(OwnershipAuthorizationFailure Failure)
         : StoredAuthorizationDenial;
 
     public sealed record RelationshipNotAuthorized(RelationshipAuthorizationFailure Failure)
@@ -118,6 +129,7 @@ internal static class RelationalCompositeStoredAuthorization
 {
     public const string NamespaceLabel = "stored-namespace-authorization";
     public const string CustomViewLabel = "stored-custom-view-authorization";
+    public const string OwnershipLabel = "stored-ownership-authorization";
     public const string RelationshipLabel = "stored-relationship-authorization";
 
     /// <summary>
@@ -355,6 +367,116 @@ internal static class RelationalCompositeStoredAuthorization
     }
 
     /// <summary>
+    /// Appends the stored ownership check behind the carrier's row guard, or reports that it does not fit
+    /// this command's remaining parameter budget so the caller can select ordered segments instead.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Appended after the namespace and custom-view statements and before the relationship one, because
+    /// statement order is precedence order in a command that aborts at its first <c>AUTH1</c>, and auth.md
+    /// places <c>OwnershipBased</c> last among the AND strategies and ahead of the relationship OR group.
+    /// Its configured index attributes a denial; it does not order the statement.
+    /// </para>
+    /// <para>
+    /// Unlike the custom-view run, a non-fit is reported rather than thrown. On SQL Server the token list
+    /// binds one scalar per token, so a large list genuinely can exhaust the budget, and running ownership
+    /// as an ordered segment after this command preserves its order relative to every other AND filter —
+    /// they all precede it either way. That is exactly what makes the degradation safe here and unsafe for a
+    /// custom-view run, which may be configured before the namespace check.
+    /// </para>
+    /// </remarks>
+    public static bool TryAppendOwnership(
+        RelationalCompositeCommandBuilder builder,
+        IRelationalCompositeTargetCarrier carrier,
+        MappingSet mappingSet,
+        RelationalOwnershipAuthorization? ownershipAuthorization,
+        out StoredOwnershipStatementPlan? statementPlan
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(carrier);
+        ArgumentNullException.ThrowIfNull(mappingSet);
+
+        if (ownershipAuthorization is null)
+        {
+            statementPlan = null;
+            return true;
+        }
+
+        var command = BuildOwnershipCommand(mappingSet, ownershipAuthorization, carrier);
+
+        if (
+            !builder.Fits(
+                CountParametersAfterSubstitution(
+                    command,
+                    OwnershipAuthorizationSqlSpecDefaults.DocumentIdParameterName
+                )
+            )
+        )
+        {
+            statementPlan = null;
+            return false;
+        }
+
+        var rewritten = RelationalCompositeStatementRewriter.Rewrite(
+            command,
+            builder.Allocator,
+            builder.NextOrdinal,
+            BuildCarrierSubstitutions(
+                carrier,
+                OwnershipAuthorizationSqlSpecDefaults.DocumentIdParameterName,
+                carrier.CapturedTargetIdExpression
+            )
+        );
+
+        builder.Append(
+            OwnershipLabel,
+            rewritten.Sql,
+            rewritten.Parameters,
+            RelationalCompositeResultShape.Rows,
+            (reader, readCancellation) =>
+                RelationalCompositeResultSetSpan.ConsumeAsync(reader, 1, readCancellation),
+            1
+        );
+
+        statementPlan = new StoredOwnershipStatementPlan(ownershipAuthorization.Check);
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the stored ownership command, carrying the carrier's row guard so the check is vacuous when
+    /// the capture observed no target. Internal so an ordered-segment caller runs the identical statement.
+    /// </summary>
+    public static RelationalCommand BuildOwnershipCommand(
+        MappingSet mappingSet,
+        RelationalOwnershipAuthorization ownershipAuthorization,
+        IRelationalCompositeTargetCarrier? carrier = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(mappingSet);
+        ArgumentNullException.ThrowIfNull(ownershipAuthorization);
+
+        var sqlPlan = new OwnershipAuthorizationSqlCompiler(mappingSet.Key.Dialect).Compile(
+            new OwnershipAuthorizationSqlSpec(
+                ownershipAuthorization.Check,
+                ownershipAuthorization.OwnershipTokenParameterization,
+                OwnershipAuthorizationSqlSpecDefaults.DocumentIdParameterName,
+                RowGuardPredicateSql: carrier?.CapturedTargetPresentPredicate
+            )
+        );
+
+        return OwnershipAuthorizationExecutor.BuildCommand(
+            sqlPlan,
+            new OwnershipAuthorizationExecutionRequest(
+                mappingSet,
+                DocumentId: 0L,
+                ownershipAuthorization.Check,
+                ownershipAuthorization.OwnershipTokenParameterization
+            )
+        );
+    }
+
+    /// <summary>
     /// Appends the stored relationship check when its disposition is
     /// <see cref="StoredRelationshipDisposition.Emitted"/> and it fits, and reports whether it did.
     /// </summary>
@@ -483,7 +605,8 @@ internal static class RelationalCompositeStoredAuthorization
         int emittedAuth1Index,
         IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
         ILogger logger,
-        StoredCustomViewStatementPlan? customViewPlan = null
+        StoredCustomViewStatementPlan? customViewPlan = null,
+        StoredOwnershipStatementPlan? ownershipPlan = null
     )
     {
         ArgumentNullException.ThrowIfNull(exception);
@@ -536,6 +659,42 @@ internal static class RelationalCompositeStoredAuthorization
                         customViewPlan.PlannedChecks
                     )
                 );
+            }
+        }
+
+        // Ownership is consulted ahead of namespace deliberately, and this is the one place arm order does
+        // carry weight today. The ownership mapper claims only own1-discriminated payloads, malformed ones
+        // included, whereas the namespace mapper still treats an undecodable payload it cannot identify as
+        // its own invalid-metadata failure. Namespace additionally yields on an own1-prefixed payload, so
+        // the two guards are independent: either alone attributes a malformed ownership payload correctly.
+        if (
+            OwnershipAuthorizationProviderFailureMapper.TryMapOwnershipAuthorizationFailure(
+                dialect,
+                exception,
+                providerFailureExtractor,
+                ownershipPlan?.Check.RawConfiguredIndex,
+                out var ownershipResult
+            )
+        )
+        {
+            switch (ownershipResult)
+            {
+                case OwnershipAuthorizationExecutionResult.NotAuthorized notAuthorized:
+                    return new StoredAuthorizationDenial.OwnershipNotAuthorized(notAuthorized.Failure);
+
+                case OwnershipAuthorizationExecutionResult.StaleTarget:
+                    return new StoredAuthorizationDenial.StaleTarget();
+
+                case OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure:
+                    return new StoredAuthorizationDenial.SecurityConfiguration(
+                        [invalidFailure.FailureMessage],
+                        invalidFailure.Diagnostics
+                    );
+
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported stored ownership authorization result '{ownershipResult!.GetType().Name}'."
+                    );
             }
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
@@ -32,6 +32,13 @@ internal sealed record RelationalDeleteCommandRequest(
     /// </summary>
     public RelationalCustomViewAuthorization? CustomViewAuthorization { get; init; }
 
+    /// <summary>
+    /// The ownership check planned for this delete, or <see langword="null"/> when <c>OwnershipBased</c> is
+    /// not configured. It authorizes the stored token only, so like the custom views it has no proposed
+    /// source here.
+    /// </summary>
+    public RelationalOwnershipAuthorization? StoredOwnershipAuthorization { get; init; }
+
     public WritePrecondition WritePrecondition { get; init; } = new WritePrecondition.None();
 
     /// <summary>
@@ -153,6 +160,18 @@ internal sealed class CompositeRelationalDeleteCommand(
         /// </summary>
         public IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> CustomViewSegmentChecks { get; init; } =
         [];
+
+        /// <summary>
+        /// The ownership check the command carried, or <see langword="null"/> when it carried none — so a
+        /// provider failure is mapped only against a check that command actually sent.
+        /// </summary>
+        public StoredOwnershipStatementPlan? OwnershipPlan { get; init; }
+
+        /// <summary>
+        /// The ownership authorization still owed as its own ordered segment because it did not fit the
+        /// opening command, or <see langword="null"/> when nothing is owed.
+        /// </summary>
+        public RelationalOwnershipAuthorization? OwnershipSegmentAuthorization { get; init; }
     }
 
     public async Task<DeleteResult> ExecuteAsync(
@@ -190,6 +209,7 @@ internal sealed class CompositeRelationalDeleteCommand(
                 request,
                 plan.NamespacePlan,
                 plan.CustomViewPlan,
+                plan.OwnershipPlan,
                 plan.RelationshipPlan,
                 exception,
                 execution.Failure
@@ -229,6 +249,21 @@ internal sealed class CompositeRelationalDeleteCommand(
         )
         {
             return customViewResult;
+        }
+
+        if (
+            await ExecuteSegmentedOwnershipAsync(
+                    request,
+                    plan.OwnershipSegmentAuthorization,
+                    capturedTarget.DocumentId,
+                    writeSession,
+                    cancellationToken
+                )
+                .ConfigureAwait(false) is
+            { } ownershipResult
+        )
+        {
+            return ownershipResult;
         }
 
         if (
@@ -356,10 +391,28 @@ internal sealed class CompositeRelationalDeleteCommand(
             && customViewsBeforeNamespace.Count > 0
                 ? new StoredCustomViewStatementPlan(customViewAuthorization.Checks)
                 : null;
+        // Ownership rides the command only once everything configured ahead of it has: it executes last
+        // among the AND filters, so a segment owed by any of them must run before it.
+        // Declared ahead of the short-circuiting chain: when a check configured earlier already owes a
+        // segment, TryAppendOwnership is never reached and no statement was emitted to map a failure against.
+        StoredOwnershipStatementPlan? ownershipPlan = null;
+        var ownershipEmitted =
+            namespaceEmitted
+            && customViewSegmentChecks.Count == 0
+            && RelationalCompositeStoredAuthorization.TryAppendOwnership(
+                builder,
+                carrier,
+                request.MappingSet,
+                request.StoredOwnershipAuthorization,
+                out ownershipPlan
+            );
+        var ownershipSegmentAuthorization = ownershipEmitted ? null : request.StoredOwnershipAuthorization;
+
         var relationshipPlan = classifiedRelationship;
         var relationshipEmitted =
             namespaceEmitted
             && customViewSegmentChecks.Count == 0
+            && ownershipEmitted
             && RelationalCompositeStoredAuthorization.TryAppendRelationship(
                 builder,
                 carrier,
@@ -385,6 +438,7 @@ internal sealed class CompositeRelationalDeleteCommand(
         if (
             namespaceEmitted
             && customViewSegmentChecks.Count == 0
+            && ownershipEmitted
             && CanCoBatchDeletes(request, relationshipPlan.Disposition)
         )
         {
@@ -403,6 +457,8 @@ internal sealed class CompositeRelationalDeleteCommand(
             CustomViewPlan = customViewPlan,
             CustomViewCommandChecks = customViewsBeforeNamespace,
             CustomViewSegmentChecks = customViewSegmentChecks,
+            OwnershipPlan = ownershipPlan,
+            OwnershipSegmentAuthorization = ownershipSegmentAuthorization,
         };
     }
 
@@ -495,6 +551,64 @@ internal sealed class CompositeRelationalDeleteCommand(
     /// executes in configured order and strictly precedes the relationship check and any deletion, at the cost
     /// of one more command on that path.
     /// </summary>
+    /// <summary>
+    /// Runs the ownership check as its own ordered segment, which happens when it did not fit the opening
+    /// command or when a check configured ahead of it took a segment first.
+    /// </summary>
+    /// <remarks>
+    /// Ordered after the custom-view segment and before the relationship check, which is the same position
+    /// it holds co-batched: ownership executes last among the AND filters and ahead of the relationship OR
+    /// group. It runs against the decoded captured id under the lock the capture holds, so it authorizes the
+    /// row the deletes would remove — and the deletes are withheld from the opening command whenever this
+    /// segment is owed.
+    /// </remarks>
+    private async Task<DeleteResult?> ExecuteSegmentedOwnershipAsync(
+        RelationalDeleteCommandRequest request,
+        RelationalOwnershipAuthorization? ownershipAuthorization,
+        long documentId,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        if (ownershipAuthorization is null)
+        {
+            return null;
+        }
+
+        var executionResult = await new OwnershipAuthorizationExecutor(
+            writeSession.CreateCommandExecutor(),
+            _providerFailureExtractor
+        )
+            .ExecuteAsync(
+                new OwnershipAuthorizationExecutionRequest(
+                    request.MappingSet,
+                    documentId,
+                    ownershipAuthorization.Check,
+                    ownershipAuthorization.OwnershipTokenParameterization
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            OwnershipAuthorizationExecutionResult.Authorized => null,
+            OwnershipAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                new DeleteResult.DeleteFailureOwnershipNotAuthorized(notAuthorized.Failure),
+            OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                new DeleteResult.DeleteFailureSecurityConfiguration(
+                    [invalidFailure.FailureMessage],
+                    invalidFailure.Diagnostics
+                ),
+            // Unreachable while the capture lock holds; the same defensive mapping the namespace and
+            // custom-view segments use.
+            OwnershipAuthorizationExecutionResult.StaleTarget => new DeleteResult.DeleteFailureNotExists(),
+            _ => throw new InvalidOperationException(
+                $"Unsupported ownership authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
+    }
+
     private async Task<DeleteResult?> ExecuteSegmentedCustomViewAsync(
         RelationalDeleteCommandRequest request,
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> segmentChecks,
@@ -809,6 +923,7 @@ internal sealed class CompositeRelationalDeleteCommand(
         RelationalDeleteCommandRequest request,
         StoredNamespaceStatementPlan? namespacePlan,
         StoredCustomViewStatementPlan? customViewPlan,
+        StoredOwnershipStatementPlan? ownershipPlan,
         StoredRelationshipStatementPlan relationshipPlan,
         DbException exception,
         RelationalCompositeFailureContext? failureContext
@@ -821,7 +936,8 @@ internal sealed class CompositeRelationalDeleteCommand(
             RelationshipAuthorizationAuth1Index,
             _providerFailureExtractor,
             _logger,
-            customViewPlan
+            customViewPlan,
+            ownershipPlan
         ) switch
         {
             // Stale is unreachable while the capture lock holds; kept as the same defensive mapping the
@@ -831,6 +947,8 @@ internal sealed class CompositeRelationalDeleteCommand(
                 new DeleteResult.DeleteFailureNamespaceNotAuthorized(failure),
             StoredAuthorizationDenial.CustomViewNotAuthorized(var failure) =>
                 new DeleteResult.DeleteFailureCustomViewNotAuthorized(failure),
+            StoredAuthorizationDenial.OwnershipNotAuthorized(var failure) =>
+                new DeleteResult.DeleteFailureOwnershipNotAuthorized(failure),
             StoredAuthorizationDenial.RelationshipNotAuthorized(var failure) =>
                 new DeleteResult.DeleteFailureRelationshipNotAuthorized(failure),
             StoredAuthorizationDenial.SecurityConfiguration(var messages, var diagnostics) =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDeleteCommandPhase.cs
@@ -546,12 +546,6 @@ internal sealed class CompositeRelationalDeleteCommand(
     }
 
     /// <summary>
-    /// Runs the custom-view checks configured after <c>NamespaceBased</c> as their own ordered segment, which
-    /// is what lets their views be validated only once that check has passed. Authorization therefore still
-    /// executes in configured order and strictly precedes the relationship check and any deletion, at the cost
-    /// of one more command on that path.
-    /// </summary>
-    /// <summary>
     /// Runs the ownership check as its own ordered segment, which happens when it did not fit the opening
     /// command or when a check configured ahead of it took a segment first.
     /// </summary>
@@ -609,6 +603,12 @@ internal sealed class CompositeRelationalDeleteCommand(
         };
     }
 
+    /// <summary>
+    /// Runs the custom-view checks configured after <c>NamespaceBased</c> as their own ordered segment, which
+    /// is what lets their views be validated only once that check has passed. Authorization therefore still
+    /// executes in configured order and strictly precedes the relationship check and any deletion, at the cost
+    /// of one more command on that path.
+    /// </summary>
     private async Task<DeleteResult?> ExecuteSegmentedCustomViewAsync(
         RelationalDeleteCommandRequest request,
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> segmentChecks,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentRowCommandBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentRowCommandBuilder.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.External.Model;
 
@@ -22,39 +23,77 @@ namespace EdFi.DataManagementService.Backend;
 /// </remarks>
 internal static class RelationalDocumentRowCommandBuilder
 {
+    /// <param name="createdByOwnershipTokenId">
+    /// The API client's <c>CreatorOwnershipTokenId</c>, or <see langword="null"/> when the client has none.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// <c>CreatedByOwnershipTokenId</c> is stamped on every create, whether or not the resource is configured
+    /// with <c>OwnershipBased</c>. That is what lets a claim set later enforce ownership over data written
+    /// before it was configured, so the column list must not become conditional on configured strategies.
+    /// </para>
+    /// <para>
+    /// The column and its parameter are emitted even when the value is null, so each dialect has exactly one
+    /// statement text. Omitting the column for a null token would double the statement-text cardinality for
+    /// no benefit and cost plan reuse on both engines.
+    /// </para>
+    /// </remarks>
     public static RelationalCommand BuildInsertCommand(
         SqlDialect dialect,
         DocumentUuid documentUuid,
-        short resourceKeyId
+        short resourceKeyId,
+        short? createdByOwnershipTokenId
     )
     {
         return dialect switch
         {
             SqlDialect.Pgsql => new RelationalCommand(
                 """
-                INSERT INTO dms."Document" ("DocumentUuid", "ResourceKeyId")
-                VALUES (@documentUuid, @resourceKeyId)
+                INSERT INTO dms."Document" ("DocumentUuid", "ResourceKeyId", "CreatedByOwnershipTokenId")
+                VALUES (@documentUuid, @resourceKeyId, @createdByOwnershipTokenId)
                 RETURNING "DocumentId";
                 """,
                 [
                     new RelationalParameter("@documentUuid", documentUuid.Value),
                     new RelationalParameter("@resourceKeyId", resourceKeyId),
+                    BuildCreatedByOwnershipTokenIdParameter(createdByOwnershipTokenId),
                 ]
             ),
             SqlDialect.Mssql => new RelationalCommand(
                 """
-                INSERT INTO [dms].[Document] ([DocumentUuid], [ResourceKeyId])
-                VALUES (@documentUuid, @resourceKeyId);
+                INSERT INTO [dms].[Document] ([DocumentUuid], [ResourceKeyId], [CreatedByOwnershipTokenId])
+                VALUES (@documentUuid, @resourceKeyId, @createdByOwnershipTokenId);
                 SELECT SCOPE_IDENTITY();
                 """,
                 [
                     new RelationalParameter("@documentUuid", documentUuid.Value),
                     new RelationalParameter("@resourceKeyId", resourceKeyId),
+                    BuildCreatedByOwnershipTokenIdParameter(createdByOwnershipTokenId),
                 ]
             ),
             _ => throw new ArgumentOutOfRangeException(nameof(dialect), dialect, null),
         };
     }
+
+    /// <summary>
+    /// The <c>CreatedByOwnershipTokenId</c> parameter, typed explicitly as <see cref="DbType.Int16"/>.
+    /// </summary>
+    /// <remarks>
+    /// The type is declared rather than left to provider inference because the value is nullable and reaches
+    /// the driver as <c>DBNull</c>, which carries no type of its own. Both providers would otherwise have to
+    /// infer a type for a null — PostgreSQL from the insert target, SQL Server by defaulting to a string type
+    /// and relying on an implicit conversion. Declaring <c>smallint</c> makes the null and non-null cases bind
+    /// identically on both engines. <c>ConfigureParameter</c> survives composite statement rewriting, so the
+    /// co-batched write path binds it the same way this one does.
+    /// </remarks>
+    private static RelationalParameter BuildCreatedByOwnershipTokenIdParameter(
+        short? createdByOwnershipTokenId
+    ) =>
+        new(
+            "@createdByOwnershipTokenId",
+            createdByOwnershipTokenId,
+            static parameter => parameter.DbType = DbType.Int16
+        );
 
     /// <summary>
     /// The scalar subquery yielding the <c>DocumentId</c> of the row whose <c>DocumentUuid</c> is bound to

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -3771,10 +3771,7 @@ public sealed class RelationalDocumentStoreRepository(
 
         if (authorizationPreflight is GetByIdAuthorizationPreflightResult.Stop preflightStop)
         {
-            await ValidateSingleRecordCustomViewsAsync(mappingSet, preflightStop.CustomViewChecksToValidate)
-                .ConfigureAwait(false);
-
-            return preflightStop.Result;
+            return await CompleteGetByIdPreflightStopAsync(mappingSet, preflightStop).ConfigureAwait(false);
         }
 
         for (var attemptIndex = 0; attemptIndex < GetByIdReadBoundaryAttemptCount; attemptIndex++)
@@ -4017,7 +4014,9 @@ public sealed class RelationalDocumentStoreRepository(
 
         if (authorizationPreflight is GetByIdAuthorizationPreflightResult.Stop preflightStop)
         {
-            return new DocumentCacheReadAccelerationGetByIdSelectionResult.Complete(preflightStop.Result);
+            return new DocumentCacheReadAccelerationGetByIdSelectionResult.Complete(
+                await CompleteGetByIdPreflightStopAsync(mappingSet, preflightStop).ConfigureAwait(false)
+            );
         }
 
         short resourceKeyId;
@@ -4328,6 +4327,29 @@ public sealed class RelationalDocumentStoreRepository(
     /// Validates the views a GET-by-id terminal carries. Empty is a no-op, so every terminal can route
     /// through this unconditionally.
     /// </summary>
+    /// <summary>
+    /// Completes a GET-by-id preflight terminal: validates the custom views configured ahead of it, then
+    /// yields the terminal's result.
+    /// </summary>
+    /// <remarks>
+    /// Shared by both GET-by-id entry points. A terminal added on one of them would otherwise be able to
+    /// skip view validation on the other — the accelerated path did exactly that — and the views ahead of a
+    /// terminal are AND filters that execute before it, so a missing or non-conforming view must keep its
+    /// own 500 rather than be hidden behind the terminal's response. It matters most for the terminals that
+    /// carry every configured view, such as the ownership token cap, since <c>OwnershipBased</c> executes
+    /// last among the AND strategies and so follows all of them.
+    /// </remarks>
+    private async Task<GetResult> CompleteGetByIdPreflightStopAsync(
+        MappingSet mappingSet,
+        GetByIdAuthorizationPreflightResult.Stop preflightStop
+    )
+    {
+        await ValidateSingleRecordCustomViewsAsync(mappingSet, preflightStop.CustomViewChecksToValidate)
+            .ConfigureAwait(false);
+
+        return preflightStop.Result;
+    }
+
     private Task ValidateSingleRecordCustomViewsAsync(
         MappingSet mappingSet,
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
@@ -4472,6 +4494,41 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null;
+
+        if (plan.NamespaceChecks.Count > 0)
+        {
+            if (
+                !NamespacePrefixParameterizationPreflight.TryCreate(
+                    mappingSet.Key.Dialect,
+                    authorizationContext.NamespacePrefixes,
+                    out var namespacePrefixParameterization,
+                    out var securityConfigurationMessage,
+                    out var securityConfigurationDiagnostics
+                )
+            )
+            {
+                return GetByIdTerminal(
+                    mappingSet,
+                    resource,
+                    new GetResult.GetFailureSecurityConfiguration(
+                        [securityConfigurationMessage],
+                        securityConfigurationDiagnostics
+                    ),
+                    plan.CustomViewStrategies,
+                    plan.NamespaceChecks[0].RawConfiguredIndex
+                );
+            }
+
+            storedNamespaceAuthorization = new RelationalWriteNamespaceAuthorization(
+                plan.NamespaceChecks,
+                namespacePrefixParameterization
+            );
+        }
+
+        // Built after the namespace parameterization, deliberately. Both are setup failures reported as the
+        // same security-configuration 500, so whichever is attempted first is the one reported when a request
+        // would fail both. NamespaceBased executes ahead of OwnershipBased, so its failure must win.
         if (
             !TryPlanGetByIdOwnershipAuthorization(
                 mappingSet,
@@ -4496,46 +4553,6 @@ public sealed class RelationalDocumentStoreRepository(
                 int.MaxValue
             );
         }
-
-        if (plan.NamespaceChecks.Count == 0)
-        {
-            return AuthorizeGetByIdRelationshipPreflight(
-                mappingSet,
-                resource,
-                null,
-                storedCustomViewAuthorization,
-                storedOwnershipAuthorization,
-                plan.NonNamespaceConfiguredStrategies,
-                authorizationContext
-            );
-        }
-
-        if (
-            !NamespacePrefixParameterizationPreflight.TryCreate(
-                mappingSet.Key.Dialect,
-                authorizationContext.NamespacePrefixes,
-                out var namespacePrefixParameterization,
-                out var securityConfigurationMessage,
-                out var securityConfigurationDiagnostics
-            )
-        )
-        {
-            return GetByIdTerminal(
-                mappingSet,
-                resource,
-                new GetResult.GetFailureSecurityConfiguration(
-                    [securityConfigurationMessage],
-                    securityConfigurationDiagnostics
-                ),
-                plan.CustomViewStrategies,
-                plan.NamespaceChecks[0].RawConfiguredIndex
-            );
-        }
-
-        var storedNamespaceAuthorization = new RelationalWriteNamespaceAuthorization(
-            plan.NamespaceChecks,
-            namespacePrefixParameterization
-        );
 
         return AuthorizeGetByIdRelationshipPreflight(
             mappingSet,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -4950,7 +4950,8 @@ public sealed class RelationalDocumentStoreRepository(
                 documentId,
                 storedNamespaceAuthorization,
                 storedCustomViewAuthorization,
-                storedOwnershipAuthorization
+                storedOwnershipAuthorization,
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -5000,14 +5001,16 @@ public sealed class RelationalDocumentStoreRepository(
         long documentId,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalCustomViewAuthorization? storedCustomViewAuthorization,
-        RelationalOwnershipAuthorization? storedOwnershipAuthorization
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization,
+        CancellationToken cancellationToken
     )
     {
         var namespaceAndCustomViewOutcome = await AuthorizeGetNamespaceAndCustomViewFiltersAsync(
                 mappingSet,
                 documentId,
                 storedNamespaceAuthorization,
-                storedCustomViewAuthorization
+                storedCustomViewAuthorization,
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -5021,7 +5024,8 @@ public sealed class RelationalDocumentStoreRepository(
             : await ExecuteGetOwnershipAuthorizationAsync(
                     mappingSet,
                     documentId,
-                    storedOwnershipAuthorization
+                    storedOwnershipAuthorization,
+                    cancellationToken
                 )
                 .ConfigureAwait(false);
     }
@@ -5041,7 +5045,8 @@ public sealed class RelationalDocumentStoreRepository(
         MappingSet mappingSet,
         long documentId,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
-        RelationalCustomViewAuthorization? storedCustomViewAuthorization
+        RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        CancellationToken cancellationToken
     )
     {
         if (storedNamespaceAuthorization is null)
@@ -5052,7 +5057,8 @@ public sealed class RelationalDocumentStoreRepository(
                         mappingSet,
                         documentId,
                         storedCustomViewAuthorization.Checks,
-                        storedCustomViewAuthorization.Checks
+                        storedCustomViewAuthorization.Checks,
+                        cancellationToken
                     )
                     .ConfigureAwait(false);
         }
@@ -5070,7 +5076,8 @@ public sealed class RelationalDocumentStoreRepository(
                     mappingSet,
                     documentId,
                     customViewsBeforeNamespace,
-                    storedCustomViewAuthorization!.Checks
+                    storedCustomViewAuthorization!.Checks,
+                    cancellationToken
                 )
                 .ConfigureAwait(false);
 
@@ -5083,7 +5090,8 @@ public sealed class RelationalDocumentStoreRepository(
         var namespaceOutcome = await ExecuteGetNamespaceAuthorizationAsync(
                 mappingSet,
                 documentId,
-                storedNamespaceAuthorization
+                storedNamespaceAuthorization,
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -5098,7 +5106,8 @@ public sealed class RelationalDocumentStoreRepository(
                     mappingSet,
                     documentId,
                     customViewsAfterNamespace,
-                    storedCustomViewAuthorization!.Checks
+                    storedCustomViewAuthorization!.Checks,
+                    cancellationToken
                 )
                 .ConfigureAwait(false);
     }
@@ -5107,12 +5116,14 @@ public sealed class RelationalDocumentStoreRepository(
         MappingSet mappingSet,
         long documentId,
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
-        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> plannedChecks,
+        CancellationToken cancellationToken
     )
     {
         var executionResult = await _customViewAuthorizationExecutor
             .ExecuteAsync(
-                new CustomViewAuthorizationExecutionRequest(mappingSet, documentId, checks, plannedChecks)
+                new CustomViewAuthorizationExecutionRequest(mappingSet, documentId, checks, plannedChecks),
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -5239,7 +5250,7 @@ public sealed class RelationalDocumentStoreRepository(
         MappingSet mappingSet,
         long documentId,
         RelationalWriteNamespaceAuthorization storedNamespaceAuthorization,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     )
     {
         var executionResult = await _namespaceAuthorizationExecutor
@@ -5290,7 +5301,7 @@ public sealed class RelationalDocumentStoreRepository(
         MappingSet mappingSet,
         long documentId,
         RelationalOwnershipAuthorization storedOwnershipAuthorization,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     )
     {
         var executionResult = await _ownershipAuthorizationExecutor

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -680,7 +680,14 @@ public sealed class RelationalDocumentStoreRepository(
         DeleteAuthorizationPreflightResult.Stop stop
     )
     {
-        await ValidateSingleRecordCustomViewsAsync(mappingSet, stop.CustomViewChecksToValidate)
+        // CancellationToken.None, and not a defaulted parameter: IDocumentStoreRepository.DeleteDocumentById
+        // takes no token, so the delete path has none to forward. Saying so here keeps the remaining gap
+        // greppable instead of hiding it behind an optional parameter that silently binds to None.
+        await ValidateSingleRecordCustomViewsAsync(
+                mappingSet,
+                stop.CustomViewChecksToValidate,
+                CancellationToken.None
+            )
             .ConfigureAwait(false);
 
         return stop.Result;
@@ -3713,9 +3720,13 @@ public sealed class RelationalDocumentStoreRepository(
                 case WriteGuardRailPreflightResult<TResult>.Stop stopResult:
                     // Views configured ahead of this terminal execute first, so a missing or non-conforming
                     // one keeps its own failure instead of being masked by the terminal's result.
+                    //
+                    // CancellationToken.None for the same reason as the delete terminal: the write
+                    // repository contract carries no token, so this path has none to forward.
                     await ValidateSingleRecordCustomViewsAsync(
                             mappingSet,
-                            stopResult.CustomViewChecksToValidate
+                            stopResult.CustomViewChecksToValidate,
+                            CancellationToken.None
                         )
                         .ConfigureAwait(false);
                     return stopResult.Result;
@@ -3941,7 +3952,8 @@ public sealed class RelationalDocumentStoreRepository(
 
         if (authorizationPreflight is GetByIdAuthorizationPreflightResult.Stop preflightStop)
         {
-            return await CompleteGetByIdPreflightStopAsync(mappingSet, preflightStop).ConfigureAwait(false);
+            return await CompleteGetByIdPreflightStopAsync(mappingSet, preflightStop, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         for (var attemptIndex = 0; attemptIndex < GetByIdReadBoundaryAttemptCount; attemptIndex++)
@@ -4185,7 +4197,8 @@ public sealed class RelationalDocumentStoreRepository(
         if (authorizationPreflight is GetByIdAuthorizationPreflightResult.Stop preflightStop)
         {
             return new DocumentCacheReadAccelerationGetByIdSelectionResult.Complete(
-                await CompleteGetByIdPreflightStopAsync(mappingSet, preflightStop).ConfigureAwait(false)
+                await CompleteGetByIdPreflightStopAsync(mappingSet, preflightStop, cancellationToken)
+                    .ConfigureAwait(false)
             );
         }
 
@@ -4507,27 +4520,39 @@ public sealed class RelationalDocumentStoreRepository(
     /// </remarks>
     private async Task<GetResult> CompleteGetByIdPreflightStopAsync(
         MappingSet mappingSet,
-        GetByIdAuthorizationPreflightResult.Stop preflightStop
+        GetByIdAuthorizationPreflightResult.Stop preflightStop,
+        CancellationToken cancellationToken
     )
     {
-        await ValidateSingleRecordCustomViewsAsync(mappingSet, preflightStop.CustomViewChecksToValidate)
+        await ValidateSingleRecordCustomViewsAsync(
+                mappingSet,
+                preflightStop.CustomViewChecksToValidate,
+                cancellationToken
+            )
             .ConfigureAwait(false);
 
         return preflightStop.Result;
     }
 
     /// <summary>
-    /// Validates the views a GET-by-id terminal carries. Empty is a no-op, so every terminal can route
+    /// Validates the views a single-record terminal carries. Empty is a no-op, so every terminal can route
     /// through this unconditionally.
     /// </summary>
+    /// <remarks>
+    /// The token is required rather than optional: this issues DB work on a path that has already decided
+    /// to refuse the request, so an omitted token means an abandoned request keeps a connection busy
+    /// validating views for a response nobody will read. Requiring it makes each caller state what it has.
+    /// </remarks>
     private Task ValidateSingleRecordCustomViewsAsync(
         MappingSet mappingSet,
-        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks
+        IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks,
+        CancellationToken cancellationToken
     ) =>
         CustomViewAuthorizationValidator.ValidateSingleRecordAsync(
             _commandExecutor,
             mappingSet.Key.Dialect,
-            checks
+            checks,
+            cancellationToken
         );
 
     private GetByIdAuthorizationPreflightResult AuthorizeGetByIdPreflight(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -2834,6 +2834,30 @@ public sealed class RelationalDocumentStoreRepository(
                     failures => BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, failures)
                 );
 
+            // The ownership token list reaches the defensive limit. A planner terminal, so it is reported
+            // before the write session opens and after the namespace terminals; the planner has already
+            // resolved custom-view configuration failures by not returning this outcome in that case.
+            case RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded ownershipTokenCapExceeded:
+                return WriteTerminal<UpsertResult>(
+                    mappingSet,
+                    resource,
+                    new UpsertResult.UpsertFailureSecurityConfiguration(
+                        [
+                            OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(
+                                ownershipTokenCapExceeded.OwnershipTokenCount
+                            ),
+                        ],
+                        AuthorizationSecurityConfigurationDiagnostics.ForOwnershipTokenParameterization(
+                            AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded
+                        )
+                    ),
+                    ownershipTokenCapExceeded.CustomViewStrategies,
+                    // Every configured view runs before this terminal: OwnershipBased executes last among
+                    // the AND strategies whatever position it is configured at.
+                    int.MaxValue,
+                    failures => BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, failures)
+                );
+
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
                 return AuthorizePostRelationshipBucket(
                     mappingSet,
@@ -2899,43 +2923,59 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        if (plan.NamespaceChecks.Count == 0)
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null;
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null;
+
+        if (plan.NamespaceChecks.Count > 0)
         {
-            return AuthorizePostRelationshipBucket(
-                mappingSet,
-                resource,
-                writePlan,
-                plan.NonNamespaceConfiguredStrategies,
-                authorizationContext,
-                storedNamespaceAuthorization: null,
-                proposedNamespaceAuthorization: null,
-                customViewAuthorization: customViewAuthorization
+            if (
+                !NamespacePrefixParameterizationPreflight.TryCreate(
+                    mappingSet.Key.Dialect,
+                    authorizationContext.NamespacePrefixes,
+                    out var namespacePrefixParameterization,
+                    out var securityConfigurationMessage,
+                    out var securityConfigurationDiagnostics
+                )
+            )
+            {
+                return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                    new UpsertResult.UpsertFailureSecurityConfiguration(
+                        [securityConfigurationMessage],
+                        securityConfigurationDiagnostics
+                    ),
+                    CustomViewChecksBeforeNamespaceCheck(customViewAuthorization, plan.NamespaceChecks)
+                );
+            }
+
+            (storedNamespaceAuthorization, proposedNamespaceAuthorization) = SplitNamespaceAuthorization(
+                plan.NamespaceChecks,
+                namespacePrefixParameterization
             );
         }
 
+        // After the namespace parameterization, as on every other path: both are setup failures reported as
+        // the same security-configuration 500, and NamespaceBased executes ahead of OwnershipBased.
         if (
-            !NamespacePrefixParameterizationPreflight.TryCreate(
-                mappingSet.Key.Dialect,
-                authorizationContext.NamespacePrefixes,
-                out var namespacePrefixParameterization,
-                out var securityConfigurationMessage,
-                out var securityConfigurationDiagnostics
+            !TryPlanStoredOwnershipAuthorization(
+                mappingSet,
+                plan.OwnershipCheck,
+                authorizationContext,
+                out var storedOwnershipAuthorization,
+                out var ownershipSecurityConfigurationMessage,
+                out var ownershipSecurityConfigurationDiagnostics
             )
         )
         {
             return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
                 new UpsertResult.UpsertFailureSecurityConfiguration(
-                    [securityConfigurationMessage],
-                    securityConfigurationDiagnostics
+                    [ownershipSecurityConfigurationMessage],
+                    ownershipSecurityConfigurationDiagnostics
                 ),
-                CustomViewChecksBeforeNamespaceCheck(customViewAuthorization, plan.NamespaceChecks)
+                // Every configured view runs before this failure: OwnershipBased executes last among the
+                // AND strategies whatever position it is configured at.
+                AllCustomViewChecks(customViewAuthorization)
             );
         }
-
-        var (storedNamespaceAuthorization, proposedNamespaceAuthorization) = SplitNamespaceAuthorization(
-            plan.NamespaceChecks,
-            namespacePrefixParameterization
-        );
 
         return AuthorizePostRelationshipBucket(
             mappingSet,
@@ -2945,7 +2985,8 @@ public sealed class RelationalDocumentStoreRepository(
             authorizationContext,
             storedNamespaceAuthorization,
             proposedNamespaceAuthorization,
-            customViewAuthorization
+            customViewAuthorization,
+            storedOwnershipAuthorization
         );
     }
 
@@ -2986,6 +3027,7 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
         RelationalCustomViewAuthorization? customViewAuthorization = null,
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization = null,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? supportedCustomViewStrategies = null
     )
     {
@@ -3055,7 +3097,8 @@ public sealed class RelationalDocumentStoreRepository(
                     null,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
-                    customViewAuthorization: customViewAuthorization
+                    customViewAuthorization: customViewAuthorization,
+                    storedOwnershipAuthorization: storedOwnershipAuthorization
                 ),
 
             RelationshipAuthorizationResult.Authorized => CreatePostRelationshipAuthorizationContinue(
@@ -3067,7 +3110,8 @@ public sealed class RelationalDocumentStoreRepository(
                 existingResourcePlan,
                 storedNamespaceAuthorization,
                 proposedNamespaceAuthorization,
-                customViewAuthorization
+                customViewAuthorization,
+                storedOwnershipAuthorization
             ),
 
             // NamespaceBased and custom view-based both AND-compose before relationship OR strategies
@@ -3084,7 +3128,8 @@ public sealed class RelationalDocumentStoreRepository(
                     noClaims,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
-                    customViewAuthorization: customViewAuthorization
+                    customViewAuthorization: customViewAuthorization,
+                    storedOwnershipAuthorization: storedOwnershipAuthorization
                 ),
 
             RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled =>
@@ -3126,7 +3171,8 @@ public sealed class RelationalDocumentStoreRepository(
         RelationshipAuthorizationUpdatePlan existingResourcePlan,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
-        RelationalCustomViewAuthorization? customViewAuthorization = null
+        RelationalCustomViewAuthorization? customViewAuthorization = null,
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization = null
     )
     {
         var createNewProposedValues = _relationshipAuthorizationPlanner.PlanProposedValues(
@@ -3154,7 +3200,8 @@ public sealed class RelationalDocumentStoreRepository(
                     createNewProposedRelationshipAuthorization,
                     createNewImmediateResult
                 ),
-                customViewAuthorization
+                customViewAuthorization,
+                storedOwnershipAuthorization
             );
 
         return createNewProposedValues switch
@@ -3252,6 +3299,30 @@ public sealed class RelationalDocumentStoreRepository(
                     failures => BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, failures)
                 );
 
+            // The ownership token list reaches the defensive limit. A planner terminal, so it is reported
+            // before the write session opens and after the namespace terminals; the planner has already
+            // resolved custom-view configuration failures by not returning this outcome in that case.
+            case RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded ownershipTokenCapExceeded:
+                return WriteTerminal<UpdateResult>(
+                    mappingSet,
+                    resource,
+                    new UpdateResult.UpdateFailureSecurityConfiguration(
+                        [
+                            OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(
+                                ownershipTokenCapExceeded.OwnershipTokenCount
+                            ),
+                        ],
+                        AuthorizationSecurityConfigurationDiagnostics.ForOwnershipTokenParameterization(
+                            AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded
+                        )
+                    ),
+                    ownershipTokenCapExceeded.CustomViewStrategies,
+                    // Every configured view runs before this terminal: OwnershipBased executes last among
+                    // the AND strategies whatever position it is configured at.
+                    int.MaxValue,
+                    failures => BuildPutAuthorizationSecurityConfigurationFailure(mappingSet, failures)
+                );
+
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
                 return AuthorizePutRelationshipBucket(
                     mappingSet,
@@ -3315,43 +3386,59 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        if (plan.NamespaceChecks.Count == 0)
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null;
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null;
+
+        if (plan.NamespaceChecks.Count > 0)
         {
-            return AuthorizePutRelationshipBucket(
-                mappingSet,
-                resource,
-                writePlan,
-                plan.NonNamespaceConfiguredStrategies,
-                authorizationContext,
-                storedNamespaceAuthorization: null,
-                proposedNamespaceAuthorization: null,
-                customViewAuthorization: customViewAuthorization
+            if (
+                !NamespacePrefixParameterizationPreflight.TryCreate(
+                    mappingSet.Key.Dialect,
+                    authorizationContext.NamespacePrefixes,
+                    out var namespacePrefixParameterization,
+                    out var securityConfigurationMessage,
+                    out var securityConfigurationDiagnostics
+                )
+            )
+            {
+                return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
+                    new UpdateResult.UpdateFailureSecurityConfiguration(
+                        [securityConfigurationMessage],
+                        securityConfigurationDiagnostics
+                    ),
+                    CustomViewChecksBeforeNamespaceCheck(customViewAuthorization, plan.NamespaceChecks)
+                );
+            }
+
+            (storedNamespaceAuthorization, proposedNamespaceAuthorization) = SplitNamespaceAuthorization(
+                plan.NamespaceChecks,
+                namespacePrefixParameterization
             );
         }
 
+        // After the namespace parameterization, as on every other path: both are setup failures reported as
+        // the same security-configuration 500, and NamespaceBased executes ahead of OwnershipBased.
         if (
-            !NamespacePrefixParameterizationPreflight.TryCreate(
-                mappingSet.Key.Dialect,
-                authorizationContext.NamespacePrefixes,
-                out var namespacePrefixParameterization,
-                out var securityConfigurationMessage,
-                out var securityConfigurationDiagnostics
+            !TryPlanStoredOwnershipAuthorization(
+                mappingSet,
+                plan.OwnershipCheck,
+                authorizationContext,
+                out var storedOwnershipAuthorization,
+                out var ownershipSecurityConfigurationMessage,
+                out var ownershipSecurityConfigurationDiagnostics
             )
         )
         {
             return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
                 new UpdateResult.UpdateFailureSecurityConfiguration(
-                    [securityConfigurationMessage],
-                    securityConfigurationDiagnostics
+                    [ownershipSecurityConfigurationMessage],
+                    ownershipSecurityConfigurationDiagnostics
                 ),
-                CustomViewChecksBeforeNamespaceCheck(customViewAuthorization, plan.NamespaceChecks)
+                // Every configured view runs before this failure: OwnershipBased executes last among the
+                // AND strategies whatever position it is configured at.
+                AllCustomViewChecks(customViewAuthorization)
             );
         }
-
-        var (storedNamespaceAuthorization, proposedNamespaceAuthorization) = SplitNamespaceAuthorization(
-            plan.NamespaceChecks,
-            namespacePrefixParameterization
-        );
 
         return AuthorizePutRelationshipBucket(
             mappingSet,
@@ -3361,7 +3448,8 @@ public sealed class RelationalDocumentStoreRepository(
             authorizationContext,
             storedNamespaceAuthorization,
             proposedNamespaceAuthorization,
-            customViewAuthorization
+            customViewAuthorization,
+            storedOwnershipAuthorization
         );
     }
 
@@ -3374,6 +3462,7 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
         RelationalCustomViewAuthorization? customViewAuthorization = null,
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization = null,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? supportedCustomViewStrategies = null
     )
     {
@@ -3442,7 +3531,8 @@ public sealed class RelationalDocumentStoreRepository(
                     null,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
-                    customViewAuthorization: customViewAuthorization
+                    customViewAuthorization: customViewAuthorization,
+                    storedOwnershipAuthorization: storedOwnershipAuthorization
                 ),
 
             // NamespaceBased and custom view-based both AND-compose before the relationship OR group
@@ -3461,14 +3551,16 @@ public sealed class RelationalDocumentStoreRepository(
                     null,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
-                    customViewAuthorization: customViewAuthorization
+                    customViewAuthorization: customViewAuthorization,
+                    storedOwnershipAuthorization: storedOwnershipAuthorization
                 )
                 : new WriteGuardRailPreflightResult<UpdateResult>.Continue(
                     null,
                     noClaims,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
-                    customViewAuthorization: customViewAuthorization
+                    customViewAuthorization: customViewAuthorization,
+                    storedOwnershipAuthorization: storedOwnershipAuthorization
                 ),
 
             RelationshipAuthorizationResult.Authorized authorized =>
@@ -3478,7 +3570,8 @@ public sealed class RelationalDocumentStoreRepository(
                         as RelationshipAuthorizationResult.Authorized,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
-                    customViewAuthorization: customViewAuthorization
+                    customViewAuthorization: customViewAuthorization,
+                    storedOwnershipAuthorization: storedOwnershipAuthorization
                 ),
 
             _ => throw new InvalidOperationException(
@@ -3587,6 +3680,7 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null;
         PostRelationshipAuthorizationPlans? postRelationshipAuthorizationPlans = null;
         RelationalCustomViewAuthorization? customViewAuthorization = null;
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization = null;
 
         if (preflight is not null)
         {
@@ -3601,6 +3695,7 @@ public sealed class RelationalDocumentStoreRepository(
                     proposedNamespaceAuthorization = continueResult.ProposedNamespaceAuthorization;
                     postRelationshipAuthorizationPlans = continueResult.PostRelationshipAuthorizationPlans;
                     customViewAuthorization = continueResult.CustomViewAuthorization;
+                    storedOwnershipAuthorization = continueResult.StoredOwnershipAuthorization;
                     break;
 
                 case WriteGuardRailPreflightResult<TResult>.Stop stopResult:
@@ -3663,6 +3758,7 @@ public sealed class RelationalDocumentStoreRepository(
                         PostRelationshipAuthorizationPlans = postRelationshipAuthorizationPlans,
                         CustomViewAuthorization = customViewAuthorization,
                         CreatorOwnershipTokenId = creatorOwnershipTokenId,
+                        StoredOwnershipAuthorization = storedOwnershipAuthorization,
                     }
                 )
                 .ConfigureAwait(false);
@@ -3725,7 +3821,8 @@ public sealed class RelationalDocumentStoreRepository(
                 RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null,
                 RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null,
                 PostRelationshipAuthorizationPlans? postRelationshipAuthorizationPlans = null,
-                RelationalCustomViewAuthorization? customViewAuthorization = null
+                RelationalCustomViewAuthorization? customViewAuthorization = null,
+                RelationalOwnershipAuthorization? storedOwnershipAuthorization = null
             )
             {
                 ValidateStoredRelationshipAuthorization(storedRelationshipAuthorization);
@@ -3736,6 +3833,7 @@ public sealed class RelationalDocumentStoreRepository(
                 ProposedNamespaceAuthorization = proposedNamespaceAuthorization;
                 PostRelationshipAuthorizationPlans = postRelationshipAuthorizationPlans;
                 CustomViewAuthorization = customViewAuthorization;
+                StoredOwnershipAuthorization = storedOwnershipAuthorization;
             }
 
             public RelationshipAuthorizationResult? StoredRelationshipAuthorization { get; }
@@ -3745,6 +3843,14 @@ public sealed class RelationalDocumentStoreRepository(
             public RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization { get; }
 
             public RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization { get; }
+
+            /// <summary>
+            /// The ownership check planned for this write, or <see langword="null"/> when
+            /// <c>OwnershipBased</c> is not configured. Ownership has one value source — the stored token —
+            /// so unlike namespace and custom view there is no proposed counterpart: the check decides an
+            /// update and is vacuous for a create.
+            /// </summary>
+            public RelationalOwnershipAuthorization? StoredOwnershipAuthorization { get; }
 
             /// <summary>
             /// Every custom-view check planned for this write, across both value sources. Null when no custom

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -481,6 +481,7 @@ public sealed class RelationalDocumentStoreRepository(
                 writePrecondition,
                 proceed.StoredNamespaceAuthorization,
                 proceed.StoredCustomViewAuthorization,
+                proceed.StoredOwnershipAuthorization,
                 proceed.StoredRelationshipAuthorization
             ),
             _ => throw new InvalidOperationException(
@@ -496,6 +497,7 @@ public sealed class RelationalDocumentStoreRepository(
         WritePrecondition writePrecondition,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization,
         RelationshipAuthorizationResult storedRelationshipAuthorization
     )
     {
@@ -558,6 +560,7 @@ public sealed class RelationalDocumentStoreRepository(
                         )
                         {
                             CustomViewAuthorization = storedCustomViewAuthorization,
+                            StoredOwnershipAuthorization = storedOwnershipAuthorization,
                             WritePrecondition = writePrecondition,
                             DeferredRelationshipDenial = BuildDeferredDeleteRelationshipDenial(
                                 storedRelationshipAuthorization,
@@ -832,10 +835,34 @@ public sealed class RelationalDocumentStoreRepository(
                     noPrefixes.RawConfiguredIndex
                 );
 
+            // The ownership token list reaches the defensive limit. Reported before the write session opens,
+            // so the target is never locked, and after the namespace terminals — the planner has already
+            // resolved custom-view configuration failures by not returning this outcome in that case.
+            case RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded ownershipTokenCapExceeded:
+                return DeleteTerminal(
+                    mappingSet,
+                    resource,
+                    new DeleteResult.DeleteFailureSecurityConfiguration(
+                        [
+                            OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(
+                                ownershipTokenCapExceeded.OwnershipTokenCount
+                            ),
+                        ],
+                        AuthorizationSecurityConfigurationDiagnostics.ForOwnershipTokenParameterization(
+                            AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded
+                        )
+                    ),
+                    ownershipTokenCapExceeded.CustomViewStrategies,
+                    // Every configured view runs before this terminal: OwnershipBased executes last among
+                    // the AND strategies whatever position it is configured at.
+                    int.MaxValue
+                );
+
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
                 return AuthorizeDeleteRelationshipPreflight(
                     mappingSet,
                     resource,
+                    null,
                     null,
                     null,
                     securityConfigurationError.RelationshipClassification.SupportedCustomViewStrategies,
@@ -847,6 +874,7 @@ public sealed class RelationalDocumentStoreRepository(
                 return AuthorizeDeleteRelationshipPreflight(
                     mappingSet,
                     resource,
+                    null,
                     null,
                     null,
                     stillUnsupported.RelationshipClassification.SupportedCustomViewStrategies,
@@ -893,26 +921,49 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        if (plan.NamespaceChecks.Count == 0)
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null;
+
+        if (plan.NamespaceChecks.Count > 0)
         {
-            return AuthorizeDeleteRelationshipPreflight(
-                mappingSet,
-                resource,
-                null,
-                storedCustomViewAuthorization,
-                null,
-                plan.NonNamespaceConfiguredStrategies,
-                authorizationContext
+            if (
+                !NamespacePrefixParameterizationPreflight.TryCreate(
+                    mappingSet.Key.Dialect,
+                    authorizationContext.NamespacePrefixes,
+                    out var namespacePrefixParameterization,
+                    out var securityConfigurationMessage,
+                    out var securityConfigurationDiagnostics
+                )
+            )
+            {
+                return DeleteTerminal(
+                    mappingSet,
+                    resource,
+                    new DeleteResult.DeleteFailureSecurityConfiguration(
+                        [securityConfigurationMessage],
+                        securityConfigurationDiagnostics
+                    ),
+                    plan.CustomViewStrategies,
+                    plan.NamespaceChecks[0].RawConfiguredIndex
+                );
+            }
+
+            storedNamespaceAuthorization = new RelationalWriteNamespaceAuthorization(
+                plan.NamespaceChecks,
+                namespacePrefixParameterization
             );
         }
 
+        // After the namespace parameterization, as on the GET-by-id path: both are setup failures reported
+        // as the same security-configuration 500, and NamespaceBased executes ahead of OwnershipBased, so a
+        // request that would fail both must report the namespace one.
         if (
-            !NamespacePrefixParameterizationPreflight.TryCreate(
-                mappingSet.Key.Dialect,
-                authorizationContext.NamespacePrefixes,
-                out var namespacePrefixParameterization,
-                out var securityConfigurationMessage,
-                out var securityConfigurationDiagnostics
+            !TryPlanGetByIdOwnershipAuthorization(
+                mappingSet,
+                plan.OwnershipCheck,
+                authorizationContext,
+                out var storedOwnershipAuthorization,
+                out var ownershipSecurityConfigurationMessage,
+                out var ownershipSecurityConfigurationDiagnostics
             )
         )
         {
@@ -920,25 +971,21 @@ public sealed class RelationalDocumentStoreRepository(
                 mappingSet,
                 resource,
                 new DeleteResult.DeleteFailureSecurityConfiguration(
-                    [securityConfigurationMessage],
-                    securityConfigurationDiagnostics
+                    [ownershipSecurityConfigurationMessage],
+                    ownershipSecurityConfigurationDiagnostics
                 ),
                 plan.CustomViewStrategies,
-                plan.NamespaceChecks[0].RawConfiguredIndex
+                int.MaxValue
             );
         }
-
-        var storedNamespaceAuthorization = new RelationalWriteNamespaceAuthorization(
-            plan.NamespaceChecks,
-            namespacePrefixParameterization
-        );
 
         return AuthorizeDeleteRelationshipPreflight(
             mappingSet,
             resource,
             storedNamespaceAuthorization,
             storedCustomViewAuthorization,
-            null,
+            storedOwnershipAuthorization,
+            customViewStrategiesToValidate: null,
             plan.NonNamespaceConfiguredStrategies,
             authorizationContext
         );
@@ -1061,6 +1108,7 @@ public sealed class RelationalDocumentStoreRepository(
         QualifiedResourceName resource,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? customViewStrategiesToValidate,
         IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
         RelationalAuthorizationContext authorizationContext
@@ -1133,6 +1181,7 @@ public sealed class RelationalDocumentStoreRepository(
             _ => new DeleteAuthorizationPreflightResult.Proceed(
                 storedNamespaceAuthorization,
                 storedCustomViewAuthorization,
+                storedOwnershipAuthorization,
                 storedRelationshipAuthorization
             ),
         };
@@ -1152,9 +1201,11 @@ public sealed class RelationalDocumentStoreRepository(
                 : this(result, []) { }
         }
 
+        /// <inheritdoc cref="GetByIdAuthorizationPreflightResult.Proceed.StoredOwnershipAuthorization"/>
         public sealed record Proceed(
             RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
             RelationalCustomViewAuthorization? StoredCustomViewAuthorization,
+            RelationalOwnershipAuthorization? StoredOwnershipAuthorization,
             RelationshipAuthorizationResult StoredRelationshipAuthorization
         ) : DeleteAuthorizationPreflightResult;
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -228,7 +228,13 @@ public sealed class RelationalDocumentStoreRepository(
                     },
                 profileWriteContext,
                 writePlan =>
-                    AuthorizePostRelationshipIfRequired(upsertRequest, mappingSet, resource, writePlan)
+                    AuthorizePostRelationshipIfRequired(upsertRequest, mappingSet, resource, writePlan),
+                // Stamped onto dms.Document when this POST resolves to a create, and ignored when it
+                // resolves to an upsert-as-update. Supplied unconditionally: stamping never consults the
+                // resource's configured authorization strategies, which is what lets a claim set later
+                // enforce ownership over data written before it was configured. Null when the API client
+                // has no creator token, which stamps null.
+                creatorOwnershipTokenId: upsertRequest.AuthorizationContext.CreatorOwnershipTokenId
             )
             .ConfigureAwait(false);
 
@@ -406,7 +412,12 @@ public sealed class RelationalDocumentStoreRepository(
                     },
                 profileWriteContext,
                 writePlan =>
-                    AuthorizePutRelationshipIfRequired(updateRequest, mappingSet, resource, writePlan)
+                    AuthorizePutRelationshipIfRequired(updateRequest, mappingSet, resource, writePlan),
+                // Deliberately null, and stated rather than left to the default. A PUT never creates — the
+                // resolved executor request rejects a CreateNew target for any operation other than POST —
+                // so there is no row for a creator token to stamp. Passing the client's token here would
+                // read as though a PUT might stamp one.
+                creatorOwnershipTokenId: null
             )
             .ConfigureAwait(false);
 
@@ -3486,7 +3497,8 @@ public sealed class RelationalDocumentStoreRepository(
         Func<string, TResult> failureFactory,
         Func<RelationalWriteExecutorResult, TResult> executorResultProjector,
         BackendProfileWriteContext? profileWriteContext = null,
-        Func<ResourceWritePlan, WriteGuardRailPreflightResult<TResult>>? preflight = null
+        Func<ResourceWritePlan, WriteGuardRailPreflightResult<TResult>>? preflight = null,
+        short? creatorOwnershipTokenId = null
     )
     {
         ArgumentNullException.ThrowIfNull(requestBody);
@@ -3594,6 +3606,7 @@ public sealed class RelationalDocumentStoreRepository(
                     {
                         PostRelationshipAuthorizationPlans = postRelationshipAuthorizationPlans,
                         CustomViewAuthorization = customViewAuthorization,
+                        CreatorOwnershipTokenId = creatorOwnershipTokenId,
                     }
                 )
                 .ConfigureAwait(false);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -4324,10 +4324,6 @@ public sealed class RelationalDocumentStoreRepository(
     ) => [.. checks.Where(check => check.ConfiguredStrategy.RawConfiguredIndex < terminalRawConfiguredIndex)];
 
     /// <summary>
-    /// Validates the views a GET-by-id terminal carries. Empty is a no-op, so every terminal can route
-    /// through this unconditionally.
-    /// </summary>
-    /// <summary>
     /// Completes a GET-by-id preflight terminal: validates the custom views configured ahead of it, then
     /// yields the terminal's result.
     /// </summary>
@@ -4350,6 +4346,10 @@ public sealed class RelationalDocumentStoreRepository(
         return preflightStop.Result;
     }
 
+    /// <summary>
+    /// Validates the views a GET-by-id terminal carries. Empty is a no-op, so every terminal can route
+    /// through this unconditionally.
+    /// </summary>
     private Task ValidateSingleRecordCustomViewsAsync(
         MappingSet mappingSet,
         IReadOnlyList<SingleRecordCustomViewAuthorizationCheckSpec> checks

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -2801,13 +2801,17 @@ public sealed class RelationalDocumentStoreRepository(
 
         // A POST may resolve to create or upsert-as-update in-session, so plan both the stored and
         // proposed namespace checks here; the executor applies the stored check only when the write
-        // resolves to an existing target.
+        // resolves to an existing target. The ownership token cap is deferred for the same reason: a create
+        // never parameterizes the list, so the planner hands the plan back and AuthorizePostPlan carries the
+        // failure into the session, to be returned only once the target proves to exist. The cap terminal is
+        // therefore never returned to this switch and has no arm in it.
         var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
             mappingSet,
             mappingSet.GetConcreteResourceModelOrThrow(resource),
             NamespaceAuthorizationOperation.Update,
             configuredAuthorizationStrategies,
-            authorizationContext
+            authorizationContext,
+            OwnershipTokenCapHandling.DeferToTargetResolution
         );
 
         switch (orchestratorOutcome)
@@ -2838,30 +2842,6 @@ public sealed class RelationalDocumentStoreRepository(
                     ),
                     noPrefixes.CustomViewStrategies,
                     noPrefixes.RawConfiguredIndex,
-                    failures => BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, failures)
-                );
-
-            // The ownership token list reaches the defensive limit. A planner terminal, so it is reported
-            // before the write session opens and after the namespace terminals; the planner has already
-            // resolved custom-view configuration failures by not returning this outcome in that case.
-            case RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded ownershipTokenCapExceeded:
-                return WriteTerminal<UpsertResult>(
-                    mappingSet,
-                    resource,
-                    new UpsertResult.UpsertFailureSecurityConfiguration(
-                        [
-                            OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(
-                                ownershipTokenCapExceeded.OwnershipTokenCount
-                            ),
-                        ],
-                        AuthorizationSecurityConfigurationDiagnostics.ForOwnershipTokenParameterization(
-                            AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded
-                        )
-                    ),
-                    ownershipTokenCapExceeded.CustomViewStrategies,
-                    // Every configured view runs before this terminal: OwnershipBased executes last among
-                    // the AND strategies whatever position it is configured at.
-                    int.MaxValue,
                     failures => BuildPostAuthorizationSecurityConfigurationFailure(mappingSet, failures)
                 );
 
@@ -2961,7 +2941,13 @@ public sealed class RelationalDocumentStoreRepository(
         }
 
         // After the namespace parameterization, as on every other path: both are setup failures reported as
-        // the same security-configuration 500, and NamespaceBased executes ahead of OwnershipBased.
+        // the same security-configuration 500, and NamespaceBased executes ahead of OwnershipBased. Unlike
+        // every other path, an over-limit list does not stop a POST here. The check authorizes the stored
+        // token, so a create is never denied by it and never parameterizes the list; the failure is carried
+        // into the write session instead and returned in the ownership slot only if the target proves to
+        // exist — after the custom-view and namespace checks, before the relationship check and any DML.
+        RelationalWriteExecutorResult? deferredStoredOwnershipFailureResult = null;
+
         if (
             !TryPlanStoredOwnershipAuthorization(
                 mappingSet,
@@ -2973,14 +2959,11 @@ public sealed class RelationalDocumentStoreRepository(
             )
         )
         {
-            return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+            deferredStoredOwnershipFailureResult = new RelationalWriteExecutorResult.Upsert(
                 new UpsertResult.UpsertFailureSecurityConfiguration(
                     [ownershipSecurityConfigurationMessage],
                     ownershipSecurityConfigurationDiagnostics
-                ),
-                // Every configured view runs before this failure: OwnershipBased executes last among the
-                // AND strategies whatever position it is configured at.
-                AllCustomViewChecks(customViewAuthorization)
+                )
             );
         }
 
@@ -2993,7 +2976,8 @@ public sealed class RelationalDocumentStoreRepository(
             storedNamespaceAuthorization,
             proposedNamespaceAuthorization,
             customViewAuthorization,
-            storedOwnershipAuthorization
+            storedOwnershipAuthorization,
+            deferredStoredOwnershipFailureResult: deferredStoredOwnershipFailureResult
         );
     }
 
@@ -3035,7 +3019,8 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
         RelationalCustomViewAuthorization? customViewAuthorization = null,
         RelationalOwnershipAuthorization? storedOwnershipAuthorization = null,
-        IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? supportedCustomViewStrategies = null
+        IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? supportedCustomViewStrategies = null,
+        RelationalWriteExecutorResult? deferredStoredOwnershipFailureResult = null
     )
     {
         supportedCustomViewStrategies ??= [];
@@ -3105,7 +3090,8 @@ public sealed class RelationalDocumentStoreRepository(
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
                     customViewAuthorization: customViewAuthorization,
-                    storedOwnershipAuthorization: storedOwnershipAuthorization
+                    storedOwnershipAuthorization: storedOwnershipAuthorization,
+                    deferredStoredOwnershipFailureResult: deferredStoredOwnershipFailureResult
                 ),
 
             RelationshipAuthorizationResult.Authorized => CreatePostRelationshipAuthorizationContinue(
@@ -3118,7 +3104,8 @@ public sealed class RelationalDocumentStoreRepository(
                 storedNamespaceAuthorization,
                 proposedNamespaceAuthorization,
                 customViewAuthorization,
-                storedOwnershipAuthorization
+                storedOwnershipAuthorization,
+                deferredStoredOwnershipFailureResult
             ),
 
             // NamespaceBased, custom view-based and ownership all AND-compose before relationship OR
@@ -3126,12 +3113,14 @@ public sealed class RelationalDocumentStoreRepository(
             // NoClaims through Continue so those filters get to deny first; the write path's second command
             // emits the NoClaims failure only once they have authorized. Ownership has to be in this
             // predicate because a POST resolving to upsert-as-update is exactly where the stored-token check
-            // can deny, and stopping here would report the relationship denial in its place. With no AND
-            // filter planned at all, short-circuit at preflight to avoid a needless executor roundtrip.
+            // can deny, and stopping here would report the relationship denial in its place — and a deferred
+            // ownership failure is that same pending check, owed on the same branch. With no AND filter
+            // planned at all, short-circuit at preflight to avoid a needless executor roundtrip.
             RelationshipAuthorizationResult.NoClaims noClaims => proposedNamespaceAuthorization is null
             && storedNamespaceAuthorization is null
             && customViewAuthorization is null
             && storedOwnershipAuthorization is null
+            && deferredStoredOwnershipFailureResult is null
                 ? BuildNoClaimsPostRelationshipAuthorizationFailure(noClaims, authorizationContext)
                 : new WriteGuardRailPreflightResult<UpsertResult>.Continue(
                     null,
@@ -3139,7 +3128,8 @@ public sealed class RelationalDocumentStoreRepository(
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization,
                     customViewAuthorization: customViewAuthorization,
-                    storedOwnershipAuthorization: storedOwnershipAuthorization
+                    storedOwnershipAuthorization: storedOwnershipAuthorization,
+                    deferredStoredOwnershipFailureResult: deferredStoredOwnershipFailureResult
                 ),
 
             RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled =>
@@ -3182,7 +3172,8 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
         RelationalCustomViewAuthorization? customViewAuthorization = null,
-        RelationalOwnershipAuthorization? storedOwnershipAuthorization = null
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization = null,
+        RelationalWriteExecutorResult? deferredStoredOwnershipFailureResult = null
     )
     {
         var createNewProposedValues = _relationshipAuthorizationPlanner.PlanProposedValues(
@@ -3193,9 +3184,9 @@ public sealed class RelationalDocumentStoreRepository(
             writePlan
         );
 
-        // Every deferral out of this method owes the executor the same namespace and custom-view plans, and
-        // only the create-new relationship result varies. Building them here rather than at each arm keeps a
-        // new arm from silently dropping a planned check by omitting a trailing argument.
+        // Every deferral out of this method owes the executor the same namespace, custom-view and ownership
+        // plans, and only the create-new relationship result varies. Building them here rather than at each
+        // arm keeps a new arm from silently dropping a planned check by omitting a trailing argument.
         WriteGuardRailPreflightResult<UpsertResult> DeferToExecutor(
             RelationshipAuthorizationResult? createNewProposedRelationshipAuthorization,
             RelationalWriteExecutorResult? createNewImmediateResult = null
@@ -3211,7 +3202,8 @@ public sealed class RelationalDocumentStoreRepository(
                     createNewImmediateResult
                 ),
                 customViewAuthorization,
-                storedOwnershipAuthorization
+                storedOwnershipAuthorization,
+                deferredStoredOwnershipFailureResult
             );
 
         return createNewProposedValues switch
@@ -3225,11 +3217,13 @@ public sealed class RelationalDocumentStoreRepository(
 
             // A pending custom view or ownership check is an AND filter too, so each has to run before this
             // denial is reported. Ownership is vacuous for the create this plan describes, but preflight does
-            // not yet know the branch, and stopping here would also discard the stored-token check the
-            // existing-resource plan owes an upsert-as-update.
+            // not yet know the branch, and stopping here would also discard the stored-token check — or the
+            // deferred ownership failure standing in for it — that the existing-resource plan owes an
+            // upsert-as-update.
             RelationshipAuthorizationResult.NoClaims noClaims => proposedNamespaceAuthorization is null
             && customViewAuthorization is null
             && storedOwnershipAuthorization is null
+            && deferredStoredOwnershipFailureResult is null
                 ? BuildNoClaimsPostRelationshipAuthorizationFailure(noClaims, authorizationContext)
                 : DeferToExecutor(noClaims),
 
@@ -3700,6 +3694,7 @@ public sealed class RelationalDocumentStoreRepository(
         PostRelationshipAuthorizationPlans? postRelationshipAuthorizationPlans = null;
         RelationalCustomViewAuthorization? customViewAuthorization = null;
         RelationalOwnershipAuthorization? storedOwnershipAuthorization = null;
+        RelationalWriteExecutorResult? deferredStoredOwnershipFailureResult = null;
 
         if (preflight is not null)
         {
@@ -3715,6 +3710,8 @@ public sealed class RelationalDocumentStoreRepository(
                     postRelationshipAuthorizationPlans = continueResult.PostRelationshipAuthorizationPlans;
                     customViewAuthorization = continueResult.CustomViewAuthorization;
                     storedOwnershipAuthorization = continueResult.StoredOwnershipAuthorization;
+                    deferredStoredOwnershipFailureResult =
+                        continueResult.DeferredStoredOwnershipFailureResult;
                     break;
 
                 case WriteGuardRailPreflightResult<TResult>.Stop stopResult:
@@ -3782,6 +3779,7 @@ public sealed class RelationalDocumentStoreRepository(
                         CustomViewAuthorization = customViewAuthorization,
                         CreatorOwnershipTokenId = creatorOwnershipTokenId,
                         StoredOwnershipAuthorization = storedOwnershipAuthorization,
+                        DeferredStoredOwnershipFailureResult = deferredStoredOwnershipFailureResult,
                     }
                 )
                 .ConfigureAwait(false);
@@ -3845,7 +3843,8 @@ public sealed class RelationalDocumentStoreRepository(
                 RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null,
                 PostRelationshipAuthorizationPlans? postRelationshipAuthorizationPlans = null,
                 RelationalCustomViewAuthorization? customViewAuthorization = null,
-                RelationalOwnershipAuthorization? storedOwnershipAuthorization = null
+                RelationalOwnershipAuthorization? storedOwnershipAuthorization = null,
+                RelationalWriteExecutorResult? deferredStoredOwnershipFailureResult = null
             )
             {
                 ValidateStoredRelationshipAuthorization(storedRelationshipAuthorization);
@@ -3857,6 +3856,7 @@ public sealed class RelationalDocumentStoreRepository(
                 PostRelationshipAuthorizationPlans = postRelationshipAuthorizationPlans;
                 CustomViewAuthorization = customViewAuthorization;
                 StoredOwnershipAuthorization = storedOwnershipAuthorization;
+                DeferredStoredOwnershipFailureResult = deferredStoredOwnershipFailureResult;
             }
 
             public RelationshipAuthorizationResult? StoredRelationshipAuthorization { get; }
@@ -3874,6 +3874,13 @@ public sealed class RelationalDocumentStoreRepository(
             /// update and is vacuous for a create.
             /// </summary>
             public RelationalOwnershipAuthorization? StoredOwnershipAuthorization { get; }
+
+            /// <summary>
+            /// The failure a POST owes if it resolves to an existing target while its ownership check could
+            /// not be parameterized, or <see langword="null"/>; see
+            /// <see cref="RelationalWriteExecutorRequest.DeferredStoredOwnershipFailureResult"/>.
+            /// </summary>
+            public RelationalWriteExecutorResult? DeferredStoredOwnershipFailureResult { get; }
 
             /// <summary>
             /// Every custom-view check planned for this write, across both value sources. Null when no custom
@@ -4762,15 +4769,16 @@ public sealed class RelationalDocumentStoreRepository(
 
     /// <summary>
     /// Builds the ownership-token parameterization for the planned ownership check, or reports the
-    /// security-configuration failure that stops the request. Shared by the GET-by-id and DELETE
-    /// preflights, so the two cannot drift on when an over-limit token list fails closed.
+    /// security-configuration failure the caller owes. Shared by every single-record preflight, so they
+    /// cannot drift on when an over-limit token list fails closed.
     /// </summary>
     /// <remarks>
-    /// Defence in depth rather than the primary gate. The planner already returns its own token-cap
-    /// terminal, which is what gives the failure correct precedence among the other authorization terminals,
-    /// so a request reaching here with a planned check is known to be under the limit. This exists so a
+    /// Defence in depth on GET-by-id, PUT and DELETE: the planner already returns its own token-cap terminal,
+    /// which is what gives the failure correct precedence among the other authorization terminals, so a
+    /// request reaching here with a planned check is known to be under the limit, and this exists so a
     /// planner change that dropped the terminal still fails closed rather than emitting an over-limit
-    /// parameter list at the SQL boundary.
+    /// parameter list at the SQL boundary. The gate on POST, which defers the planner's cap to target
+    /// resolution and carries the failure reported here into the write session.
     /// </remarks>
     private static bool TryPlanStoredOwnershipAuthorization(
         MappingSet mappingSet,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -37,6 +37,7 @@ public sealed class RelationalDocumentStoreRepository(
     ISingleRecordRelationshipAuthorizationExecutor singleRecordRelationshipAuthorizationExecutor,
     INamespaceAuthorizationExecutor namespaceAuthorizationExecutor,
     ICustomViewAuthorizationExecutor customViewAuthorizationExecutor,
+    IOwnershipAuthorizationExecutor ownershipAuthorizationExecutor,
     IRelationalCommandExecutor commandExecutor,
     IDocumentCacheReadAccelerationCoordinator readAccelerationCoordinator,
     IRelationalParameterConfigurator? relationalParameterConfigurator = null,
@@ -85,6 +86,9 @@ public sealed class RelationalDocumentStoreRepository(
     private readonly ICustomViewAuthorizationExecutor _customViewAuthorizationExecutor =
         customViewAuthorizationExecutor
         ?? throw new ArgumentNullException(nameof(customViewAuthorizationExecutor));
+    private readonly IOwnershipAuthorizationExecutor _ownershipAuthorizationExecutor =
+        ownershipAuthorizationExecutor
+        ?? throw new ArgumentNullException(nameof(ownershipAuthorizationExecutor));
 
     // The read executor. Custom view-based GET-many validation runs on it rather than on a write session:
     // each call takes a separate read connection and round trip, but a read never opens a write
@@ -3810,6 +3814,7 @@ public sealed class RelationalDocumentStoreRepository(
                             mappingSet,
                             proceed.StoredNamespaceAuthorization,
                             proceed.StoredCustomViewAuthorization,
+                            proceed.StoredOwnershipAuthorization,
                             proceed.StoredRelationshipAuthorization,
                             existingDocument.DocumentId,
                             existingDocument.ContentVersion,
@@ -4073,6 +4078,7 @@ public sealed class RelationalDocumentStoreRepository(
                             mappingSet,
                             proceed.StoredNamespaceAuthorization,
                             proceed.StoredCustomViewAuthorization,
+                            proceed.StoredOwnershipAuthorization,
                             proceed.StoredRelationshipAuthorization,
                             existingDocument.DocumentId,
                             existingDocument.ContentVersion,
@@ -4384,10 +4390,35 @@ public sealed class RelationalDocumentStoreRepository(
                     noPrefixes.RawConfiguredIndex
                 );
 
+            // The ownership token list reaches the defensive limit. A planner terminal, so it is reported
+            // before any statement is emitted and before every relationship terminal, but after the
+            // namespace terminals and after any custom-view configuration failure — which the planner has
+            // already resolved by not returning this outcome in that case.
+            case RelationalAuthorizationPlanOutcome.OwnershipTokenCapExceeded ownershipTokenCapExceeded:
+                return GetByIdTerminal(
+                    mappingSet,
+                    resource,
+                    new GetResult.GetFailureSecurityConfiguration(
+                        [
+                            OwnershipAuthorizationSecurityConfigurationMessages.TokenCapExceeded(
+                                ownershipTokenCapExceeded.OwnershipTokenCount
+                            ),
+                        ],
+                        AuthorizationSecurityConfigurationDiagnostics.ForOwnershipTokenParameterization(
+                            AuthorizationSecurityConfigurationDiagnostics.OwnershipTokenCapExceeded
+                        )
+                    ),
+                    ownershipTokenCapExceeded.CustomViewStrategies,
+                    // Views configured anywhere run before this terminal: OwnershipBased executes last
+                    // among the AND strategies whatever position it is configured at.
+                    int.MaxValue
+                );
+
             case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
                 return AuthorizeGetByIdRelationshipPreflight(
                     mappingSet,
                     resource,
+                    null,
                     null,
                     null,
                     securityConfigurationError.NonNamespaceConfiguredStrategies,
@@ -4399,6 +4430,7 @@ public sealed class RelationalDocumentStoreRepository(
                 return AuthorizeGetByIdRelationshipPreflight(
                     mappingSet,
                     resource,
+                    null,
                     null,
                     null,
                     stillUnsupported.NonNamespaceConfiguredStrategies,
@@ -4440,6 +4472,31 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
+        if (
+            !TryPlanGetByIdOwnershipAuthorization(
+                mappingSet,
+                plan.OwnershipCheck,
+                authorizationContext,
+                out var storedOwnershipAuthorization,
+                out var ownershipSecurityConfigurationMessage,
+                out var ownershipSecurityConfigurationDiagnostics
+            )
+        )
+        {
+            return GetByIdTerminal(
+                mappingSet,
+                resource,
+                new GetResult.GetFailureSecurityConfiguration(
+                    [ownershipSecurityConfigurationMessage],
+                    ownershipSecurityConfigurationDiagnostics
+                ),
+                plan.CustomViewStrategies,
+                // Every configured view runs before this failure: OwnershipBased executes last among the
+                // AND strategies whatever position it is configured at.
+                int.MaxValue
+            );
+        }
+
         if (plan.NamespaceChecks.Count == 0)
         {
             return AuthorizeGetByIdRelationshipPreflight(
@@ -4447,6 +4504,7 @@ public sealed class RelationalDocumentStoreRepository(
                 resource,
                 null,
                 storedCustomViewAuthorization,
+                storedOwnershipAuthorization,
                 plan.NonNamespaceConfiguredStrategies,
                 authorizationContext
             );
@@ -4484,9 +4542,59 @@ public sealed class RelationalDocumentStoreRepository(
             resource,
             storedNamespaceAuthorization,
             storedCustomViewAuthorization,
+            storedOwnershipAuthorization,
             plan.NonNamespaceConfiguredStrategies,
             authorizationContext
         );
+    }
+
+    /// <summary>
+    /// Builds the ownership-token parameterization for the planned ownership check, or reports the
+    /// security-configuration failure that stops the read.
+    /// </summary>
+    /// <remarks>
+    /// Defence in depth rather than the primary gate. The planner already returns its own token-cap
+    /// terminal, which is what gives the failure correct precedence among the other authorization terminals,
+    /// so a request reaching here with a planned check is known to be under the limit. This exists so a
+    /// planner change that dropped the terminal still fails closed rather than emitting an over-limit
+    /// parameter list at the SQL boundary.
+    /// </remarks>
+    private static bool TryPlanGetByIdOwnershipAuthorization(
+        MappingSet mappingSet,
+        OwnershipAuthorizationCheckSpec? ownershipCheck,
+        RelationalAuthorizationContext authorizationContext,
+        out RelationalOwnershipAuthorization? storedOwnershipAuthorization,
+        out string securityConfigurationMessage,
+        out SecurityConfigurationFailureDiagnostic[] securityConfigurationDiagnostics
+    )
+    {
+        storedOwnershipAuthorization = null;
+        securityConfigurationMessage = string.Empty;
+        securityConfigurationDiagnostics = [];
+
+        if (ownershipCheck is null)
+        {
+            return true;
+        }
+
+        if (
+            !OwnershipTokenParameterizationPreflight.TryCreate(
+                mappingSet.Key.Dialect,
+                authorizationContext.OwnershipTokenIds,
+                out var ownershipTokenParameterization,
+                out securityConfigurationMessage,
+                out securityConfigurationDiagnostics
+            )
+        )
+        {
+            return false;
+        }
+
+        storedOwnershipAuthorization = new RelationalOwnershipAuthorization(
+            ownershipCheck,
+            ownershipTokenParameterization
+        );
+        return true;
     }
 
     /// <summary>
@@ -4553,6 +4661,7 @@ public sealed class RelationalDocumentStoreRepository(
         QualifiedResourceName resource,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization,
         IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
         RelationalAuthorizationContext authorizationContext,
         IReadOnlyList<SupportedCustomViewAuthorizationStrategy>? customViewStrategiesToValidate = null
@@ -4629,6 +4738,7 @@ public sealed class RelationalDocumentStoreRepository(
             _ => new GetByIdAuthorizationPreflightResult.Proceed(
                 storedNamespaceAuthorization,
                 storedCustomViewAuthorization,
+                storedOwnershipAuthorization,
                 storedRelationshipAuthorization
             ),
         };
@@ -4639,6 +4749,7 @@ public sealed class RelationalDocumentStoreRepository(
         MappingSet mappingSet,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
         RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization,
         RelationshipAuthorizationResult storedRelationshipAuthorization,
         long documentId,
         long storedContentVersion,
@@ -4650,7 +4761,8 @@ public sealed class RelationalDocumentStoreRepository(
                 mappingSet,
                 documentId,
                 storedNamespaceAuthorization,
-                storedCustomViewAuthorization
+                storedCustomViewAuthorization,
+                storedOwnershipAuthorization
             )
             .ConfigureAwait(false);
 
@@ -4668,7 +4780,11 @@ public sealed class RelationalDocumentStoreRepository(
             )
             .ConfigureAwait(false);
 
-        if (storedNamespaceAuthorization is null && storedCustomViewAuthorization is null)
+        if (
+            storedNamespaceAuthorization is null
+            && storedCustomViewAuthorization is null
+            && storedOwnershipAuthorization is null
+        )
         {
             return relationshipOutcome;
         }
@@ -4682,8 +4798,49 @@ public sealed class RelationalDocumentStoreRepository(
     }
 
     /// <summary>
-    /// Runs the AND-combined stored checks in CMS-configured order, returning the first failing outcome or
-    /// <see langword="null"/> when all of them authorize.
+    /// Runs the AND-combined stored checks, returning the first failing outcome or <see langword="null"/>
+    /// when all of them authorize.
+    /// </summary>
+    /// <remarks>
+    /// Ownership runs after the namespace and custom-view stage and is deliberately not interleaved with it.
+    /// auth.md places <c>OwnershipBased</c> last among the AND strategies whatever position it is configured
+    /// at, so its configured index attributes a denial to it but does not order its execution. This is the
+    /// one place where configured order and execution order diverge on purpose.
+    /// </remarks>
+    private async Task<GetAuthorizationOutcome?> AuthorizeGetAndFiltersAsync(
+        MappingSet mappingSet,
+        long documentId,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalCustomViewAuthorization? storedCustomViewAuthorization,
+        RelationalOwnershipAuthorization? storedOwnershipAuthorization
+    )
+    {
+        var namespaceAndCustomViewOutcome = await AuthorizeGetNamespaceAndCustomViewFiltersAsync(
+                mappingSet,
+                documentId,
+                storedNamespaceAuthorization,
+                storedCustomViewAuthorization
+            )
+            .ConfigureAwait(false);
+
+        if (namespaceAndCustomViewOutcome is not null)
+        {
+            return namespaceAndCustomViewOutcome;
+        }
+
+        return storedOwnershipAuthorization is null
+            ? null
+            : await ExecuteGetOwnershipAuthorizationAsync(
+                    mappingSet,
+                    documentId,
+                    storedOwnershipAuthorization
+                )
+                .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the namespace and custom view-based stored checks in CMS-configured order, returning the first
+    /// failing outcome or <see langword="null"/> when all of them authorize.
     /// </summary>
     /// <remarks>
     /// Custom views and <c>NamespaceBased</c> interleave by configured index, and the first failure is the one
@@ -4692,7 +4849,7 @@ public sealed class RelationalDocumentStoreRepository(
     /// command per contiguous run — two only when custom views straddle the namespace index, which is why the
     /// list is partitioned rather than executed check by check.
     /// </remarks>
-    private async Task<GetAuthorizationOutcome?> AuthorizeGetAndFiltersAsync(
+    private async Task<GetAuthorizationOutcome?> AuthorizeGetNamespaceAndCustomViewFiltersAsync(
         MappingSet mappingSet,
         long documentId,
         RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
@@ -4941,6 +5098,56 @@ public sealed class RelationalDocumentStoreRepository(
         };
     }
 
+    private async Task<GetAuthorizationOutcome?> ExecuteGetOwnershipAuthorizationAsync(
+        MappingSet mappingSet,
+        long documentId,
+        RelationalOwnershipAuthorization storedOwnershipAuthorization,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var executionResult = await _ownershipAuthorizationExecutor
+            .ExecuteAsync(
+                new OwnershipAuthorizationExecutionRequest(
+                    mappingSet,
+                    documentId,
+                    storedOwnershipAuthorization.Check,
+                    storedOwnershipAuthorization.OwnershipTokenParameterization
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            OwnershipAuthorizationExecutionResult.Authorized => null,
+            OwnershipAuthorizationExecutionResult.NotAuthorized notAuthorized => new GetAuthorizationOutcome(
+                new GetResult.GetFailureOwnershipNotAuthorized(notAuthorized.Failure),
+                null,
+                false
+            ),
+            OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                new GetAuthorizationOutcome(
+                    new GetResult.GetFailureSecurityConfiguration(
+                        [invalidFailure.FailureMessage],
+                        invalidFailure.Diagnostics
+                    ),
+                    null,
+                    false
+                ),
+            // The stored target row was deleted between the unlocked target lookup and this check.
+            // Request a retry so the read boundary re-resolves the target; a target that is still gone on
+            // the next attempt surfaces as a 404 rather than an ownership denial.
+            OwnershipAuthorizationExecutionResult.StaleTarget => new GetAuthorizationOutcome(
+                null,
+                null,
+                RetryTargetResolution: true
+            ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported ownership authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
+    }
+
     private async Task<GetAuthorizationOutcome> ExecuteGetRelationshipAuthorizationAsync(
         MappingSet mappingSet,
         long documentId,
@@ -5068,9 +5275,17 @@ public sealed class RelationalDocumentStoreRepository(
 
         // Document-dependent authorization remains and runs per attempt against the resolved target.
         // StoredNamespaceAuthorization is null when only relationship strategies must be evaluated.
+        /// <param name="StoredOwnershipAuthorization">
+        /// The planned ownership check, or null when the request configured none. Carried only here and
+        /// never on a Stop: unlike a custom view, an ownership check has nothing to validate structurally
+        /// ahead of a terminal — its table and column are fixed and its token parameterization was already
+        /// validated during preflight — so a document-independent terminal simply preempts it, exactly as it
+        /// preempts the namespace check.
+        /// </param>
         public sealed record Proceed(
             RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
             RelationalCustomViewAuthorization? StoredCustomViewAuthorization,
+            RelationalOwnershipAuthorization? StoredOwnershipAuthorization,
             RelationshipAuthorizationResult StoredRelationshipAuthorization
         ) : GetByIdAuthorizationPreflightResult;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -3114,14 +3114,17 @@ public sealed class RelationalDocumentStoreRepository(
                 storedOwnershipAuthorization
             ),
 
-            // NamespaceBased and custom view-based both AND-compose before relationship OR strategies
-            // (auth.md). When any of them is planned, defer NoClaims through Continue so those filters get to
-            // deny first; the write path's second command emits the NoClaims failure only once they have
-            // authorized. With no AND filter planned at all, short-circuit at preflight to avoid a needless
-            // executor roundtrip.
+            // NamespaceBased, custom view-based and ownership all AND-compose before relationship OR
+            // strategies (auth.md), with ownership last among them. When any of them is planned, defer
+            // NoClaims through Continue so those filters get to deny first; the write path's second command
+            // emits the NoClaims failure only once they have authorized. Ownership has to be in this
+            // predicate because a POST resolving to upsert-as-update is exactly where the stored-token check
+            // can deny, and stopping here would report the relationship denial in its place. With no AND
+            // filter planned at all, short-circuit at preflight to avoid a needless executor roundtrip.
             RelationshipAuthorizationResult.NoClaims noClaims => proposedNamespaceAuthorization is null
             && storedNamespaceAuthorization is null
             && customViewAuthorization is null
+            && storedOwnershipAuthorization is null
                 ? BuildNoClaimsPostRelationshipAuthorizationFailure(noClaims, authorizationContext)
                 : new WriteGuardRailPreflightResult<UpsertResult>.Continue(
                     null,
@@ -3213,9 +3216,13 @@ public sealed class RelationalDocumentStoreRepository(
                 createNewAuthorized
             ),
 
-            // A pending custom view is an AND filter too, so it has to run before this denial is reported.
+            // A pending custom view or ownership check is an AND filter too, so each has to run before this
+            // denial is reported. Ownership is vacuous for the create this plan describes, but preflight does
+            // not yet know the branch, and stopping here would also discard the stored-token check the
+            // existing-resource plan owes an upsert-as-update.
             RelationshipAuthorizationResult.NoClaims noClaims => proposedNamespaceAuthorization is null
             && customViewAuthorization is null
+            && storedOwnershipAuthorization is null
                 ? BuildNoClaimsPostRelationshipAuthorizationFailure(noClaims, authorizationContext)
                 : DeferToExecutor(noClaims),
 
@@ -3540,9 +3547,14 @@ public sealed class RelationalDocumentStoreRepository(
             // NoClaims denial into the proposed-relationship slot so those filters get to deny first; the
             // write path's second command emits the NoClaims denial only after they authorize. Leaving it in
             // the stored slot with custom views pending ends the write at the first phase, before the proposed
-            // custom-view checks run at all. With no AND filter planned, keep NoClaims in the stored slot so
-            // the stored boundary emits it after the target lock, preserving the existing 404-over-403
-            // ordering for a missing PUT target.
+            // custom-view checks run at all. With neither planned, keep NoClaims in the stored slot so the
+            // stored boundary emits it after the target lock, preserving the existing 404-over-403 ordering
+            // for a missing PUT target.
+            //
+            // Ownership is an AND filter too, but it deliberately stays out of this predicate: a stored-slot
+            // NoClaims routes the write down the ordered-segments path, where the ownership segment already
+            // runs ahead of the stored relationship boundary. The ownership denial wins there without a
+            // deferral, and without the merge the proposed slot would run before reporting it.
             RelationshipAuthorizationResult.NoClaims noClaims => storedNamespaceAuthorization is null
             && proposedNamespaceAuthorization is null
             && customViewAuthorization is null

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -459,11 +459,12 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        // Planner terminals (namespace setup failures, relationship security-configuration failures,
-        // and known unsupported relationship composition) resolve before the write session opens, so
-        // those denials issue no DB roundtrip and never lock the target. Target-dependent namespace
-        // and relationship checks still run inside the delete session against the locked target (see
-        // AuthorizeDeleteIfRequiredAsync).
+        // Planner terminals (namespace setup failures, the ownership token cap, relationship
+        // security-configuration failures, and known unsupported relationship composition) resolve before
+        // the write session opens, so those denials issue no DB roundtrip and never lock the target. The
+        // target-dependent custom-view, namespace, ownership and relationship checks run inside the delete
+        // session against the locked target, co-batched with the deletes or as ordered segments ahead of
+        // them (see CompositeRelationalDeleteCommand).
         var authorizationPreflight = AuthorizeDeletePreflight(deleteRequest, mappingSet, resource);
 
         return authorizationPreflight switch
@@ -957,7 +958,7 @@ public sealed class RelationalDocumentStoreRepository(
         // as the same security-configuration 500, and NamespaceBased executes ahead of OwnershipBased, so a
         // request that would fail both must report the namespace one.
         if (
-            !TryPlanGetByIdOwnershipAuthorization(
+            !TryPlanStoredOwnershipAuthorization(
                 mappingSet,
                 plan.OwnershipCheck,
                 authorizationContext,
@@ -3813,11 +3814,11 @@ public sealed class RelationalDocumentStoreRepository(
         CancellationToken cancellationToken = default
     )
     {
-        // Planner terminals (namespace setup failures, relationship security-configuration failures,
-        // and known unsupported relationship composition) resolve before the target lookup, so those
-        // denials issue no read roundtrip and never depend on document existence. Target-dependent
-        // namespace and relationship checks still run per attempt against the resolved target (see
-        // AuthorizeGetByIdAgainstTargetAsync).
+        // Planner terminals (namespace setup failures, the ownership token cap, relationship
+        // security-configuration failures, and known unsupported relationship composition) resolve before
+        // the target lookup, so those denials issue no read roundtrip and never depend on document
+        // existence. The target-dependent custom-view, namespace, ownership and relationship checks still
+        // run per attempt against the resolved target (see AuthorizeGetByIdAgainstTargetAsync).
         var authorizationPreflight = AuthorizeGetByIdPreflight(relationalGetRequest, mappingSet, resource);
 
         if (authorizationPreflight is GetByIdAuthorizationPreflightResult.Stop preflightStop)
@@ -4581,7 +4582,7 @@ public sealed class RelationalDocumentStoreRepository(
         // same security-configuration 500, so whichever is attempted first is the one reported when a request
         // would fail both. NamespaceBased executes ahead of OwnershipBased, so its failure must win.
         if (
-            !TryPlanGetByIdOwnershipAuthorization(
+            !TryPlanStoredOwnershipAuthorization(
                 mappingSet,
                 plan.OwnershipCheck,
                 authorizationContext,
@@ -4618,7 +4619,8 @@ public sealed class RelationalDocumentStoreRepository(
 
     /// <summary>
     /// Builds the ownership-token parameterization for the planned ownership check, or reports the
-    /// security-configuration failure that stops the read.
+    /// security-configuration failure that stops the request. Shared by the GET-by-id and DELETE
+    /// preflights, so the two cannot drift on when an over-limit token list fails closed.
     /// </summary>
     /// <remarks>
     /// Defence in depth rather than the primary gate. The planner already returns its own token-cap
@@ -4627,7 +4629,7 @@ public sealed class RelationalDocumentStoreRepository(
     /// planner change that dropped the terminal still fails closed rather than emitting an over-limit
     /// parameter list at the SQL boundary.
     /// </remarks>
-    private static bool TryPlanGetByIdOwnershipAuthorization(
+    private static bool TryPlanStoredOwnershipAuthorization(
         MappingSet mappingSet,
         OwnershipAuthorizationCheckSpec? ownershipCheck,
         RelationalAuthorizationContext authorizationContext,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -855,6 +855,16 @@ public sealed record RelationalWriteExecutorRequest
     /// which is why one plan can serve a POST whose branch is not yet known.
     /// </summary>
     public RelationalOwnershipAuthorization? StoredOwnershipAuthorization { get; init; }
+
+    /// <summary>
+    /// The result a POST owes if it resolves to an existing target while its stored ownership check could not
+    /// be parameterized — today only the token cap — or <see langword="null"/>. Returned in the ownership
+    /// slot, after the custom-view and namespace checks and before the relationship check, so no DML is
+    /// issued. A create never sees it: ownership never denies a create, and the over-limit list is never
+    /// parameterized for one. Set only by the POST preflight, and only with
+    /// <see cref="StoredOwnershipAuthorization"/> null.
+    /// </summary>
+    public RelationalWriteExecutorResult? DeferredStoredOwnershipFailureResult { get; init; }
 }
 
 /// <summary>
@@ -976,6 +986,9 @@ public sealed record RelationalWriteExecutorInput
     /// <inheritdoc cref="RelationalWriteExecutorRequest.StoredOwnershipAuthorization"/>
     public RelationalOwnershipAuthorization? StoredOwnershipAuthorization { get; init; }
 
+    /// <inheritdoc cref="RelationalWriteExecutorRequest.DeferredStoredOwnershipFailureResult"/>
+    public RelationalWriteExecutorResult? DeferredStoredOwnershipFailureResult { get; init; }
+
     /// <summary>
     /// Produces the fully resolved executor request for a target the executor observed inside its
     /// write session. All cross-field validation runs in the resolved request's constructor.
@@ -1005,6 +1018,7 @@ public sealed record RelationalWriteExecutorInput
             CustomViewAuthorization = CustomViewAuthorization,
             CreatorOwnershipTokenId = CreatorOwnershipTokenId,
             StoredOwnershipAuthorization = StoredOwnershipAuthorization,
+            DeferredStoredOwnershipFailureResult = DeferredStoredOwnershipFailureResult,
         };
 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -1014,6 +1014,25 @@ public sealed record RelationalWriteNamespaceAuthorization(
 );
 
 /// <summary>
+/// Ownership authorization inputs threaded from a repository preflight into execution.
+/// </summary>
+/// <param name="Check">
+/// The single planned ownership check. A value rather than a list: ownership reads one column against one
+/// token list, so it evaluates once per operation however many times <c>OwnershipBased</c> is configured.
+/// </param>
+/// <param name="OwnershipTokenParameterization">The dialect-specific ownership-token parameterization.</param>
+/// <remarks>
+/// The check's <c>RawConfiguredIndex</c> is the configured position the AUTH1 payload carries, used to
+/// attribute a denial back to this check. It deliberately does not order execution: ownership always runs
+/// last among the AND-combined strategies whatever position it is configured at, so unlike the custom-view
+/// checks it is never partitioned around <c>NamespaceBased</c> by configured index.
+/// </remarks>
+public sealed record RelationalOwnershipAuthorization(
+    OwnershipAuthorizationCheckSpec Check,
+    OwnershipTokenParameterization OwnershipTokenParameterization
+);
+
+/// <summary>
 /// Every custom view-based check planned for one request, across both value sources.
 /// </summary>
 /// <remarks>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -848,6 +848,13 @@ public sealed record RelationalWriteExecutorRequest
     /// </para>
     /// </remarks>
     public short? CreatorOwnershipTokenId { get; init; }
+
+    /// <summary>
+    /// The ownership check planned for this write, or <see langword="null"/> when <c>OwnershipBased</c> is
+    /// not configured. It authorizes the stored token, so it decides an update and is vacuous for a create —
+    /// which is why one plan can serve a POST whose branch is not yet known.
+    /// </summary>
+    public RelationalOwnershipAuthorization? StoredOwnershipAuthorization { get; init; }
 }
 
 /// <summary>
@@ -966,6 +973,9 @@ public sealed record RelationalWriteExecutorInput
     /// <inheritdoc cref="RelationalWriteExecutorRequest.CreatorOwnershipTokenId"/>
     public short? CreatorOwnershipTokenId { get; init; }
 
+    /// <inheritdoc cref="RelationalWriteExecutorRequest.StoredOwnershipAuthorization"/>
+    public RelationalOwnershipAuthorization? StoredOwnershipAuthorization { get; init; }
+
     /// <summary>
     /// Produces the fully resolved executor request for a target the executor observed inside its
     /// write session. All cross-field validation runs in the resolved request's constructor.
@@ -994,6 +1004,7 @@ public sealed record RelationalWriteExecutorInput
             PostRelationshipAuthorizationPlans = PostRelationshipAuthorizationPlans,
             CustomViewAuthorization = CustomViewAuthorization,
             CreatorOwnershipTokenId = CreatorOwnershipTokenId,
+            StoredOwnershipAuthorization = StoredOwnershipAuthorization,
         };
 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -830,6 +830,24 @@ public sealed record RelationalWriteExecutorRequest
     /// selection inside the executor's write session.
     /// </summary>
     internal PostRelationshipAuthorizationPlans? PostRelationshipAuthorizationPlans { get; init; }
+
+    /// <summary>
+    /// The API client's <c>CreatorOwnershipTokenId</c>, stamped onto <c>dms.Document</c> when this write
+    /// creates a document. Null when the client has no creator token, which stamps null.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Not an authorization input. This value is only ever written; ownership authorization reads the client's
+    /// <c>OwnershipTokenIds</c> against the stored column instead. A create is therefore never denied by
+    /// ownership, whatever this value is.
+    /// </para>
+    /// <para>
+    /// Carried on every write regardless of configured strategies, because stamping is unconditional. It is
+    /// ignored for a write that resolves to an existing target: no <c>UPDATE</c> statement mentions the
+    /// column, which is what preserves the stored token across PUT and upsert-as-update.
+    /// </para>
+    /// </remarks>
+    public short? CreatorOwnershipTokenId { get; init; }
 }
 
 /// <summary>
@@ -945,6 +963,9 @@ public sealed record RelationalWriteExecutorInput
     /// <inheritdoc cref="RelationalWriteExecutorRequest.PostRelationshipAuthorizationPlans"/>
     internal PostRelationshipAuthorizationPlans? PostRelationshipAuthorizationPlans { get; init; }
 
+    /// <inheritdoc cref="RelationalWriteExecutorRequest.CreatorOwnershipTokenId"/>
+    public short? CreatorOwnershipTokenId { get; init; }
+
     /// <summary>
     /// Produces the fully resolved executor request for a target the executor observed inside its
     /// write session. All cross-field validation runs in the resolved request's constructor.
@@ -972,6 +993,7 @@ public sealed record RelationalWriteExecutorInput
         {
             PostRelationshipAuthorizationPlans = PostRelationshipAuthorizationPlans,
             CustomViewAuthorization = CustomViewAuthorization,
+            CreatorOwnershipTokenId = CreatorOwnershipTokenId,
         };
 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
@@ -84,6 +84,25 @@ internal static class RelationalWriteExecutorResults
         };
     }
 
+    public static RelationalWriteExecutorResult BuildOwnershipAuthorizationFailureResult(
+        RelationalWriteOperationKind operationKind,
+        OwnershipAuthorizationFailure ownershipFailure
+    )
+    {
+        ArgumentNullException.ThrowIfNull(ownershipFailure);
+
+        return operationKind switch
+        {
+            RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.UpsertFailureOwnershipNotAuthorized(ownershipFailure)
+            ),
+            RelationalWriteOperationKind.Put => new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateFailureOwnershipNotAuthorized(ownershipFailure)
+            ),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, null),
+        };
+    }
+
     public static RelationalWriteExecutorResult BuildCustomViewAuthorizationFailureResult(
         RelationalWriteOperationKind operationKind,
         CustomViewAuthorizationFailure customViewFailure

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
@@ -330,7 +330,7 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         // After the namespace statement and before the relationship one, matching auth.md: ownership is the
         // last AND filter and the relationship OR group follows every AND filter. A non-fit sends the whole
         // request to the ordered-segments path, as a namespace non-fit already does, rather than degrading
-        // this one check â€” that path executes and validates every check in configured order anyway.
+        // this one check — that path executes and validates every check in configured order anyway.
         if (
             !RelationalCompositeStoredAuthorization.TryAppendOwnership(
                 builder,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
@@ -220,6 +220,12 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         public StoredCustomViewStatementPlan? CustomViewPlan { get; init; }
 
         /// <summary>
+        /// The ownership check the command carried, or <see langword="null"/> when it carried none — so a
+        /// provider failure is mapped only against a check that command actually sent.
+        /// </summary>
+        public StoredOwnershipStatementPlan? OwnershipPlan { get; init; }
+
+        /// <summary>
         /// Exactly the custom-view checks the command carries statements for, so their views are validated
         /// before it runs and no other view's contract can preempt what it decides.
         /// </summary>
@@ -321,6 +327,23 @@ internal sealed class CompositeRelationalWriteFirstPhase(
                 ? new StoredCustomViewStatementPlan(customViewAuthorization.Checks)
                 : null;
 
+        // After the namespace statement and before the relationship one, matching auth.md: ownership is the
+        // last AND filter and the relationship OR group follows every AND filter. A non-fit sends the whole
+        // request to the ordered-segments path, as a namespace non-fit already does, rather than degrading
+        // this one check â€” that path executes and validates every check in configured order anyway.
+        if (
+            !RelationalCompositeStoredAuthorization.TryAppendOwnership(
+                builder,
+                carrier,
+                input.MappingSet,
+                input.StoredOwnershipAuthorization,
+                out var ownershipPlan
+            )
+        )
+        {
+            return null;
+        }
+
         if (
             !RelationalCompositeStoredAuthorization.TryAppendRelationship(
                 builder,
@@ -353,6 +376,7 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         {
             CustomViewPlan = customViewPlan,
             CustomViewCommandChecks = customViewsBeforeNamespace,
+            OwnershipPlan = ownershipPlan,
         };
     }
 
@@ -399,6 +423,7 @@ internal sealed class CompositeRelationalWriteFirstPhase(
                     input,
                     namespacePlan,
                     plan.CustomViewPlan,
+                    plan.OwnershipPlan,
                     relationshipPlan,
                     exception,
                     execution.Failure
@@ -583,6 +608,23 @@ internal sealed class CompositeRelationalWriteFirstPhase(
                 return RelationalWriteFirstPhaseResolution.Immediate(customViewAfterResult);
             }
 
+            // Ownership last among the AND filters, so after both custom-view runs and the namespace check,
+            // and still ahead of the relationship OR group. Reached only inside this captured-target branch,
+            // which is what makes a create vacuous here just as the carrier row guard does co-batched.
+            if (
+                await ExecuteStandaloneStoredOwnershipAsync(
+                        executionRequest,
+                        capturedTarget.DocumentId,
+                        writeSession,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false) is
+                { } ownershipResult
+            )
+            {
+                return RelationalWriteFirstPhaseResolution.Immediate(ownershipResult);
+            }
+
             var storedRelationshipResult = await ResolveStandaloneStoredRelationshipDispositionAsync(
                     executionRequest,
                     ClassifyStoredRelationshipDisposition(input),
@@ -744,6 +786,59 @@ internal sealed class CompositeRelationalWriteFirstPhase(
                 cancellationToken
             )
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the ownership check as its own ordered segment against the captured target.
+    /// </summary>
+    private async Task<RelationalWriteExecutorResult?> ExecuteStandaloneStoredOwnershipAsync(
+        RelationalWriteExecutorRequest executionRequest,
+        long targetDocumentId,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        if (executionRequest.StoredOwnershipAuthorization is not { } ownershipAuthorization)
+        {
+            return null;
+        }
+
+        var executionResult = await new OwnershipAuthorizationExecutor(
+            writeSession.CreateCommandExecutor(),
+            _providerFailureExtractor
+        )
+            .ExecuteAsync(
+                new OwnershipAuthorizationExecutionRequest(
+                    executionRequest.MappingSet,
+                    targetDocumentId,
+                    ownershipAuthorization.Check,
+                    ownershipAuthorization.OwnershipTokenParameterization
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            OwnershipAuthorizationExecutionResult.Authorized => null,
+            OwnershipAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                RelationalWriteExecutorResults.BuildOwnershipAuthorizationFailureResult(
+                    executionRequest.OperationKind,
+                    notAuthorized.Failure
+                ),
+            OwnershipAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
+                    executionRequest.OperationKind,
+                    [invalidFailure.FailureMessage],
+                    invalidFailure.Diagnostics
+                ),
+            // Unreachable while the capture lock holds; the same defensive mapping the sibling segments use.
+            OwnershipAuthorizationExecutionResult.StaleTarget =>
+                RelationalWriteExecutorResults.BuildStaleTargetResult(executionRequest.OperationKind),
+            _ => throw new InvalidOperationException(
+                $"Unsupported ownership authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
     }
 
     private async Task<RelationalWriteExecutorResult?> ResolveStandaloneStoredRelationshipDispositionAsync(
@@ -964,6 +1059,7 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         RelationalWriteExecutorInput input,
         StoredNamespaceStatementPlan? namespacePlan,
         StoredCustomViewStatementPlan? customViewPlan,
+        StoredOwnershipStatementPlan? ownershipPlan,
         StoredRelationshipStatementPlan relationshipPlan,
         DbException exception,
         RelationalCompositeFailureContext? failureContext
@@ -977,9 +1073,7 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             _providerFailureExtractor,
             _logger,
             customViewPlan,
-            // The write path plans no ownership check yet; Phase 6 wires it. Passed explicitly rather than
-            // defaulted so a valid own1 denial cannot fail closed as a 500 through an omitted argument.
-            ownershipPlan: null
+            ownershipPlan
         ) switch
         {
             // Stale is unreachable while the capture lock holds; kept as the same defensive mapping the
@@ -994,6 +1088,11 @@ internal sealed class CompositeRelationalWriteFirstPhase(
                 ),
             StoredAuthorizationDenial.CustomViewNotAuthorized(var failure) =>
                 RelationalWriteExecutorResults.BuildCustomViewAuthorizationFailureResult(
+                    input.OperationKind,
+                    failure
+                ),
+            StoredAuthorizationDenial.OwnershipNotAuthorized(var failure) =>
+                RelationalWriteExecutorResults.BuildOwnershipAuthorizationFailureResult(
                     input.OperationKind,
                     failure
                 ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
@@ -258,6 +258,10 @@ internal sealed class CompositeRelationalWriteFirstPhase(
 
         if (
             input.PostRelationshipAuthorizationPlans?.CreateNewImmediateResult is not null
+            // A deferred ownership failure is owed in the ownership slot, ahead of the relationship statement
+            // and the hydration this command would carry, so the request takes the ordered-segments path the
+            // way a create-new immediate result does.
+            || input.DeferredStoredOwnershipFailureResult is not null
             || relationshipDisposition.Disposition
                 is not (StoredRelationshipDisposition.None or StoredRelationshipDisposition.Emitted)
         )
@@ -789,7 +793,8 @@ internal sealed class CompositeRelationalWriteFirstPhase(
     }
 
     /// <summary>
-    /// Runs the ownership check as its own ordered segment against the captured target.
+    /// Runs the ownership check as its own ordered segment against the captured target, or returns the failure
+    /// a POST deferred from preflight in the check's place.
     /// </summary>
     private async Task<RelationalWriteExecutorResult?> ExecuteStandaloneStoredOwnershipAsync(
         RelationalWriteExecutorRequest executionRequest,
@@ -798,6 +803,13 @@ internal sealed class CompositeRelationalWriteFirstPhase(
         CancellationToken cancellationToken
     )
     {
+        // The target exists, so the check preflight could not parameterize would have run here; the request
+        // fails closed in the same slot, with no DML issued.
+        if (executionRequest.DeferredStoredOwnershipFailureResult is { } deferredFailureResult)
+        {
+            return deferredFailureResult;
+        }
+
         if (executionRequest.StoredOwnershipAuthorization is not { } ownershipAuthorization)
         {
             return null;

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFirstPhase.cs
@@ -976,7 +976,10 @@ internal sealed class CompositeRelationalWriteFirstPhase(
             RelationalWriteExecutorResults.GetRelationshipAuthorizationAuth1Index(input.OperationKind),
             _providerFailureExtractor,
             _logger,
-            customViewPlan
+            customViewPlan,
+            // The write path plans no ownership check yet; Phase 6 wires it. Passed explicitly rather than
+            // defaulted so a valid own1 denial cannot fail closed as a 500 through an omitted argument.
+            ownershipPlan: null
         ) switch
         {
             // Stale is unreachable while the capture lock holds; kept as the same defensive mapping the

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteNoProfilePersister.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteNoProfilePersister.cs
@@ -77,6 +77,7 @@ internal sealed class RelationalWriteNoProfilePersister(
                 request.WritePlan,
                 targetContext,
                 mergeResult,
+                request.CreatorOwnershipTokenId,
                 writeSession,
                 cancellationToken
             )
@@ -216,11 +217,16 @@ internal sealed class RelationalWriteNoProfilePersister(
             _ => throw new ArgumentOutOfRangeException(nameof(targetContext), targetContext, null),
         };
 
+    /// <param name="createdByOwnershipTokenId">
+    /// Stamped onto the created <c>dms.Document</c> row. Ignored for an existing target: this path issues no
+    /// statement that mentions the column, which is what preserves the stored token across an update.
+    /// </param>
     private async Task<long> ResolveRootDocumentIdAsync(
         MappingSet mappingSet,
         ResourceWritePlan writePlan,
         RelationalWriteTargetContext targetContext,
         RelationalWriteMergeResult mergeResult,
+        short? createdByOwnershipTokenId,
         IRelationalWriteSession writeSession,
         CancellationToken cancellationToken
     )
@@ -232,6 +238,7 @@ internal sealed class RelationalWriteNoProfilePersister(
                     writePlan,
                     documentUuid,
                     mergeResult,
+                    createdByOwnershipTokenId,
                     writeSession,
                     cancellationToken
                 )
@@ -246,6 +253,7 @@ internal sealed class RelationalWriteNoProfilePersister(
         ResourceWritePlan writePlan,
         DocumentUuid documentUuid,
         RelationalWriteMergeResult mergeResult,
+        short? createdByOwnershipTokenId,
         IRelationalWriteSession writeSession,
         CancellationToken cancellationToken
     )
@@ -254,7 +262,8 @@ internal sealed class RelationalWriteNoProfilePersister(
         var command = RelationalDocumentRowCommandBuilder.BuildInsertCommand(
             mappingSet.Key.Dialect,
             documentUuid,
-            RelationalWriteSupport.GetResourceKeyIdOrThrow(mappingSet, resource)
+            RelationalWriteSupport.GetResourceKeyIdOrThrow(mappingSet, resource),
+            createdByOwnershipTokenId
         );
         var relationshipAuthorizationRuntimeCheck = mergeResult.ProposedRelationshipAuthorizationRuntimeCheck;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteSecondCommandPhase.cs
@@ -122,8 +122,12 @@ internal sealed class CompositeRelationalWriteSecondCommand(
     private const string DocumentInsertLabel = "document-insert";
     private const string ContentVersionReadLabel = "content-version-read";
 
-    /// <summary>The <c>dms.Document</c> insert's bound <c>DocumentUuid</c> and <c>ResourceKeyId</c>.</summary>
-    private const int DocumentInsertParameterCount = 2;
+    /// <summary>
+    /// The <c>dms.Document</c> insert's bound <c>DocumentUuid</c>, <c>ResourceKeyId</c> and
+    /// <c>CreatedByOwnershipTokenId</c>. The ownership token is bound even when null, so the count does not
+    /// vary with whether the client has a creator token.
+    /// </summary>
+    private const int DocumentInsertParameterCount = 3;
 
     /// <summary>
     /// Stands in for the created document id's subquery while a statement's parameter count is measured. Only
@@ -1231,7 +1235,8 @@ internal sealed class CompositeRelationalWriteSecondCommand(
                 RelationalWriteSupport.GetResourceKeyIdOrThrow(
                     request.MappingSet,
                     request.WritePlan.Model.Resource
-                )
+                ),
+                request.CreatorOwnershipTokenId
             ),
             builder.Allocator,
             builder.NextOrdinal

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationshipAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationshipAuthorizationProviderFailureMapper.cs
@@ -167,9 +167,14 @@ internal static class RelationshipAuthorizationProviderFailureMapper
 
     /// <summary>
     /// Whether <paramref name="payloadText"/> carries the discriminator of an AUTH1 family other than
-    /// relationship. Namespace payloads lead with <c>ns1|</c> and custom view-based payloads with
-    /// <c>cv1|</c>; the relationship family leads with its own payload version.
+    /// relationship. Namespace payloads lead with <c>ns1|</c>, custom view-based payloads with <c>cv1|</c>,
+    /// and ownership payloads with <c>own1|</c>; the relationship family leads with its own payload version.
     /// </summary>
+    /// <remarks>
+    /// Every new AUTH1 family must be added here. The relationship mapper reports an undecodable payload as
+    /// its own parse-failure diagnostic, which callers turn into a 500, so a family missing from this list
+    /// has its 403 converted into a relationship 500 as soon as one command carries both statements.
+    /// </remarks>
     private static bool IsForeignAuthorizationPayload(string payloadText) =>
         payloadText.StartsWith(
             NamespaceAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
@@ -177,6 +182,10 @@ internal static class RelationshipAuthorizationProviderFailureMapper
         )
         || payloadText.StartsWith(
             CustomViewAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
+            StringComparison.Ordinal
+        )
+        || payloadText.StartsWith(
+            OwnershipAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
             StringComparison.Ordinal
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationshipAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationshipAuthorizationProviderFailureMapper.cs
@@ -89,9 +89,14 @@ internal static class RelationshipAuthorizationProviderFailureMapper
         // diagnostic so the codec that owns the discriminator claims it. Without this, a command carrying
         // both relationship and custom-view statements would report a custom-view 403 as a relationship
         // invalid-payload 500, because an unparseable payload below is treated as our own malformed one.
-        // Only *known* foreign discriminators yield: undecodable text with no discriminator still takes the
-        // parse-failure path, so a genuinely corrupt payload stays a loud security-configuration error.
-        if (IsForeignAuthorizationPayload(payloadText))
+        // Only *known* foreign discriminators yield: text the dispatcher recognizes no family for still
+        // takes the parse-failure path, so a genuinely corrupt payload stays a loud
+        // security-configuration error.
+        if (
+            RelationalAuthorizationAuth1Dispatcher.RecognizeFamily(payloadText)
+            is not null
+                and not RelationalAuthorizationAuth1PayloadFamily.Relationship
+        )
         {
             return false;
         }
@@ -164,30 +169,6 @@ internal static class RelationshipAuthorizationProviderFailureMapper
             diagnostic.MappingFailureCategory
         );
     }
-
-    /// <summary>
-    /// Whether <paramref name="payloadText"/> carries the discriminator of an AUTH1 family other than
-    /// relationship. Namespace payloads lead with <c>ns1|</c>, custom view-based payloads with <c>cv1|</c>,
-    /// and ownership payloads with <c>own1|</c>; the relationship family leads with its own payload version.
-    /// </summary>
-    /// <remarks>
-    /// Every new AUTH1 family must be added here. The relationship mapper reports an undecodable payload as
-    /// its own parse-failure diagnostic, which callers turn into a 500, so a family missing from this list
-    /// has its 403 converted into a relationship 500 as soon as one command carries both statements.
-    /// </remarks>
-    private static bool IsForeignAuthorizationPayload(string payloadText) =>
-        payloadText.StartsWith(
-            NamespaceAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
-            StringComparison.Ordinal
-        )
-        || payloadText.StartsWith(
-            CustomViewAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
-            StringComparison.Ordinal
-        )
-        || payloadText.StartsWith(
-            OwnershipAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|",
-            StringComparison.Ordinal
-        );
 
     private static RelationshipAuthorizationProviderFailureDiagnostic BuildDiagnostic(
         SqlDialect dialect,

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/DeleteResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/DeleteResult.cs
@@ -56,6 +56,13 @@ public abstract record DeleteResult
         : DeleteResult();
 
     /// <summary>
+    /// A failure because stored ownership-based authorization denied the delete. Carries the ownership
+    /// failure metadata so Core can build the §2.13/§2.14 ProblemDetails response.
+    /// </summary>
+    public record DeleteFailureOwnershipNotAuthorized(OwnershipAuthorizationFailure OwnershipFailure)
+        : DeleteResult();
+
+    /// <summary>
     /// A failure because the requested delete operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/GetResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/GetResult.cs
@@ -59,6 +59,13 @@ public record GetResult
         : GetResult();
 
     /// <summary>
+    /// A failure because stored ownership-based authorization denied access to the document. Carries the
+    /// ownership failure metadata so Core can build the §2.13/§2.14 ProblemDetails response.
+    /// </summary>
+    public record GetFailureOwnershipNotAuthorized(OwnershipAuthorizationFailure OwnershipFailure)
+        : GetResult();
+
+    /// <summary>
     /// A failure because the requested read operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/OwnershipAuthorizationFailure.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/OwnershipAuthorizationFailure.cs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Backend;
+
+/// <summary>
+/// Identifies the failed ownership-based authorization condition.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both kinds describe an <em>existing</em> stored document, because ownership authorizes only stored values:
+/// the API client's <c>OwnershipTokenIds</c> authorize reads and mutations, while the single
+/// <c>CreatorOwnershipTokenId</c> is used solely to stamp <c>dms.Document.CreatedByOwnershipTokenId</c> on
+/// creation and is never an authorization input. A create therefore has nothing for this strategy to deny.
+/// </para>
+/// <para>
+/// Two conditions the SQL check can also raise are deliberately absent. A stale stored target is a retry
+/// signal that resolves to a 404, never a response of its own. An <c>OwnershipTokenIds</c> count at or above
+/// the defensive limit is a security-configuration problem carrying the <c>urn:ed-fi:api:system</c> 500,
+/// reported as a planner terminal rather than as an authorization denial.
+/// </para>
+/// </remarks>
+public enum OwnershipAuthorizationFailureKind
+{
+    /// <summary>
+    /// The stored <c>CreatedByOwnershipTokenId</c> is non-null but matches none of the caller's ownership
+    /// tokens. auth.md §2.13 — ownership, access denied, ownership mismatch.
+    /// </summary>
+    OwnershipTokenMismatch,
+
+    /// <summary>
+    /// The stored <c>CreatedByOwnershipTokenId</c> is null, so the existing item can never be reached through
+    /// ownership-based authorization. auth.md §2.14 — ownership, invalid data, ownership uninitialized.
+    /// </summary>
+    StoredOwnershipTokenUninitialized,
+}
+
+/// <summary>
+/// Cross-boundary metadata for a failed ownership-based authorization check.
+/// </summary>
+/// <param name="FailureKind">Which of §2.13 / §2.14 applies.</param>
+/// <param name="ConfiguredStrategyIndex">
+/// Zero-based position of <c>OwnershipBased</c> in the CMS-configured strategy list for this request — the
+/// configured index, not an emitted statement ordinal.
+/// <para>
+/// This differs from the namespace and custom view-based failure records, which carry an emitted AUTH1
+/// ordinal, and the difference is deliberate. Those strategies emit several checks per request that share one
+/// provider exception, so they need an emitted ordinal to resolve a payload to a specific check within a
+/// batch. Ownership emits exactly one check per operation, so an emitted ordinal would be a constant zero
+/// carrying no information, while the configured index identifies the strategy that denied the request — which
+/// is what the AUTH1 design calls for.
+/// </para>
+/// <para>
+/// Non-nullable because every ownership denial arrives through AUTH1. Ownership has no planner/preflight 403
+/// analogous to the namespace no-prefixes-configured case: a caller with an empty ownership-token list still
+/// executes the stored-row check, so that the response can distinguish a stored null (§2.14) from a
+/// non-matching stored value (§2.13) rather than guessing.
+/// </para>
+/// </param>
+/// <param name="StrategyName">The configured strategy name — always <c>OwnershipBased</c>.</param>
+/// <remarks>
+/// No value-source discriminator: unlike namespace and custom view-based authorization, ownership evaluates
+/// only stored values, so there is no proposed-value counterpart to distinguish. §2.13's and §2.14's
+/// <c>detail</c> text carries no existing/proposed variation either, so nothing downstream needs one.
+/// </remarks>
+public sealed record OwnershipAuthorizationFailure(
+    OwnershipAuthorizationFailureKind FailureKind,
+    int ConfiguredStrategyIndex,
+    string StrategyName
+);

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpdateResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpdateResult.cs
@@ -121,6 +121,13 @@ public record UpdateResult
         : UpdateResult();
 
     /// <summary>
+    /// A failure because stored ownership-based authorization denied the PUT/update. Carries the ownership
+    /// failure metadata so Core can build the §2.13/§2.14 ProblemDetails response.
+    /// </summary>
+    public record UpdateFailureOwnershipNotAuthorized(OwnershipAuthorizationFailure OwnershipFailure)
+        : UpdateResult();
+
+    /// <summary>
     /// A failure because the requested PUT/update operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpsertResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpsertResult.cs
@@ -121,6 +121,19 @@ public record UpsertResult
         : UpsertResult();
 
     /// <summary>
+    /// A failure because stored ownership-based authorization denied the POST resolving to an
+    /// upsert-as-update. Carries the ownership failure metadata so Core can build the §2.13/§2.14
+    /// ProblemDetails response.
+    /// </summary>
+    /// <remarks>
+    /// Only ever produced for a POST that resolved to an existing target. Ownership authorizes stored values,
+    /// and a create has none: <c>CreatorOwnershipTokenId</c> stamps the new row rather than authorizing it, so
+    /// a POST resolving to a create is never denied by this strategy.
+    /// </remarks>
+    public record UpsertFailureOwnershipNotAuthorized(OwnershipAuthorizationFailure OwnershipFailure)
+        : UpsertResult();
+
+    /// <summary>
     /// A failure because the requested POST/upsert operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
 using EdFi.DataManagementService.Core.Handler;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
@@ -498,6 +499,72 @@ public class DeleteByIdHandlerTests
                     expected: {expected}
 
                     actual: {_customViewRequestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Repository_That_Returns_Ownership_Not_Authorized : DeleteByIdHandlerTests
+    {
+        internal static readonly OwnershipAuthorizationFailure OwnershipFailure = new(
+            OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized,
+            ConfiguredStrategyIndex: 2,
+            StrategyName: AuthorizationStrategyNameConstants.OwnershipBased
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<DeleteResult> DeleteDocumentById(IDeleteRequest deleteRequest)
+            {
+                return Task.FromResult<DeleteResult>(
+                    new DeleteFailureOwnershipNotAuthorized(OwnershipFailure)
+                );
+            }
+        }
+
+        private static readonly string _ownershipTraceId = "ownership-delete-403";
+        private readonly RequestInfo _ownershipRequestInfo = RequestInfoWithRelationalMappingSet(
+            _ownershipTraceId
+        );
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var projectSchemaNode = new JsonObject
+            {
+                ["educationOrganizationTypes"] = new JsonArray { "Type1", "Type2" },
+            };
+            _ownershipRequestInfo.ProjectSchema = new ProjectSchema(projectSchemaNode, NullLogger.Instance);
+            _ownershipRequestInfo.ResourceSchema = GetResourceSchema();
+
+            var (deleteHandler, serviceProvider) = Handler(new Repository());
+            _ownershipRequestInfo.ScopedServiceProvider = serviceProvider;
+
+            await deleteHandler.Execute(_ownershipRequestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_ownership_denial_to_the_canonical_problem_details_403()
+        {
+            _ownershipRequestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _ownershipRequestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = OwnershipAuthorizationFailureResponse.ForFailure(
+                OwnershipFailure,
+                new TraceId(_ownershipTraceId)
+            );
+
+            _ownershipRequestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_ownershipRequestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_ownershipRequestInfo.FrontendResponse.Body}
                     """
                 );
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
@@ -648,6 +648,66 @@ public class GetByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Ownership_Not_Authorized : GetByIdHandlerTests
+    {
+        internal static readonly OwnershipAuthorizationFailure OwnershipFailure = new(
+            OwnershipAuthorizationFailureKind.OwnershipTokenMismatch,
+            ConfiguredStrategyIndex: 1,
+            StrategyName: AuthorizationStrategyNameConstants.OwnershipBased
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<GetResult> GetDocumentById(
+                IGetRequest getRequest,
+                CancellationToken cancellationToken = default
+            )
+            {
+                return Task.FromResult<GetResult>(new GetFailureOwnershipNotAuthorized(OwnershipFailure));
+            }
+        }
+
+        private static readonly string _ownershipTraceId = "ownership-get-403";
+        private readonly RequestInfo _ownershipRequestInfo = RequestInfoWithRelationalMappingSet(
+            _ownershipTraceId
+        );
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (getByIdHandler, serviceProvider) = Handler(new Repository());
+            _ownershipRequestInfo.ScopedServiceProvider = serviceProvider;
+
+            await getByIdHandler.Execute(_ownershipRequestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_ownership_denial_to_the_canonical_problem_details_403()
+        {
+            _ownershipRequestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _ownershipRequestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = OwnershipAuthorizationFailureResponse.ForFailure(
+                OwnershipFailure,
+                new TraceId(_ownershipTraceId)
+            );
+
+            _ownershipRequestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_ownershipRequestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_ownershipRequestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : GetByIdHandlerTests
     {
         internal static readonly NamespaceAuthorizationFailure Failure = new(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/RelationalWriteSeamTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/RelationalWriteSeamTests.cs
@@ -758,6 +758,7 @@ actual: {requestInfo.FrontendResponse.Body}
                 A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
                 A.Fake<INamespaceAuthorizationExecutor>(),
                 A.Fake<ICustomViewAuthorizationExecutor>(),
+                A.Fake<IOwnershipAuthorizationExecutor>(),
                 A.Fake<IRelationalCommandExecutor>(),
                 A.Fake<IDocumentCacheReadAccelerationCoordinator>()
             );

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
@@ -9,6 +9,7 @@ using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
 using EdFi.DataManagementService.Core.Handler;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
@@ -1002,6 +1003,65 @@ public class UpdateByIdHandlerTests
                     expected: {expected}
 
                     actual: {_customViewRequestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Repository_That_Returns_Ownership_Not_Authorized : UpdateByIdHandlerTests
+    {
+        internal static readonly OwnershipAuthorizationFailure OwnershipFailure = new(
+            OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized,
+            ConfiguredStrategyIndex: 3,
+            StrategyName: AuthorizationStrategyNameConstants.OwnershipBased
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpdateResult> UpdateDocumentById(IUpdateRequest updateRequest)
+            {
+                return Task.FromResult<UpdateResult>(
+                    new UpdateFailureOwnershipNotAuthorized(OwnershipFailure)
+                );
+            }
+        }
+
+        private static readonly string _ownershipTraceId = "ownership-put-403";
+        private readonly RequestInfo _ownershipRequestInfo = RequestInfoWithRelationalMappingSet(
+            _ownershipTraceId
+        );
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (updateHandler, serviceProvider) = Handler(new Repository());
+            _ownershipRequestInfo.ScopedServiceProvider = serviceProvider;
+
+            await updateHandler.Execute(_ownershipRequestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_ownership_denial_to_the_canonical_problem_details_403()
+        {
+            _ownershipRequestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _ownershipRequestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = OwnershipAuthorizationFailureResponse.ForFailure(
+                OwnershipFailure,
+                new TraceId(_ownershipTraceId)
+            );
+
+            _ownershipRequestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_ownershipRequestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_ownershipRequestInfo.FrontendResponse.Body}
                     """
                 );
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
@@ -1073,6 +1073,69 @@ public class UpsertHandlerTests
         }
     }
 
+    /// <summary>
+    /// Only reachable for a POST that resolved to an upsert-as-update. A POST resolving to a create has no
+    /// stored ownership token to authorize against, so it is never denied by this strategy.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Repository_That_Returns_Ownership_Not_Authorized : UpsertHandlerTests
+    {
+        internal static readonly OwnershipAuthorizationFailure OwnershipFailure = new(
+            OwnershipAuthorizationFailureKind.OwnershipTokenMismatch,
+            ConfiguredStrategyIndex: 0,
+            StrategyName: AuthorizationStrategyNameConstants.OwnershipBased
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpsertResult> UpsertDocument(IUpsertRequest upsertRequest)
+            {
+                return Task.FromResult<UpsertResult>(
+                    new UpsertFailureOwnershipNotAuthorized(OwnershipFailure)
+                );
+            }
+        }
+
+        private static readonly string _ownershipTraceId = "ownership-post-403";
+        private readonly RequestInfo _ownershipRequestInfo = RequestInfoWithRelationalMappingSet(
+            _ownershipTraceId
+        );
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (upsertHandler, serviceProvider) = Handler(new Repository());
+            _ownershipRequestInfo.ScopedServiceProvider = serviceProvider;
+
+            await upsertHandler.Execute(_ownershipRequestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_ownership_denial_to_the_canonical_problem_details_403()
+        {
+            _ownershipRequestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _ownershipRequestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = OwnershipAuthorizationFailureResponse.ForFailure(
+                OwnershipFailure,
+                new TraceId(_ownershipTraceId)
+            );
+
+            _ownershipRequestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_ownershipRequestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_ownershipRequestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
     [TestFixture]
     [Parallelizable]
     public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : UpsertHandlerTests

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/OwnershipAuthorizationFailureResponseTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/OwnershipAuthorizationFailureResponseTests.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
+using EdFi.DataManagementService.Core.Response;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Response;
+
+[TestFixture]
+[Parallelizable]
+public class Given_Failure_Response_For_Ownership_Authorization
+{
+    private const string ExpectedTitle = "Authorization Denied";
+    private const int ExpectedStatus = 403;
+
+    /// <summary>
+    /// auth.md gives §2.13 and §2.14 the same client-facing detail; only the type and the errors differ.
+    /// </summary>
+    private const string ExpectedDetail =
+        "Access to the requested data could not be authorized. The item is not owned by the caller.";
+
+    private static readonly TraceId _traceId = new("ownership-auth-trace");
+
+    private static OwnershipAuthorizationFailure Failure(
+        OwnershipAuthorizationFailureKind failureKind,
+        int configuredStrategyIndex = 0
+    ) => new(failureKind, configuredStrategyIndex, AuthorizationStrategyNameConstants.OwnershipBased);
+
+    [Test]
+    public void It_renders_the_ownership_mismatch_problem_details()
+    {
+        var response = OwnershipAuthorizationFailureResponse.ForFailure(
+            Failure(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch),
+            _traceId
+        );
+
+        response["type"]!
+            .ToString()
+            .Should()
+            .Be("urn:ed-fi:api:security:authorization:ownership:access-denied:ownership-mismatch");
+        response["title"]!.ToString().Should().Be(ExpectedTitle);
+        response["status"]!.GetValue<int>().Should().Be(ExpectedStatus);
+        response["correlationId"]!.ToString().Should().Be(_traceId.Value);
+        response["detail"]!.ToString().Should().Be(ExpectedDetail);
+        response["errors"]!.AsArray().Should().BeEmpty();
+        response["validationErrors"]!.AsObject().Count.Should().Be(0);
+    }
+
+    [Test]
+    public void It_renders_the_stored_ownership_token_uninitialized_problem_details()
+    {
+        var response = OwnershipAuthorizationFailureResponse.ForFailure(
+            Failure(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized),
+            _traceId
+        );
+
+        response["type"]!
+            .ToString()
+            .Should()
+            .Be("urn:ed-fi:api:security:authorization:ownership:invalid-data:ownership-uninitialized");
+        response["title"]!.ToString().Should().Be(ExpectedTitle);
+        response["status"]!.GetValue<int>().Should().Be(ExpectedStatus);
+        response["correlationId"]!.ToString().Should().Be(_traceId.Value);
+        response["detail"]!.ToString().Should().Be(ExpectedDetail);
+        response["errors"]!
+            .AsArray()
+            .Select(static error => error!.ToString())
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(
+                "The existing resource item has no 'CreatedByOwnershipTokenId' value assigned and thus will never be accessible to clients using the 'OwnershipBased' authorization strategy."
+            );
+        response["validationErrors"]!.AsObject().Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The two cases must stay distinguishable by type even though auth.md gives them one detail sentence, so a
+    /// client can tell "not yours" from "will never be yours" without the response spelling it out.
+    /// </summary>
+    [Test]
+    public void It_distinguishes_the_two_cases_only_by_type_and_errors()
+    {
+        var mismatch = OwnershipAuthorizationFailureResponse.ForFailure(
+            Failure(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch),
+            _traceId
+        );
+        var uninitialized = OwnershipAuthorizationFailureResponse.ForFailure(
+            Failure(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized),
+            _traceId
+        );
+
+        mismatch["detail"]!.ToString().Should().Be(uninitialized["detail"]!.ToString());
+        mismatch["title"]!.ToString().Should().Be(uninitialized["title"]!.ToString());
+        mismatch["status"]!.GetValue<int>().Should().Be(uninitialized["status"]!.GetValue<int>());
+        mismatch["type"]!.ToString().Should().NotBe(uninitialized["type"]!.ToString());
+        mismatch["errors"]!.AsArray().Count.Should().NotBe(uninitialized["errors"]!.AsArray().Count);
+    }
+
+    /// <summary>
+    /// The configured strategy index exists for log traceability. Rendering it would leak the caller's claim-set
+    /// shape into a client response for no benefit, so no case may include it.
+    /// </summary>
+    [TestCase(OwnershipAuthorizationFailureKind.OwnershipTokenMismatch)]
+    [TestCase(OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized)]
+    public void It_never_renders_the_configured_strategy_index(OwnershipAuthorizationFailureKind failureKind)
+    {
+        // A value no other part of the rendered body can produce, so the assertion cannot pass or fail by
+        // coincidence with a status code, a trace id, or a URN segment.
+        const int DistinctiveIndex = 91357;
+
+        var response = OwnershipAuthorizationFailureResponse.ForFailure(
+            Failure(failureKind, DistinctiveIndex),
+            _traceId
+        );
+
+        response.ToJsonString().Should().NotContain(DistinctiveIndex.ToString(CultureInfo.InvariantCulture));
+    }
+
+    [Test]
+    public void It_rejects_a_null_failure()
+    {
+        Action act = () => OwnershipAuthorizationFailureResponse.ForFailure(null!, _traceId);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void It_rejects_an_unsupported_failure_kind()
+    {
+        Action act = () =>
+            OwnershipAuthorizationFailureResponse.ForFailure(
+                Failure((OwnershipAuthorizationFailureKind)999),
+                _traceId
+            );
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
@@ -103,6 +103,15 @@ internal class DeleteByIdHandler(ILogger _logger, ResiliencePipeline _resilience
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            DeleteFailureOwnershipNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: OwnershipAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.OwnershipFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             DeleteFailureNotImplemented failure => new FrontendResponse(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/GetByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/GetByIdHandler.cs
@@ -113,6 +113,15 @@ internal class GetByIdHandler(ILogger _logger, ResiliencePipeline _resiliencePip
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            GetFailureOwnershipNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: OwnershipAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.OwnershipFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             UnknownFailure failure => CreateUnknownFailureResponse(
                 _logger,
                 requestInfo,

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
@@ -185,6 +185,15 @@ internal class UpdateByIdHandler(ILogger _logger, ResiliencePipeline _resilience
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            UpdateFailureOwnershipNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: OwnershipAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.OwnershipFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             UpdateFailureNotImplemented failure => new FrontendResponse(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
@@ -182,6 +182,15 @@ internal class UpsertHandler(ILogger _logger, ResiliencePipeline _resiliencePipe
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            UpsertFailureOwnershipNotAuthorized notAuthorized => new(
+                StatusCode: 403,
+                Body: OwnershipAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.OwnershipFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             UpsertFailureNotImplemented failure => new(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/OwnershipAuthorizationFailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/OwnershipAuthorizationFailureResponse.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.Response;
+
+/// <summary>
+/// ProblemDetails factories for ownership-based authorization failures (auth.md §2.13, §2.14).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both cases share one <c>detail</c> sentence. That is auth.md's wording, not a copy-paste: the client is told
+/// only that the item is not owned by the caller, and the distinction between a stored token that matched
+/// nothing (§2.13) and a stored token that was never assigned (§2.14) is carried by <c>type</c> and by §2.14's
+/// <c>errors</c> entry. Keep the shared sentence in one constant so the two cases cannot drift apart.
+/// </para>
+/// <para>
+/// Neither body reveals an ownership token value — not the caller's and not the stored one — and neither
+/// renders <see cref="OwnershipAuthorizationFailure.ConfiguredStrategyIndex"/>, which exists for log
+/// traceability rather than for the client.
+/// </para>
+/// <para>
+/// There is no preflight case here, unlike <see cref="NamespaceAuthorizationFailureResponse"/> with its §2.9
+/// no-prefixes-configured response. A caller holding no ownership tokens still executes the stored-row check,
+/// precisely so the response can tell §2.13 from §2.14 instead of guessing before reading the row.
+/// </para>
+/// </remarks>
+public static class OwnershipAuthorizationFailureResponse
+{
+    private const string ForbiddenTypePrefix = "urn:ed-fi:api:security:authorization:ownership";
+    private const string ForbiddenTitle = "Authorization Denied";
+
+    /// <summary>
+    /// The single client-facing sentence both §2.13 and §2.14 use.
+    /// </summary>
+    private const string NotOwnedDetail =
+        "Access to the requested data could not be authorized. The item is not owned by the caller.";
+
+    public static JsonNode ForFailure(OwnershipAuthorizationFailure failure, TraceId traceId)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+
+        return failure.FailureKind switch
+        {
+            OwnershipAuthorizationFailureKind.OwnershipTokenMismatch => ForMismatch(traceId),
+            OwnershipAuthorizationFailureKind.StoredOwnershipTokenUninitialized => ForStoredUninitialized(
+                failure.StrategyName,
+                traceId
+            ),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failure),
+                failure.FailureKind,
+                "Unsupported ownership authorization failure kind."
+            ),
+        };
+    }
+
+    private static JsonNode ForMismatch(TraceId traceId) =>
+        CreateResponse($"{ForbiddenTypePrefix}:access-denied:ownership-mismatch", [], traceId);
+
+    private static JsonNode ForStoredUninitialized(string strategyName, TraceId traceId) =>
+        CreateResponse(
+            $"{ForbiddenTypePrefix}:invalid-data:ownership-uninitialized",
+            [
+                $"The existing resource item has no 'CreatedByOwnershipTokenId' value assigned and thus will never be accessible to clients using the '{strategyName}' authorization strategy.",
+            ],
+            traceId
+        );
+
+    private static JsonNode CreateResponse(string type, string[] errors, TraceId traceId) =>
+        FailureResponse.CreateBaseJsonObject(
+            detail: NotOwnedDetail,
+            type: type,
+            title: ForbiddenTitle,
+            status: 403,
+            correlationId: traceId.Value,
+            validationErrors: [],
+            errors: errors
+        );
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/OwnershipAuthorizationIntegrationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/OwnershipAuthorizationIntegrationScenario.cs
@@ -330,6 +330,50 @@ internal static class OwnershipAuthorizationIntegrationScenario
     }
 
     /// <summary>
+    /// The cap gates reads, updates and deletes, not creates: <c>OwnershipTokenIds</c> authorize a stored
+    /// token, and a create has none to authorize. So the over-cap tenant still creates, and its create is still
+    /// stamped from its creator token. The same tenant's POST of the same identity resolves to an
+    /// upsert-as-update, which the cap fails closed before any DML: the row keeps its token and its name.
+    /// </summary>
+    public static async Task It_creates_over_the_ownership_token_cap_and_fails_closed_for_the_post_as_update(
+        ApiIntegrationHarness harness
+    )
+    {
+        Guid documentId = await CreateAsync(harness, TokenCapTenant, 1701, "ownership-over-cap-create");
+
+        (await ReadStoredOwnershipTokenAsync(harness, documentId)).Should().Be(CreatorToken);
+
+        using HttpResponseMessage postAsUpdateResponse = await PostAsync(
+            harness,
+            TokenCapTenant,
+            1701,
+            "ownership-over-cap-post-as-update"
+        );
+        string postAsUpdateBody = await postAsUpdateResponse.Content.ReadAsStringAsync();
+
+        postAsUpdateResponse.StatusCode.Should().Be(HttpStatusCode.InternalServerError, postAsUpdateBody);
+        postAsUpdateResponse.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        JsonObject postAsUpdateProblem = JsonNode.Parse(postAsUpdateBody)!.AsObject();
+        postAsUpdateProblem["type"]!.GetValue<string>().Should().Be(SecurityConfigurationProblemDetails.Type);
+        postAsUpdateProblem["status"]!
+            .GetValue<int>()
+            .Should()
+            .Be(SecurityConfigurationProblemDetails.Status);
+
+        (await ReadStoredOwnershipTokenAsync(harness, documentId)).Should().Be(CreatorToken);
+
+        // The owner still reads the created representation, so the refused upsert-as-update wrote nothing.
+        using HttpResponseMessage ownerGetResponse = await harness.HttpClient.GetAsync(
+            ResourcePath(OwnerTenant, documentId)
+        );
+        string ownerGetBody = await ownerGetResponse.Content.ReadAsStringAsync();
+        ownerGetResponse.StatusCode.Should().Be(HttpStatusCode.OK, ownerGetBody);
+        ownerGetBody.Should().Contain("ownership-over-cap-create");
+        ownerGetBody.Should().NotContain("ownership-over-cap-post-as-update");
+    }
+
+    /// <summary>
     /// GET-many ownership filtering belongs to a later story, so <c>OwnershipBased</c> on a collection read
     /// stays a 501 rather than silently serving an unfiltered page. The 501 names the strategy, which is what
     /// makes the withholding diagnosable rather than mysterious.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/OwnershipAuthorizationIntegrationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/OwnershipAuthorizationIntegrationScenario.cs
@@ -245,6 +245,21 @@ internal static class OwnershipAuthorizationIntegrationScenario
         );
         await AssertOwnershipDenialAsync(putResponse, StoredUninitializedType, _storedUninitializedErrors);
 
+        // The same identity, so this POST resolves to an upsert-as-update against the stored row rather than
+        // to a create - and only the update branch can produce 2.14 from a POST, because a create stamps NULL
+        // without ever being denied for it.
+        using HttpResponseMessage postAsUpdateResponse = await PostAsync(
+            harness,
+            ForeignTenant,
+            1301,
+            "ownership-uninitialized-post-as-update"
+        );
+        await AssertOwnershipDenialAsync(
+            postAsUpdateResponse,
+            StoredUninitializedType,
+            _storedUninitializedErrors
+        );
+
         using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(
             ResourcePath(ForeignTenant, documentId)
         );

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/OwnershipAuthorizationIntegrationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/OwnershipAuthorizationIntegrationScenario.cs
@@ -78,6 +78,21 @@ internal static class OwnershipAuthorizationIntegrationScenario
     ];
 
     /// <summary>
+    /// Every property <c>FailureResponse.CreateBaseJsonObject</c> emits, and nothing else. Pinned so the
+    /// no-disclosure scan cannot be outflanked by a field it does not know to look at.
+    /// </summary>
+    private static readonly string[] _problemDetailsProperties =
+    [
+        "detail",
+        "type",
+        "title",
+        "status",
+        "correlationId",
+        "validationErrors",
+        "errors",
+    ];
+
+    /// <summary>
     /// <c>OwnershipBased</c> on every resource and action, which exercises the whole surface at once: a create
     /// is stamped and never denied, every single-record read and write is enforced, and GET-many and descriptor
     /// storage stay withheld. Seeding still works precisely because a create cannot be denied by ownership.
@@ -240,9 +255,10 @@ internal static class OwnershipAuthorizationIntegrationScenario
 
     /// <summary>
     /// No ownership denial may disclose a token value - not the caller's and not the stored one. Ownership
-    /// tokens are numeric, so the property asserted is that no served string carries a digit at all: it holds
-    /// for both denial shapes and cannot be satisfied by a body that leaked one. The correlation id is excluded
-    /// because it is the request's own trace id.
+    /// tokens are numeric, so the property asserted is that no served value carries a digit at all, JSON
+    /// numbers as well as strings, because a leaked token would most naturally arrive as a number. The body's
+    /// property set is pinned alongside the scan, so a field cannot be added to a denial and skipped. Only the
+    /// correlation id, which is the request's own trace id, and the 403 status itself are excused.
     /// </summary>
     public static async Task It_never_discloses_an_ownership_token_value(ApiIntegrationHarness harness)
     {
@@ -512,14 +528,24 @@ internal static class OwnershipAuthorizationIntegrationScenario
 
         JsonObject problem = JsonNode.Parse(body)!.AsObject();
 
+        // Pinning the property set is what makes the scan below complete rather than best-effort: a field
+        // added to a denial body in future has to be accounted for here before it can be excluded from the
+        // scan, so it cannot arrive already exempt.
+        problem.Select(static property => property.Key).Should().BeEquivalentTo(_problemDetailsProperties);
+
         foreach ((string propertyName, JsonNode? value) in problem)
         {
-            if (string.Equals(propertyName, "correlationId", StringComparison.Ordinal))
+            // The correlation id is the request's own trace id, and the status is the 403 itself. Everything
+            // else in the body is client-facing prose that has no reason to carry a number.
+            if (
+                string.Equals(propertyName, "correlationId", StringComparison.Ordinal)
+                || string.Equals(propertyName, "status", StringComparison.Ordinal)
+            )
             {
                 continue;
             }
 
-            foreach (string text in CollectStrings(value))
+            foreach (string text in CollectScalarText(value))
             {
                 text.Any(char.IsDigit)
                     .Should()
@@ -530,7 +556,12 @@ internal static class OwnershipAuthorizationIntegrationScenario
         }
     }
 
-    private static IEnumerable<string> CollectStrings(JsonNode? node)
+    /// <summary>
+    /// Every scalar under <paramref name="node"/> rendered as text, non-strings included. An ownership token
+    /// leaked into a body would most naturally arrive as a JSON number, which a string-only walk would step
+    /// straight over.
+    /// </summary>
+    private static IEnumerable<string> CollectScalarText(JsonNode? node)
     {
         switch (node)
         {
@@ -538,15 +569,19 @@ internal static class OwnershipAuthorizationIntegrationScenario
                 yield return text;
                 break;
 
+            case JsonValue value:
+                yield return value.ToJsonString();
+                break;
+
             case JsonArray array:
-                foreach (string text in array.SelectMany(CollectStrings))
+                foreach (string text in array.SelectMany(CollectScalarText))
                 {
                     yield return text;
                 }
                 break;
 
             case JsonObject jsonObject:
-                foreach (string text in jsonObject.SelectMany(property => CollectStrings(property.Value)))
+                foreach (string text in jsonObject.SelectMany(property => CollectScalarText(property.Value)))
                 {
                     yield return text;
                 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/OwnershipAuthorizationIntegrationScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/OwnershipAuthorizationIntegrationScenario.cs
@@ -1,0 +1,605 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using FluentAssertions;
+
+namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+/// <summary>
+/// Public-boundary coverage for OwnershipBased authorization: the exact ProblemDetails wire contracts from
+/// <c>auth.md</c> 2.13 and 2.14, stamping on create, the authorized round trip, the provider-independent token
+/// cap, and the scopes that stay withheld with a 501. The provider matrix lives in the backend suites; this
+/// scenario owns only what those cannot observe - the served response body and the real application-context
+/// plumbing that carries the caller's ownership tokens.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Token sets vary per tenant rather than per test class. The production scoped
+/// <c>CachedApplicationContextProvider</c> stays wired and only the CMS-facing
+/// <c>IConfigurationServiceApplicationProvider</c> underneath it is replaced, so one host can serve an owner, a
+/// non-owner, a client with no creator token, and both sides of the token cap. That is what lets a single
+/// request sequence seed a row as its owner and then be refused as somebody else.
+/// </para>
+/// <para>
+/// Every tenant resolves to the same data store, so all of them see the same rows. That is the point:
+/// ownership is a per-row check against a stored token, not a tenancy boundary.
+/// </para>
+/// </remarks>
+internal static class OwnershipAuthorizationIntegrationScenario
+{
+    /// <summary>The token a create stamps on every tenant that carries one.</summary>
+    public const short CreatorToken = 42;
+
+    /// <summary>A token no seeded row was ever stamped with.</summary>
+    public const short ForeignToken = 7;
+
+    public const string OwnerTenant = "ownership-owner-tenant";
+    public const string ForeignTenant = "ownership-foreign-tenant";
+    public const string NoCreatorTokenTenant = "ownership-no-creator-token-tenant";
+    public const string TokenCapTenant = "ownership-token-cap-tenant";
+    public const string UnderTokenCapTenant = "ownership-under-token-cap-tenant";
+
+    /// <summary>
+    /// The defensive limit is stated as 2,000 or more fails closed, so the over-cap tenant holds exactly 2,000
+    /// and the under-cap tenant exactly 1,999 - the two values the rule turns on.
+    /// </summary>
+    private const int OverCapTokenCount = 2000;
+
+    private const int UnderCapTokenCount = 1999;
+
+    private const string NullableResourcesEndpointFormat = "/{0}/data/authz/authorizationNullableResources";
+    private const string GradeLevelDescriptorsEndpointFormat = "/{0}/data/ed-fi/gradeLevelDescriptors";
+
+    private const string MismatchType =
+        "urn:ed-fi:api:security:authorization:ownership:access-denied:ownership-mismatch";
+    private const string StoredUninitializedType =
+        "urn:ed-fi:api:security:authorization:ownership:invalid-data:ownership-uninitialized";
+    private const string NotOwnedDetail =
+        "Access to the requested data could not be authorized. The item is not owned by the caller.";
+
+    private static readonly string[] _storedUninitializedErrors =
+    [
+        "The existing resource item has no 'CreatedByOwnershipTokenId' value assigned and thus will never be accessible to clients using the '"
+            + AuthorizationStrategyNameConstants.OwnershipBased
+            + "' authorization strategy.",
+    ];
+
+    /// <summary>
+    /// <c>OwnershipBased</c> on every resource and action, which exercises the whole surface at once: a create
+    /// is stamped and never denied, every single-record read and write is enforced, and GET-many and descriptor
+    /// storage stay withheld. Seeding still works precisely because a create cannot be denied by ownership.
+    /// </summary>
+    public static IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        new ConfigurableClaimSetProvider(
+            fixture,
+            static (_, _) => [AuthorizationStrategyNameConstants.OwnershipBased]
+        );
+
+    /// <summary>
+    /// Resolves the simulated CMS application context for a tenant. Only the ownership fields differ; every
+    /// tenant is the same client against the same data store.
+    /// </summary>
+    public static ApplicationContextResult Resolve(string clientId, string? tenant) =>
+        tenant switch
+        {
+            OwnerTenant => Success(applicationId: 301, CreatorToken, [ForeignToken, CreatorToken]),
+            ForeignTenant => Success(applicationId: 302, CreatorToken, [ForeignToken]),
+            NoCreatorTokenTenant => Success(applicationId: 303, null, [ForeignToken]),
+            TokenCapTenant => Success(applicationId: 304, CreatorToken, TokenRange(OverCapTokenCount)),
+            UnderTokenCapTenant => Success(applicationId: 305, CreatorToken, TokenRange(UnderCapTokenCount)),
+            _ => Success(applicationId: 300, CreatorToken, [CreatorToken]),
+        };
+
+    /// <summary>
+    /// A create is stamped from the caller's creator token and is never denied by ownership, even for a caller
+    /// holding no token that stamp would authorize. The no-creator-token client stamps NULL, which is the value
+    /// 2.14 is about, and it too is created rather than refused.
+    /// </summary>
+    public static async Task It_stamps_the_creator_ownership_token_on_create_and_never_denies_it(
+        ApiIntegrationHarness harness
+    )
+    {
+        Guid stampedId = await CreateAsync(harness, OwnerTenant, 1001, "ownership-stamped-create");
+
+        (await ReadStoredOwnershipTokenAsync(harness, stampedId)).Should().Be(CreatorToken);
+
+        // Holds only the foreign token and carries no creator token, so nothing about this client could
+        // authorize the row it is about to create. It still creates it.
+        Guid unstampedId = await CreateAsync(harness, NoCreatorTokenTenant, 1002, "ownership-null-create");
+
+        (await ReadStoredOwnershipTokenAsync(harness, unstampedId)).Should().BeNull();
+    }
+
+    /// <summary>
+    /// An owner may read, update and delete, and the update leaves the stored token alone even though the
+    /// request carries a creator token a create would have stamped.
+    /// </summary>
+    public static async Task It_authorizes_the_full_round_trip_for_a_holder_of_the_stored_token(
+        ApiIntegrationHarness harness
+    )
+    {
+        Guid documentId = await CreateAsync(harness, OwnerTenant, 1101, "ownership-round-trip");
+        string resourcePath = ResourcePath(OwnerTenant, documentId);
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(resourcePath);
+        string getBody = await getResponse.Content.ReadAsStringAsync();
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK, getBody);
+
+        using HttpResponseMessage putResponse = await PutAsync(
+            harness,
+            OwnerTenant,
+            documentId,
+            1101,
+            "ownership-round-trip-updated"
+        );
+        string putBody = await putResponse.Content.ReadAsStringAsync();
+        putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent, putBody);
+        (await ReadStoredOwnershipTokenAsync(harness, documentId)).Should().Be(CreatorToken);
+
+        using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(resourcePath);
+        string deleteBody = await deleteResponse.Content.ReadAsStringAsync();
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent, deleteBody);
+    }
+
+    /// <summary>
+    /// 2.13 on every enforced operation for a caller whose tokens do not include the stored one, including the
+    /// POST that resolves to an upsert-as-update. The row, its token, and its readability by the owner are all
+    /// unchanged afterwards, which is the assertion that a denial cannot write.
+    /// </summary>
+    public static async Task It_returns_ownership_mismatch_problem_details_for_reads_and_writes(
+        ApiIntegrationHarness harness
+    )
+    {
+        Guid documentId = await CreateAsync(harness, OwnerTenant, 1201, "ownership-mismatch");
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(
+            ResourcePath(ForeignTenant, documentId)
+        );
+        await AssertOwnershipDenialAsync(getResponse, MismatchType, []);
+
+        using HttpResponseMessage putResponse = await PutAsync(
+            harness,
+            ForeignTenant,
+            documentId,
+            1201,
+            "ownership-mismatch-put"
+        );
+        await AssertOwnershipDenialAsync(putResponse, MismatchType, []);
+
+        // The same identity, so this POST resolves to an upsert-as-update against the stored row rather than
+        // to a create - the branch a create's vacuous check must not be allowed to cover.
+        using HttpResponseMessage postAsUpdateResponse = await PostAsync(
+            harness,
+            ForeignTenant,
+            1201,
+            "ownership-mismatch-post-as-update"
+        );
+        await AssertOwnershipDenialAsync(postAsUpdateResponse, MismatchType, []);
+
+        using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(
+            ResourcePath(ForeignTenant, documentId)
+        );
+        await AssertOwnershipDenialAsync(deleteResponse, MismatchType, []);
+
+        (await ReadStoredOwnershipTokenAsync(harness, documentId)).Should().Be(CreatorToken);
+
+        using HttpResponseMessage ownerGetResponse = await harness.HttpClient.GetAsync(
+            ResourcePath(OwnerTenant, documentId)
+        );
+        string ownerGetBody = await ownerGetResponse.Content.ReadAsStringAsync();
+        ownerGetResponse.StatusCode.Should().Be(HttpStatusCode.OK, ownerGetBody);
+        ownerGetBody.Should().Contain("ownership-mismatch");
+    }
+
+    /// <summary>
+    /// 2.14 on every enforced operation against a row created without a token: a distinct <c>type</c> and an
+    /// <c>errors</c> entry naming the strategy, over the same shared detail sentence 2.13 uses.
+    /// </summary>
+    public static async Task It_returns_stored_uninitialized_problem_details_for_reads_and_writes(
+        ApiIntegrationHarness harness
+    )
+    {
+        Guid documentId = await CreateAsync(harness, NoCreatorTokenTenant, 1301, "ownership-uninitialized");
+
+        (await ReadStoredOwnershipTokenAsync(harness, documentId)).Should().BeNull();
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(
+            ResourcePath(ForeignTenant, documentId)
+        );
+        await AssertOwnershipDenialAsync(getResponse, StoredUninitializedType, _storedUninitializedErrors);
+
+        using HttpResponseMessage putResponse = await PutAsync(
+            harness,
+            ForeignTenant,
+            documentId,
+            1301,
+            "ownership-uninitialized-put"
+        );
+        await AssertOwnershipDenialAsync(putResponse, StoredUninitializedType, _storedUninitializedErrors);
+
+        using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(
+            ResourcePath(ForeignTenant, documentId)
+        );
+        await AssertOwnershipDenialAsync(deleteResponse, StoredUninitializedType, _storedUninitializedErrors);
+
+        (await ReadStoredOwnershipTokenAsync(harness, documentId)).Should().BeNull();
+    }
+
+    /// <summary>
+    /// No ownership denial may disclose a token value - not the caller's and not the stored one. Ownership
+    /// tokens are numeric, so the property asserted is that no served string carries a digit at all: it holds
+    /// for both denial shapes and cannot be satisfied by a body that leaked one. The correlation id is excluded
+    /// because it is the request's own trace id.
+    /// </summary>
+    public static async Task It_never_discloses_an_ownership_token_value(ApiIntegrationHarness harness)
+    {
+        Guid mismatchId = await CreateAsync(harness, OwnerTenant, 1401, "ownership-no-disclosure-mismatch");
+        Guid uninitializedId = await CreateAsync(
+            harness,
+            NoCreatorTokenTenant,
+            1402,
+            "ownership-no-disclosure-uninitialized"
+        );
+
+        using HttpResponseMessage mismatchResponse = await harness.HttpClient.GetAsync(
+            ResourcePath(ForeignTenant, mismatchId)
+        );
+        using HttpResponseMessage uninitializedResponse = await harness.HttpClient.GetAsync(
+            ResourcePath(ForeignTenant, uninitializedId)
+        );
+
+        await AssertNoDigitsInServedTextAsync(mismatchResponse);
+        await AssertNoDigitsInServedTextAsync(uninitializedResponse);
+    }
+
+    /// <summary>
+    /// The provider-independent cap: 2,000 tokens fails closed with the security-configuration 500 on both
+    /// engines, and 1,999 is authorized on both. The pair runs against the same stored row, so the token count
+    /// is the only thing that differs between the two outcomes.
+    /// </summary>
+    public static async Task It_fails_closed_at_the_ownership_token_cap_and_authorizes_just_under_it(
+        ApiIntegrationHarness harness
+    )
+    {
+        Guid documentId = await CreateAsync(harness, OwnerTenant, 1501, "ownership-token-cap");
+
+        using HttpResponseMessage overCapResponse = await harness.HttpClient.GetAsync(
+            ResourcePath(TokenCapTenant, documentId)
+        );
+        string overCapBody = await overCapResponse.Content.ReadAsStringAsync();
+
+        overCapResponse.StatusCode.Should().Be(HttpStatusCode.InternalServerError, overCapBody);
+        overCapResponse.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        JsonObject overCapProblem = JsonNode.Parse(overCapBody)!.AsObject();
+        overCapProblem["type"]!.GetValue<string>().Should().Be(SecurityConfigurationProblemDetails.Type);
+        overCapProblem["status"]!.GetValue<int>().Should().Be(SecurityConfigurationProblemDetails.Status);
+
+        // 1,999 is the largest authorized list, and it carries the stored token, so the row is served.
+        using HttpResponseMessage underCapResponse = await harness.HttpClient.GetAsync(
+            ResourcePath(UnderTokenCapTenant, documentId)
+        );
+        string underCapBody = await underCapResponse.Content.ReadAsStringAsync();
+
+        underCapResponse.StatusCode.Should().Be(HttpStatusCode.OK, underCapBody);
+        underCapBody.Should().Contain("ownership-token-cap");
+    }
+
+    /// <summary>
+    /// GET-many ownership filtering belongs to a later story, so <c>OwnershipBased</c> on a collection read
+    /// stays a 501 rather than silently serving an unfiltered page. The 501 names the strategy, which is what
+    /// makes the withholding diagnosable rather than mysterious.
+    /// </summary>
+    public static async Task It_withholds_get_many_from_ownership_with_a_501(ApiIntegrationHarness harness)
+    {
+        await CreateAsync(harness, OwnerTenant, 1601, "ownership-get-many");
+
+        using HttpResponseMessage response = await harness.HttpClient.GetAsync(
+            string.Format(NullableResourcesEndpointFormat, OwnerTenant)
+        );
+
+        await AssertNotImplementedAsync(response);
+    }
+
+    /// <summary>
+    /// Descriptor ownership enforcement stays withheld on all four operations. The read and write paths are
+    /// given a document id nothing was created with, so a 501 there also proves the gate precedes target
+    /// lookup rather than depending on a row being present.
+    /// </summary>
+    public static async Task It_withholds_descriptor_operations_from_ownership_with_a_501(
+        ApiIntegrationHarness harness
+    )
+    {
+        string descriptorsEndpoint = string.Format(GradeLevelDescriptorsEndpointFormat, OwnerTenant);
+        string unknownId = Guid.NewGuid().ToString();
+        string descriptorPath = $"{descriptorsEndpoint}/{unknownId}";
+
+        using HttpResponseMessage postResponse = await SendJsonAsync(
+            harness,
+            HttpMethod.Post,
+            descriptorsEndpoint,
+            CreateDescriptorBody(resourceId: null)
+        );
+        await AssertNotImplementedAsync(postResponse);
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(descriptorPath);
+        await AssertNotImplementedAsync(getResponse);
+
+        using HttpResponseMessage putResponse = await SendJsonAsync(
+            harness,
+            HttpMethod.Put,
+            descriptorPath,
+            CreateDescriptorBody(unknownId)
+        );
+        await AssertNotImplementedAsync(putResponse);
+
+        using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(descriptorPath);
+        await AssertNotImplementedAsync(deleteResponse);
+    }
+
+    private static ApplicationContextResult Success(
+        long applicationId,
+        short? creatorOwnershipTokenId,
+        IReadOnlyList<short> ownershipTokenIds
+    ) =>
+        new ApplicationContextResult.Success(
+            new ApplicationContext(
+                Id: applicationId,
+                ApplicationId: applicationId,
+                ClientId: ExternalDoublesConstants.SmokeClientId,
+                ClientUuid: ExternalDoublesConstants.StableClientUuid,
+                DataStoreIds: [ExternalDoublesConstants.StableDataStoreId],
+                CreatorOwnershipTokenId: creatorOwnershipTokenId,
+                OwnershipTokenIds: ownershipTokenIds
+            )
+        );
+
+    /// <summary>
+    /// Distinct tokens starting at 1, so the range always contains <see cref="CreatorToken"/> and an authorized
+    /// outcome under the cap can never be mistaken for one the cap decided.
+    /// </summary>
+    private static IReadOnlyList<short> TokenRange(int count) =>
+        [.. Enumerable.Range(1, count).Select(static tokenId => (short)tokenId)];
+
+    private static string ResourcePath(string tenant, Guid documentId) =>
+        $"{string.Format(NullableResourcesEndpointFormat, tenant)}/{documentId}";
+
+    private static async Task<Guid> CreateAsync(
+        ApiIntegrationHarness harness,
+        string tenant,
+        int authorizationNullableId,
+        string name
+    )
+    {
+        using HttpResponseMessage response = await PostAsync(harness, tenant, authorizationNullableId, name);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, body);
+
+        return Guid.Parse(GetLocationPath(response).Split('/', StringSplitOptions.RemoveEmptyEntries)[^1]);
+    }
+
+    private static async Task<HttpResponseMessage> PostAsync(
+        ApiIntegrationHarness harness,
+        string tenant,
+        int authorizationNullableId,
+        string name
+    ) =>
+        await SendJsonAsync(
+            harness,
+            HttpMethod.Post,
+            string.Format(NullableResourcesEndpointFormat, tenant),
+            CreateBody(authorizationNullableId, name, resourceId: null)
+        );
+
+    private static async Task<HttpResponseMessage> PutAsync(
+        ApiIntegrationHarness harness,
+        string tenant,
+        Guid documentId,
+        int authorizationNullableId,
+        string name
+    ) =>
+        await SendJsonAsync(
+            harness,
+            HttpMethod.Put,
+            ResourcePath(tenant, documentId),
+            CreateBody(authorizationNullableId, name, documentId.ToString())
+        );
+
+    /// <summary>
+    /// <c>nullableSchoolId</c> is deliberately omitted, so the resource carries no securable element and no
+    /// reference data has to be seeded: ownership is the only strategy this scenario is about.
+    /// </summary>
+    private static JsonObject CreateBody(int authorizationNullableId, string name, string? resourceId)
+    {
+        JsonObject body = new() { ["authorizationNullableId"] = authorizationNullableId, ["name"] = name };
+
+        if (resourceId is not null)
+        {
+            body["id"] = resourceId;
+        }
+
+        return body;
+    }
+
+    private static JsonObject CreateDescriptorBody(string? resourceId)
+    {
+        JsonObject body = new()
+        {
+            ["codeValue"] = "Tenth grade",
+            ["description"] = "Tenth grade",
+            ["namespace"] = "uri://ed-fi.org/GradeLevelDescriptor",
+            ["shortDescription"] = "Tenth grade",
+        };
+
+        if (resourceId is not null)
+        {
+            body["id"] = resourceId;
+        }
+
+        return body;
+    }
+
+    private static async Task<HttpResponseMessage> SendJsonAsync(
+        ApiIntegrationHarness harness,
+        HttpMethod method,
+        string endpoint,
+        JsonObject body
+    )
+    {
+        using var request = new HttpRequestMessage(method, endpoint)
+        {
+            Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
+        };
+
+        return await harness.HttpClient.SendAsync(request);
+    }
+
+    private static string GetLocationPath(HttpResponseMessage response)
+    {
+        response.Headers.Location.Should().NotBeNull();
+
+        return response.Headers.Location!.IsAbsoluteUri
+            ? response.Headers.Location.AbsolutePath
+            : response.Headers.Location.OriginalString;
+    }
+
+    private static async Task AssertOwnershipDenialAsync(
+        HttpResponseMessage response,
+        string expectedType,
+        IReadOnlyList<string> expectedErrors
+    )
+    {
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden, body);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        JsonObject problem = JsonNode.Parse(body)!.AsObject();
+        problem["type"]!.GetValue<string>().Should().Be(expectedType);
+        problem["title"]!.GetValue<string>().Should().Be("Authorization Denied");
+        problem["status"]!.GetValue<int>().Should().Be(403);
+        // One sentence for both kinds, by design: the client is told only that the item is not owned, and the
+        // distinction is carried by type and by the errors entry.
+        problem["detail"]!.GetValue<string>().Should().Be(NotOwnedDetail);
+        problem["correlationId"]!.GetValue<string>().Should().NotBeNullOrWhiteSpace();
+        problem["validationErrors"]!.AsObject().Count.Should().Be(0);
+        problem["errors"]!
+            .AsArray()
+            .Select(static error => error!.GetValue<string>())
+            .Should()
+            .Equal(expectedErrors);
+    }
+
+    private static async Task AssertNoDigitsInServedTextAsync(HttpResponseMessage response)
+    {
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden, body);
+
+        JsonObject problem = JsonNode.Parse(body)!.AsObject();
+
+        foreach ((string propertyName, JsonNode? value) in problem)
+        {
+            if (string.Equals(propertyName, "correlationId", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (string text in CollectStrings(value))
+            {
+                text.Any(char.IsDigit)
+                    .Should()
+                    .BeFalse(
+                        $"'{propertyName}' must not carry an ownership token value, and '{text}' contains a digit"
+                    );
+            }
+        }
+    }
+
+    private static IEnumerable<string> CollectStrings(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonValue value when value.TryGetValue(out string? text):
+                yield return text;
+                break;
+
+            case JsonArray array:
+                foreach (string text in array.SelectMany(CollectStrings))
+                {
+                    yield return text;
+                }
+                break;
+
+            case JsonObject jsonObject:
+                foreach (string text in jsonObject.SelectMany(property => CollectStrings(property.Value)))
+                {
+                    yield return text;
+                }
+                break;
+        }
+    }
+
+    private static async Task AssertNotImplementedAsync(HttpResponseMessage response)
+    {
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented, body);
+        JsonNode.Parse(body)!.AsObject()["error"]!
+            .GetValue<string>()
+            .Should()
+            .Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+    }
+
+    private static async Task<short?> ReadStoredOwnershipTokenAsync(
+        ApiIntegrationHarness harness,
+        Guid documentUuid
+    )
+    {
+        string sql = IsMssql(harness.DbConnection)
+            ? """
+                SELECT [CreatedByOwnershipTokenId]
+                FROM [dms].[Document]
+                WHERE [DocumentUuid] = @documentUuid;
+                """
+            : """
+                SELECT "CreatedByOwnershipTokenId"
+                FROM "dms"."Document"
+                WHERE "DocumentUuid" = @documentUuid;
+                """;
+
+        await using DbCommand command = harness.DbConnection.CreateCommand();
+        command.CommandText = sql;
+
+        DbParameter parameter = command.CreateParameter();
+        parameter.ParameterName = "@documentUuid";
+        parameter.Value = documentUuid;
+        command.Parameters.Add(parameter);
+
+        object? value = await command.ExecuteScalarAsync();
+
+        value.Should().NotBeNull("the document row must exist for its stored ownership token to be read");
+
+        return value is DBNull ? null : Convert.ToInt16(value, CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsMssql(DbConnection connection)
+    {
+        string? fullName = connection.GetType().FullName;
+        return fullName is not null && fullName.Contains("SqlClient", StringComparison.Ordinal);
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_OwnershipAuthorization.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_OwnershipAuthorization.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Mssql;
+
+/// <summary>
+/// OwnershipBased authorization at the public HTTP boundary against SQL Server: stamping, the authorized round
+/// trip, the two denial ProblemDetails contracts, the token cap, and the withheld scopes. The real
+/// authorization middleware runs, and the caller's ownership tokens arrive through the production
+/// application-context provider rather than being injected into the backend.
+/// </summary>
+public sealed class Given_Mssql_OwnershipAuthorization : MssqlApiIntegrationTestBase
+{
+    private readonly RecordingConfigurationServiceApplicationProvider _applicationContextProvider = new(
+        OwnershipAuthorizationIntegrationScenario.Resolve
+    );
+
+    protected override FixtureKey Fixture => FixtureKey.AuthorizationQuery;
+
+    protected override bool BypassAuthorization => false;
+
+    /// <summary>
+    /// The tenant route qualifier is how one host serves several ownership token sets: the replaced CMS-facing
+    /// provider resolves a different set per tenant, so an owner and a non-owner can act on the same row inside
+    /// one test.
+    /// </summary>
+    protected override bool MultiTenancy => true;
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        OwnershipAuthorizationIntegrationScenario.CreateClaimSetProvider(fixture);
+
+    protected override IConfigurationServiceApplicationProvider? ApplicationContextConfigurationProviderOverride =>
+        _applicationContextProvider;
+
+    [Test]
+    public Task It_stamps_the_creator_ownership_token_on_create_and_never_denies_it() =>
+        OwnershipAuthorizationIntegrationScenario.It_stamps_the_creator_ownership_token_on_create_and_never_denies_it(
+            Harness
+        );
+
+    [Test]
+    public Task It_authorizes_the_full_round_trip_for_a_holder_of_the_stored_token() =>
+        OwnershipAuthorizationIntegrationScenario.It_authorizes_the_full_round_trip_for_a_holder_of_the_stored_token(
+            Harness
+        );
+
+    [Test]
+    public Task It_returns_ownership_mismatch_problem_details_for_reads_and_writes() =>
+        OwnershipAuthorizationIntegrationScenario.It_returns_ownership_mismatch_problem_details_for_reads_and_writes(
+            Harness
+        );
+
+    [Test]
+    public Task It_returns_stored_uninitialized_problem_details_for_reads_and_writes() =>
+        OwnershipAuthorizationIntegrationScenario.It_returns_stored_uninitialized_problem_details_for_reads_and_writes(
+            Harness
+        );
+
+    [Test]
+    public Task It_never_discloses_an_ownership_token_value() =>
+        OwnershipAuthorizationIntegrationScenario.It_never_discloses_an_ownership_token_value(Harness);
+
+    [Test]
+    public Task It_fails_closed_at_the_ownership_token_cap_and_authorizes_just_under_it() =>
+        OwnershipAuthorizationIntegrationScenario.It_fails_closed_at_the_ownership_token_cap_and_authorizes_just_under_it(
+            Harness
+        );
+
+    [Test]
+    public Task It_withholds_get_many_from_ownership_with_a_501() =>
+        OwnershipAuthorizationIntegrationScenario.It_withholds_get_many_from_ownership_with_a_501(Harness);
+
+    [Test]
+    public Task It_withholds_descriptor_operations_from_ownership_with_a_501() =>
+        OwnershipAuthorizationIntegrationScenario.It_withholds_descriptor_operations_from_ownership_with_a_501(
+            Harness
+        );
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_OwnershipAuthorization.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_OwnershipAuthorization.cs
@@ -76,6 +76,12 @@ public sealed class Given_Mssql_OwnershipAuthorization : MssqlApiIntegrationTest
         );
 
     [Test]
+    public Task It_creates_over_the_ownership_token_cap_and_fails_closed_for_the_post_as_update() =>
+        OwnershipAuthorizationIntegrationScenario.It_creates_over_the_ownership_token_cap_and_fails_closed_for_the_post_as_update(
+            Harness
+        );
+
+    [Test]
     public Task It_withholds_get_many_from_ownership_with_a_501() =>
         OwnershipAuthorizationIntegrationScenario.It_withholds_get_many_from_ownership_with_a_501(Harness);
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_OwnershipAuthorization.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_OwnershipAuthorization.cs
@@ -76,6 +76,12 @@ public sealed class Given_Postgresql_OwnershipAuthorization : PostgresqlApiInteg
         );
 
     [Test]
+    public Task It_creates_over_the_ownership_token_cap_and_fails_closed_for_the_post_as_update() =>
+        OwnershipAuthorizationIntegrationScenario.It_creates_over_the_ownership_token_cap_and_fails_closed_for_the_post_as_update(
+            Harness
+        );
+
+    [Test]
     public Task It_withholds_get_many_from_ownership_with_a_501() =>
         OwnershipAuthorizationIntegrationScenario.It_withholds_get_many_from_ownership_with_a_501(Harness);
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_OwnershipAuthorization.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_OwnershipAuthorization.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Postgresql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Postgresql;
+
+/// <summary>
+/// OwnershipBased authorization at the public HTTP boundary against PostgreSQL: stamping, the authorized round
+/// trip, the two denial ProblemDetails contracts, the token cap, and the withheld scopes. The real
+/// authorization middleware runs, and the caller's ownership tokens arrive through the production
+/// application-context provider rather than being injected into the backend.
+/// </summary>
+public sealed class Given_Postgresql_OwnershipAuthorization : PostgresqlApiIntegrationTestBase
+{
+    private readonly RecordingConfigurationServiceApplicationProvider _applicationContextProvider = new(
+        OwnershipAuthorizationIntegrationScenario.Resolve
+    );
+
+    protected override FixtureKey Fixture => FixtureKey.AuthorizationQuery;
+
+    protected override bool BypassAuthorization => false;
+
+    /// <summary>
+    /// The tenant route qualifier is how one host serves several ownership token sets: the replaced CMS-facing
+    /// provider resolves a different set per tenant, so an owner and a non-owner can act on the same row inside
+    /// one test.
+    /// </summary>
+    protected override bool MultiTenancy => true;
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        OwnershipAuthorizationIntegrationScenario.CreateClaimSetProvider(fixture);
+
+    protected override IConfigurationServiceApplicationProvider? ApplicationContextConfigurationProviderOverride =>
+        _applicationContextProvider;
+
+    [Test]
+    public Task It_stamps_the_creator_ownership_token_on_create_and_never_denies_it() =>
+        OwnershipAuthorizationIntegrationScenario.It_stamps_the_creator_ownership_token_on_create_and_never_denies_it(
+            Harness
+        );
+
+    [Test]
+    public Task It_authorizes_the_full_round_trip_for_a_holder_of_the_stored_token() =>
+        OwnershipAuthorizationIntegrationScenario.It_authorizes_the_full_round_trip_for_a_holder_of_the_stored_token(
+            Harness
+        );
+
+    [Test]
+    public Task It_returns_ownership_mismatch_problem_details_for_reads_and_writes() =>
+        OwnershipAuthorizationIntegrationScenario.It_returns_ownership_mismatch_problem_details_for_reads_and_writes(
+            Harness
+        );
+
+    [Test]
+    public Task It_returns_stored_uninitialized_problem_details_for_reads_and_writes() =>
+        OwnershipAuthorizationIntegrationScenario.It_returns_stored_uninitialized_problem_details_for_reads_and_writes(
+            Harness
+        );
+
+    [Test]
+    public Task It_never_discloses_an_ownership_token_value() =>
+        OwnershipAuthorizationIntegrationScenario.It_never_discloses_an_ownership_token_value(Harness);
+
+    [Test]
+    public Task It_fails_closed_at_the_ownership_token_cap_and_authorizes_just_under_it() =>
+        OwnershipAuthorizationIntegrationScenario.It_fails_closed_at_the_ownership_token_cap_and_authorizes_just_under_it(
+            Harness
+        );
+
+    [Test]
+    public Task It_withholds_get_many_from_ownership_with_a_501() =>
+        OwnershipAuthorizationIntegrationScenario.It_withholds_get_many_from_ownership_with_a_501(Harness);
+
+    [Test]
+    public Task It_withholds_descriptor_operations_from_ownership_with_a_501() =>
+        OwnershipAuthorizationIntegrationScenario.It_withholds_descriptor_operations_from_ownership_with_a_501(
+            Harness
+        );
+}


### PR DESCRIPTION
## What

Implements ownership-based authorization for the single-record operations GET-by-id, POST, PUT and DELETE on relationally stored resources, per `auth.md` sections 2.13 and 2.14.

## Why

`OwnershipBased` was recognized but not enforced: a claim set configuring it fell through to a fail-closed 501. DMS-1373 already loads and caches `CreatorOwnershipTokenId` and `OwnershipTokenIds` from the tenant-qualified CMS `ApplicationContext`, so the values were available but nothing consumed them. This story consumes them, so a client configured with `OwnershipBased` is authorized against the stored `CreatedByOwnershipTokenId` rather than refused.

GET-many is deliberately left out and stays 501 — it is a page filter rather than a single-record check, and belongs to DMS-1410.

## Changes

Contracts and responses:
- `OwnershipAuthorizationFailure` with `OwnershipTokenMismatch` and `StoredOwnershipTokenUninitialized`, and the four `…FailureOwnershipNotAuthorized` result members on `GetResult`, `UpsertResult`, `UpdateResult` and `DeleteResult`.
- `OwnershipAuthorizationFailureResponse` producing the section 2.13 and 2.14 ProblemDetails, plus the dispatch arm in each of the four handlers. Neither body discloses a token value or the configured strategy index.

Planning and SQL:
- `OwnershipAuthorizationPlanner`, `OwnershipAuthorizationSqlCompiler` for both dialects, and the `own1` `AUTH1` payload family with its codec and dispatcher arm. The payload carries the CMS-configured strategy index, and a payload whose index does not match the planned check maps to a 500 rather than to a denial.
- `OwnershipTokenParameterization` binds one array parameter on PostgreSQL and one scalar per token on SQL Server; no TVP. `OwnershipTokenLimitExceededException` fails closed at 2,000 or more tokens on both dialects, guarded before deduplication so a padded list cannot slip under the cap.
- `RelationalAuthorizationPlanner` gains the enablement gate, the cap terminal, and its precedence: after both namespace terminals, ahead of every relationship terminal, and yielding to a custom-view configuration failure.

Execution:
- `OwnershipAuthorizationExecutor` and `OwnershipAuthorizationProviderFailureMapper`.
- `RelationalCompositeStoredAuthorization.TryAppendOwnership` places the statement after the custom-view and namespace statements and before the relationship statement, so statement order is precedence order. DELETE co-batches it into the command carrying the deletes, so an `AUTH1` abort leaves the row present. POST and PUT place it in the write's first-phase command, ahead of the second command that carries the DML. Both appends are budget-guarded and fall back to ordered same-session segments.
- Stamping on `RelationalDocumentRowCommandBuilder` applies to every create, including resources not configured with `OwnershipBased`; a missing creator token stamps null, and a PUT never changes the stored value.

Deliberate non-goals, each behind a named predicate rather than an accidental gap:
- Descriptors stamp but do not enforce — a descriptor action configured with `OwnershipBased` stays 501, via the `ResourceStorageKind.SharedDescriptorTable` arm of `EnforcesOwnershipChecks`.
- A POST resolving to create is never denied by ownership, pinned by the carrier row guard and by a wire-level 201 for a caller holding no tokens.
- GET-many and change queries keep their existing 501 and 500.

Documentation:
- `11-ownership-auth-strategy.md` acceptance criteria now separate the read path from the write and delete paths, separate descriptor stamping from descriptor enforcement, and record the budget-guarded segment fallback.
- `08-write-roundtrip-batching.md` records the GET-by-id one-added-command deviation next to the existing authorized-GET-by-id one, and qualifies the write/delete co-batch claim.

No schema change: `CreatedByOwnershipTokenId` already exists on `main`.

This PR also keeps the GET-by-id preflight terminal custom-view validation fix in DMS-1060 because ownership made the pre-existing accelerated-path gap reachable: the ownership token-cap terminal carries every configured custom view, since OwnershipBased executes last among AND strategies. Both regular and read-accelerated GET-by-id now complete preflight terminals through CompleteGetByIdPreflightStopAsync so custom-view validation behavior is consistent.

## Testing

About 16,000 tests, one failure, which is inherited — see below.

- Unit, all 11 projects: 14,138 passed.
- Backend integration `Category=Authorization`: 235 passed on PostgreSQL, 285 on SQL Server.
- API integration, full in-process HTTP pipeline on both providers: 418 passed, 1 failed.
- E2E shards 1 through 4: 909 passed, 0 failed, 13 skipped across 922 scenarios. No skip is an authorization scenario.
- `dotnet csharpier check src/dms` clean.

Each enablement gate was reverted individually to confirm its own test fails and no branch is covered only incidentally. That exercise found one branch covered only by its extracted predicate and not through the planner, and added the missing test.

## Expected CI noise, not hidden

`Given_DocumentCacheStatusEndpointProductionService.It_keeps_normal_api_routing_open_when_later_projection_work_makes_cdc_status_not_caught_up` fails with a 401 where it expects a 201. This is pre-existing on `main` and unrelated to this PR:

- Every file on that request path is byte-identical to `main` tip: `ApiService.cs`, `JwtAuthenticationMiddleware.cs`, `JwtRoleAuthenticationMiddleware.cs`, `ExternalDoublesRegistration.cs`, and the failing test itself.
- `main` is an ancestor of this branch, so `main` runs that test with identical inputs.
- The 401 is returned during authentication, upstream of anything this PR touches. The test's own fixture replaces `IJwtValidationService` with a document-cache status double and then makes a data-path request through it.
- It is invisible on `main` because the API integration project runs only in `on-dms-pullrequest.yml`, which fires on PRs.

It deserves its own ticket rather than a fix folded into this PR.

## Not included

Phase 9, Docker E2E ownership coverage, is optional and separable and is not part of this PR. It would add E2E step definitions for `POST /v3/ownershipTokens/` and `PUT /v3/apiClients/{id}/ownership` plus an `OwnershipAuthorization.feature`. It was scoped out because `AuthorizationDataProvider` may not currently surface the CMS apiClient id the assignment needs, and extending it is potentially broad. Enforcement is already proven at the unit, backend integration and API integration levels on both providers, and the existing E2E authorization shards prove no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

