### PR TITLE
[DMS-1340] Mask generated smoke-test credentials in smoke-test logs

### DIFF
--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -440,6 +440,9 @@ jobs:
         run: |
           Import-Module ./modules/SmokeTest.psm1 -Force
           $credentials = Get-SmokeTestCredential -ConfigServiceUrl "http://localhost:8081" -DataStoreIds @([long]$env:SMOKE_DATA_STORE_ID)
+          # Mask the credentials in the job log before they can be written or echoed anywhere
+          Write-Host "::add-mask::$($credentials.Key)"
+          Write-Host "::add-mask::$($credentials.Secret)"
           # Store credentials in environment variables for subsequent steps
           "SMOKE_TEST_KEY=$($credentials.Key)" | Out-File -FilePath $env:GITHUB_ENV -Append
           "SMOKE_TEST_SECRET=$($credentials.Secret)" | Out-File -FilePath $env:GITHUB_ENV -Append

--- a/eng/Dms-Management.psm1
+++ b/eng/Dms-Management.psm1
@@ -591,8 +591,11 @@ function Add-Vendor {
     .EXAMPLE
         $creds = Add-Application -VendorId 12345 -AccessToken $token -ApplicationName "MyApp" -DataStoreIds @(1,2)
         Write-Output "App ID: $($creds.Id)"
-        Write-Output "App Key: $($creds.Key)"
-        Write-Output "App Secret: $($creds.Secret)"
+
+        # Hand the key and secret straight to the consumer instead of echoing them. They
+        # authenticate against the API, so they do not belong in console output that ends
+        # up in a shared terminal or a CI log.
+        $apiToken = Get-DmsToken -DmsUrl "http://localhost:8080" -Key $creds.Key -Secret $creds.Secret
 #>
 function Add-Application {
     [CmdletBinding()]

--- a/eng/smoke_test/SMOKETEST.md
+++ b/eng/smoke_test/SMOKETEST.md
@@ -56,12 +56,25 @@ $credentials = Get-SmokeTestCredential -ConfigServiceUrl "http://localhost:8081"
 
 - `ConfigServiceUrl` (Required): The URL of the Configuration Service
 - `SysAdminId` (Optional): System administrator ID (default: "smoke-test-admin")
-- `SysAdminSecret` (Optional): System administrator secret (default: "SmokeTest12!")
+- `SysAdminSecret` (Optional): System administrator secret. The default is a fixed
+  bootstrap literal defined in `modules/SmokeTest.psm1`, not a generated credential.
 - `VendorName` (Optional): Vendor name (default: "Smoke Test Vendor")
 - `ApplicationName` (Optional): Application name (default: "Smoke Test Application")
 - `ClaimSetName` (Optional): Claim set name (default: "EdFiSandbox")
-- `EducationOrganizationIds` (Optional): Array of education organization IDs
+- `EducationOrganizationIds` (Optional): Array of education organization IDs (default:
+  5, 6, 7, 255901, 19255901, 100000, 200000, 300000). The first three keep the TPDM
+  sample education organizations reachable, since `educatorPreparationProgram` defaults
+  to a `RelationshipsWithEdOrgsOnly` claim.
+- `DataStoreIds` (Optional): Array of data store IDs to associate with the application
+  (default: empty, in which case the first available data store is used)
+- `Tenant` (Optional): Tenant name, for multi-tenant Configuration Service deployments
+  (default: empty, meaning single tenant)
+
+The function returns the key and secret to the caller and does not write them to the
+console. Keep them in a variable and pass them onward rather than echoing them.
 
 ### Example
 
-See `Example-GetCredentials.ps1` for a complete example of how to use the function.
+The `Usage` section above is a complete example. For a working invocation inside a
+larger script, see `eng/docker-compose/start-published-dms.ps1`, which calls
+`Get-SmokeTestCredential` when run with `-AddSmokeTestCredentials`.

--- a/eng/smoke_test/modules/SmokeTest.psm1
+++ b/eng/smoke_test/modules/SmokeTest.psm1
@@ -72,9 +72,23 @@ function Invoke-SmokeTestUtility {
         $options += @("-l", $SdkPath)
     }
 
+    # Build a brand-new array for the echo rather than assigning $options to another
+    # variable: PowerShell array assignment is a reference copy, so redacting elements
+    # of a variable that still points at $options would redact the real array that
+    # gets passed to dotnet below and break authentication for every smoke-test leg.
+    $display = @()
+    for ($i = 0; $i -lt $options.Length; $i++) {
+        if ($i -gt 0 -and ($options[$i - 1] -eq "-k" -or $options[$i - 1] -eq "-s")) {
+            $display += "***"
+        }
+        else {
+            $display += $options[$i]
+        }
+    }
+
     $previousForegroundColor = $host.UI.RawUI.ForegroundColor
     $host.UI.RawUI.ForegroundColor = "Cyan"
-    Write-Output $ToolPath $options
+    Write-Output $ToolPath $display
     $host.UI.RawUI.ForegroundColor = $previousForegroundColor
 
     $path = (Join-Path -Path ($ToolPath).Trim() -ChildPath "tools/net*/any/EdFi.SmokeTest.Console.dll")

--- a/eng/smoke_test/tests/SmokeTest.Tests.ps1
+++ b/eng/smoke_test/tests/SmokeTest.Tests.ps1
@@ -32,3 +32,63 @@ Describe "Get-SmokeTestCredential" {
         }
     }
 }
+
+Describe "Invoke-SmokeTestUtility" {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../modules/SmokeTest.psm1" -Force
+    }
+
+    It "redacts the key and secret from the echoed invocation instead of printing them in the clear" {
+        $capturedOutput = $null
+        $resolveFailure = $null
+
+        try {
+            Invoke-SmokeTestUtility -BaseUrl 'http://localhost:8080' -Key 'TESTKEY_abc123' -Secret 'TESTSECRET_s3cr3t' -ToolPath '/nonexistent/tool/path' -TestSet 'NonDestructiveApi' -OutVariable capturedOutput | Out-Null
+        }
+        catch {
+            # Resolve-Path throws for this nonexistent -ToolPath, but only after the echo has
+            # already written the key and secret to the success stream. -OutVariable captures
+            # that echo regardless of the later terminating error, which is exactly how the
+            # leak was reproduced. The error is kept so the assertions below can prove the
+            # intended path was the one exercised.
+            $resolveFailure = $_
+        }
+
+        $echoedText = $capturedOutput | Out-String
+
+        $resolveFailure | Should -Not -BeNullOrEmpty -Because "this test only exercises the real leak if the run got past the echo and then died on the unresolvable tool path; a clean return would mean it is asserting against something else entirely"
+        $echoedText | Should -Not -BeNullOrEmpty -Because "the echo must run before Resolve-Path fails, or this test is not exercising the real leak"
+        $echoedText | Should -Not -Match 'TESTSECRET_s3cr3t' -Because "printing the raw secret to console output defeats the purpose of a machine-issued smoke-test credential that operators may paste into shared logs or terminals"
+        $echoedText | Should -Not -Match 'TESTKEY_abc123' -Because "the key identifies the smoke-test application and should not be echoed in the clear alongside its secret"
+        ([regex]::Matches($echoedText, '\*\*\*')).Count | Should -Be 2 -Because "both the key and the secret should be replaced with the same redaction placeholder"
+    }
+
+    It "still passes the real key and secret to dotnet, proving the redacted echo is a separate array and not an alias of the real argument list" {
+        $toolRoot = Join-Path $TestDrive "tool"
+        New-Item -ItemType Directory -Path (Join-Path $toolRoot "tools/net10.0/any") -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $toolRoot "tools/net10.0/any/EdFi.SmokeTest.Console.dll") -Force | Out-Null
+
+        $calls = [System.Collections.Generic.List[object]]::new()
+        Mock dotnet -ModuleName SmokeTest {
+            # Pester mocks a native command with a function, and function argument
+            # binding (unlike native-command binding) does not flatten the $options
+            # array into $path's sibling positional argument, so $args here is
+            # @($path, $options) with $options still nested one level deep. The
+            # += below relies on PowerShell's array-concatenation semantics to
+            # flatten that one level back out.
+            $flatArgs = @()
+            foreach ($item in $args) { $flatArgs += $item }
+            $calls.Add($flatArgs)
+        }
+
+        Invoke-SmokeTestUtility -BaseUrl 'http://localhost:8080' -Key 'TESTKEY_abc123' -Secret 'TESTSECRET_s3cr3t' -ToolPath $toolRoot -TestSet 'NonDestructiveApi' | Out-Null
+
+        $calls.Count | Should -Be 1 -Because "the mocked dotnet invocation should have been reached now that Resolve-Path succeeds against the staged tool tree"
+
+        $realArgs = $calls[0] -join ' '
+
+        $realArgs | Should -Match 'TESTKEY_abc123' -Because "if this were the same array reference as the redacted echo, the key dotnet receives would already have been overwritten with ***, and authentication would fail on every smoke-test leg"
+        $realArgs | Should -Match 'TESTSECRET_s3cr3t' -Because "if this were the same array reference as the redacted echo, the secret dotnet receives would already have been overwritten with ***, and authentication would fail on every smoke-test leg"
+        $realArgs | Should -Not -Match '\*\*\*' -Because "the argument list handed to dotnet must never be the redacted display copy"
+    }
+}


### PR DESCRIPTION
## Summary

The scheduled smoke-test workflow mints an ephemeral API key/secret per matrix leg, and the shared smoke-test module echoed that secret in plaintext before each API/SDK test run.
Nothing registered a GitHub log mask, so the values landed in a public Actions log on every leg, PostgreSQL and MSSQL alike.

Severity is low in practice: the credential only authenticates against the docker-compose stack on the ephemeral runner and dies with the job.
Public logs should still not print credentials.

## Changes

- `.github/workflows/scheduled-smoke-test.yml`: register `::add-mask::` for both generated values immediately after they are minted and before they are written to `GITHUB_ENV`. Masking is job-wide from the point of registration, so it also covers output from `EdFi.SmokeTest.Console.dll`, a third-party package this repo cannot edit.
- `eng/smoke_test/modules/SmokeTest.psm1`: `Invoke-SmokeTestUtility` now echoes a redacted copy of the argument list, with the `-k` and `-s` values replaced by `***`. The other arguments stay visible as operator diagnostics. This matters outside CI: `Invoke-NonDestructiveApiTests.ps1`, `Invoke-NonDestructiveSdkTests.ps1`, and `Invoke-DestructiveSdkTests.ps1` are operator entry points where no job-wide mask exists.
- `eng/smoke_test/tests/SmokeTest.Tests.ps1`: two new cases covering both halves of the redaction.

## Note on how the redaction is built

The redacted array is constructed fresh rather than assigned from `$options`.
PowerShell array assignment is a reference copy, so redacting a variable that still points at `$options` would redact the real argument list handed to `dotnet`, breaking authentication on every leg while still satisfying an echo-only assertion.

The second new test mocks `dotnet` and asserts the real arguments reach it unredacted.
It was negative-controlled: temporarily introducing the aliasing form makes that test fail while the echo test continues to pass, which is what confirms the test can tell the two implementations apart.

Redaction keys off the preceding `-k` / `-s` token rather than a fixed index, since the positions only happen to be stable today because the optional `-o` and `-l` arguments are appended last.

## Verification

| Check | Result |
| --- | --- |
| `eng/smoke_test/tests/SmokeTest.Tests.ps1` | 4 passed, 0 failed |
| PSScriptAnalyzer, both changed PowerShell files | 0 findings across 75 rules, 0 rules erroring |
| `eng/DatabaseTemplates/tests/Smoke-LegSelection.Tests.ps1` | 11 passed, 0 failed |

The end-to-end check is this PR's own Scheduled Smoke Test run: both changed paths map to every leg, so the full PostgreSQL/MSSQL x DS 5.2/6.1 matrix runs automatically.
Reviewers should confirm the legs show `***` where the credentials would have appeared **and** that they pass, since a passing run is what proves the real credentials still reached the console app.

## Second commit: aligning the surrounding docs with actual behavior

Reviewing the credential paths turned up documentation that had drifted from the code.
None of it is an exposure, but all of it describes or demonstrates the behavior this PR changes, so it is corrected here rather than left to contradict the new convention.

`eng/smoke_test/SMOKETEST.md`, the `Get-SmokeTestCredential` reference:

- The documented `SysAdminSecret` default was `"SmokeTest12!"`, which is not the literal the module actually uses. The default is now described rather than duplicated, so it cannot drift again.
- `EducationOrganizationIds` listed no default. It now records the real envelope and why the TPDM sample education organizations are in it.
- `DataStoreIds` and `Tenant` were undocumented despite being real parameters.
- The `Example` section pointed at `Example-GetCredentials.ps1`, a file that does not exist and never has. It now points at `start-published-dms.ps1 -AddSmokeTestCredentials`, which is a real caller.
- Added a line stating that the function returns credentials to the caller and does not write them to the console.

`eng/Dms-Management.psm1`, the `Add-Application` comment-based help:

- The `.EXAMPLE` block demonstrated `Write-Output "App Secret: ..."`. It never executed, so it was not a leak, but it taught the exact pattern the rest of this PR removes. It now shows the credentials being passed to `Get-DmsToken` instead of printed.

Verified: PSScriptAnalyzer still reports 0 findings across 75 rules on `Dms-Management.psm1`, the module still imports with all 24 functions exported, its comment-based help still parses, and the smoke-test suite is unchanged at 4 passed / 0 failed.
