### PR TITLE
[DMS-1468] Document the RelationalMappingVersion release-cadence convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Do not infer the current release line from `src/dms/Directory.Build.props`; it i
 git log --oneline --date=short --format="%h %cd %s" -G "public const string RelationalMappingVersion" -- src\dms\core\EdFi.DataManagementService.Core\Utilities\SchemaHashConstants.cs
 ```
 
-Why the cadence matters: `EffectiveSchemaHashProvider` includes the constant in the hashed manifest, so changing it changes `EffectiveSchemaHash` for every dialect. Databases provisioned against the previous hash then fail startup validation in `ValidateStartupInstancesTask` and receive HTTP 503 at request time until they are re-provisioned. Every bump is a forced re-provision of every existing database, so each extra bump within one release cycle forces an extra one. See `docs/RELATIONAL-BACKEND.md` for the full schema-fingerprint validation flow.
+Why the cadence matters: `EffectiveSchemaHashProvider` includes the constant in the hashed manifest, so changing it changes `EffectiveSchemaHash` for every dialect. Databases provisioned against the previous hash then fail startup validation in `ValidateStartupInstancesTask` and receive HTTP 503 at request time until they are re-provisioned. Every bump is a forced re-provision of every existing database, so each extra bump within one release cycle forces an extra one. Holding the value also has a cost: `EffectiveSchemaHash` does not include generated DDL or mapping-set output, so a mapping-only physical change made without a bump can leave validation unable to detect a database provisioned before that change; those databases must be deliberately reprovisioned. See `docs/RELATIONAL-BACKEND.md` for the full schema-fingerprint validation flow.
 
 ## Working with Data Management Service E2E Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,31 @@ This repository contains the **Ed-Fi Data Management Service (DMS) Platform**, w
 
 - `dotnet csharpier format <directory or file>`
 
+## RelationalMappingVersion Release Cadence
+
+`SchemaHashConstants.RelationalMappingVersion` in
+`src/dms/core/EdFi.DataManagementService.Core/Utilities/SchemaHashConstants.cs`
+tracks the **DMS release line**, not individual changes.
+
+- Bump it at most **once per release**, and only if relational mapping actually changed during that release cycle.
+- Once the current release line's value has been bumped, further relational mapping changes landing before that release ships keep the same value. Do not bump again.
+- Never lower or revert the value.
+
+Current mapping:
+
+- DMS 8.0 released with `v1`.
+- DMS 8.1 releases with `v3`. The 8.1 cycle bumped twice (`v1` -> `v2` -> `v3`), which is more than the convention allows; `v3` stands as the value 8.1 releases with and must not be reverted.
+- Any relational mapping change landing before the 8.1 release keeps `v3`.
+- The next legitimate bump is `v4`, at the first qualifying relational mapping change after 8.1 ships.
+
+Do not infer the current release line from `src/dms/Directory.Build.props`; it is not kept in step with the release line. To review the constant's actual change history:
+
+```powershell
+git log --oneline --date=short --format="%h %cd %s" -G "public const string RelationalMappingVersion" -- src\dms\core\EdFi.DataManagementService.Core\Utilities\SchemaHashConstants.cs
+```
+
+Why the cadence matters: `EffectiveSchemaHashProvider` includes the constant in the hashed manifest, so changing it changes `EffectiveSchemaHash` for every dialect. Databases provisioned against the previous hash then fail startup validation in `ValidateStartupInstancesTask` and receive HTTP 503 at request time until they are re-provisioned. Every bump is a forced re-provision of every existing database, so each extra bump within one release cycle forces an extra one. See `docs/RELATIONAL-BACKEND.md` for the full schema-fingerprint validation flow.
+
 ## Working with Data Management Service E2E Tests
 
 The Data Management Service E2E tests directory is `src/dms/tests/EdFi.DataManagementService.Tests.E2E/`.

--- a/src/dms/core/EdFi.DataManagementService.Core/Utilities/SchemaHashConstants.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Utilities/SchemaHashConstants.cs
@@ -18,7 +18,11 @@ public static class SchemaHashConstants
 
     /// <summary>
     /// Version identifier for the relational mapping conventions.
-    /// Bump this when mapping rules change to force schema mismatch detection.
+    /// Tracks the DMS release line: bump at most once per release, and only if relational
+    /// mapping actually changed during that release cycle. Changing this changes
+    /// EffectiveSchemaHash for every dialect and forces every provisioned database to be
+    /// re-provisioned. See the RelationalMappingVersion release cadence section in the
+    /// repository root AGENTS.md.
     /// This value MUST match the relational_mapping_version used in .mpack files.
     /// </summary>
     public const string RelationalMappingVersion = "v3";


### PR DESCRIPTION
## Summary

`SchemaHashConstants.RelationalMappingVersion` tracks the DMS **release line**, but the codebase had no written statement of that, and its doc comment read as per-change guidance. As a result the constant has been bumped per change rather than per release.

This PR documents the convention. It is documentation and comments only.

## Background

The value's history shows the drift:

| Commit | Date | Value | Ticket |
|---|---|---|---|
| `7adf02c70` | 2026-02-04 | `v1` | DMS-925 |
| `0cd93964a` | 2026-07-17 | `v2` | DMS-1258 |
| `90be9e30a` | 2026-08-25 | `v3` | DMS-1408 |

`git merge-base --is-ancestor 7adf02c70 v8.0.0` is true, while `0cd93964a` is not an ancestor of the `v8.0.0` tag. So `v1` shipped in 8.0, and both `v2` and `v3` landed inside the 8.1 cycle — the cycle bumped twice, where the convention allows at most one bump per release.

Why it matters: `EffectiveSchemaHashProvider` includes the constant in the hashed manifest, so each bump changes `EffectiveSchemaHash` for every dialect. Databases provisioned against the previous hash then fail startup validation in `ValidateStartupInstancesTask` and receive HTTP 503 at request time until re-provisioned. Every extra bump within one release cycle is an extra forced re-provision for every existing database.

## Changes

**`AGENTS.md`** (+25, −0) — new `## RelationalMappingVersion Release Cadence` section, inserted between `### Format Code` and `## Working with Data Management Service E2E Tests`. It records:

- the convention: bump at most once per release, and only if relational mapping actually changed during that cycle;
- the current mapping — DMS 8.0 released with `v1`, DMS 8.1 releases with `v3`;
- that `v3` must not be reverted, and that changes landing before 8.1 ships keep `v3`;
- that the next legitimate bump is `v4`, at the first qualifying change after 8.1 ships;
- that `src/dms/Directory.Build.props` (still `8.0.0`) must not be used to infer the release line;
- the `git log -G` command for checking the value's real history.

**`SchemaHashConstants.cs`** (+5, −1) — replaces one sentence in the XML doc comment, `Bump this when mapping rules change to force schema mismatch detection.`, with the release-line convention and the blast radius. The opening line and the `.mpack relational_mapping_version` requirement are kept verbatim. The 8.0/8.1 mapping is deliberately **not** duplicated in the comment — it changes every release, so the comment points at the `AGENTS.md` section that owns it.

## Scope

The constant's value is unchanged: it remains `v3`.

Not touched: authoritative fixtures under `src/dms/backend/Fixtures/authoritative/` (already carry `relational_mapping_version: "v3"`, so nothing is inconsistent), DDL, manifests, schema hashes, Northridge artifacts (consequence-only; belongs with DMS-1351/DMS-1352), `docs/RELATIONAL-BACKEND.md`, and the backend-redesign design docs.

Full branch diff is two files, +30/−1.

## Validation

- `dotnet csharpier check src/dms/core/EdFi.DataManagementService.Core/Utilities/SchemaHashConstants.cs` — **passed** (`Checked 1 files`, exit 0; no reformatting needed).
- `dotnet build src/dms/core/EdFi.DataManagementService.Core/EdFi.DataManagementService.Core.csproj` — **passed**, 0 warnings, 0 errors. This is a real guard: `Directory.Build.props` sets `TreatWarningsAsErrors=True`, so a malformed XML doc comment would fail the build.
- `dotnet test --filter "FullyQualifiedName~EffectiveSchemaHashProviderTests"` — **passed**, 19/19, 0 failed, 0 skipped.

The test run includes `Given_Known_Fixture_Schema.It_produces_expected_locked_hash`, which asserts the locked hash `adcf936481b92324aa45437a0e4699afd610c40aee0cbcb614a3bda2b06b2686`. It passing is direct proof that the manifest string and `EffectiveSchemaHash` are byte-identical, so no re-bless and no fixture regeneration is required.

A guard confirming no value change was run against both `origin/main...HEAD` and the base SHA `3aa4c9786..HEAD`, matching `^[+-].*RelationalMappingVersion\s*=` — no output in either range. The value line appears only as unchanged context in the diff.

No runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
