### PR TITLE
[DMS-1512] Send the tenant header per request in the CMS claim-set provider

### DIFF
--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/ConfigurationServiceClaimSetProviderHeaderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/ConfigurationServiceClaimSetProviderHeaderTests.cs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Core.Security.Model;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Security;
+
+/// <summary>
+/// Covers the outbound header contract of ConfigurationServiceClaimSetProvider. The provider shares one
+/// HttpClient with the token handler and the other Configuration Service providers, so authorization and
+/// tenant selection must travel on the individual request rather than on the client's default headers.
+/// </summary>
+public class ConfigurationServiceClaimSetProviderHeaderTests
+{
+    private const string TenantHeaderName = "Tenant";
+    private const string BaseAddress = "https://api.example.com";
+    private const string CmsToken = "cms-access-token";
+
+    /// <summary>
+    /// What one outbound call looked like from inside the transport: the headers the request itself
+    /// carried, plus the tenant state visible on the shared client at the moment the request arrived.
+    /// </summary>
+    private sealed record ObservedRequest(
+        string? RequestTenantHeader,
+        string? RequestAuthorizationParameter,
+        string? SharedClientTenantHeader
+    );
+
+    /// <summary>
+    /// Records each outbound request and holds every request open until the expected number of them has
+    /// arrived, so concurrent fetches are genuinely in flight together rather than serialized by chance.
+    /// </summary>
+    private sealed class GatedRecordingHandler(int releaseAfterRequestCount) : HttpMessageHandler
+    {
+        private readonly ConcurrentQueue<ObservedRequest> _observed = new();
+        private readonly TaskCompletionSource _allRequestsArrived = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        private int _arrivedCount;
+
+        /// <summary>
+        /// The client the provider shares with the token handler and the sibling providers. The handler
+        /// snapshots its default headers on arrival so a test can tell whether the fetch published its
+        /// tenant onto shared state.
+        /// </summary>
+        public HttpClient? SharedClient { get; set; }
+
+        /// <summary>
+        /// Produces the authorization metadata body for the tenant the request asked for.
+        /// </summary>
+        public Func<string?, string> ResponseBodyForTenant { get; set; } = _ => "[]";
+
+        public IReadOnlyList<ObservedRequest> Observed => [.. _observed];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            string? requestTenant = SingleHeaderValue(request.Headers, TenantHeaderName);
+            string? sharedClientTenant = SharedClient is null
+                ? null
+                : SingleHeaderValue(SharedClient.DefaultRequestHeaders, TenantHeaderName);
+
+            _observed.Enqueue(
+                new ObservedRequest(
+                    requestTenant,
+                    request.Headers.Authorization?.Parameter,
+                    sharedClientTenant
+                )
+            );
+
+            if (Interlocked.Increment(ref _arrivedCount) >= releaseAfterRequestCount)
+            {
+                _allRequestsArrived.TrySetResult();
+            }
+
+            await _allRequestsArrived.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    ResponseBodyForTenant(requestTenant),
+                    Encoding.UTF8,
+                    "application/json"
+                ),
+            };
+        }
+
+        private static string? SingleHeaderValue(System.Net.Http.Headers.HttpHeaders headers, string name) =>
+            headers.TryGetValues(name, out var values) ? string.Join(",", values) : null;
+    }
+
+    private static HttpClient CreateSharedClient(GatedRecordingHandler handler)
+    {
+        var responseHandler = new ConfigurationServiceResponseHandler(
+            NullLogger<ConfigurationServiceResponseHandler>.Instance
+        )
+        {
+            InnerHandler = handler,
+        };
+
+        var client = new HttpClient(responseHandler) { BaseAddress = new Uri(BaseAddress) };
+        handler.SharedClient = client;
+        return client;
+    }
+
+    private static ConfigurationServiceClaimSetProvider CreateProvider(HttpClient client)
+    {
+        var tokenHandler = A.Fake<IConfigurationServiceTokenHandler>();
+        A.CallTo(() =>
+                tokenHandler.GetTokenAsync(A<string>._, A<string>._, A<string>._, A<CancellationToken>._)
+            )
+            .Returns(CmsToken);
+
+        return new ConfigurationServiceClaimSetProvider(
+            new ConfigurationServiceApiClient(client),
+            tokenHandler,
+            new ConfigurationServiceContext("dms-client", "dms-secret", "fullaccess")
+        );
+    }
+
+    /// <summary>
+    /// One claim set named for the tenant that asked for it, so a crossed request is visible in the result.
+    /// </summary>
+    private static string ClaimSetMetadataBodyFor(string? tenant) =>
+        JsonSerializer.Serialize(
+            new List<ClaimSetMetadata> { new($"{tenant ?? "NoTenant"}ClaimSet", [], []) }
+        );
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_ClaimSet_Fetch_For_A_Tenant : ConfigurationServiceClaimSetProviderHeaderTests
+    {
+        private GatedRecordingHandler _handler = null!;
+        private HttpClient _client = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _handler = new GatedRecordingHandler(releaseAfterRequestCount: 1)
+            {
+                ResponseBodyForTenant = ClaimSetMetadataBodyFor,
+            };
+            _client = CreateSharedClient(_handler);
+
+            await CreateProvider(_client).GetAllClaimSets("TenantA");
+        }
+
+        [TearDown]
+        public void TearDown() => _client.Dispose();
+
+        [Test]
+        public void It_Should_Send_The_Tenant_On_The_Individual_Request()
+        {
+            _handler.Observed.Should().ContainSingle();
+            _handler.Observed[0].RequestTenantHeader.Should().Be("TenantA");
+        }
+
+        [Test]
+        public void It_Should_Send_The_Cms_Bearer_Token_On_The_Individual_Request()
+        {
+            _handler.Observed[0].RequestAuthorizationParameter.Should().Be(CmsToken);
+        }
+
+        [Test]
+        public void It_Should_Not_Write_The_Tenant_To_The_Shared_Client()
+        {
+            _client.DefaultRequestHeaders.Contains(TenantHeaderName).Should().BeFalse();
+        }
+
+        [Test]
+        public void It_Should_Not_Write_The_Authorization_To_The_Shared_Client()
+        {
+            _client.DefaultRequestHeaders.Authorization.Should().BeNull();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_ClaimSet_Fetch_Without_A_Tenant : ConfigurationServiceClaimSetProviderHeaderTests
+    {
+        private GatedRecordingHandler _handler = null!;
+        private HttpClient _client = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _handler = new GatedRecordingHandler(releaseAfterRequestCount: 1)
+            {
+                ResponseBodyForTenant = ClaimSetMetadataBodyFor,
+            };
+            _client = CreateSharedClient(_handler);
+
+            await CreateProvider(_client).GetAllClaimSets();
+        }
+
+        [TearDown]
+        public void TearDown() => _client.Dispose();
+
+        [Test]
+        public void It_Should_Omit_The_Tenant_Header()
+        {
+            _handler.Observed.Should().ContainSingle();
+            _handler.Observed[0].RequestTenantHeader.Should().BeNull();
+        }
+
+        [Test]
+        public void It_Should_Not_Write_The_Authorization_To_The_Shared_Client()
+        {
+            _client.DefaultRequestHeaders.Authorization.Should().BeNull();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_ClaimSet_Fetch_With_An_Empty_Tenant : ConfigurationServiceClaimSetProviderHeaderTests
+    {
+        private GatedRecordingHandler _handler = null!;
+        private HttpClient _client = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _handler = new GatedRecordingHandler(releaseAfterRequestCount: 1)
+            {
+                ResponseBodyForTenant = ClaimSetMetadataBodyFor,
+            };
+            _client = CreateSharedClient(_handler);
+
+            await CreateProvider(_client).GetAllClaimSets("");
+        }
+
+        [TearDown]
+        public void TearDown() => _client.Dispose();
+
+        [Test]
+        public void It_Should_Omit_The_Tenant_Header()
+        {
+            _handler.Observed.Should().ContainSingle();
+            _handler.Observed[0].RequestTenantHeader.Should().BeNull();
+        }
+    }
+
+    /// <summary>
+    /// The cached provider's stampede lock is keyed per tenant, so two cold misses for different tenants
+    /// are unsynchronized and reach the CMS provider concurrently. This is the window the fix closes.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Concurrent_Cold_Cache_Misses_For_Two_Tenants
+        : ConfigurationServiceClaimSetProviderHeaderTests
+    {
+        private GatedRecordingHandler _handler = null!;
+        private HttpClient _client = null!;
+        private MemoryCache _memoryCache = null!;
+        private IList<ClaimSet> _tenantAClaimSets = null!;
+        private IList<ClaimSet> _tenantBClaimSets = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _handler = new GatedRecordingHandler(releaseAfterRequestCount: 2)
+            {
+                ResponseBodyForTenant = ClaimSetMetadataBodyFor,
+            };
+            _client = CreateSharedClient(_handler);
+            _memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+            var cachedProvider = new CachedClaimSetProvider(
+                CreateProvider(_client),
+                _memoryCache,
+                new CacheSettings(),
+                NullLogger<CachedClaimSetProvider>.Instance
+            );
+
+            Task<IList<ClaimSet>> tenantA = Task.Run(() => cachedProvider.GetAllClaimSets("TenantA"));
+            Task<IList<ClaimSet>> tenantB = Task.Run(() => cachedProvider.GetAllClaimSets("TenantB"));
+
+            IList<ClaimSet>[] results = await Task.WhenAll(tenantA, tenantB);
+            _tenantAClaimSets = results[0];
+            _tenantBClaimSets = results[1];
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _memoryCache.Dispose();
+            _client.Dispose();
+        }
+
+        [Test]
+        public void It_Should_Send_Each_Tenant_On_Its_Own_Request()
+        {
+            _handler
+                .Observed.Select(observed => observed.RequestTenantHeader)
+                .Should()
+                .BeEquivalentTo("TenantA", "TenantB");
+        }
+
+        [Test]
+        public void It_Should_Not_Expose_Tenant_State_On_The_Shared_Client_During_The_Fetches()
+        {
+            _handler
+                .Observed.Select(observed => observed.SharedClientTenantHeader)
+                .Should()
+                .AllSatisfy(sharedTenant => sharedTenant.Should().BeNull());
+        }
+
+        [Test]
+        public void It_Should_Return_Each_Tenants_Own_Claim_Sets()
+        {
+            _tenantAClaimSets.Should().ContainSingle().Which.Name.Should().Be("TenantAClaimSet");
+            _tenantBClaimSets.Should().ContainSingle().Which.Name.Should().Be("TenantBClaimSet");
+        }
+
+        [Test]
+        public void It_Should_Cache_Each_Tenants_Claim_Sets_Under_Its_Own_Key()
+        {
+            _memoryCache
+                .Get<IList<ClaimSet>>("ClaimSets:TenantA")
+                .Should()
+                .ContainSingle()
+                .Which.Name.Should()
+                .Be("TenantAClaimSet");
+
+            _memoryCache
+                .Get<IList<ClaimSet>>("ClaimSets:TenantB")
+                .Should()
+                .ContainSingle()
+                .Which.Name.Should()
+                .Be("TenantBClaimSet");
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/ConfigurationServiceClaimSetProviderHeaderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/ConfigurationServiceClaimSetProviderHeaderTests.cs
@@ -19,9 +19,9 @@ using NUnit.Framework;
 namespace EdFi.DataManagementService.Core.Tests.Unit.Security;
 
 /// <summary>
-/// Covers the outbound header contract of ConfigurationServiceClaimSetProvider. The provider shares one
-/// HttpClient with the token handler and the other Configuration Service providers, so authorization and
-/// tenant selection must travel on the individual request rather than on the client's default headers.
+/// Covers the outbound header contract of ConfigurationServiceClaimSetProvider. The provider is a
+/// singleton serving every tenant over one long-lived HttpClient, so authorization and tenant selection
+/// must travel on the individual request rather than on the client's default headers.
 /// </summary>
 public class ConfigurationServiceClaimSetProviderHeaderTests
 {
@@ -52,9 +52,9 @@ public class ConfigurationServiceClaimSetProviderHeaderTests
         private int _arrivedCount;
 
         /// <summary>
-        /// The client the provider shares with the token handler and the sibling providers. The handler
-        /// snapshots its default headers on arrival so a test can tell whether the fetch published its
-        /// tenant onto shared state.
+        /// The one long-lived client the provider uses for every tenant. The handler snapshots its
+        /// default headers on arrival so a test can tell whether the fetch published its tenant onto
+        /// that shared state.
         /// </summary>
         public HttpClient? SharedClient { get; set; }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/ConfigurationServiceClaimSetProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/ConfigurationServiceClaimSetProvider.cs
@@ -35,40 +35,40 @@ public class ConfigurationServiceClaimSetProvider(
             configurationServiceContext.clientSecret,
             configurationServiceContext.scope
         );
-        configurationServiceApiClient.Client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", configurationServiceToken);
-
-        // Set Tenant header for multi-tenant scenarios
-        SetTenantHeader(tenant);
-
-        return (await FetchAuthorizationMetadata()).Select(CreateClaimSet).ToList();
+        return (await FetchAuthorizationMetadata(configurationServiceToken, tenant))
+            .Select(CreateClaimSet)
+            .ToList();
     }
 
     /// <summary>
-    /// Sets or removes the Tenant header based on the tenant value.
+    /// Fetches claim set metadata from the Configuration Service API. Authorization and tenant selection
+    /// travel on the individual request because the HttpClient is shared across tenants and callers.
     /// </summary>
-    private void SetTenantHeader(string? tenant)
-    {
-        // Remove existing Tenant header if present
-        configurationServiceApiClient.Client.DefaultRequestHeaders.Remove(TenantHeaderName);
-
-        // Add Tenant header if tenant is specified
-        if (!string.IsNullOrEmpty(tenant))
-        {
-            configurationServiceApiClient.Client.DefaultRequestHeaders.Add(TenantHeaderName, tenant);
-        }
-    }
-
-    /// <summary>
-    /// Fetches claim set metadata from the Configuration Service API.
-    /// </summary>
-    private async Task<IList<ClaimSetMetadata>> FetchAuthorizationMetadata()
+    private async Task<IList<ClaimSetMetadata>> FetchAuthorizationMetadata(
+        string? configurationServiceToken,
+        string? tenant
+    )
     {
         // Retrieve all claim sets with their authorization metadata in one call by omitting claimSetName
         string authorizationMetadataEndpoint = "v3/authorizationMetadata";
-        HttpResponseMessage response = await configurationServiceApiClient.Client.GetAsync(
-            authorizationMetadataEndpoint
-        );
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, authorizationMetadataEndpoint);
+
+        if (!string.IsNullOrEmpty(configurationServiceToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                "Bearer",
+                configurationServiceToken
+            );
+        }
+
+        // Send the Tenant header for multi-tenant scenarios, omitting it entirely otherwise
+        if (!string.IsNullOrEmpty(tenant))
+        {
+            request.Headers.Add(TenantHeaderName, tenant);
+        }
+
+        HttpResponseMessage response = await configurationServiceApiClient.Client.SendAsync(request);
 
         string claimSetMetadataJson = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<IList<ClaimSetMetadata>>(claimSetMetadataJson, _jsonOptions) ?? [];

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/ConfigurationServiceClaimSetProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/ConfigurationServiceClaimSetProvider.cs
@@ -42,7 +42,7 @@ public class ConfigurationServiceClaimSetProvider(
 
     /// <summary>
     /// Fetches claim set metadata from the Configuration Service API. Authorization and tenant selection
-    /// travel on the individual request because the HttpClient is shared across tenants and callers.
+    /// travel on the individual request because this singleton serves every tenant over one HttpClient.
     /// </summary>
     private async Task<IList<ClaimSetMetadata>> FetchAuthorizationMetadata(
         string? configurationServiceToken,


### PR DESCRIPTION
Corrects a cross-tenant authorization defect in the CMS-backed claim-set provider, so that identity service-claim authorization can safely become another caller of that path.

`ConfigurationServiceClaimSetProvider.GetAllClaimSets` mutated the shared `HttpClient`'s `Authorization` and `Tenant` default request headers before each fetch, while `CachedClaimSetProvider`'s stampede lock is keyed per tenant. Two cold misses for different tenants were therefore mutually unsynchronized. This is a pre-existing defect on the resource authorization path, not one introduced by Identity Management; it is filed as its own story so it can be reviewed and released as a security fix, and DMS-1515 declares it as a dependency.

The window is not the startup path. `CacheClaimSetsTask` warms each tenant sequentially at boot, so concurrent cold misses occur after cache expiry or an explicit invalidation, and that recurs for the life of the process.

## The change

Both headers now travel on the individual `HttpRequestMessage`, sent with `SendAsync`. This is the pattern the rest of DMS Core already uses — `ConfigurationServiceApplicationProvider`, `ConfigurationServiceDataStoreProvider`, and `ConfigurationServiceProfileProvider` all send the tenant per request, the last of them with an explicit comment saying it does so for thread safety. The claim-set provider was the remaining outlier. No other Configuration Service provider is modified.

**A correction to the first commit's message, since it is permanent.** That message justified the fix with an `HttpClient` "shared across tenants and callers" and claimed an incidental win: that it stopped a stale `Bearer` token and `Tenant` header leaking onto `ConfigurationServiceTokenHandler`'s `connect/token` POST. Both are wrong, and `3f4e7e557` retracts them in the code comments. `AddHttpClient<ConfigurationServiceApiClient>` (`DmsCoreServiceExtensions.cs:354`) is the only registration of that type, and `AddHttpClient<TClient>` registers the typed client **transient**; every consumer is a singleton and so captures its own instance. `DefaultRequestHeaders` live on `HttpClient`, not on the pooled message handler, so no header one of them wrote was ever visible to another, and that leak was never reachable. The sibling providers send headers per request on their own merit, not because they share a client.

The accurate justification is narrower and sufficient: **this provider is a singleton that serves every tenant over one long-lived `HttpClient`**, and concurrent cold misses for different tenants raced on that one client's default headers. The defect, the fix, and the tests are unchanged.

## The concurrent test reproduces the defect rather than describing it

The acceptance criteria ask for a controlled test that holds two cold misses open and asserts the header on each outbound request. That assertion alone would pass against the unfixed code: `HttpClient` merges `DefaultRequestHeaders` into the request message synchronously inside `SendAsync`, before the message reaches any test `HttpMessageHandler`, so by the time a handler can hold a request open the header is already correct on it. The real race is the few nanoseconds between the header mutation and that merge.

So the test also snapshots the shared client's default headers from inside the transport, at the moment each request arrives. That is deterministic, and it is what fails on the unfixed code. Running the new fixture against `main`'s provider, five tests failed, and the concurrent case reproduced the corruption end to end rather than by inference: one outbound request carried `Tenant: TenantA,TenantB`, and the `ClaimSets:TenantA` cache entry held the claim sets CMS returned for that combined value.

```
It_Should_Not_Write_The_Tenant_To_The_Shared_Client
  Expected _client.DefaultRequestHeaders.Contains(TenantHeaderName) to be False, but found True.

It_Should_Not_Expose_Tenant_State_On_The_Shared_Client_During_The_Fetches
  At index 0: Expected sharedTenant to be <null>, but found "TenantB"
  At index 1: Expected sharedTenant to be <null>, but found "TenantB"

It_Should_Cache_Each_Tenants_Claim_Sets_Under_Its_Own_Key
  Expected _memoryCache.Get<IList<ClaimSet>>("ClaimSets:TenantA") to be "TenantAClaimSet",
  but "TenantA,TenantBClaimSet" ... differs near ",Te" (index 7).
```

The two remaining failures were the `Authorization` leak onto the shared client, in both the tenant and no-tenant fixtures.

Note that `It_Should_Send_Each_Tenant_On_Its_Own_Request` and `It_Should_Return_Each_Tenants_Own_Claim_Sets` happened to pass on that run and would fail only intermittently against the unfixed code — the race is real but narrow. They are the post-fix contract assertions; the deterministic shared-state assertions above are what prove the fix.

## Verification

- The new fixture is 11/11 green, and the full `EdFi.DataManagementService.Core.Tests.Unit` suite is 5091 passed / 0 failed / 7 skipped (the skips are the pre-existing Unix-permission cases).
- `EdFi.DataManagementService.sln` builds with 0 errors under warnings-as-errors.
- CSharpier reports `Formatted 2 files` and then a clean `check`. Note that the Husky `dotnet-format-staged-files` hook reports `Formatted 0 files` on this branch: CSharpier finds nothing inside a git worktree, so the hook passes vacuously and the formatting above was run explicitly with `--ignore-path` pointed at an empty file.
- Existing claim-set tests are unchanged. `SecurityMetadataProviderTests` sets `DefaultRequestHeaders.Authorization` in its own setup but never asserts on it, and a per-request `Authorization` takes precedence over the client default, so those fixtures still pass as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
