### PR TITLE
[DMS-1430] Store the PostgreSQL token expiration as an instant

### DIFF
--- a/reference/design/configuration-service/TOKEN-CLEANUP.md
+++ b/reference/design/configuration-service/TOKEN-CLEANUP.md
@@ -49,14 +49,13 @@ A row expired beyond that skew is therefore unreachable by the only production r
 The DMS data API never reads the table at all: there are zero `OpenIddictToken` references
 anywhere under `src/dms`, because the data API validates bearer tokens statelessly via JWKS.
 
-Timestamps are UTC wall-clock values, stored as `timestamp without time zone` on PostgreSQL and
-`DATETIME2` on SQL Server.
+`ExpirationDate` is an instant, stored as `timestamp with time zone` on PostgreSQL and `DATETIME2`
+holding UTC on SQL Server.
 Any deletion predicate must therefore compare against UTC "now", never local time.
-On PostgreSQL the UTC-wall-clock property holds because writes pass `DateTimeOffset` values that
-Npgsql sends as `timestamptz`, which the server converts through the session time zone; the
-shipped containers run UTC, and the sweep's bound takes the identical conversion path as the
-pre-existing insert, so the two stay consistent under any single session time zone (see the
-latent observation below).
+As shipped by DMS-1354 the PostgreSQL column was `timestamp without time zone`, which made both the
+insert and the sweep convert through the session time zone; DMS-1430 replaced that with the
+`timestamptz` declaration described under Time-Zone Independence below, so neither path converts
+any more.
 A deletion predicate is already index-supported on both engines: `IX_OpenIddictToken_ExpirationDate`
 exists in both engines' DDL, in `0016_Create_openiddict_Token_Table.sql`.
 
@@ -210,22 +209,103 @@ sufficient to run it.
   consistent with the bounded-staleness stance the
   [ownership-token operational-lifecycle record](../backend-redesign/design-docs/ownership-token-operational-lifecycle.md)
   adopted.
-- The PostgreSQL storage of these timestamps carries a latent time-zone dependence: both the
-  pre-existing insert and the sweep's bound convert through the session time zone, so they stay
-  mutually consistent, but a server configured with a DST-observing time zone would interpret
-  wall-clock values near transitions up to an hour off, which could delete a row while the
-  validator still accepts its token.
-  The shipped containers run UTC, so this has never bitten; any fix must change the insert path,
-  the sweep bound, and possibly the column type (`timestamptz`) together, and is therefore
-  recorded here rather than folded into this change.
-  The SQL Server implementation compares `DATETIME2` against a UTC `DateTime` and has no such
-  dependence.
+- The PostgreSQL time-zone dependence this record originally deferred is resolved by DMS-1430; see
+  Time-Zone Independence below.
 - Integration test coverage for `DeleteExpiredTokensAsync` exists for both engines, in each
   project's `OpenIddictDataRepositoryTests.cs`
   (`EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration` and
   `EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration`), covering a mix of expired
   and unexpired rows and a row at the exact expiration boundary; the SQL Server cases skip
   locally when no SQL Server connection is configured and run in CI.
+
+## Time-Zone Independence (DMS-1430)
+
+DMS-1354 shipped `ExpirationDate` as `timestamp without time zone` while both repository paths bound
+`DateTimeOffset` values, which Npgsql sends as `timestamptz`.
+The insert cast down to a wall clock through the PostgreSQL session time zone, and the sweep's
+predicate cast the stored column back up through it, using the operator `timestamp_le_timestamptz`.
+Those two conversions do not round-trip on a DST-observing server.
+DMS-1430 declares the column `timestamp with time zone`, adds the guarded migration
+`0032_Alter_OpenIddictToken_ExpirationDate_TimeZone.sql`, and pins both the insert parameter and the
+sweep bound to `DbType.DateTimeOffset` normalized with `ToUniversalTime()`.
+Neither path converts any more, so no stored value and no comparison depends on the session zone.
+
+### Correction to the original failure description
+
+This record previously stated that a DST-observing server "could delete a row while the validator
+still accepts its token".
+That framing is wrong for a *stable* session zone and is corrected here.
+Under a single unchanging DST-observing zone the round trip errs strictly late: a fall-back wall
+clock is ambiguous and PostgreSQL resolves it to the later of the two candidate instants, and a
+spring-forward gap resolves forward, so the sweep could only *under*-delete and rows lingered past
+their true expiry.
+Premature deletion of a live token was real but needed the session zone to **differ** between the
+write and the sweep - an operator changing the server `timezone`, setting `PGTZ`, or adding
+`Timezone=` to one connection string, with rows written under the old zone still present.
+Both defects are removed by the same change; the distinction matters only for describing the
+pre-fix severity honestly.
+
+### What the migration can and cannot recover
+
+`0032` reinterprets each stored wall clock through the session time zone *the migration runs under*.
+That is the best available inverse of how the rows were written, not a full repair, because the old
+column type discarded information before the script ever runs.
+Three cases, and they differ in whether the result can land early:
+
+1. **Same session zone as the write, unambiguous wall clock.** Exact recovery.
+   On the shipped UTC containers this is the identity, no value moves, and this case applies
+   throughout.
+2. **Same session zone, wall clock in a DST transition window.** Late or equal.
+   Two instants an hour apart were already stored identically, so both recover as the later one.
+   This matches how the sweep already read such a row before the fix, and the error direction is
+   late: the token lingers, it is never swept early.
+3. **Session zone changed since the write.** Irrecoverable, and the result may land **earlier** as
+   well as later, by the difference between the two offsets.
+   A row written under `America/New_York` for `18:00Z` stores `14:00`; migrated under `UTC` it
+   reconstructs as `14:00Z`, four hours early.
+   The zone a row was written under was never recorded, so nothing in the migration can detect or
+   correct this.
+   The mitigation is operational: run the upgrade under the same session time zone the rows were
+   written under.
+
+Case 2's "later or equal" property does **not** extend to case 3.
+The script carries no `USING` clause for the same reason: the implicit assignment cast is the
+inverse of how the rows were written, whereas `USING "ExpirationDate" AT TIME ZONE 'UTC'` forces
+case 3 on every row of a non-UTC server.
+
+### Operational cost
+
+`ALTER COLUMN ... TYPE` takes an `ACCESS EXCLUSIVE` lock and rewrites the table and the
+`ExpirationDate` index.
+This applies only to an existing database still carrying the old column type: the script's guard
+checks the declared type first, so the rewrite happens at most once per database and is skipped
+entirely on a fresh install and on any replay.
+The pause is proportional to the row count, which the sweep above bounds; an install upgrading from
+a pre-DMS-1354 build may still carry an unbounded backlog and should expect a correspondingly longer
+one-time pause.
+No operator time-zone requirement follows from this change - the point of the fix is that the
+session zone no longer matters at run time.
+
+### Deliberate scope limit
+
+`CreationDate` and `RedemptionDate` on the same table remain `timestamp without time zone` and carry
+the same latent dependence.
+They are intentionally out of scope for DMS-1430: no predicate compares them, and no production code
+path reads them, so nothing about cleanup or validation safety depends on them.
+Converting them is available as follow-up cleanup rather than part of this fix.
+The CMS-wide `CreatedAt` / `LastModifiedAt` audit columns follow one convention across every `dmscs`
+table and are a separate decision again.
+SQL Server needed no counterpart change and has none.
+
+### Coverage
+
+`Given_A_DST_Observing_PostgreSQL_Session_Time_Zone` in the PostgreSQL
+`OpenIddictDataRepositoryTests.cs` runs the repository against an `America/New_York` session
+connection with two expirations that collide on one wall clock, asserting distinct stored instants,
+a sweep that deletes only the truly expired row, and an unchanged read-back.
+`Given_a_pre_DMS_1430_OpenIddictToken_PostgreSQL_upgrade` exercises `0032` against a journaled
+pre-upgrade database, pinning exact recovery, `NULL` preservation, replay safety, and both
+unrecoverable cases above.
 
 ## Evidence Baseline
 
@@ -237,3 +317,9 @@ This record was evaluated against DMS
   [`24fe66cfc`](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/tree/24fe66cfc04459ad6d6cac09d635d3c149b24669).
 - Ed-Fi-ODS-Implementation at
   [`37ff595c1`](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/tree/37ff595c171b73e524d96b13103ef9ae01712beb).
+
+The Time-Zone Independence section was added for DMS-1430 and evaluated separately, against
+PostgreSQL 16.8 (`postgres:16.8-alpine`, the image the shipped stacks use) and Npgsql 8.0.4.
+Its conversion, ambiguity-resolution, and migration claims were measured on that version rather than
+derived from documentation; the ambiguity-resolution rule was checked across `America/New_York`,
+`Europe/London`, `Australia/Sydney`, and `America/Santiago`.

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DatabaseShapeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DatabaseShapeTests.cs
@@ -298,6 +298,34 @@ public class Given_CMS_PostgreSQL_database_shape
         }
     }
 
+    /// <summary>
+    /// DMS-1430: the token cleanup sweep compares this column against a bound the repository binds
+    /// as an instant. While it was declared timestamp without time zone, both the insert and the
+    /// sweep converted through the PostgreSQL session time zone, and those conversions do not
+    /// round-trip on a DST-observing server. Only the timestamptz declaration keeps the stored value
+    /// and the sweep bound in agreement, so the declared type is asserted here rather than left to
+    /// the DDL alone. CreationDate and RedemptionDate remain wall-clock columns: no predicate
+    /// compares them and no production path reads them, so converting them is a possible follow-up
+    /// rather than part of this fix.
+    /// </summary>
+    [Test]
+    public void It_should_declare_the_OpenIddictToken_expiration_as_an_instant()
+    {
+        ColumnShape expirationColumn = _columns
+            .Should()
+            .ContainSingle(column =>
+                column.TableName == "OpenIddictToken" && column.ColumnName == "ExpirationDate"
+            )
+            .Which;
+
+        expirationColumn
+            .DataType.Should()
+            .Be(
+                "timestamp with time zone",
+                "the cleanup sweep must compare instants, not session-time-zone wall clocks"
+            );
+    }
+
     [Test]
     public void It_should_use_DMS_style_constraint_names_for_representative_core_tenant_and_OpenIddict_tables()
     {

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/OpenIddictDataRepositoryTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/OpenIddictDataRepositoryTests.cs
@@ -3,8 +3,11 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using Dapper;
 using EdFi.DmsConfigurationService.Backend.Postgresql.OpenIddict.Repositories;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration;
 
@@ -124,5 +127,116 @@ public class OpenIddictDataRepositoryTests : DatabaseTest
             deletedCount.Should().Be(1);
             (await _repository.GetTokenStatusAsync(_tokenId)).Should().BeNull();
         }
+    }
+
+    /// <summary>
+    /// DMS-1430. The repository binds expirations and the cleanup bound as instants, and the column
+    /// stores instants, so neither the stored value nor the sweep may depend on the PostgreSQL
+    /// session time zone. This fixture runs the real repository against a connection whose session
+    /// zone observes DST, and picks two instants that a wall-clock column provably cannot tell
+    /// apart, so the assertions fail if either binding or the column type regresses.
+    /// </summary>
+    [TestFixture]
+    public class Given_A_DST_Observing_PostgreSQL_Session_Time_Zone : OpenIddictDataRepositoryTests
+    {
+        private const string DstSessionTimeZone = "America/New_York";
+
+        // America/New_York leaves DST at 2026-11-01 06:00Z, where 01:59:59 EDT (-04) is followed by
+        // 01:00:00 EST (-05). Both instants below therefore land on local wall clock 01:30 despite
+        // being an hour apart, which is exactly the collision a timestamp without time zone column
+        // cannot represent. Fixed instants, so the fixture never depends on the current date.
+        private static readonly DateTimeOffset EarlierExpiration = new(2026, 11, 1, 5, 30, 0, TimeSpan.Zero);
+        private static readonly DateTimeOffset LaterExpiration = new(2026, 11, 1, 6, 30, 0, TimeSpan.Zero);
+
+        // The bound the cleanup service would sweep with at 06:00Z, namely UTC now minus the
+        // validator's five-minute clock skew. The earlier expiration sits 25 minutes past this
+        // bound and must be deleted, while the later one is still 35 minutes away and must survive.
+        private static readonly DateTimeOffset SweepBound = new(2026, 11, 1, 5, 55, 0, TimeSpan.Zero);
+
+        private OpenIddictDataRepository _repository = null!;
+        private Guid _earlierTokenId;
+        private Guid _laterTokenId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _repository = new OpenIddictDataRepository(DstSessionDatabaseOptions());
+            var applicationId = await RegisterApplicationAsync(
+                _repository,
+                $"dst-session-client-{Guid.NewGuid():N}"
+            );
+
+            _earlierTokenId = Guid.NewGuid();
+            _laterTokenId = Guid.NewGuid();
+
+            await _repository.StoreTokenAsync(
+                _earlierTokenId,
+                applicationId,
+                "subject-earlier",
+                EarlierExpiration
+            );
+            await _repository.StoreTokenAsync(_laterTokenId, applicationId, "subject-later", LaterExpiration);
+        }
+
+        [Test]
+        public async Task It_stores_each_expiration_as_a_distinct_instant()
+        {
+            (await StoredExpirationAsync(_earlierTokenId)).Should().Be(EarlierExpiration.UtcDateTime);
+            (await StoredExpirationAsync(_laterTokenId)).Should().Be(LaterExpiration.UtcDateTime);
+        }
+
+        [Test]
+        public async Task It_deletes_only_the_token_that_is_truly_expired()
+        {
+            var deletedCount = await _repository.DeleteExpiredTokensAsync(SweepBound);
+
+            deletedCount.Should().Be(1);
+            (await _repository.GetTokenStatusAsync(_earlierTokenId)).Should().BeNull();
+            (await _repository.GetTokenStatusAsync(_laterTokenId)).Should().Be("valid");
+        }
+
+        /// <summary>
+        /// Narrow read-path check: the sweep is the safety-critical path, but the same column feeds
+        /// TokenInfo, so this pins that the stored instant also comes back out unchanged rather than
+        /// being reinterpreted through the session zone on the way.
+        /// </summary>
+        [Test]
+        public async Task It_reads_the_expiration_back_as_the_same_instant()
+        {
+            var token = await _repository.GetTokenByIdAsync(_laterTokenId);
+
+            token.Should().NotBeNull();
+            token!.ExpirationDate.Should().Be(LaterExpiration);
+        }
+
+        /// <summary>
+        /// Reads the raw column through a connection using the same DST session zone, so a value
+        /// that only looks correct because it was read back under UTC cannot pass.
+        /// </summary>
+        private static async Task<DateTime> StoredExpirationAsync(Guid tokenId)
+        {
+            await using NpgsqlConnection connection = new(DstSessionConnectionString());
+            await connection.OpenAsync();
+
+            return await connection.QuerySingleAsync<DateTime>(
+                "SELECT \"ExpirationDate\" FROM \"dmscs\".\"OpenIddictToken\" WHERE \"Id\" = @Id",
+                new { Id = tokenId }
+            );
+        }
+
+        private static string DstSessionConnectionString() =>
+            new NpgsqlConnectionStringBuilder(Configuration.DatabaseOptions.Value.DatabaseConnection)
+            {
+                Timezone = DstSessionTimeZone,
+            }.ConnectionString;
+
+        private static IOptions<DatabaseOptions> DstSessionDatabaseOptions() =>
+            Options.Create(
+                new DatabaseOptions
+                {
+                    DatabaseConnection = DstSessionConnectionString(),
+                    EncryptionKey = Configuration.DatabaseOptions.Value.EncryptionKey,
+                }
+            );
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/OpenIddictTokenExpirationUpgradeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/OpenIddictTokenExpirationUpgradeTests.cs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Dapper;
+using EdFi.DmsConfigurationService.Backend.Deploy;
+using FluentAssertions;
+using Npgsql;
+
+namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Exercises the DMS-1430 upgrade against a journaled pre-upgrade database, which is the state a
+/// real deployment upgrades from. Each test reverts the isolated database to that state, seeds rows
+/// with SQL so they carry exactly the wall clocks Npgsql would have written, and runs the deploy
+/// again so only 0032 executes.
+///
+/// The migration reinterprets each stored wall clock through the session time zone the deploy runs
+/// under. That is the best available inverse of how the rows were written, not a full repair,
+/// because the old column type discarded information before the script ever runs. The three cases
+/// below pin the three outcomes, including the one that lands early, so the limitation stays
+/// documented rather than being mistaken for a safety guarantee.
+/// </summary>
+[TestFixture]
+public class Given_a_pre_DMS_1430_OpenIddictToken_PostgreSQL_upgrade
+{
+    private const string JournalPattern = "%0032_Alter_OpenIddictToken_ExpirationDate_TimeZone%";
+    private const string WriteTimeZone = "America/New_York";
+
+    // A June instant, far from any DST transition, so the -04:00 offset is unambiguous.
+    private static readonly DateTimeOffset UnambiguousInstant = new(2026, 6, 1, 18, 0, 0, TimeSpan.Zero);
+
+    // America/New_York leaves DST at 2026-11-01 06:00Z. These two instants are an hour apart and
+    // both land on local wall clock 01:30, so the old column stored them identically.
+    private static readonly DateTimeOffset AmbiguousEarlierInstant = new(
+        2026,
+        11,
+        1,
+        5,
+        30,
+        0,
+        TimeSpan.Zero
+    );
+    private static readonly DateTimeOffset AmbiguousLaterInstant = new(2026, 11, 1, 6, 30, 0, TimeSpan.Zero);
+
+    private string _databaseName = string.Empty;
+    private string _connectionString = string.Empty;
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        _connectionString = CreateIsolatedConnectionString(WriteTimeZone);
+        DeploySuccessfully(_connectionString);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTeardown()
+    {
+        if (string.IsNullOrEmpty(_databaseName))
+        {
+            return;
+        }
+
+        await using NpgsqlConnection connection = new(CreateMaintenanceConnectionString());
+        await connection.OpenAsync();
+        await connection.ExecuteAsync($"""DROP DATABASE IF EXISTS "{_databaseName}" WITH (FORCE);""");
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await RevertToPreUpgradeStateAsync();
+    }
+
+    [Test]
+    public async Task It_recovers_the_exact_instant_when_the_session_zone_is_unchanged()
+    {
+        await SeedStoredExpirationAsync("unambiguous", UnambiguousInstant);
+
+        DeploySuccessfully(_connectionString);
+
+        (await UpgradedColumnTypeAsync()).Should().Be("timestamp with time zone");
+        (await UpgradedExpirationAsync("unambiguous")).Should().Be(UnambiguousInstant.UtcDateTime);
+    }
+
+    [Test]
+    public async Task It_preserves_a_null_expiration()
+    {
+        await SeedStoredExpirationAsync("null-expiration", expiration: null);
+
+        DeploySuccessfully(_connectionString);
+
+        (await UpgradedExpirationAsync("null-expiration")).Should().BeNull();
+    }
+
+    [Test]
+    public async Task It_leaves_the_value_untouched_when_the_script_is_replayed()
+    {
+        await SeedStoredExpirationAsync("replayed", UnambiguousInstant);
+
+        DeploySuccessfully(_connectionString);
+        await ReplayUpgradeScriptAsync();
+
+        (await UpgradedExpirationAsync("replayed")).Should().Be(UnambiguousInstant.UtcDateTime);
+    }
+
+    /// <summary>
+    /// Two instants an hour apart were already stored identically by the old column type, so the
+    /// migration cannot separate them again: both recover as the later of the two. This is
+    /// information the write destroyed, not something the migration loses. Recovering late is the
+    /// safe direction here, because such a token lingers rather than being swept early.
+    /// </summary>
+    [Test]
+    public async Task It_recovers_a_DST_ambiguous_wall_clock_as_the_later_instant()
+    {
+        await SeedStoredExpirationAsync("ambiguous-earlier", AmbiguousEarlierInstant);
+        await SeedStoredExpirationAsync("ambiguous-later", AmbiguousLaterInstant);
+
+        DeploySuccessfully(_connectionString);
+
+        (await UpgradedExpirationAsync("ambiguous-earlier")).Should().Be(AmbiguousLaterInstant.UtcDateTime);
+        (await UpgradedExpirationAsync("ambiguous-later")).Should().Be(AmbiguousLaterInstant.UtcDateTime);
+    }
+
+    /// <summary>
+    /// The irrecoverable case, pinned so nobody mistakes the ambiguity result above for a general
+    /// guarantee. A row written under America/New_York and migrated under UTC reconstructs against
+    /// the migration-time zone, which places it EARLIER than the true instant by the offset
+    /// difference. The zone a row was written under was never recorded, so the migration cannot
+    /// detect this. The mitigation is operational: upgrade under the zone the rows were written
+    /// under.
+    /// </summary>
+    [Test]
+    public async Task It_shifts_the_instant_when_the_session_zone_changed_since_the_write()
+    {
+        await SeedStoredExpirationAsync("zone-changed", UnambiguousInstant);
+
+        DeploySuccessfully(CreateConnectionString(_databaseName, "UTC"));
+
+        DateTime? recovered = await UpgradedExpirationAsync("zone-changed");
+
+        recovered.Should().NotBe(UnambiguousInstant.UtcDateTime);
+        recovered.Should().Be(UnambiguousInstant.UtcDateTime.AddHours(-4));
+    }
+
+    /// <summary>
+    /// Removes the 0032 journal entry and puts the column back to its pre-upgrade type, which is the
+    /// state a deployment upgrading from an earlier release starts in. Reverting only this script
+    /// keeps the outcome attributable to it, rather than to some earlier script replaying.
+    /// </summary>
+    private async Task RevertToPreUpgradeStateAsync()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        await connection.ExecuteAsync("""DELETE FROM "dmscs"."OpenIddictToken";""");
+        await connection.ExecuteAsync(
+            """
+            ALTER TABLE "dmscs"."OpenIddictToken"
+                ALTER COLUMN "ExpirationDate" TYPE timestamp without time zone;
+            """
+        );
+        await connection.ExecuteAsync(
+            """DELETE FROM public."dmscs_SchemaVersions" WHERE scriptname LIKE @JournalPattern;""",
+            new { JournalPattern }
+        );
+    }
+
+    /// <summary>
+    /// Writes the row the way the pre-upgrade code did: an instant bound as timestamptz, which
+    /// PostgreSQL casts down to a wall clock using the session time zone of this connection.
+    /// </summary>
+    private async Task SeedStoredExpirationAsync(string subject, DateTimeOffset? expiration)
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        await connection.ExecuteAsync(
+            """
+            INSERT INTO "dmscs"."OpenIddictToken" ("Id", "Subject", "ExpirationDate")
+            VALUES (@Id, @Subject, @Expiration)
+            """,
+            new
+            {
+                Id = Guid.NewGuid(),
+                Subject = subject,
+                Expiration = expiration,
+            }
+        );
+    }
+
+    private async Task<DateTime?> UpgradedExpirationAsync(string subject)
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        return await connection.QuerySingleAsync<DateTime?>(
+            """SELECT "ExpirationDate" AT TIME ZONE 'UTC' FROM "dmscs"."OpenIddictToken" WHERE "Subject" = @Subject;""",
+            new { Subject = subject }
+        );
+    }
+
+    private async Task<string> UpgradedColumnTypeAsync()
+    {
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+
+        return await connection.QuerySingleAsync<string>(
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'dmscs'
+              AND table_name = 'OpenIddictToken'
+              AND column_name = 'ExpirationDate';
+            """
+        );
+    }
+
+    /// <summary>
+    /// Runs the shipped script body a second time against the already-upgraded database, which is
+    /// what the database shape test's script replay does. The guard should make this a no-op.
+    /// </summary>
+    private async Task ReplayUpgradeScriptAsync()
+    {
+        string scriptName = typeof(Deploy.DatabaseDeploy)
+            .Assembly.GetManifestResourceNames()
+            .Single(name =>
+                name.Contains("0032_Alter_OpenIddictToken_ExpirationDate_TimeZone", StringComparison.Ordinal)
+            );
+
+        await using Stream stream =
+            typeof(Deploy.DatabaseDeploy).Assembly.GetManifestResourceStream(scriptName)
+            ?? throw new InvalidOperationException($"Embedded deploy script not found: {scriptName}");
+        using StreamReader reader = new(stream);
+        string script = await reader.ReadToEndAsync();
+
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+        await connection.ExecuteAsync(script);
+    }
+
+    private string CreateIsolatedConnectionString(string timeZone)
+    {
+        _databaseName = $"dms1430_upgrade_{Guid.NewGuid():N}";
+        return CreateConnectionString(_databaseName, timeZone);
+    }
+
+    private static string CreateConnectionString(string databaseName, string timeZone) =>
+        new NpgsqlConnectionStringBuilder(Configuration.DatabaseOptions.Value.DatabaseConnection)
+        {
+            Database = databaseName,
+            Timezone = timeZone,
+            Pooling = false,
+        }.ConnectionString;
+
+    private static string CreateMaintenanceConnectionString() =>
+        new NpgsqlConnectionStringBuilder(Configuration.DatabaseOptions.Value.DatabaseConnection)
+        {
+            Database = "postgres",
+            Pooling = false,
+        }.ConnectionString;
+
+    private static void DeploySuccessfully(string connectionString)
+    {
+        DatabaseDeployResult result = new Deploy.DatabaseDeploy().DeployDatabase(connectionString);
+
+        if (result is DatabaseDeployResult.DatabaseDeployFailure failure)
+        {
+            Assert.Fail($"Database deploy failed: {failure.Error}");
+        }
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/OpenIddictTokenExpirationUpgradeTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/OpenIddictTokenExpirationUpgradeTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using Dapper;
+using DbUp.Engine.Output;
 using EdFi.DmsConfigurationService.Backend.Deploy;
 using FluentAssertions;
 using Npgsql;
@@ -26,6 +27,8 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration;
 public class Given_a_pre_DMS_1430_OpenIddictToken_PostgreSQL_upgrade
 {
     private const string JournalPattern = "%0032_Alter_OpenIddictToken_ExpirationDate_TimeZone%";
+    private const string TimeZoneDiagnosticPrefix =
+        "DMS-1430 OpenIddictToken ExpirationDate migration running with PostgreSQL TimeZone=";
     private const string WriteTimeZone = "America/New_York";
 
     // A June instant, far from any DST transition, so the -04:00 offset is unambiguous.
@@ -46,6 +49,7 @@ public class Given_a_pre_DMS_1430_OpenIddictToken_PostgreSQL_upgrade
 
     private string _databaseName = string.Empty;
     private string _connectionString = string.Empty;
+    private ScriptOutputCapture _scriptOutput = new();
 
     [OneTimeSetUp]
     public void OneTimeSetup()
@@ -142,6 +146,51 @@ public class Given_a_pre_DMS_1430_OpenIddictToken_PostgreSQL_upgrade
 
         recovered.Should().NotBe(UnambiguousInstant.UtcDateTime);
         recovered.Should().Be(UnambiguousInstant.UtcDateTime.AddHours(-4));
+    }
+
+    /// <summary>
+    /// The shift above leaves no trace in the database, so the deploy log is the only place an
+    /// operator can find which zone the migration reinterpreted the stored wall clocks through.
+    /// Pinned here because the diagnostic only reaches that log as a result set: a RAISE NOTICE
+    /// would leave it silent, and so would the same statement placed inside the migration's DO
+    /// block.
+    /// </summary>
+    [Test]
+    public void It_logs_the_session_time_zone_the_migration_runs_under()
+    {
+        DeploySuccessfully(CreateConnectionString(_databaseName, "UTC"));
+
+        string scriptOutput = _scriptOutput.Output;
+
+        scriptOutput
+            .Should()
+            .Contain(
+                TimeZoneDiagnosticPrefix,
+                "the deploy log is the only record of the zone the guarded ALTER ran under"
+            );
+        scriptOutput
+            .Should()
+            .Contain("TimeZone=UTC", "the diagnostic reports the zone in effect, not a fixed string");
+    }
+
+    [Test]
+    public async Task It_does_not_log_the_session_time_zone_when_the_migration_guard_does_not_run()
+    {
+        DeploySuccessfully(CreateConnectionString(_databaseName, "UTC"));
+
+        await using NpgsqlConnection connection = new(_connectionString);
+        await connection.OpenAsync();
+        int removedJournalEntries = await connection.ExecuteAsync(
+            """DELETE FROM public."dmscs_SchemaVersions" WHERE scriptname LIKE @JournalPattern;""",
+            new { JournalPattern }
+        );
+        removedJournalEntries.Should().Be(1, "the preceding deploy should journal the DMS-1430 migration");
+
+        DeploySuccessfully(CreateConnectionString(_databaseName, "UTC"));
+
+        _scriptOutput
+            .Output.Should()
+            .NotContain(TimeZoneDiagnosticPrefix, "the diagnostic is scoped to the same guard as the ALTER");
     }
 
     /// <summary>
@@ -261,13 +310,42 @@ public class Given_a_pre_DMS_1430_OpenIddictToken_PostgreSQL_upgrade
             Pooling = false,
         }.ConnectionString;
 
-    private static void DeploySuccessfully(string connectionString)
+    private void DeploySuccessfully(string connectionString)
     {
-        DatabaseDeployResult result = new Deploy.DatabaseDeploy().DeployDatabase(connectionString);
+        _scriptOutput = new ScriptOutputCapture();
+
+        DatabaseDeployResult result = new Deploy.DatabaseDeploy
+        {
+            ScriptOutputLog = _scriptOutput,
+        }.DeployDatabase(connectionString);
 
         if (result is DatabaseDeployResult.DatabaseDeployFailure failure)
         {
             Assert.Fail($"Database deploy failed: {failure.Error}");
         }
+    }
+
+    /// <summary>
+    /// Captures the script output DbUp writes for every result set an upgrade script returns, which
+    /// is the channel the migration's time zone diagnostic travels on.
+    /// </summary>
+    private sealed class ScriptOutputCapture : IUpgradeLog
+    {
+        private readonly List<string> _lines = [];
+
+        public string Output => string.Join(Environment.NewLine, _lines);
+
+        public void WriteInformation(string format, params object[] args) => Append(format, args);
+
+        public void WriteWarning(string format, params object[] args) => Append(format, args);
+
+        public void WriteError(string format, params object[] args) => Append(format, args);
+
+        /// <summary>
+        /// DbUp passes result-set rows through with no arguments, so the row text is never treated
+        /// as a format string and a brace in the data cannot break the capture.
+        /// </summary>
+        private void Append(string format, object[] args) =>
+            _lines.Add(args.Length == 0 ? format : string.Format(format, args));
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0016_Create_openiddict_Token_Table.sql
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0016_Create_openiddict_Token_Table.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS "dmscs"."OpenIddictToken" (
     "Subject" varchar(100),
     "Type" varchar(50),
     "ReferenceId" varchar(100),
-    "ExpirationDate" timestamp without time zone,
+    "ExpirationDate" timestamp with time zone,
     "Status" varchar(50) DEFAULT 'valid',
     "CreatedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
     "CreatedBy" VARCHAR(256),

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0032_Alter_OpenIddictToken_ExpirationDate_TimeZone.sql
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0032_Alter_OpenIddictToken_ExpirationDate_TimeZone.sql
@@ -9,6 +9,26 @@
 -- conversions do not round-trip, which made the cleanup sweep's view of a token's expiry depend on
 -- the server's time zone. Storing the instant directly removes the conversion from both paths.
 
+-- Records the session time zone the guarded ALTER below runs under. Case 3 in that comment leaves
+-- no trace in the database afterwards: the implicit cast does not record the zone it reinterpreted
+-- each wall clock through, so a deploy log that omits the zone gives an operator no way to tell an
+-- exact recovery from a silently shifted one. Emitted as a result set rather than RAISE NOTICE
+-- because DbUp's LogScriptOutput captures result sets and never sees a notice, and kept outside the
+-- DO block because an anonymous block returns no result set to the client. The guard is the one the
+-- DO block uses, so an already-upgraded database returns no rows and logs nothing.
+SELECT format(
+    'DMS-1430 OpenIddictToken ExpirationDate migration running with PostgreSQL TimeZone=%s',
+    current_setting('TimeZone')
+) AS "OpenIddictTokenExpirationDateMigrationTimeZone"
+WHERE EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'dmscs'
+      AND table_name = 'OpenIddictToken'
+      AND column_name = 'ExpirationDate'
+      AND data_type = 'timestamp without time zone'
+);
+
 DO $$
 BEGIN
     IF EXISTS (

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0032_Alter_OpenIddictToken_ExpirationDate_TimeZone.sql
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Deploy/Scripts/0032_Alter_OpenIddictToken_ExpirationDate_TimeZone.sql
@@ -1,0 +1,50 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+-- DMS-1430: "ExpirationDate" held an instant in a wall-clock column. Npgsql sends DateTimeOffset
+-- as timestamptz, so the insert converted down through the session time zone and the cleanup
+-- predicate converted the stored column back up through it. On a DST-observing server those two
+-- conversions do not round-trip, which made the cleanup sweep's view of a token's expiry depend on
+-- the server's time zone. Storing the instant directly removes the conversion from both paths.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'dmscs'
+          AND table_name = 'OpenIddictToken'
+          AND column_name = 'ExpirationDate'
+          AND data_type = 'timestamp without time zone'
+    ) THEN
+        -- No USING clause, deliberately. The implicit assignment cast reinterprets each stored
+        -- wall clock through the session time zone this script runs under. That is the best
+        -- available inverse of how Npgsql wrote the rows, but it is not a full repair: the old
+        -- column type discarded information before this script ever runs. Three cases, and they
+        -- differ in whether the result can land early:
+        --
+        --   1. Same session zone as the write, unambiguous wall clock. Exact recovery.
+        --
+        --   2. Same session zone, wall clock in a DST transition window. PostgreSQL's own
+        --      resolution applies: a fall-back wall clock is ambiguous, because two instants an
+        --      hour apart were stored identically, and resolves to the later of the two; a
+        --      spring-forward gap wall clock resolves forward. Both land later than or equal to
+        --      the true instant, so cleanup errs toward retaining the row.
+        --
+        --   3. Session zone changed since the write. Irrecoverable, and the result may shift
+        --      EARLIER as well as later, depending on the two offsets. A row written under
+        --      America/New_York for 18:00Z stores 14:00; migrated under UTC it reconstructs as
+        --      14:00Z, four hours early. Nothing here can detect or correct that, because the
+        --      zone the row was written under was never recorded. Where it matters, run the
+        --      upgrade under the same session time zone the rows were written under; on the
+        --      shipped UTC containers that is automatic and case 1 applies throughout.
+        --
+        -- `USING "ExpirationDate" AT TIME ZONE 'UTC'` looks equivalent and is not. It forces case
+        -- 3 on every row of a non-UTC server, reading each stored wall clock as though it were
+        -- already UTC and shifting it by the server's offset.
+        ALTER TABLE "dmscs"."OpenIddictToken"
+            ALTER COLUMN "ExpirationDate" TYPE timestamp with time zone;
+    END IF;
+END$$;

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/OpenIddict/Repositories/OpenIddictDataRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/OpenIddict/Repositories/OpenIddictDataRepository.cs
@@ -370,20 +370,22 @@ UPDATE ""dmscs"".""OpenIddictApplication""
                 VALUES
                 (@Id, @ApplicationId, @Subject, @Type, @CreationDate, @ExpirationDate, @Status, @ReferenceId)";
 
-            await connection.ExecuteAsync(
-                insertSql,
-                new
-                {
-                    Id = tokenId,
-                    ApplicationId = applicationId,
-                    Subject = subject,
-                    Type = "access_token",
-                    CreationDate = DateTimeOffset.UtcNow,
-                    ExpirationDate = expiration,
-                    Status = "valid",
-                    ReferenceId = tokenId.ToString("N"),
-                }
-            );
+            DynamicParameters parameters = new();
+            parameters.Add("Id", tokenId);
+            parameters.Add("ApplicationId", applicationId);
+            parameters.Add("Subject", subject);
+            parameters.Add("Type", "access_token");
+            parameters.Add("CreationDate", DateTimeOffset.UtcNow);
+            // ExpirationDate is a timestamptz instant. This binding and the sweep bound in
+            // DeleteExpiredTokensAsync are a pair and must move together: binding either side as a
+            // wall-clock timestamp puts a session-time-zone conversion back on that side alone,
+            // which is the DMS-1430 defect. ToUniversalTime keeps the offset at zero, which is what
+            // Npgsql requires for timestamptz, even if a caller ever passes a non-UTC offset.
+            parameters.Add("ExpirationDate", expiration.ToUniversalTime(), DbType.DateTimeOffset);
+            parameters.Add("Status", "valid");
+            parameters.Add("ReferenceId", tokenId.ToString("N"));
+
+            await connection.ExecuteAsync(insertSql, parameters);
         }
 
         public async Task<string?> GetTokenStatusAsync(Guid tokenId)
@@ -413,7 +415,11 @@ UPDATE ""dmscs"".""OpenIddictApplication""
             await connection.OpenAsync();
             const string sql =
                 "DELETE FROM \"dmscs\".\"OpenIddictToken\" WHERE \"ExpirationDate\" <= @ExpiredBefore";
-            return await connection.ExecuteAsync(sql, new { ExpiredBefore = expiredBefore });
+            // Bound as a timestamptz instant, matching how StoreTokenAsync binds ExpirationDate.
+            // See the note there: the two bindings are a pair.
+            DynamicParameters parameters = new();
+            parameters.Add("ExpiredBefore", expiredBefore.ToUniversalTime(), DbType.DateTimeOffset);
+            return await connection.ExecuteAsync(sql, parameters);
         }
 
         public async Task<(string PrivateKey, string KeyId)?> GetActivePrivateKeyInternalAsync(


### PR DESCRIPTION
## What

Stores `dmscs.OpenIddictToken.ExpirationDate` as a PostgreSQL instant (`timestamp with time zone`) instead of a session-time-zone wall clock, so the expired-token cleanup sweep no longer depends on the server's time zone.

## Why

DMS-1354 shipped the column as `timestamp without time zone` while both repository paths bind `DateTimeOffset` values, which Npgsql sends as `timestamptz`. The two paths then converted in opposite directions: the insert cast the instant down to a wall clock through the session time zone, and the cleanup predicate cast the stored column back up through it via `timestamp_le_timestamptz`. Those conversions do not round-trip on a DST-observing server. DMS-1354 recorded the issue and deliberately deferred it, because a correct fix has to move the insert, the sweep bound, and the column type together.

SQL Server was never affected: it compares `DATETIME2` against a UTC `DateTime` with the parameter type pinned explicitly.

### Correction to the failure direction in the ticket

The ticket describes this as the sweep deleting a row the validator still accepts, twice a year. That is not reproducible under a *stable* DST-observing zone, and the investigation is recorded in the design record and on the ticket. Every edge case in the reverse conversion resolves later or equal - a fall-back wall clock is ambiguous and PostgreSQL picks the later candidate instant, a spring-forward gap resolves forward - so the sweep could only *under*-delete, leaving rows to linger past their expiry.

Premature deletion of a live token is real but requires the session zone to *differ* between the write and the sweep (an operator changing the server `timezone`, setting `PGTZ`, or adding `Timezone=` to one connection string). Reproduced during investigation: a row written under `America/New_York` expiring 18:00Z, swept under UTC at 14:00Z, deleted four hours early. Both defects are removed by this change; the distinction affects only how the pre-fix severity is described.

## Changes

Schema (`ee7e45b6b`):

- `0016_Create_openiddict_Token_Table.sql` declares `ExpirationDate` as `timestamp with time zone` for clean installs.
- New `0032_Alter_OpenIddictToken_ExpirationDate_TimeZone.sql` migrates existing installs, PostgreSQL only. The `ALTER` is wrapped in a conditional on the current column type, so the `ACCESS EXCLUSIVE` rewrite runs at most once per database and is a no-op on fresh installs and under the shape test's script replay.
- The script deliberately carries no `USING` clause, and says why: the implicit assignment cast is the inverse of how Npgsql wrote the rows, whereas `USING "ExpirationDate" AT TIME ZONE 'UTC'` corrupts data on any non-UTC server.
- `DatabaseShapeTests` asserts the declared column type, pinning the DDL against regression.

Repository bindings (`bc76cb132`):

- `StoreTokenAsync` and `DeleteExpiredTokensAsync` both pin their parameter to `DbType.DateTimeOffset`, normalized with `ToUniversalTime()`, in a single commit. `StoreTokenAsync` moves to `DynamicParameters` to allow the pin, matching the SQL Server implementation's shape and closing the cross-engine asymmetry noted in DMS-1411 AC7.
- This is expressiveness and defence in depth rather than a behavior change: Npgsql already maps `DateTimeOffset` to `timestamptz`, so against the new column type the pinned and unpinned forms are equivalent. The column type carries the correctness. Verified against PostgreSQL's bind-parameter log under a non-UTC session, where a UTC session cannot distinguish the two wire types.
- `CreationDate` is restated with the same value and no explicit `DbType`, so its behavior is unchanged.

Tests (`c3e0f0b6a`):

- `Given_A_DST_Observing_PostgreSQL_Session_Time_Zone` runs the real repository against an `America/New_York` session connection, storing two expirations an hour apart that both land on local wall clock 01:30 across the 2026 fall-back. Asserts distinct stored instants, a sweep that deletes only the truly expired row, and an unchanged read-back through `GetTokenByIdAsync`.
- `Given_a_pre_DMS_1430_OpenIddictToken_PostgreSQL_upgrade` exercises `0032` against a journaled pre-upgrade database: exact recovery under an unchanged zone, `NULL` preservation, replay safety, and the two cases the migration cannot repair.

Documentation (`8f2c2c3b5`):

- `TOKEN-CLEANUP.md` gains a "Time-Zone Independence (DMS-1430)" section and its stale Current State paragraph is corrected. Records the corrected failure direction, the three migration cases, the bounded one-time rewrite cost, the deliberate scope limit, and the new coverage.

## Testing

| Suite | Result |
| --- | --- |
| PostgreSQL CMS integration (full) | 427 passed, 0 failed, 0 skipped |
| SQL Server CMS integration (full) | 432 passed, 0 failed, 0 skipped |
| SQL Server OpenIddict cleanup (targeted) | 6 passed, 0 failed, 0 skipped |

SQL Server ran against a temporary `mcr.microsoft.com/mssql/server:2025-latest` instance, so the cleanup coverage was genuinely executed rather than skipped. CSharpier is clean on all four touched C# files.

Fault injection confirms each half of the fix is independently covered, and no injected edit remains in the tree:

| Injected fault | Result |
| --- | --- |
| Column reverted to `timestamp without time zone`, code untouched | all 3 DST tests fail |
| Insert misbound as a wall clock, sweep left correct | all 3 fail |
| Sweep bound misbound as a wall clock, insert left correct | only the deletion test fails; storage and read stay green |

The third row is the one-sided change the ticket asked the suite to catch.

## Residual risks

- **Existing rows in a DST fall-back window are not repaired.** Two instants an hour apart were already stored identically by the old column type, so the migration recovers both as the later one. The write destroyed that distinction; the migration cannot recover it. The error direction is late, so such a token lingers rather than being swept early.
- **A database whose session zone changed since its rows were written reconstructs against the migration-time zone**, which can place a value *earlier* than the true instant. The zone a row was written under was never recorded, so the migration cannot detect this. Mitigation is operational: upgrade under the zone the rows were written under. On the shipped UTC containers this case does not arise.
- **`CreationDate` and `RedemptionDate` remain wall-clock columns** with the same latent dependence. Deliberately out of scope: no predicate compares them and no production path reads them. Recorded as possible follow-up cleanup.
- **The DST tests depend on stable `America/New_York` 2026 tzdata.** US DST rules are stable and the assertions are behavioral rather than on PostgreSQL internals, but a tzdata change to US DST rules would move them.

Full detail is in `reference/design/configuration-service/TOKEN-CLEANUP.md`, section "Time-Zone Independence (DMS-1430)", and in the DMS-1430 ticket description under Implementation Decision.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
