### PR TITLE
[DMS-1497] Add plugin configuration, discovery, and isolated loading

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -42,6 +42,10 @@
     <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="7.0.0" />
     <PackageVersion Include="OpenIddict.Validation.SystemNetHttp" Version="7.0.0" />
     <PackageVersion Include="Snapshooter.NUnit" Version="1.0.1" />
+    <!-- Test-only, and referenced only by a plugin loader fixture: it ships a native library for
+         every runtime identifier that suite runs on, which is what lets the fixture resolve and
+         call one through a plugin's own load context. No production project references it. -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.1.25451.107" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.12.0" />

--- a/src/config/EdFi.DmsConfigurationService.sln
+++ b/src/config/EdFi.DmsConfigurationService.sln
@@ -43,6 +43,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Api.Plugins", "..\plug
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Api.Plugins.Hosting", "..\plugins\EdFi.Api.Plugins.Hosting\EdFi.Api.Plugins.Hosting.csproj", "{B7B695A4-4C0B-4986-AB14-77A15E77EF88}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Api.Plugins.Hosting.Tests.Unit", "..\plugins\EdFi.Api.Plugins.Hosting.Tests.Unit\EdFi.Api.Plugins.Hosting.Tests.Unit.csproj", "{065955B5-7B7D-496E-8EAF-A605626DDA8A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -233,6 +235,18 @@ Global
 		{B7B695A4-4C0B-4986-AB14-77A15E77EF88}.Release|x64.Build.0 = Release|Any CPU
 		{B7B695A4-4C0B-4986-AB14-77A15E77EF88}.Release|x86.ActiveCfg = Release|Any CPU
 		{B7B695A4-4C0B-4986-AB14-77A15E77EF88}.Release|x86.Build.0 = Release|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Debug|x64.Build.0 = Debug|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Debug|x86.Build.0 = Debug|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Release|x64.ActiveCfg = Release|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Release|x64.Build.0 = Release|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Release|x86.ActiveCfg = Release|Any CPU
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -253,6 +267,7 @@ Global
 		{C4A4F8B4-41CE-4BD3-9042-CBF862125980} = {82B01A63-4B8A-4965-9806-001128050FB5}
 		{46A1F3B3-CCEE-43F7-B443-7FBD2C93099C} = {07D57EEB-2F50-60C4-C011-FE4FA775C9A8}
 		{B7B695A4-4C0B-4986-AB14-77A15E77EF88} = {07D57EEB-2F50-60C4-C011-FE4FA775C9A8}
+		{065955B5-7B7D-496E-8EAF-A605626DDA8A} = {07D57EEB-2F50-60C4-C011-FE4FA775C9A8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB22426B-6AA8-4C58-9557-376F107B547B}

--- a/src/dms/EdFi.DataManagementService.sln
+++ b/src/dms/EdFi.DataManagementService.sln
@@ -106,6 +106,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Api.Plugins", "..\plug
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Api.Plugins.Hosting", "..\plugins\EdFi.Api.Plugins.Hosting\EdFi.Api.Plugins.Hosting.csproj", "{215C5DAB-FBE9-491C-BD39-213C8D53386B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Api.Plugins.Hosting.Tests.Unit", "..\plugins\EdFi.Api.Plugins.Hosting.Tests.Unit\EdFi.Api.Plugins.Hosting.Tests.Unit.csproj", "{E4F4A889-55F8-436D-BF8A-4D868998723F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -632,6 +634,18 @@ Global
 		{215C5DAB-FBE9-491C-BD39-213C8D53386B}.Release|x64.Build.0 = Release|Any CPU
 		{215C5DAB-FBE9-491C-BD39-213C8D53386B}.Release|x86.ActiveCfg = Release|Any CPU
 		{215C5DAB-FBE9-491C-BD39-213C8D53386B}.Release|x86.Build.0 = Release|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Debug|x64.Build.0 = Debug|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Debug|x86.Build.0 = Debug|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Release|x64.ActiveCfg = Release|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Release|x64.Build.0 = Release|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Release|x86.ActiveCfg = Release|Any CPU
+		{E4F4A889-55F8-436D-BF8A-4D868998723F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -680,6 +694,7 @@ Global
 			{5FCACA76-0EED-44FD-9251-AA9706203D4E} = {2B193382-DF21-4223-888A-CE5CD3B52C25}
 		{F7D8D237-B7E8-4C06-A65E-3C46BCA81A89} = {07D57EEB-2F50-60C4-C011-FE4FA775C9A8}
 		{215C5DAB-FBE9-491C-BD39-213C8D53386B} = {07D57EEB-2F50-60C4-C011-FE4FA775C9A8}
+		{E4F4A889-55F8-436D-BF8A-4D868998723F} = {07D57EEB-2F50-60C4-C011-FE4FA775C9A8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CAB3D5DE-BC6C-44FD-831C-9C7BE3935343}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/ChildProcess.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/ChildProcess.cs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// Runs a child process to completion under a deadline, capturing everything it wrote.
+/// </summary>
+/// <remarks>
+/// Some claims about the loader can only be made in a process of its own, and this is what runs those
+/// processes. It exists once rather than per caller because each way of getting it wrong is invisible
+/// in a passing run and costs a hung suite when it is not: a child that never exits, a child that fills
+/// one pipe while the runner reads the other, and a child that exits leaving its streams held open by
+/// something else.
+/// </remarks>
+internal static class ChildProcess
+{
+    /// <summary>How long the runner waits for a process it has killed to be reaped.</summary>
+    private static readonly TimeSpan _reapDeadline = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The least time the streams are given to finish after the process itself has exited.
+    /// </summary>
+    /// <remarks>
+    /// What is left of the deadline is usually the allowance, but a process that exits at the very
+    /// edge of it would otherwise be given nothing at all and lose its last line to a race.
+    /// </remarks>
+    private static readonly TimeSpan _minimumDrain = TimeSpan.FromSeconds(5);
+
+    internal sealed record Result(int ExitCode, string Output);
+
+    /// <summary>Starts the process, drains both its streams, and waits for it under the deadline.</summary>
+    /// <param name="start">The process to run, with both streams redirected.</param>
+    /// <param name="deadline">How long the process may run before it is killed and the call fails.</param>
+    /// <param name="what">How to name the process in the failure message.</param>
+    internal static Result Run(ProcessStartInfo start, TimeSpan deadline, string what)
+    {
+        using Process process =
+            Process.Start(start) ?? throw new AssertionException($"{what} did not start.");
+
+        // Both streams are drained as the child writes them, rather than one to its end and then the
+        // other. A child that fills one pipe while the runner waits on the other blocks on its write,
+        // never closes the stream being waited on, and both sides wait forever; a deadline cannot help,
+        // because a blocking read only reaches one after it has returned. Draining concurrently is what
+        // makes the deadlines below the things that actually bound this.
+        Lock outputLock = new();
+        StringBuilder output = new();
+        TaskCompletionSource standardOutputClosed = new();
+        TaskCompletionSource standardErrorClosed = new();
+
+        DataReceivedEventHandler Capture(TaskCompletionSource closed) =>
+            (_, received) =>
+            {
+                // A null line is how the reader says the stream reached its end.
+                if (received.Data is not { } line)
+                {
+                    closed.TrySetResult();
+                    return;
+                }
+
+                lock (outputLock)
+                {
+                    output.AppendLine(line);
+                }
+            };
+
+        string CapturedOutput()
+        {
+            lock (outputLock)
+            {
+                return output.ToString();
+            }
+        }
+
+        process.OutputDataReceived += Capture(standardOutputClosed);
+        process.ErrorDataReceived += Capture(standardErrorClosed);
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        if (!process.WaitForExit(deadline))
+        {
+            KillQuietly(process);
+            process.WaitForExit(_reapDeadline);
+
+            throw new AssertionException(
+                $"{what} did not finish within its deadline. Output so far: {CapturedOutput()}"
+            );
+        }
+
+        // The overload above returns the moment the process exits and does not wait for the readers to
+        // deliver what it wrote last. The parameterless overload does wait for them, but waits without
+        // a bound: a grandchild that inherited the pipe holds the streams open after the child itself
+        // is gone, and the wait then never returns. So the wait is on the readers, for what is left of
+        // the deadline, and what was captured is reported either way.
+        TimeSpan drainAllowance = deadline - elapsed.Elapsed;
+
+        if (drainAllowance < _minimumDrain)
+        {
+            drainAllowance = _minimumDrain;
+        }
+
+        if (!Task.WhenAll(standardOutputClosed.Task, standardErrorClosed.Task).Wait(drainAllowance))
+        {
+            KillQuietly(process);
+
+            throw new AssertionException(
+                $"{what} exited, but something held its streams open past the deadline. "
+                    + $"Output so far: {CapturedOutput()}"
+            );
+        }
+
+        return new Result(process.ExitCode, CapturedOutput());
+    }
+
+    /// <summary>
+    /// Ends the process and anything it started, without turning the reason for killing it into a
+    /// different failure.
+    /// </summary>
+    private static void KillQuietly(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (Exception exception)
+            when (exception is InvalidOperationException or NotSupportedException or Win32Exception)
+        {
+            // The process, or a descendant of it, is already gone. The caller is about to report the
+            // real problem, and it is not this.
+        }
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EdFi.Api.Plugins.Hosting.Tests.Unit.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EdFi.Api.Plugins.Hosting.Tests.Unit.csproj
@@ -36,6 +36,15 @@
         <ProjectReference
             Include="..\EdFi.Api.Plugins.Hosting\EdFi.Api.Plugins.Hosting.csproj"
         />
+        <!--
+            The one fixture project this project references, and therefore the one inside the solution
+            build graph. The skew checks compare a plugin's declaration against what the host carries, so
+            the host has to carry something: this puts Acme.HostShared 1.0.0 in the test process, against
+            which the fixtures that declare 2.0.0 are refused. It commits a lock file for that reason.
+        -->
+        <ProjectReference
+            Include="Fixtures\Support\AcmeHostShared1\Acme.HostShared.v1.csproj"
+        />
     </ItemGroup>
     <Import Project="PluginFixtures.targets" />
 </Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EdFi.Api.Plugins.Hosting.Tests.Unit.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EdFi.Api.Plugins.Hosting.Tests.Unit.csproj
@@ -34,6 +34,15 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <!--
+            The host side of the isolation regressions. A plugin's ContributeServices registers into a
+            real ServiceCollection and the options it binds are resolved from a real provider, so this
+            project has to be able to build one and to name IOptions<T>. Both also put the host's own
+            copies of Microsoft.Extensions.Options and Microsoft.Extensions.Primitives in the default
+            context, which is what host-first then serves to the plugin in place of its own.
+        -->
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EdFi.Api.Plugins.Hosting.Tests.Unit.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EdFi.Api.Plugins.Hosting.Tests.Unit.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    <!--
+        Fixtures/ holds whole plugin projects that are published as test assets, several of them
+        deliberately malformed. They are not part of this assembly and must not be compiled into it,
+        embedded in it, or copied by its default None glob; the staging target below is the only thing
+        that builds them.
+    -->
+    <ItemGroup>
+        <Compile Remove="Fixtures/**" />
+        <EmbeddedResource Remove="Fixtures/**" />
+        <None Remove="Fixtures/**" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference
+            Include="..\EdFi.Api.Plugins.Hosting\EdFi.Api.Plugins.Hosting.csproj"
+        />
+    </ItemGroup>
+    <Import Project="PluginFixtures.targets" />
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EdFi.Api.Plugins.Hosting.Tests.Unit.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EdFi.Api.Plugins.Hosting.Tests.Unit.csproj
@@ -17,6 +17,18 @@
         <EmbeddedResource Remove="Fixtures/**" />
         <None Remove="Fixtures/**" />
     </ItemGroup>
+    <!--
+        The staging regressions run PluginFixtures.targets against a temporary output tree of their own,
+        so they need the path of that file. A compiled test cannot otherwise know where its own sources
+        are, and deriving it by walking up from the output directory would encode this project's build
+        layout in a test about something else.
+    -->
+    <ItemGroup>
+        <AssemblyMetadata
+            Include="PluginFixtureTargetsFile"
+            Value="$(MSBuildThisFileDirectory)PluginFixtures.targets"
+        />
+    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.Extensions.Configuration" />

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EnumeratedSharedSetControl.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/EnumeratedSharedSetControl.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// The rejected alternative to host-first, built so the decision can be measured rather than restated.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It unifies a named list - the Ed-Fi contract plus the two abstractions that appear in the hook
+/// signature - and serves everything else from the plugin's own directory. That is the design any
+/// reasonable implementer reaches for first, which is why refuting it needs a working copy of it.
+/// </para>
+/// <para>
+/// It lives here and only here. Nothing in the loader can be configured into this behaviour, so there
+/// is no production switch, no strategy parameter, and no way for a host to select it by accident.
+/// </para>
+/// </remarks>
+internal sealed class EnumeratedSharedSetContext : AssemblyLoadContext
+{
+    /// <summary>
+    /// The assemblies this alternative shares: the contract, and the two the hook signature names.
+    /// </summary>
+    /// <remarks>
+    /// Microsoft.Extensions.Primitives is deliberately not here, and that is the whole point rather
+    /// than an oversight. It holds <c>IChangeToken</c>, which is the return type of
+    /// <c>IConfiguration.GetReloadToken()</c>, so it is reachable through a shared interface without
+    /// appearing in any hook signature. Any list written by inspecting the signatures omits it.
+    /// </remarks>
+    private static readonly string[] SharedNames =
+    [
+        "EdFi.Api.Plugins",
+        "Microsoft.Extensions.DependencyInjection.Abstractions",
+        "Microsoft.Extensions.Configuration.Abstractions",
+    ];
+
+    private readonly AssemblyDependencyResolver _resolver;
+
+    private EnumeratedSharedSetContext(string pluginName, string entryAssemblyPath)
+        : base($"{pluginName}.enumerated-shared-set", isCollectible: false)
+    {
+        _resolver = new AssemblyDependencyResolver(entryAssemblyPath);
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        if (assemblyName.Name is not { } simpleName)
+        {
+            return null;
+        }
+
+        if (SharedNames.Contains(simpleName, StringComparer.Ordinal))
+        {
+            return Default.LoadFromAssemblyName(new AssemblyName(simpleName));
+        }
+
+        // Everything else comes from the plugin, which is what host-first refuses to do and what
+        // splits an identity the host reaches through one of the shared interfaces.
+        string? path = _resolver.ResolveAssemblyToPath(assemblyName);
+        return path is null ? null : LoadFromAssemblyPath(path);
+    }
+
+    /// <summary>
+    /// Loads a staged plugin under the enumerated set, invokes its hook, and reports what happened.
+    /// </summary>
+    /// <remarks>
+    /// The whole point is that the plugin loads cleanly under either strategy and the difference shows
+    /// up when the hook runs, so this deliberately separates the two and returns the hook's failure
+    /// rather than asserting on it. A load failure would be a different finding and is thrown.
+    /// </remarks>
+    internal static Exception? InvokeContributeServices(
+        string pluginDirectory,
+        string pluginName,
+        IConfiguration configuration
+    )
+    {
+        string entryPath = Path.Combine(pluginDirectory, $"{pluginName}.dll");
+        EnumeratedSharedSetContext context = new(pluginName, entryPath);
+
+        Assembly entryAssembly = context.LoadFromAssemblyPath(entryPath);
+
+        Type pluginType = entryAssembly
+            .GetExportedTypes()
+            .Single(candidate =>
+                typeof(EdFiApiPlugin).IsAssignableFrom(candidate)
+                && candidate is { IsAbstract: false, IsInterface: false }
+            );
+
+        EdFiApiPlugin instance = (EdFiApiPlugin)Activator.CreateInstance(pluginType)!;
+
+        try
+        {
+            instance.ContributeServices(new ServiceCollection(), configuration);
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Contracts/Contract_1_1/EdFi.Api.Plugins.v1_1.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Contracts/Contract_1_1/EdFi.Api.Plugins.v1_1.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The production plugin contract at an additive 1.1.0, built as a test asset so that the
+        1.0-plugin-on-a-1.1-host proof has a 1.1 host to run in. It carries the production 1.0.0 public
+        surface unchanged plus one added no-op virtual, which is the only evolution the contract's
+        additive-only policy allows.
+
+        This is a copy of a public surface rather than a reference to it on purpose: the point of the
+        proof is two different assembly versions of one assembly name, and a project reference would
+        give exactly one. A test asserts by reflection that every public member of the real production
+        contract is present here with the same signature, so this file cannot drift into a different
+        contract and let that proof pass vacuously.
+
+        Nothing in production references it, and the production contract's own source and version are
+        untouched.
+    -->
+    <PropertyGroup>
+        <AssemblyName>EdFi.Api.Plugins</AssemblyName>
+        <RootNamespace>EdFi.Api.Plugins</RootNamespace>
+        <AssemblyVersion>1.1.0</AssemblyVersion>
+        <FileVersion>1.1.0</FileVersion>
+        <Version>1.1.0</Version>
+    </PropertyGroup>
+    <!--
+        The two abstractions the hook signature names, at the versions the production contract uses, so
+        the copied signature really is the same signature.
+    -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Contracts/Contract_1_1/EdFiApiPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Contracts/Contract_1_1/EdFiApiPlugin.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EdFi.Api.Plugins;
+
+/// <summary>
+/// The production contract's 1.0.0 public surface, plus the one added no-op virtual that makes this
+/// 1.1.0.
+/// </summary>
+/// <remarks>
+/// Every member below other than <see cref="DescribeCapabilities"/> is the production declaration, and
+/// a reflection test asserts that: the production surface must be a subset of this one, member for
+/// member and signature for signature. Change the production contract and that test fails here rather
+/// than letting the compatibility proof pass against a surface that is no longer the contract's.
+/// </remarks>
+public abstract class EdFiApiPlugin
+{
+    /// <summary>
+    /// The plugin's name, which must equal the name of the directory the plugin was loaded from.
+    /// </summary>
+    public abstract string Name { get; }
+
+    /// <summary>
+    /// Contributes service registrations to the host's container before it is built.
+    /// </summary>
+    /// <param name="services">The host's service collection, as it stands before the container is built.</param>
+    /// <param name="configuration">The host's own configuration, fully layered.</param>
+    public virtual void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        // Intentionally does nothing, exactly as the production 1.0.0 body does.
+    }
+
+    /// <summary>
+    /// The 1.1.0 addition: a new virtual with a no-op body, which is the only evolution the contract's
+    /// additive-only policy permits.
+    /// </summary>
+    /// <remarks>
+    /// A plugin compiled against 1.0.0 has never heard of it and does not override it, so it runs
+    /// unchanged on a 1.1.0 host. Its presence on the type the host loaded is what a test reads to show
+    /// the plugin really was served the newer contract rather than its own copy.
+    /// </remarks>
+    public virtual void DescribeCapabilities()
+    {
+        // Intentionally does nothing. A new virtual with a no-op body is binary-compatible with every
+        // plugin already published against 1.0.0, which is the whole reason the policy allows it.
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Directory.Build.props
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Directory.Build.props
@@ -1,0 +1,26 @@
+<Project>
+    <!--
+        Deliberately imports nothing. A nested Directory.Build.props does not import its parent, which
+        src/plugins/Directory.Build.props records in its own header, so this file is what stops the
+        fixture tree inheriting that one.
+
+        That is the point rather than a side effect. Fixtures are test assets, several of them
+        deliberately malformed: one exposes no plugin type, one exposes two, one declares a name that
+        disagrees with its directory. Under the parent's TreatWarningsAsErrors and analyzer set, assets
+        written to be wrong would have to be written to be wrong in only the approved ways. They also
+        take no committed lock file, because nothing restores them in locked mode and a lock file
+        per fixture would be a maintenance cost with no reader.
+
+        The exception is any fixture project the test project references directly, which is part of the
+        solution's build graph; such a project sets RestorePackagesWithLockFile itself and commits its
+        lock file.
+    -->
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Directory.Packages.props
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Directory.Packages.props
@@ -1,0 +1,31 @@
+<Project>
+    <!--
+        Central package versions for the fixture tree only.
+
+        Unlike the Directory.Build.props beside it, this file deliberately DOES import its parent, so
+        fixtures keep every version the repository already manages and this file adds to that set rather
+        than replacing it. A nested Directory.Packages.props is not chained automatically: MSBuild
+        imports the nearest one and stops, so the import below is what keeps Microsoft.Data.SqlClient,
+        SQLitePCLRaw.lib.e_sqlite3 and the rest available to fixtures.
+
+        Why the addition lives here instead of in src/Directory.Packages.props, which is where a new
+        central version would normally go: measured, adding
+        Microsoft.Extensions.Options.ConfigurationExtensions there rewrote thirty-two committed
+        production lock files, turning that package's entry from "Transitive" to "CentralTransitive" in
+        every project that already had it transitively. The resolved version was identical in all of
+        them, so nothing about the build would have changed - but a plugins-only story has no business
+        editing the lock file of every DMS project, and CI restores both solutions in locked mode.
+        Scoping the version to the fixture tree keeps the blast radius to the fixtures that need it,
+        which are the only projects that reference the package.
+    -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
+    <ItemGroup>
+        <!--
+            The package the IChangeToken regression fixture is built on. Its own publish emits the
+            private copies of Options, Configuration, Configuration.Binder and Primitives that make the
+            enumerated-set control fail, which is why the fixture uses the real package rather than
+            hand-rolling an equivalent.
+        -->
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.1" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginHostRunner/PluginHostRunner.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginHostRunner/PluginHostRunner.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A host process of its own, because the proof it exists for cannot be made inside the test host:
+        this test assembly's default context already holds the production contract at 1.0.0 through its
+        project reference, and a host that carries 1.1.0 has to be a different process.
+
+        It references the real loader by project and calls the real public PluginLoader.Load. It is
+        compiled against the production contract at 1.0.0, like any host, and discovers the 1.1 addition
+        by reflection rather than by naming it - so this program cannot be the thing that proves 1.1 is
+        loaded by having been built against it.
+
+        Published portable and never for a runtime identifier: a runtime-specific publish would restore
+        its project references with that identifier and rewrite their committed lock files.
+    -->
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <AssemblyName>PluginHostRunner</AssemblyName>
+        <RootNamespace>PluginHostRunner</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference
+            Include="..\..\..\..\EdFi.Api.Plugins.Hosting\EdFi.Api.Plugins.Hosting.csproj"
+        />
+    </ItemGroup>
+    <!--
+        A real container, because "the hook ran" is only worth asserting if what the hook registered can
+        actually be resolved from a built provider.
+    -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginHostRunner/Program.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginHostRunner/Program.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Text.Json;
+using EdFi.Api.Plugins;
+using EdFi.Api.Plugins.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace PluginHostRunner;
+
+/// <summary>
+/// A host whose default context carries contract 1.1.0, loading a plugin built against 1.0.0 through
+/// the real loader.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The staging that gives this process a 1.1.0 contract happens outside it, in a temporary copy of its
+/// own publish output. That makes the identity it ends up with a thing to be verified rather than
+/// assumed, which is why the first thing this program does is read the contract version out of its own
+/// default context and refuse to go on unless it is exactly 1.1.0.0. A run that reported success
+/// against a 1.0.0 host would prove nothing at all, and this is what stops that being possible.
+/// </para>
+/// <para>
+/// Everything else it reports is read rather than asserted. The caller does the asserting, so a
+/// failure is diagnosable from the output instead of hiding behind an exit code.
+/// </para>
+/// </remarks>
+internal static class Program
+{
+    /// <summary>The contract identity this program requires its own default context to carry.</summary>
+    private static readonly Version _requiredHostContract = new(1, 1, 0, 0);
+
+    /// <summary>The line prefix the caller looks for, so ordinary output cannot be mistaken for it.</summary>
+    private const string ResultPrefix = "RESULT ";
+
+    private static int Main(string[] args)
+    {
+        if (args.Length != 2)
+        {
+            Console.Error.WriteLine("usage: PluginHostRunner <plugin-root> <plugin-name>");
+            return 2;
+        }
+
+        Version? hostContract = typeof(EdFiApiPlugin).Assembly.GetName().Version;
+
+        if (hostContract != _requiredHostContract)
+        {
+            // Named, and before anything is loaded. Staging is what puts 1.1.0 here, and staging that
+            // silently did not take would otherwise turn this whole proof into a 1.0-on-1.0 run.
+            Console.Error.WriteLine(
+                $"HOST CONTRACT MISMATCH: this process requires EdFi.Api.Plugins "
+                    + $"{_requiredHostContract} in its default context and carries "
+                    + $"{hostContract?.ToString() ?? "no version"}."
+            );
+
+            return 3;
+        }
+
+        try
+        {
+            return Report(args[0], args[1], hostContract);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"RUN FAILURE {exception.GetType().FullName}: {exception.Message}");
+            return 1;
+        }
+    }
+
+    private static int Report(string root, string pluginName, Version hostContract)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Plugins:Directory"] = root,
+                    ["Plugins:Allowed"] = pluginName,
+                }
+            )
+            .Build();
+
+        // The real public entry point, with the contract assembly name a host passes.
+        LoadedPlugin plugin = PluginLoader.Load(configuration, ["EdFi.Api.Plugins"]).Plugins[0];
+
+        Type pluginType = plugin.Instance.GetType();
+
+        // The 1.1 addition, found by name because this program was compiled against 1.0.0 and cannot
+        // refer to it. Invoked as well as found, so "present and does nothing" is a fact of the run
+        // rather than a claim about a member nobody called.
+        MethodInfo? addedVirtual = pluginType.GetMethod("DescribeCapabilities");
+
+        addedVirtual?.Invoke(plugin.Instance, null);
+
+        ServiceCollection services = [];
+        plugin.Instance.ContributeServices(services, configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        object? marker = pluginType.Assembly.GetType("Acme.OldContract.OldContractMarker") is { } markerType
+            ? provider.GetService(markerType)
+            : null;
+
+        RunnerResult result = new(
+            hostContract.ToString(),
+            plugin.Name,
+            pluginType.BaseType!.Assembly.GetName().Version!.ToString(),
+            addedVirtual is not null,
+            marker?.GetType().GetProperty("PluginName")?.GetValue(marker) as string,
+            [
+                .. plugin
+                    .MaterializeSubstitutions()
+                    .Select(substitution => new RunnerSubstitution(
+                        substitution.AssemblyName,
+                        substitution.RequestedVersion?.ToString(),
+                        substitution.HostVersion.ToString(),
+                        substitution.DeclaredVersion?.ToString()
+                    )),
+            ]
+        );
+
+        Console.WriteLine(ResultPrefix + JsonSerializer.Serialize(result));
+
+        return 0;
+    }
+}
+
+/// <summary>What one run observed, for the caller to assert on.</summary>
+internal sealed record RunnerResult(
+    string HostContractVersion,
+    string PluginName,
+    string PluginBaseContractVersion,
+    bool AddedVirtualVisible,
+    string? HookMarkerPluginName,
+    RunnerSubstitution[] Substitutions
+);
+
+/// <summary>One host-first substitution the run recorded.</summary>
+internal sealed record RunnerSubstitution(
+    string AssemblyName,
+    string? RequestedVersion,
+    string HostVersion,
+    string? DeclaredVersion
+);

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginNativeProbeHost/PluginNativeProbeHost.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginNativeProbeHost/PluginNativeProbeHost.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A process of its own, because two of the native assertions cannot be made honestly inside the
+        test host. Both platforms resolve a native module by name once it is loaded, so a sibling test
+        that has already loaded a module satisfies a later call whatever the plugin under test ships;
+        an in-process assertion would turn on test order rather than on behaviour. Each run of this
+        program starts clean.
+
+        Published portable and never for a runtime identifier: it references the loader by project, and
+        a runtime-specific publish would restore that project with a runtime identifier and rewrite its
+        committed lock file.
+    -->
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <AssemblyName>PluginNativeProbeHost</AssemblyName>
+        <RootNamespace>PluginNativeProbeHost</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference
+            Include="..\..\..\..\EdFi.Api.Plugins.Hosting\EdFi.Api.Plugins.Hosting.csproj"
+        />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginNativeProbeHost/Program.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginNativeProbeHost/Program.cs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.Loader;
+using EdFi.Api.Plugins;
+using EdFi.Api.Plugins.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace PluginNativeProbeHost;
+
+/// <summary>
+/// Loads one plugin and calls its native entry point, in a process that has loaded no native module
+/// before it starts.
+/// </summary>
+/// <remarks>
+/// Two modes, and the difference between them is the whole point. <c>loader</c> uses the real
+/// <see cref="PluginLoader"/>, whose context answers for unmanaged dependencies. <c>plain</c> uses a
+/// context that resolves managed assemblies host-first exactly as the real one does and overrides
+/// nothing for unmanaged ones, which is what the runtime's own probing is left to handle. Running one
+/// plugin through both is what shows whether the unmanaged override is doing anything, and a plugin
+/// whose native library sits beside its entry assembly is satisfied by probing either way.
+/// </remarks>
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        if (args.Length != 3)
+        {
+            Console.Error.WriteLine(
+                "usage: PluginNativeProbeHost <plugin-root> <plugin-name> <loader|plain>"
+            );
+            return 2;
+        }
+
+        string root = args[0];
+        string pluginName = args[1];
+        string mode = args[2];
+
+        try
+        {
+            Assembly entryAssembly = mode switch
+            {
+                "loader" => LoadThroughTheRealLoader(root, pluginName),
+                "plain" => LoadWithoutAnUnmanagedOverride(root, pluginName),
+                _ => throw new ArgumentException($"unknown mode '{mode}'"),
+            };
+
+            Console.WriteLine("LOAD SUCCEEDED");
+
+            MethodInfo nativeCall = entryAssembly
+                .GetTypes()
+                .Select(type =>
+                    type.GetMethod("NativeLibraryVersion", BindingFlags.Public | BindingFlags.Static)
+                )
+                .First(method => method is not null)!;
+
+            try
+            {
+                Console.WriteLine($"NATIVE RESULT {nativeCall.Invoke(null, null)}");
+            }
+            catch (TargetInvocationException invocation) when (invocation.InnerException is { } cause)
+            {
+                Console.WriteLine($"NATIVE FAILURE {cause.GetType().FullName}");
+            }
+
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine($"LOAD FAILURE {exception.GetType().FullName}: {exception.Message}");
+            return 1;
+        }
+    }
+
+    private static Assembly LoadThroughTheRealLoader(string root, string pluginName)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Plugins:Directory"] = root,
+                    ["Plugins:Allowed"] = pluginName,
+                }
+            )
+            .Build();
+
+        return PluginLoader.Load(configuration, ["EdFi.Api.Plugins"]).Plugins[0].Instance.GetType().Assembly;
+    }
+
+    private static Assembly LoadWithoutAnUnmanagedOverride(string root, string pluginName)
+    {
+        string entryAssemblyPath = Path.Combine(root, pluginName, $"{pluginName}.dll");
+
+        return new ManagedOnlyContext(pluginName, entryAssemblyPath).LoadFromAssemblyPath(entryAssemblyPath);
+    }
+
+    /// <summary>
+    /// The control: host-first for managed assemblies, and nothing at all for unmanaged ones.
+    /// </summary>
+    private sealed class ManagedOnlyContext(string pluginName, string entryAssemblyPath)
+        : AssemblyLoadContext(pluginName, isCollectible: false)
+    {
+        private readonly AssemblyDependencyResolver _resolver = new(entryAssemblyPath);
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            if (assemblyName.Name is not { } simpleName)
+            {
+                return null;
+            }
+
+            try
+            {
+                return Default.LoadFromAssemblyName(new AssemblyName(simpleName));
+            }
+            catch (FileNotFoundException)
+            {
+                string? path = _resolver.ResolveAssemblyToPath(assemblyName);
+                return path is null ? null : LoadFromAssemblyPath(path);
+            }
+        }
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginNativeProbeHost/Program.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Hosts/PluginNativeProbeHost/Program.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
 using EdFi.Api.Plugins;
@@ -16,12 +17,21 @@ namespace PluginNativeProbeHost;
 /// before it starts.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Two modes, and the difference between them is the whole point. <c>loader</c> uses the real
 /// <see cref="PluginLoader"/>, whose context answers for unmanaged dependencies. <c>plain</c> uses a
 /// context that resolves managed assemblies host-first exactly as the real one does and overrides
 /// nothing for unmanaged ones, which is what the runtime's own probing is left to handle. Running one
 /// plugin through both is what shows whether the unmanaged override is doing anything, and a plugin
 /// whose native library sits beside its entry assembly is satisfied by probing either way.
+/// </para>
+/// <para>
+/// Three further modes load no plugin at all. <c>stall</c> never exits, <c>spew</c> fills its error
+/// stream before it writes anything to its output stream, and <c>linger</c> exits immediately after
+/// starting a process of its own that inherits the streams and outlives it. They exist so that the
+/// runner's deadlines and its stream draining are exercised by a child that really behaves that way,
+/// rather than asserted by reading the runner.
+/// </para>
 /// </remarks>
 internal static class Program
 {
@@ -30,7 +40,7 @@ internal static class Program
         if (args.Length != 3)
         {
             Console.Error.WriteLine(
-                "usage: PluginNativeProbeHost <plugin-root> <plugin-name> <loader|plain>"
+                "usage: PluginNativeProbeHost <plugin-root> <plugin-name> <loader|plain|stall|spew>"
             );
             return 2;
         }
@@ -38,6 +48,31 @@ internal static class Program
         string root = args[0];
         string pluginName = args[1];
         string mode = args[2];
+
+        // None of these load a plugin. They are here so that the runner's deadlines and its stream
+        // draining are exercised by a child that really stalls, really fills a pipe, and really leaves
+        // its streams held open by something else.
+        if (mode == "stall")
+        {
+            return Stall();
+        }
+
+        if (mode == "spew")
+        {
+            return Spew();
+        }
+
+        if (mode == "linger")
+        {
+            return Linger();
+        }
+
+        if (mode == "linger-child")
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(30));
+
+            return 0;
+        }
 
         try
         {
@@ -73,6 +108,77 @@ internal static class Program
             Console.WriteLine($"LOAD FAILURE {exception.GetType().FullName}: {exception.Message}");
             return 1;
         }
+    }
+
+    /// <summary>Announces itself and then never finishes, so the runner's deadline is what ends it.</summary>
+    private static int Stall()
+    {
+        Console.WriteLine("STALLING");
+        Console.Out.Flush();
+        Thread.Sleep(Timeout.Infinite);
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Writes far more to the error stream than a pipe buffer holds, and only then writes to the output
+    /// stream.
+    /// </summary>
+    /// <remarks>
+    /// A runner that reads one stream to its end before touching the other never gets here: this
+    /// process blocks writing its error stream, so its output stream never reaches end of file and both
+    /// sides wait forever. The order is the whole point of the case.
+    /// </remarks>
+    private static int Spew()
+    {
+        string line = new('e', 1024);
+
+        for (int written = 0; written < 2048; written++)
+        {
+            Console.Error.WriteLine(line);
+        }
+
+        Console.WriteLine("SPEW DONE");
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Starts a process that inherits this one's streams, then exits at once and leaves it holding
+    /// them.
+    /// </summary>
+    /// <remarks>
+    /// The grandchild redirects nothing, so it keeps the write end of the pipes the runner is reading.
+    /// Those streams therefore never reach their end, and a runner that waits for them without a bound
+    /// waits forever even though the process it started is long gone. The grandchild sleeps for a
+    /// bounded time rather than forever, so nothing survives the test that has to be hunted down.
+    /// </remarks>
+    private static int Linger()
+    {
+        ProcessStartInfo start = new()
+        {
+            FileName = Environment.ProcessPath ?? "dotnet",
+            UseShellExecute = false,
+        };
+
+        if (
+            !Path.GetFileNameWithoutExtension(start.FileName)
+                .Equals("dotnet", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            start.FileName = "dotnet";
+        }
+
+        start.ArgumentList.Add(Assembly.GetExecutingAssembly().Location);
+        start.ArgumentList.Add(".");
+        start.ArgumentList.Add("none");
+        start.ArgumentList.Add("linger-child");
+
+        Process.Start(start);
+
+        Console.WriteLine("LINGER STARTED");
+
+        return 0;
     }
 
     private static Assembly LoadThroughTheRealLoader(string root, string pluginName)

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.BackstopCtor/Acme.BackstopCtor.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.BackstopCtor/Acme.BackstopCtor.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        References a higher version of an assembly the host carries without shipping it, so the
+        manifest declares nothing for it and the preflight cannot see it. Its constructor touches it,
+        which puts the refusal inside the loader own call and is what the unwrapping has to turn into
+        a message naming both versions.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.BackstopCtor</AssemblyName>
+        <RootNamespace>Acme.BackstopCtor</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference
+            Include="..\..\Support\AcmeHostShared2\Acme.HostShared.v2.csproj"
+            Private="false"
+        />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.BackstopCtor/BackstopCtorPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.BackstopCtor/BackstopCtorPlugin.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.HostShared;
+using EdFi.Api.Plugins;
+
+namespace Acme.BackstopCtor;
+
+public sealed class BackstopCtorPlugin : EdFiApiPlugin
+{
+    private readonly string _described;
+
+    public BackstopCtorPlugin()
+    {
+        // Resolves Acme.HostShared while the loader is constructing this type, so the refusal has a
+        // loader frame above it.
+        _described = HostSharedMarker.Describe();
+    }
+
+    public override string Name => _described;
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.BackstopHook/Acme.BackstopHook.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.BackstopHook/Acme.BackstopHook.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The same suppressed manifest row as Acme.BackstopCtor, touched for the first time in the
+        contribution hook instead of in the constructor. That moves the refusal to after the loader has
+        returned, where there is no loader frame to catch it and nothing to unwrap it: the caller sees
+        the runtime's own FileLoadException wrapper. Characterising that honestly is the point, because
+        claiming a friendly loader-time report for this case would be false.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.BackstopHook</AssemblyName>
+        <RootNamespace>Acme.BackstopHook</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference
+            Include="..\..\Support\AcmeHostShared2\Acme.HostShared.v2.csproj"
+            Private="false"
+        />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.BackstopHook/BackstopHookPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.BackstopHook/BackstopHookPlugin.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.HostShared;
+using EdFi.Api.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Acme.BackstopHook;
+
+/// <summary>
+/// Loads cleanly and then asks for the skewed assembly, so the refusal happens after the loader has
+/// finished.
+/// </summary>
+public sealed class BackstopHookPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.BackstopHook";
+
+    public override void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        // The first and only resolution of Acme.HostShared. Nothing above this frame belongs to the
+        // loader, which is exactly what the test characterises.
+        services.AddSingleton(new BackstopHookMarker(HostSharedMarker.Describe()));
+    }
+}
+
+/// <summary>What the hook would register if the resolution succeeded, which it does not.</summary>
+public sealed record BackstopHookMarker(string Described);

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CaseName/Acme.CaseName.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CaseName/Acme.CaseName.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A plugin whose Name differs from its directory only in case. The comparison is ordinal, so a
+        plugin identity does not depend on which filesystem the image happened to be built on.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.CaseName</AssemblyName>
+        <RootNamespace>Acme.CaseName</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CaseName/CaseNamePlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CaseName/CaseNamePlugin.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.CaseName;
+
+public sealed class CaseNamePlugin : EdFiApiPlugin
+{
+    public override string Name => "acme.casename";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CtorSignatureMissing/Acme.CtorSignatureMissing.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CtorSignatureMissing/Acme.CtorSignatureMissing.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The same shape, with the overload's parameter type coming from an assembly the plugin did not
+        ship and the host does not carry at all. That is the general missing-dependency branch rather
+        than the version-skew one, and it has to be named just as clearly.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.CtorSignatureMissing</AssemblyName>
+        <RootNamespace>Acme.CtorSignatureMissing</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference
+            Include="..\..\Support\AcmePrivate\Acme.Private.csproj"
+            Private="false"
+        />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CtorSignatureMissing/CtorSignatureMissingPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CtorSignatureMissing/CtorSignatureMissingPlugin.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.Private;
+using EdFi.Api.Plugins;
+
+namespace Acme.CtorSignatureMissing;
+
+public sealed class CtorSignatureMissingPlugin : EdFiApiPlugin
+{
+    public CtorSignatureMissingPlugin() { }
+
+    /// <summary>Never called, and its parameter type is nowhere the runtime can find it.</summary>
+    public CtorSignatureMissingPlugin(PrivateHandle handle)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+    }
+
+    public override string Name => "Acme.CtorSignatureMissing";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CtorSignatureSkew/Acme.CtorSignatureSkew.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CtorSignatureSkew/Acme.CtorSignatureSkew.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A perfectly ordinary plugin shape: a public parameterless constructor beside an overload that
+        takes a dependency. The overload's parameter type comes from a higher version of an assembly
+        the host carries, referenced without shipping it, so the manifest declares nothing for it and
+        the preflight cannot see it. Asking for the parameterless constructor makes the runtime bind
+        the other constructor's parameter types, which is where the refusal happens.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.CtorSignatureSkew</AssemblyName>
+        <RootNamespace>Acme.CtorSignatureSkew</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference
+            Include="..\..\Support\AcmeHostShared2\Acme.HostShared.v2.csproj"
+            Private="false"
+        />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CtorSignatureSkew/CtorSignatureSkewPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.CtorSignatureSkew/CtorSignatureSkewPlugin.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.HostShared;
+using EdFi.Api.Plugins;
+
+namespace Acme.CtorSignatureSkew;
+
+public sealed class CtorSignatureSkewPlugin : EdFiApiPlugin
+{
+    public CtorSignatureSkewPlugin() { }
+
+    /// <summary>Never called. Its signature alone is what the runtime has to resolve.</summary>
+    public CtorSignatureSkewPlugin(HostSharedMarker marker)
+    {
+        ArgumentNullException.ThrowIfNull(marker);
+    }
+
+    public override string Name => "Acme.CtorSignatureSkew";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.DeclaredSkew/Acme.DeclaredSkew.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.DeclaredSkew/Acme.DeclaredSkew.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Declares a higher version of an assembly the host carries, in a manifest entry, and never runs
+        the code that would touch it. That is the case the Load override alone would miss, because
+        Load is called when a type resolution first needs an assembly and nothing here ever asks.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.DeclaredSkew</AssemblyName>
+        <RootNamespace>Acme.DeclaredSkew</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference Include="..\..\Support\AcmeHostShared2\Acme.HostShared.v2.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.DeclaredSkew/DeclaredSkewPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.DeclaredSkew/DeclaredSkewPlugin.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.HostShared;
+using EdFi.Api.Plugins;
+
+namespace Acme.DeclaredSkew;
+
+public sealed class DeclaredSkewPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.DeclaredSkew";
+
+    /// <summary>
+    /// Never called. It exists so the compiler records the reference the manifest then declares,
+    /// while no executed code path ever resolves the assembly.
+    /// </summary>
+    public static string NeverCalled() => HostSharedMarker.Describe();
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.FrameworkOnly/Acme.FrameworkOnly.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.FrameworkOnly/Acme.FrameworkOnly.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Takes the assemblies in the hook signature from the shared framework instead of from packages,
+        which is what a FrameworkReference does and what an ASP.NET Core plugin author would write. A
+        framework-dependent publish then declares none of them: they are not in the manifest and not in
+        the plugin directory, so the skew preflight, which reads the manifest, cannot see them at all.
+
+        What this fixture proves is provenance and resolution: those assemblies are absent from the
+        declaration and the host's own copies are the ones the plugin gets when it uses them. It does
+        not prove a refusal, because a genuine shared-framework version skew would need a plugin
+        compiled against a newer shared framework than the host runs and there is one runtime installed
+        here. The refusal half is Acme.BackstopCtor's, over an ordinary assembly whose manifest row is
+        suppressed, and the two claims are asserted separately on purpose.
+
+        No Microsoft.Extensions.* PackageReference here, deliberately: adding one would put the package
+        copy in the plugin directory and destroy the property the fixture exists for.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.FrameworkOnly</AssemblyName>
+        <RootNamespace>Acme.FrameworkOnly</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.FrameworkOnly/FrameworkOnlyPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.FrameworkOnly/FrameworkOnlyPlugin.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Acme.FrameworkOnly;
+
+/// <summary>
+/// Names the hook signature's assemblies in its own public surface, taking them from the shared
+/// framework rather than from packages.
+/// </summary>
+public sealed class FrameworkOnlyPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.FrameworkOnly";
+
+    /// <summary>
+    /// The identity of <see cref="IServiceCollection"/> as this plugin's own assembly resolves it.
+    /// </summary>
+    /// <remarks>
+    /// A type reference in this assembly's metadata, resolved when the method runs, so the answer is
+    /// the assembly the plugin's context actually served rather than the one the host happens to hold.
+    /// </remarks>
+    public static Type ServiceCollectionType() => typeof(IServiceCollection);
+
+    /// <summary>The identity of <see cref="IConfiguration"/>, resolved the same way.</summary>
+    public static Type ConfigurationType() => typeof(IConfiguration);
+
+    public override void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton(new FrameworkOnlyMarker(Name, configuration.GetSection("Acme").Path));
+    }
+}
+
+/// <summary>What <see cref="FrameworkOnlyPlugin"/> registers, so the hook is observably reached.</summary>
+public sealed record FrameworkOnlyMarker(string PluginName, string SectionPath);

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Good/Acme.Good.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Good/Acme.Good.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The well-formed plugin: directory name, entry assembly file name, AssemblyName and Name all
+        equal, published framework-dependent exactly as the implementer guide tells a third party to
+        publish. Its output also carries a private copy of EdFi.Api.Plugins, which is what a real
+        plugin's publish produces and what the host-first assertions need on disk.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.Good</AssemblyName>
+        <RootNamespace>Acme.Good</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference
+            Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj"
+        />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Good/GoodPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Good/GoodPlugin.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Acme.Good;
+
+/// <summary>
+/// A well-formed plugin. Its contribution is one marker registration, which is how a test tells that
+/// this plugin's hook ran rather than another's.
+/// </summary>
+public sealed class GoodPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.Good";
+
+    public override void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton(new GoodPluginMarker(Name));
+    }
+}
+
+/// <summary>What <see cref="GoodPlugin"/> registers, so a test can resolve it and name the source.</summary>
+public sealed record GoodPluginMarker(string PluginName);

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.LibV1/Acme.LibV1.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.LibV1/Acme.LibV1.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Ships Acme.Shared 1.0.0. Its sibling Acme.LibV2 ships 2.0.0 of the same assembly name, and the
+        host carries neither, so nothing can be preferred and each plugin has to be served its own
+        copy. Loaded together, the two are the collision that made drop-in loading worth isolating.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.LibV1</AssemblyName>
+        <RootNamespace>Acme.LibV1</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference Include="..\..\Support\AcmeShared1\Acme.Shared.v1.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.LibV1/LibV1Plugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.LibV1/LibV1Plugin.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.Shared;
+using EdFi.Api.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Acme.LibV1;
+
+/// <summary>
+/// Reports, and registers, whatever version of Acme.Shared this plugin was actually served.
+/// </summary>
+public sealed class LibV1Plugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.LibV1";
+
+    /// <summary>Reads the private copy, which is what forces it to be resolved.</summary>
+    public static string DescribeSharedDependency() => SharedMarker.Describe();
+
+    /// <summary>
+    /// The private copy's own type, so a test can compare identities rather than names.
+    /// </summary>
+    public static Type SharedMarkerType() => typeof(SharedMarker);
+
+    public override void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        // Registering through the hook rather than answering a static call is the half of the claim
+        // that matters to a host: both plugins contribute to one container, and each contribution
+        // carries the version its own copy reports.
+        services.AddSingleton(new LibV1Marker(Name, SharedMarker.Describe()));
+    }
+}
+
+/// <summary>What <see cref="LibV1Plugin"/> registers, named for the version its copy declares.</summary>
+public sealed record LibV1Marker(string PluginName, string SharedVersion);

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.LibV2/Acme.LibV2.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.LibV2/Acme.LibV2.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Ships Acme.Shared 2.0.0, the second major of the assembly Acme.LibV1 ships at 1.0.0.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.LibV2</AssemblyName>
+        <RootNamespace>Acme.LibV2</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference Include="..\..\Support\AcmeShared2\Acme.Shared.v2.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.LibV2/LibV2Plugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.LibV2/LibV2Plugin.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.Shared;
+using EdFi.Api.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Acme.LibV2;
+
+/// <summary>
+/// The same shape as Acme.LibV1, over the second major of the same private dependency.
+/// </summary>
+public sealed class LibV2Plugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.LibV2";
+
+    public static string DescribeSharedDependency() => SharedMarker.Describe();
+
+    public static Type SharedMarkerType() => typeof(SharedMarker);
+
+    public override void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton(new LibV2Marker(Name, SharedMarker.Describe()));
+    }
+}
+
+/// <summary>What <see cref="LibV2Plugin"/> registers, named for the version its copy declares.</summary>
+public sealed record LibV2Marker(string PluginName, string SharedVersion);

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Localized/Acme.Localized.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Localized/Acme.Localized.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Ships a satellite resource assembly, which is the one asset kind whose published location a
+        file name alone cannot find: a publish puts it under its culture's directory, and its
+        manifest declares it in a resources section carrying that culture. Without this fixture the
+        locale branch of the path mapping is reasoning rather than behaviour.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.Localized</AssemblyName>
+        <RootNamespace>Acme.Localized</RootNamespace>
+        <NeutralLanguage>en</NeutralLanguage>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Update="Strings.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Localized/LocalizedPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Localized/LocalizedPlugin.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using System.Resources;
+using EdFi.Api.Plugins;
+
+namespace Acme.Localized;
+
+public sealed class LocalizedPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.Localized";
+
+    /// <summary>Reads the French resource, which lives in the satellite assembly.</summary>
+    public static string FrenchGreeting() =>
+        new ResourceManager("Acme.Localized.Strings", typeof(LocalizedPlugin).Assembly).GetString(
+            "Greeting",
+            new CultureInfo("fr")
+        )!;
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Localized/Strings.fr.resx
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Localized/Strings.fr.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="xml:space" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>bonjour</value>
+  </data>
+</root>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Localized/Strings.resx
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Localized/Strings.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="xml:space" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>hello</value>
+  </data>
+</root>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NameMismatch/Acme.NameMismatch.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NameMismatch/Acme.NameMismatch.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A plugin whose Name disagrees with its directory. The name an operator writes in the
+        allowlist and the name that appears in diagnostics have to be one string.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.NameMismatch</AssemblyName>
+        <RootNamespace>Acme.NameMismatch</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NameMismatch/MisnamedPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NameMismatch/MisnamedPlugin.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.NameMismatch;
+
+public sealed class MisnamedPlugin : EdFiApiPlugin
+{
+    public override string Name => "Some.Other.Name";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Native/Acme.Native.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Native/Acme.Native.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Ships a native library, which is the case the managed Load override never reaches: nothing in
+        it resolves an unmanaged dependency, so the context has to answer for those separately. The
+        library is SQLite because it is tiny, published for every runtime identifier this suite runs
+        on including Alpine's musl one, and exposes an entry point that takes no arguments and touches
+        no state, so the fixture can genuinely call into it rather than merely resolve it.
+
+        Published for a runtime identifier, so like the other runtime-specific fixtures it references
+        the built contract assembly by path rather than by project: a runtime-specific publish would
+        otherwise rewrite the contract's committed lock file.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.Native</AssemblyName>
+        <RootNamespace>Acme.Native</RootNamespace>
+        <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="EdFi.Api.Plugins">
+            <HintPath>$(PluginContractAssemblyPath)</HintPath>
+            <Private>true</Private>
+        </Reference>
+        <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Native/NativePlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Native/NativePlugin.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Runtime.InteropServices;
+using EdFi.Api.Plugins;
+
+namespace Acme.Native;
+
+public sealed class NativePlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.Native";
+
+    /// <summary>
+    /// Calls into the native library the plugin shipped. Resolving it goes through the plugin's own
+    /// load context, which is the only thing that knows where the plugin put it.
+    /// </summary>
+    public static int NativeLibraryVersion() => NativeMethods.NativeLibraryVersionNumber();
+}
+
+internal static class NativeMethods
+{
+    // DllImport rather than LibraryImport: the generated marshalling LibraryImport emits needs unsafe
+    // code, and a fixture that ships one native call has no reason to turn that on. The entry point
+    // name is the library's own and is not this repository's to rename.
+    [DllImport("e_sqlite3", EntryPoint = "sqlite3_libversion_number")]
+    internal static extern int NativeLibraryVersionNumber();
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NativePortable/Acme.NativePortable.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NativePortable/Acme.NativePortable.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The same native library as Acme.Native, published portable rather than for a runtime
+        identifier. A portable publish leaves native assets under runtimes/, and its manifest
+        declares them as runtimeTargets rows that the resolver matches against the running runtime
+        identifier. That is the layout the unmanaged override exists for: a copy flattened beside the
+        entry assembly is found by the runtime's own probing whether the override is there or not, so
+        only this layout can show that the override is what resolves it.
+
+        The package ships natives for forty-odd identifiers, eighty megabytes in all. The staging
+        target publishes this one to the intermediate output and stages the top level plus the
+        running identifier's runtimes subtree, so the manifest is a real portable manifest declaring
+        every identifier while the staged tree carries only the one this process can use. The rest
+        become absent inventory rows, which is a truthful description of the directory.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.NativePortable</AssemblyName>
+        <RootNamespace>Acme.NativePortable</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NativePortable/NativePortablePlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NativePortable/NativePortablePlugin.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Runtime.InteropServices;
+using EdFi.Api.Plugins;
+
+namespace Acme.NativePortable;
+
+public sealed class NativePortablePlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.NativePortable";
+
+    /// <summary>
+    /// Calls into the native library the plugin shipped, which sits under runtimes/ rather than
+    /// beside the entry assembly, so only the plugin's own context knows where to find it.
+    /// </summary>
+    public static int NativeLibraryVersion() => NativeMethods.NativeLibraryVersionNumber();
+}
+
+internal static class NativeMethods
+{
+    [DllImport("e_sqlite3", EntryPoint = "sqlite3_libversion_number")]
+    internal static extern int NativeLibraryVersionNumber();
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NewerContract/Acme.NewerContract.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NewerContract/Acme.NewerContract.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Built against a contract version the host does not carry. It also exposes a type whose load
+        would fail with a different, recognizable error, so a test can tell that the refusal came from
+        reading the entry assembly references rather than from loading a type.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.NewerContract</AssemblyName>
+        <RootNamespace>Acme.NewerContract</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\Support\Contract2\Acme.Contract2.csproj" />
+        <ProjectReference
+            Include="..\..\Support\AcmeHostShared2\Acme.HostShared.v2.csproj"
+            Private="false"
+        />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NewerContract/NewerContractPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NewerContract/NewerContractPlugin.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.HostShared;
+using EdFi.Api.Plugins;
+
+namespace Acme.NewerContract;
+
+public sealed class NewerContractPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.NewerContract";
+}
+
+/// <summary>
+/// Derives from a type in an assembly this plugin does not ship, so enumerating the exported types
+/// produces an error naming Acme.HostShared. A test asserts that error is not the one reported.
+/// </summary>
+public sealed class RecognizableTypeLoadFailure : HostSharedMarker { }

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NoSubclass/Acme.NoSubclass.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NoSubclass/Acme.NoSubclass.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A plugin directory that is well formed in every way except the one that matters: it references
+        the contract and exposes public types, and none of them is an EdFiApiPlugin. This is the shape
+        an implementer produces by forgetting to derive, so the loader has to name that rather than
+        report a missing file.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.NoSubclass</AssemblyName>
+        <RootNamespace>Acme.NoSubclass</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference
+            Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj"
+        />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NoSubclass/NotAPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NoSubclass/NotAPlugin.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.NoSubclass;
+
+/// <summary>
+/// A public exported type that names the contract without deriving from it, which is the mistake this
+/// fixture exists to reproduce.
+/// </summary>
+public sealed class NotAPlugin
+{
+    /// <summary>Names the contract type so the reference is real rather than incidental.</summary>
+    public static string ContractTypeName => typeof(EdFiApiPlugin).FullName ?? nameof(EdFiApiPlugin);
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NonCandidates/Acme.NonCandidates.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NonCandidates/Acme.NonCandidates.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        One constructible plugin type beside every shape that is a subclass and still not something
+        the host can construct. Counting any of those would turn a plugin type that cannot be
+        constructed into an assembly that exposes two plugins.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.NonCandidates</AssemblyName>
+        <RootNamespace>Acme.NonCandidates</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NonCandidates/NonCandidates.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NonCandidates/NonCandidates.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.NonCandidates;
+
+/// <summary>Abstract, so it cannot be constructed.</summary>
+public abstract class AbstractPlugin : EdFiApiPlugin
+{
+    public override string Name => "abstract";
+}
+
+/// <summary>Open generic, so there is no closed type to construct.</summary>
+public sealed class GenericPlugin<T> : EdFiApiPlugin
+{
+    public override string Name => typeof(T).Name;
+}
+
+/// <summary>Not exported at all.</summary>
+internal sealed class InternalPlugin : EdFiApiPlugin
+{
+    public override string Name => "internal";
+}
+
+/// <summary>Public, but its only constructor is not.</summary>
+public sealed class PrivateConstructorPlugin : EdFiApiPlugin
+{
+    private PrivateConstructorPlugin() { }
+
+    public override string Name => "private-ctor";
+}
+
+/// <summary>Public, but the host has nothing to pass it.</summary>
+public sealed class ParameterizedPlugin : EdFiApiPlugin
+{
+    public ParameterizedPlugin(string name)
+    {
+        Name = name;
+    }
+
+    public override string Name { get; }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NonCandidates/TheOnePlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NonCandidates/TheOnePlugin.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.NonCandidates;
+
+public sealed class TheOnePlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.NonCandidates";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NullName/Acme.NullName.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NullName/Acme.NullName.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Returns null from Name. The contract declares Name non-nullable, and a third-party assembly
+        is not constrained by that at runtime, so the loader has to treat a null as a name that is
+        not the directory name rather than dereference it. Nullable is off here so the fixture can
+        say what a careless implementer's assembly would say.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.NullName</AssemblyName>
+        <RootNamespace>Acme.NullName</RootNamespace>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NullName/NullNamePlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.NullName/NullNamePlugin.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.NullName;
+
+public sealed class NullNamePlugin : EdFiApiPlugin
+{
+    public override string Name => null;
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.OldContract/Acme.OldContract.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.OldContract/Acme.OldContract.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Compiled against the real production contract at 1.0.0, by project reference, which is what
+        makes this the plugin half of the 1.0-on-1.1 proof rather than a plugin built against a fixture.
+        Its published bytes reference EdFi.Api.Plugins 1.0.0.0 and its manifest declares that version;
+        the host it is loaded into carries 1.1.0.0, and nothing about this project knows that.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.OldContract</AssemblyName>
+        <RootNamespace>Acme.OldContract</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.OldContract/OldContractPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.OldContract/OldContractPlugin.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Acme.OldContract;
+
+/// <summary>
+/// An ordinary plugin, written against contract 1.0.0 and knowing nothing of any later version.
+/// </summary>
+/// <remarks>
+/// It overrides the one hook 1.0.0 declares. On a 1.1.0 host that override still has to run, which is
+/// the compatibility direction the upgrade story needs, and the marker it registers is how the runner
+/// reports that the hook really ran rather than merely resolved.
+/// </remarks>
+public sealed class OldContractPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.OldContract";
+
+    public override void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton(new OldContractMarker(Name));
+    }
+}
+
+/// <summary>What the hook registers, so the runner can resolve it and say the hook ran.</summary>
+public sealed record OldContractMarker(string PluginName);

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.OnlyNonCandidates/Acme.OnlyNonCandidates.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.OnlyNonCandidates/Acme.OnlyNonCandidates.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The same shapes with no constructible type among them, so the loader has to report that none
+        was found rather than that too many were.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.OnlyNonCandidates</AssemblyName>
+        <RootNamespace>Acme.OnlyNonCandidates</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.OnlyNonCandidates/NonCandidates.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.OnlyNonCandidates/NonCandidates.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.OnlyNonCandidates;
+
+/// <summary>Abstract, so it cannot be constructed.</summary>
+public abstract class AbstractPlugin : EdFiApiPlugin
+{
+    public override string Name => "abstract";
+}
+
+/// <summary>Open generic, so there is no closed type to construct.</summary>
+public sealed class GenericPlugin<T> : EdFiApiPlugin
+{
+    public override string Name => typeof(T).Name;
+}
+
+/// <summary>Not exported at all.</summary>
+internal sealed class InternalPlugin : EdFiApiPlugin
+{
+    public override string Name => "internal";
+}
+
+/// <summary>Public, but its only constructor is not.</summary>
+public sealed class PrivateConstructorPlugin : EdFiApiPlugin
+{
+    private PrivateConstructorPlugin() { }
+
+    public override string Name => "private-ctor";
+}
+
+/// <summary>Public, but the host has nothing to pass it.</summary>
+public sealed class ParameterizedPlugin : EdFiApiPlugin
+{
+    public ParameterizedPlugin(string name)
+    {
+        Name = name;
+    }
+
+    public override string Name { get; }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Options/Acme.Options.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Options/Acme.Options.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The most ordinary plugin there is: it reads configuration and binds options. That is what makes
+        it the regression test for the IChangeToken split, because a framework-dependent publish of a
+        project referencing these two packages emits its own copies of Microsoft.Extensions.Options,
+        Microsoft.Extensions.Configuration, Microsoft.Extensions.Configuration.Binder and
+        Microsoft.Extensions.Primitives, and only the two Abstractions assemblies appear in the hook
+        signature. Primitives holds IChangeToken, so unifying the signature assemblies while isolating
+        the rest splits IChangeToken across an interface the host calls.
+
+        Under host-first every one of those is served from the host, so nothing is split and the options
+        bind. The enumerated-set control that fails on this same fixture lives in the test assembly, not
+        here and not in the loader.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.Options</AssemblyName>
+        <RootNamespace>Acme.Options</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Options/OptionsPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Options/OptionsPlugin.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+
+namespace Acme.Options;
+
+/// <summary>
+/// Binds its own options from the host's configuration, over defaults it composes itself.
+/// </summary>
+public sealed class OptionsPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.Options";
+
+    /// <summary>
+    /// The identity of <see cref="IChangeToken"/> as this plugin's own assembly resolves it, which is
+    /// the type the split would duplicate.
+    /// </summary>
+    public static Type ChangeTokenType() => typeof(IChangeToken);
+
+    public override void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        // Building a configuration of its own is what puts this plugin's copies of
+        // Microsoft.Extensions.Configuration and Microsoft.Extensions.Primitives to work rather than
+        // merely on disk: a provider it constructs has to satisfy the IConfiguration the host passed
+        // in, and IConfiguration.GetReloadToken returns IChangeToken. A plugin composing its own
+        // defaults is also ordinary, so this is not a contrivance built to break.
+        IConfiguration defaults = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Greeting"] = "from the plugin's own defaults",
+                    ["Retries"] = "3",
+                }
+            )
+            .Build();
+
+        services.Configure<AcmeOptions>(defaults);
+
+        // Then the host's own section, which layers over those defaults. Configure binds through
+        // Microsoft.Extensions.Options.ConfigurationExtensions and registers a change-token source
+        // whose GetChangeToken returns the IChangeToken of whichever Primitives this plugin resolved.
+        services.Configure<AcmeOptions>(configuration.GetSection("Acme"));
+    }
+}
+
+/// <summary>The options this plugin binds, which is a plugin type the host never names.</summary>
+public sealed class AcmeOptions
+{
+    public string Greeting { get; set; } = string.Empty;
+
+    public int Retries { get; set; }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.PrivateDependency/Acme.PrivateDependency.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.PrivateDependency/Acme.PrivateDependency.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Ships a dependency the host does not carry, which is the ordinary case host-first resolution
+        leaves alone: the plugin gets its own copy because the host has nothing to prefer. It is also
+        the only fixture that references an assembly a caller could name as a contract and the host
+        could not resolve.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.PrivateDependency</AssemblyName>
+        <RootNamespace>Acme.PrivateDependency</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference Include="..\..\Support\AcmePrivate\Acme.Private.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.PrivateDependency/PrivateDependencyPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.PrivateDependency/PrivateDependencyPlugin.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.Private;
+using EdFi.Api.Plugins;
+
+namespace Acme.PrivateDependency;
+
+public sealed class PrivateDependencyPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.PrivateDependency";
+
+    /// <summary>Resolves the private copy, which is the assembly the plugin shipped.</summary>
+    public static string DescribePrivateDependency() => PrivateMarker.Describe();
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.RidSpecific/Acme.RidSpecific.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.RidSpecific/Acme.RidSpecific.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Published for a runtime identifier but framework-dependent, which names the RID in
+        runtimeTarget and carries no runtimepack. That publish is legitimate and is how a plugin ships
+        native assets, so it has to load.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.RidSpecific</AssemblyName>
+        <RootNamespace>Acme.RidSpecific</RootNamespace>
+    </PropertyGroup>
+    <!--
+        The contract is referenced as a built assembly rather than as a project, and only these
+        runtime-specific fixtures do that. A publish carrying a runtime identifier restores its project
+        references with that identifier and NuGet rewrites their lock files to record it, which would
+        edit the contract's committed lock file. The staging target passes the path.
+    -->
+    <ItemGroup>
+        <Reference Include="EdFi.Api.Plugins">
+            <HintPath>$(PluginContractAssemblyPath)</HintPath>
+            <Private>true</Private>
+        </Reference>
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.RidSpecific/RidSpecificPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.RidSpecific/RidSpecificPlugin.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.RidSpecific;
+
+public sealed class RidSpecificPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.RidSpecific";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.RuntimeTargets/Acme.RuntimeTargets.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.RuntimeTargets/Acme.RuntimeTargets.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Ships a package with runtime-identifier-specific managed assets, which is the shape the skew
+        preflight's sufficiency rests on: the preflight reads top-level runtime entries only, and that
+        is safe only if a managed runtimeTargets row always repeats the same simple name and
+        assemblyVersion at the top level. Microsoft.Data.SqlClient is that package, and it is already
+        centrally versioned because the host itself uses it.
+
+        Published portable, with no runtime identifier, deliberately. A -r publish resolves the assets
+        for the one identifier and emits no managed runtimeTargets rows at all, so a fixture built that
+        way would assert an invariant over an empty set and pass without measuring anything.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.RuntimeTargets</AssemblyName>
+        <RootNamespace>Acme.RuntimeTargets</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.RuntimeTargets/RuntimeTargetsPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.RuntimeTargets/RuntimeTargetsPlugin.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+using Microsoft.Data.SqlClient;
+
+namespace Acme.RuntimeTargets;
+
+/// <summary>
+/// A plugin whose only distinguishing feature is the publish shape of its dependency.
+/// </summary>
+public sealed class RuntimeTargetsPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.RuntimeTargets";
+
+    /// <summary>
+    /// Names a type from the package, so the reference in this assembly's metadata is real rather
+    /// than a package reference the compiler dropped for want of a use.
+    /// </summary>
+    public static string DescribeConnectionStringBuilder() =>
+        new SqlConnectionStringBuilder { DataSource = "nowhere" }.DataSource;
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.SelfContained/Acme.SelfContained.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.SelfContained/Acme.SelfContained.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Published self-contained, which is what puts a runtimepack library in its manifest. Only its
+        entry assembly and manifest are staged: the check reads the manifest and refuses before
+        anything is loaded, and staging the whole shared framework would put hundreds of megabytes in
+        the test output for files the loader never opens.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.SelfContained</AssemblyName>
+        <RootNamespace>Acme.SelfContained</RootNamespace>
+    </PropertyGroup>
+    <!--
+        The contract is referenced as a built assembly rather than as a project, and only these
+        runtime-specific fixtures do that. A publish carrying a runtime identifier restores its project
+        references with that identifier and NuGet rewrites their lock files to record it, which would
+        edit the contract's committed lock file. The staging target passes the path.
+    -->
+    <ItemGroup>
+        <Reference Include="EdFi.Api.Plugins">
+            <HintPath>$(PluginContractAssemblyPath)</HintPath>
+            <Private>true</Private>
+        </Reference>
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.SelfContained/SelfContainedPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.SelfContained/SelfContainedPlugin.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.SelfContained;
+
+public sealed class SelfContainedPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.SelfContained";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Substitution/Acme.Substitution.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Substitution/Acme.Substitution.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Ships an older copy of an assembly the host carries, and does not touch it until asked. The
+        host serves its own copy when the plugin first needs one, which is what a substitution record
+        is: a resolution that happened, not a prediction that one might.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.Substitution</AssemblyName>
+        <RootNamespace>Acme.Substitution</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+        <ProjectReference Include="..\..\Support\AcmeHostShared0\Acme.HostShared.v0.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Substitution/SubstitutionPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.Substitution/SubstitutionPlugin.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Acme.HostShared;
+using EdFi.Api.Plugins;
+
+namespace Acme.Substitution;
+
+public sealed class SubstitutionPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.Substitution";
+
+    /// <summary>
+    /// Resolves Acme.HostShared for the first time. Until this is called nothing has asked for it,
+    /// and the substitution record is empty because no substitution has happened.
+    /// </summary>
+    public static string DescribeHostShared() => HostSharedMarker.Describe();
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.ThrowingCtor/Acme.ThrowingCtor.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.ThrowingCtor/Acme.ThrowingCtor.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Throws from its constructor, which reaches the loader wrapped in a TargetInvocationException
+        and has to be reported with the plugin's own message rather than the wrapper's.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.ThrowingCtor</AssemblyName>
+        <RootNamespace>Acme.ThrowingCtor</RootNamespace>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.ThrowingCtor/ThrowingCtorPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.ThrowingCtor/ThrowingCtorPlugin.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.ThrowingCtor;
+
+public sealed class ThrowingCtorPlugin : EdFiApiPlugin
+{
+    public ThrowingCtorPlugin()
+    {
+        throw new InvalidOperationException("Acme.ThrowingCtor refuses to be constructed.");
+    }
+
+    public override string Name => "Acme.ThrowingCtor";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.ThrowingName/Acme.ThrowingName.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.ThrowingName/Acme.ThrowingName.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Throws when its Name is read, which the loader has to report as a named refusal rather than
+        letting a third party's exception escape the loader unlabelled.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.ThrowingName</AssemblyName>
+        <RootNamespace>Acme.ThrowingName</RootNamespace>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.ThrowingName/ThrowingNamePlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.ThrowingName/ThrowingNamePlugin.cs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.ThrowingName;
+
+public sealed class ThrowingNamePlugin : EdFiApiPlugin
+{
+    public override string Name =>
+        throw new InvalidOperationException("Acme.ThrowingName refuses to say its name.");
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.TwoSubclasses/Acme.TwoSubclasses.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.TwoSubclasses/Acme.TwoSubclasses.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        Two constructible plugin types. Choosing between them would be arbitrary, so it is fatal.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.TwoSubclasses</AssemblyName>
+        <RootNamespace>Acme.TwoSubclasses</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.TwoSubclasses/Plugins.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Plugins/Acme.TwoSubclasses/Plugins.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Api.Plugins;
+
+namespace Acme.TwoSubclasses;
+
+public sealed class FirstPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.TwoSubclasses";
+}
+
+public sealed class SecondPlugin : EdFiApiPlugin
+{
+    public override string Name => "Acme.TwoSubclasses";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared0/Acme.HostShared.v0.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared0/Acme.HostShared.v0.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A version below the one the host carries, so a plugin that ships this one is served the
+        host's instead. That is the ordinary, silent, almost always correct case host-first exists
+        for, and the only evidence it ever leaves is the substitution record.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.HostShared</AssemblyName>
+        <RootNamespace>Acme.HostShared</RootNamespace>
+        <AssemblyVersion>0.5.0</AssemblyVersion>
+        <FileVersion>0.5.0</FileVersion>
+        <Version>0.5.0</Version>
+    </PropertyGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared0/HostSharedMarker.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared0/HostSharedMarker.cs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace Acme.HostShared;
+
+/// <summary>Names the version a plugin shipped, so a test can tell which copy was served.</summary>
+public class HostSharedMarker
+{
+    public const string DeclaredVersion = "0.5.0";
+
+    public static string Describe() => "Acme.HostShared 0.5.0";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared1/Acme.HostShared.v1.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared1/Acme.HostShared.v1.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        An assembly the host itself carries, so that a plugin declaring a higher version of it is
+        refused rather than quietly served its own copy. This is the copy the test project
+        references, which is what puts it in the host, and it is therefore the one fixture project
+        inside the solution build graph, so it commits a lock file.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.HostShared</AssemblyName>
+        <RootNamespace>Acme.HostShared</RootNamespace>
+        <AssemblyVersion>1.0.0</AssemblyVersion>
+        <FileVersion>1.0.0</FileVersion>
+        <Version>1.0.0</Version>
+        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    </PropertyGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared1/HostSharedMarker.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared1/HostSharedMarker.cs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace Acme.HostShared;
+
+/// <summary>
+/// Names the version the host carries, so a test can tell which copy was served.
+/// </summary>
+public class HostSharedMarker
+{
+    public const string DeclaredVersion = "1.0.0";
+
+    public static string Describe() => "Acme.HostShared 1.0.0";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared1/packages.lock.json
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared1/packages.lock.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {}
+  }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared2/Acme.HostShared.v2.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared2/Acme.HostShared.v2.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The higher version a plugin declares, which the host cannot serve. Nothing references this
+        except the fixtures that exist to be refused.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.HostShared</AssemblyName>
+        <RootNamespace>Acme.HostShared</RootNamespace>
+        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <FileVersion>2.0.0</FileVersion>
+        <Version>2.0.0</Version>
+    </PropertyGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared2/HostSharedMarker.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeHostShared2/HostSharedMarker.cs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace Acme.HostShared;
+
+/// <summary>
+/// Names the version a plugin declares, so a test can tell which copy was served.
+/// </summary>
+public class HostSharedMarker
+{
+    public const string DeclaredVersion = "2.0.0";
+
+    public static string Describe() => "Acme.HostShared 2.0.0";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmePrivate/Acme.Private.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmePrivate/Acme.Private.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        An assembly the host does not carry, which is what makes it plugin-private: host-first
+        resolution serves the plugin its own copy, because there is no host copy to prefer.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.Private</AssemblyName>
+        <RootNamespace>Acme.Private</RootNamespace>
+        <AssemblyVersion>1.0.0</AssemblyVersion>
+        <FileVersion>1.0.0</FileVersion>
+        <Version>1.0.0</Version>
+    </PropertyGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmePrivate/PrivateHandle.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmePrivate/PrivateHandle.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace Acme.Private;
+
+/// <summary>A type a plugin can name in a signature, so its resolution can be made to fail.</summary>
+public sealed class PrivateHandle { }

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmePrivate/PrivateMarker.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmePrivate/PrivateMarker.cs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace Acme.Private;
+
+/// <summary>Something only a plugin that ships this assembly can reach.</summary>
+public static class PrivateMarker
+{
+    public static string Describe() => "Acme.Private 1.0.0";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeShared1/Acme.Shared.v1.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeShared1/Acme.Shared.v1.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A third-party library at its first major version, which the host does not carry at any
+        version. Two plugins shipping different majors of it is the collision host-first resolution
+        deliberately leaves alone: there is no host copy to prefer, so each plugin is served its own.
+
+        Its sibling AcmeShared2 declares the same assembly name and the same type names at 2.0.0, so
+        the two copies are one identity by name and two by version. That is what makes the isolation
+        claim about identity rather than about file paths.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.Shared</AssemblyName>
+        <RootNamespace>Acme.Shared</RootNamespace>
+        <AssemblyVersion>1.0.0</AssemblyVersion>
+        <FileVersion>1.0.0</FileVersion>
+        <Version>1.0.0</Version>
+    </PropertyGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeShared1/SharedMarker.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeShared1/SharedMarker.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace Acme.Shared;
+
+/// <summary>
+/// Names the major version this copy is, so a test can tell which of two copies answered.
+/// </summary>
+/// <remarks>
+/// The type's full name is identical in both copies on purpose. A test that compared type names
+/// would see one type; comparing the <see cref="System.Type"/> objects themselves is what shows there
+/// are two, each belonging to its own plugin's assembly.
+/// </remarks>
+public static class SharedMarker
+{
+    public const string DeclaredVersion = "1.0.0";
+
+    public static string Describe() => "Acme.Shared 1.0.0";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeShared2/Acme.Shared.v2.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeShared2/Acme.Shared.v2.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        The second major of the same library. Nothing references this except the plugin fixture that
+        exists to prove a second plugin gets its own copy rather than the first plugin's.
+    -->
+    <PropertyGroup>
+        <AssemblyName>Acme.Shared</AssemblyName>
+        <RootNamespace>Acme.Shared</RootNamespace>
+        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <FileVersion>2.0.0</FileVersion>
+        <Version>2.0.0</Version>
+    </PropertyGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeShared2/SharedMarker.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/AcmeShared2/SharedMarker.cs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace Acme.Shared;
+
+/// <summary>
+/// The second major's copy of the same type, declaring the same full name at a different version.
+/// </summary>
+public static class SharedMarker
+{
+    public const string DeclaredVersion = "2.0.0";
+
+    public static string Describe() => "Acme.Shared 2.0.0";
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/Contract2/Acme.Contract2.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/Contract2/Acme.Contract2.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <!--
+        A stand-in for the plugin contract at a version this host does not carry, so that a fixture
+        can be built against a newer contract than the host and refused at load. It carries the
+        contract assembly name because that is what the reference an entry assembly records has to
+        say; the project file is named differently so that no two project files under src/plugins
+        share a name.
+    -->
+    <PropertyGroup>
+        <AssemblyName>EdFi.Api.Plugins</AssemblyName>
+        <RootNamespace>EdFi.Api.Plugins</RootNamespace>
+        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <FileVersion>2.0.0</FileVersion>
+        <Version>2.0.0</Version>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    </ItemGroup>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/Contract2/EdFiApiPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/Fixtures/Support/Contract2/EdFiApiPlugin.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EdFi.Api.Plugins;
+
+/// <summary>
+/// The plugin contract as a later major version would declare it. Only the shape matters here: a
+/// plugin built against this records a reference to EdFi.Api.Plugins 2.0.0, which is what the
+/// contract-skew check reads out of the entry assembly.
+/// </summary>
+public abstract class EdFiApiPlugin
+{
+    public abstract string Name { get; }
+
+    public virtual void ContributeServices(IServiceCollection services, IConfiguration configuration)
+    {
+        // Intentionally does nothing, exactly as the shipped contract does.
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginContractCompatibilityTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginContractCompatibilityTests.cs
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>What one run of the 1.1 host reported, as the runner serialised it.</summary>
+internal sealed record HostRunnerResult(
+    string HostContractVersion,
+    string PluginName,
+    string PluginBaseContractVersion,
+    bool AddedVirtualVisible,
+    string? HookMarkerPluginName,
+    HostRunnerSubstitution[] Substitutions
+);
+
+/// <summary>One host-first substitution the run recorded.</summary>
+internal sealed record HostRunnerSubstitution(
+    string AssemblyName,
+    string? RequestedVersion,
+    string HostVersion,
+    string? DeclaredVersion
+);
+
+/// <summary>
+/// Stages a private copy of the host runner whose default context carries contract 1.1.0, and runs it.
+/// </summary>
+/// <remarks>
+/// The staged runner is published against the production contract at 1.0.0, like any host. Making a
+/// 1.1 host out of it is done to a copy, in a temporary directory of its own, so no shared staged
+/// output is ever the thing whose identity is rewritten and two cases cannot observe each other's
+/// staging.
+/// </remarks>
+internal sealed class TemporaryHostRunner : IDisposable
+{
+    /// <summary>
+    /// Generous, because the work is a process start, a restore-free load and a plugin load, and a
+    /// build machine is slow at all three. It bounds a hang; it is not a performance assertion.
+    /// </summary>
+    private static readonly TimeSpan _deadline = TimeSpan.FromMinutes(2);
+
+    private readonly string _base;
+
+    private TemporaryHostRunner(string basePath, string runnerPath)
+    {
+        _base = basePath;
+        RunnerPath = runnerPath;
+    }
+
+    /// <summary>The copied runner assembly to execute.</summary>
+    internal string RunnerPath { get; }
+
+    /// <summary>
+    /// Copies the staged runner, and unless <paramref name="substituteContract"/> is false replaces
+    /// that copy's contract assembly with the additive 1.1 build and rewrites its manifest rows.
+    /// </summary>
+    internal static TemporaryHostRunner Create(bool substituteContract = true)
+    {
+        string basePath = Path.Combine(Path.GetTempPath(), "edfi-plugin-hosts", Guid.NewGuid().ToString("N"));
+        string runnerDirectory = Path.Combine(basePath, PluginFixtures.HostRunnerName);
+
+        CopyDirectory(PluginFixtures.HostRunnerDirectory, runnerDirectory);
+
+        if (substituteContract)
+        {
+            // The whole substitution: one file, and the two version rows in the manifest that describe
+            // it. Rewritten with System.Text.Json against a real published manifest rather than by text
+            // replacement, so every other byte the publish produced survives.
+            File.Copy(
+                PluginFixtures.Contract11Assembly,
+                Path.Combine(runnerDirectory, "EdFi.Api.Plugins.dll"),
+                overwrite: true
+            );
+
+            RewriteContractVersionRows(
+                Path.Combine(runnerDirectory, $"{PluginFixtures.HostRunnerName}.deps.json"),
+                "1.1.0.0"
+            );
+        }
+
+        return new TemporaryHostRunner(
+            basePath,
+            Path.Combine(runnerDirectory, $"{PluginFixtures.HostRunnerName}.dll")
+        );
+    }
+
+    /// <summary>Runs the copied runner against a plugin root, under a deadline.</summary>
+    internal ChildProcess.Result Run(string pluginRoot, string pluginName)
+    {
+        ProcessStartInfo start = new()
+        {
+            FileName = Environment.ProcessPath ?? "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        // The test host is itself dotnet, so its own path runs the runner. Falling back to the name on
+        // PATH covers a host that is something else.
+        if (
+            !Path.GetFileNameWithoutExtension(start.FileName)
+                .Equals("dotnet", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            start.FileName = "dotnet";
+        }
+
+        start.ArgumentList.Add(RunnerPath);
+        start.ArgumentList.Add(pluginRoot);
+        start.ArgumentList.Add(pluginName);
+
+        return ChildProcess.Run(start, _deadline, "The 1.1 contract host");
+    }
+
+    /// <summary>Reads the runner's serialised result out of everything it wrote.</summary>
+    internal static HostRunnerResult ResultOf(ChildProcess.Result run)
+    {
+        const string prefix = "RESULT ";
+
+        string? line = Array.Find(
+            run.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+            candidate => candidate.StartsWith(prefix, StringComparison.Ordinal)
+        );
+
+        if (line is null)
+        {
+            throw new AssertionException(
+                $"The host wrote no result line. Exit code {run.ExitCode}. Output: {run.Output}"
+            );
+        }
+
+        return JsonSerializer.Deserialize<HostRunnerResult>(
+            line[prefix.Length..],
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
+        )!;
+    }
+
+    private static void RewriteContractVersionRows(string manifestPath, string version)
+    {
+        JsonNode manifest = JsonNode.Parse(File.ReadAllText(manifestPath))!;
+        string targetName = manifest["runtimeTarget"]!["name"]!.GetValue<string>();
+        bool rewritten = false;
+
+        foreach (KeyValuePair<string, JsonNode?> library in manifest["targets"]![targetName]!.AsObject())
+        {
+            if (library.Value?["runtime"] is not JsonObject runtime)
+            {
+                continue;
+            }
+
+            foreach (KeyValuePair<string, JsonNode?> asset in runtime)
+            {
+                if (
+                    !Path.GetFileNameWithoutExtension(asset.Key)
+                        .Equals("EdFi.Api.Plugins", StringComparison.Ordinal)
+                    || asset.Value is not JsonObject declaration
+                )
+                {
+                    continue;
+                }
+
+                declaration["assemblyVersion"] = version;
+                declaration["fileVersion"] = version;
+                rewritten = true;
+            }
+        }
+
+        if (!rewritten)
+        {
+            throw new AssertionException(
+                $"'{manifestPath}' declares no runtime asset for EdFi.Api.Plugins, so the staged host "
+                    + "cannot be given a different contract identity."
+            );
+        }
+
+        File.WriteAllText(manifestPath, manifest.ToJsonString());
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_base, recursive: true);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // The run is over and the process is gone, but a file can still be held briefly on
+            // Windows. Leaving a temporary directory behind is not worth failing a passing test over.
+        }
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+
+        foreach (string file in Directory.EnumerateFiles(source))
+        {
+            File.Copy(file, Path.Combine(destination, Path.GetFileName(file)), overwrite: true);
+        }
+
+        foreach (string directory in Directory.EnumerateDirectories(source))
+        {
+            CopyDirectory(directory, Path.Combine(destination, Path.GetFileName(directory)));
+        }
+    }
+}
+
+/// <summary>
+/// Loads one assembly by path while everything it depends on comes from the host.
+/// </summary>
+/// <remarks>
+/// Collectible, because it exists only to be reflected over and then discarded. It is not the
+/// production load context and makes no claim about resolution policy: it is the smallest way to have
+/// two assembly versions of one name in this process at once.
+/// </remarks>
+internal sealed class HostFirstProbeContext : AssemblyLoadContext, IDisposable
+{
+    internal HostFirstProbeContext()
+        : base("contract-surface-probe", isCollectible: true) { }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        if (assemblyName.Name is not { } simpleName)
+        {
+            return null;
+        }
+
+        try
+        {
+            return Default.LoadFromAssemblyName(new AssemblyName(simpleName));
+        }
+        catch (FileNotFoundException)
+        {
+            // Nothing here ships a private copy of anything, so an assembly the host does not carry is
+            // left to the runtime's own probing rather than answered wrongly.
+            return null;
+        }
+    }
+
+    public void Dispose() => Unload();
+}
+
+/// <summary>
+/// The additive 1.1 contract fixture, against the real production contract it claims to extend.
+/// </summary>
+/// <remarks>
+/// The 1.0-on-1.1 proof is only worth anything if the 1.1 assembly really is the production contract
+/// plus an addition. A fixture that had quietly drifted into a different surface would still load a
+/// 1.0 plugin and still report a substitution, and the proof would say nothing about compatibility. So
+/// the superset relation is asserted rather than assumed, member by member and signature by signature.
+/// </remarks>
+[TestFixture]
+public class Given_the_additive_contract_fixture
+{
+    private Type _production = null!;
+    private Type _fixture = null!;
+    private HostFirstProbeContext _fixtureContext = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _production = typeof(EdFiApiPlugin);
+
+        // Its own context, because the default one already holds the production contract under the same
+        // assembly name and the two versions cannot both be there.
+        _fixtureContext = new HostFirstProbeContext();
+
+        _fixture = _fixtureContext
+            .LoadFromAssemblyPath(PluginFixtures.Contract11Assembly)
+            .GetType("EdFi.Api.Plugins.EdFiApiPlugin")!;
+    }
+
+    /// <summary>
+    /// Signature as a string, so members from two assembly versions can be compared at all.
+    /// </summary>
+    /// <remarks>
+    /// The two types come from different load contexts, so their parameter types are different
+    /// <see cref="Type"/> instances however identical the signature is; comparing the instances would
+    /// report every member as different. Names are what the comparison can be made on, and they are
+    /// what a compiler binds against.
+    /// </remarks>
+    private static IEnumerable<string> PublicSurfaceOf(Type type) =>
+        type.GetMembers(
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly
+            )
+            .Select(Describe)
+            .Order(StringComparer.Ordinal);
+
+    private static string Describe(MemberInfo member) =>
+        member switch
+        {
+            MethodInfo method => $"method {method.ReturnType.FullName} {method.Name}("
+                + string.Join(", ", method.GetParameters().Select(p => p.ParameterType.FullName))
+                + $") abstract={method.IsAbstract} virtual={method.IsVirtual} static={method.IsStatic}",
+            PropertyInfo property => $"property {property.PropertyType.FullName} {property.Name} "
+                + $"get={property.CanRead} set={property.CanWrite}",
+            ConstructorInfo constructor => $"ctor("
+                + string.Join(", ", constructor.GetParameters().Select(p => p.ParameterType.FullName))
+                + ")",
+            _ => $"{member.MemberType} {member.Name}",
+        };
+
+    [TearDown]
+    public void TearDown() => _fixtureContext.Dispose();
+
+    [Test]
+    public void It_is_a_different_assembly_version_of_the_same_assembly_name()
+    {
+        // The premise of the whole proof. One assembly name, two versions; if the fixture were a
+        // differently named assembly nothing would ever be substituted for anything.
+        _fixture.Assembly.GetName().Name.Should().Be(_production.Assembly.GetName().Name);
+        _production.Assembly.GetName().Version.Should().Be(new Version(1, 0, 0, 0));
+        _fixture.Assembly.GetName().Version.Should().Be(new Version(1, 1, 0, 0));
+    }
+
+    [Test]
+    public void It_keeps_every_public_member_the_production_contract_declares()
+    {
+        string[] production = [.. PublicSurfaceOf(_production)];
+        string[] fixture = [.. PublicSurfaceOf(_fixture)];
+
+        TestContext.Out.WriteLine($"production 1.0.0: {string.Join(" | ", production)}");
+        TestContext.Out.WriteLine($"fixture 1.1.0:    {string.Join(" | ", fixture)}");
+
+        // Superset, member for member and signature for signature. An added member is allowed; a
+        // removed or altered one is what the additive-only policy forbids and what this catches.
+        production.Should().NotBeEmpty();
+        fixture.Should().Contain(production);
+    }
+
+    [Test]
+    public void It_adds_exactly_one_no_op_virtual()
+    {
+        string[] added =
+        [
+            .. PublicSurfaceOf(_fixture).Except(PublicSurfaceOf(_production), StringComparer.Ordinal),
+        ];
+
+        TestContext.Out.WriteLine($"added: {string.Join(" | ", added)}");
+
+        // One addition, and a virtual rather than an abstract: a new abstract member would break every
+        // plugin already published, which is exactly what the policy rules out.
+        added.Should().HaveCount(1);
+        added[0]
+            .Should()
+            .Contain("DescribeCapabilities")
+            .And.Contain("abstract=False")
+            .And.Contain("virtual=True");
+    }
+}
+
+/// <summary>
+/// A plugin compiled against contract 1.0.0, loaded by the real loader in a host carrying 1.1.0.
+/// </summary>
+/// <remarks>
+/// Draft 02's criterion taken literally. A unit-test process cannot be the host, because this
+/// assembly's own default context already holds the production contract at 1.0.0 through a project
+/// reference, so the proof runs in a process of its own whose contract assembly has been replaced in a
+/// private copy of its publish output.
+/// </remarks>
+[TestFixture]
+public class Given_a_plugin_built_against_the_older_contract_on_a_newer_host
+{
+    private TemporaryPluginRoot _root = null!;
+    private TemporaryHostRunner _host = null!;
+    private ChildProcess.Result _run = null!;
+    private HostRunnerResult _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.OldContract);
+
+        _host = TemporaryHostRunner.Create();
+        _run = _host.Run(_root.RootPath, PluginFixtures.OldContract);
+
+        TestContext.Out.WriteLine($"exit {_run.ExitCode}: {_run.Output}");
+
+        // Asserted here because every case below reads the result, and a non-zero exit with the child's
+        // whole output attached is the diagnosable failure rather than a deserialisation error.
+        _run.ExitCode.Should().Be(0, $"the host wrote: {_run.Output}");
+
+        _result = TemporaryHostRunner.ResultOf(_run);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _host.Dispose();
+        _root.Dispose();
+    }
+
+    [Test]
+    public void It_really_is_a_1_1_host()
+    {
+        // Read out of the running process's own default context before it loaded anything, which is
+        // what makes the staged identity a fact of the run instead of an assumption about staging.
+        _result.HostContractVersion.Should().Be("1.1.0.0");
+    }
+
+    [Test]
+    public void It_loads_the_plugin_and_names_it()
+    {
+        _result.PluginName.Should().Be(PluginFixtures.OldContract);
+    }
+
+    [Test]
+    public void It_serves_the_plugin_the_hosts_newer_contract()
+    {
+        // The plugin ships its own 1.0.0 copy and declares 1.0.0, and its base type came from the
+        // host's 1.1.0 assembly instead. That is host-first resolving the contract, and it is the
+        // direction the upgrade story needs.
+        _result.PluginBaseContractVersion.Should().Be("1.1.0.0");
+    }
+
+    [Test]
+    public void It_exposes_the_member_only_the_newer_contract_declares()
+    {
+        // Found and invoked by the runner, so this is "present and does nothing" rather than a claim
+        // about a member nobody called. A plugin served its own 1.0.0 copy could not have it at all.
+        _result.AddedVirtualVisible.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_runs_the_hook_the_older_contract_declared()
+    {
+        // Resolved out of a real provider in that process. A plugin that loaded but whose hook no
+        // longer ran would be a compatibility break that every other assertion here would miss.
+        _result.HookMarkerPluginName.Should().Be(PluginFixtures.OldContract);
+    }
+
+    [Test]
+    public void It_records_the_contract_substitution_it_made()
+    {
+        HostRunnerSubstitution substitution = _result
+            .Substitutions.Should()
+            .ContainSingle(row => row.AssemblyName == "EdFi.Api.Plugins")
+            .Subject;
+
+        substitution.RequestedVersion.Should().Be("1.0.0.0");
+        substitution.HostVersion.Should().Be("1.1.0.0");
+        substitution.DeclaredVersion.Should().Be("1.0.0.0");
+    }
+}
+
+/// <summary>
+/// The same runner without the contract substitution, which is the control on its self-verification.
+/// </summary>
+/// <remarks>
+/// The proof above rests entirely on the host really carrying 1.1.0, and the only thing that
+/// establishes it is the runner refusing to proceed otherwise. If that refusal did not work, a staging
+/// step that silently failed would turn the whole case into a 1.0-on-1.0 run reporting success. This
+/// runs the unmodified staged output to show the refusal happens and says so by name.
+/// </remarks>
+[TestFixture]
+public class Given_the_host_runner_was_not_given_the_newer_contract
+{
+    private TemporaryPluginRoot _root = null!;
+    private TemporaryHostRunner _host = null!;
+    private ChildProcess.Result _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.OldContract);
+
+        _host = TemporaryHostRunner.Create(substituteContract: false);
+        _run = _host.Run(_root.RootPath, PluginFixtures.OldContract);
+
+        TestContext.Out.WriteLine($"exit {_run.ExitCode}: {_run.Output}");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _host.Dispose();
+        _root.Dispose();
+    }
+
+    [Test]
+    public void It_refuses_before_loading_anything()
+    {
+        _run.ExitCode.Should().Be(3, $"the host wrote: {_run.Output}");
+    }
+
+    [Test]
+    public void It_names_the_identity_it_required_and_the_one_it_found()
+    {
+        _run.Output.Should().Contain("HOST CONTRACT MISMATCH");
+        _run.Output.Should().Contain("1.1.0.0");
+        _run.Output.Should().Contain("1.0.0.0");
+    }
+
+    [Test]
+    public void It_reports_no_result_at_all()
+    {
+        // Nothing was loaded, so there is nothing to report. A run that both refused and reported would
+        // mean the refusal came too late to protect anything.
+        _run.Output.Should().NotContain("RESULT ");
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginDepsManifestTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginDepsManifestTests.cs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+[TestFixture]
+public class Given_a_dependency_manifest_that_is_not_json
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+
+        File.WriteAllText(
+            Path.Combine(_root.RootPath, PluginFixtures.Good, $"{PluginFixtures.Good}.deps.json"),
+            "this file is not JSON at all"
+        );
+
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_with_a_named_failure_rather_than_a_raw_parse_error()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.DepsJsonUnreadable);
+        _run.Failure!.InnerException.Should().NotBeNull();
+    }
+}
+
+[TestFixture]
+public class Given_a_dependency_manifest_naming_a_target_it_does_not_declare
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+
+        // Valid JSON, and not the shape a publish produces. The target is selected by the name
+        // runtimeTarget gives rather than by taking whatever single entry happens to be there, so a
+        // manifest that names one it does not declare is refused rather than read as empty.
+        File.WriteAllText(
+            Path.Combine(_root.RootPath, PluginFixtures.Good, $"{PluginFixtures.Good}.deps.json"),
+            """{"runtimeTarget": {"name": ".NETCoreApp,Version=v10.0/linux-x64"}, "targets": {".NETCoreApp,Version=v10.0": {}}}"""
+        );
+
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_rather_than_silently_reading_no_declarations()
+    {
+        // Reading the wrong target would make every skew declaration invisible, which is worse than
+        // refusing: the preflight would pass on a plugin it had never actually examined.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.DepsJsonUnreadable);
+    }
+}
+
+[TestFixture]
+public class Given_a_dependency_manifest_carrying_a_byte_order_mark
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+
+        string manifestPath = Path.Combine(
+            _root.RootPath,
+            PluginFixtures.Good,
+            $"{PluginFixtures.Good}.deps.json"
+        );
+
+        // A publish writes no byte order mark, but an operator or a tool that rewrote the file may. The
+        // bytes are still valid JSON, so refusing them would be a refusal over an encoding detail.
+        File.WriteAllText(manifestPath, File.ReadAllText(manifestPath), new UTF8Encoding(true));
+
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_reads_the_manifest_anyway()
+    {
+        _run.Failure.Should().BeNull();
+        _run.Result!.Plugins.Should().ContainSingle();
+    }
+}
+
+[TestFixture]
+public class Given_a_native_library_the_plugin_did_not_ship
+{
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_defers_to_the_default_probing()
+    {
+        // The override answers with a handle, and returning zero is how it says "I have nothing; probe
+        // as you normally would". Returning a handle it does not have, or throwing, would break every
+        // native library a plugin does not itself ship.
+        PluginLoadContext context = new(
+            PluginFixtures.Good,
+            Path.Combine(_root.RootPath, PluginFixtures.Good, $"{PluginFixtures.Good}.dll")
+        );
+
+        MethodInfo loadUnmanagedDll = typeof(PluginLoadContext).GetMethod(
+            "LoadUnmanagedDll",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        )!;
+
+        object? handle = loadUnmanagedDll.Invoke(context, ["acme-no-such-native-library"]);
+
+        handle.Should().Be(IntPtr.Zero);
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureFreshnessTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureFreshnessTests.cs
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Diagnostics;
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// Runs the real staging rules against an output tree of this test's own.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The staging target decides two things no assertion over the staged output can see: whether a tree
+/// is fresh, and which directories in it are unaccounted for. Both are wrong in ways that leave a
+/// passing suite behind. A tree wrongly called stale republishes every fixture on every build, which
+/// costs minutes and looks like nothing; a directory wrongly kept serves a probe built from sources
+/// that have since changed, which is worse, because the answer is then about code nobody is looking at.
+/// </para>
+/// <para>
+/// So the target itself is run, from a project written here that imports it and reports what it
+/// decided, with the output and intermediate directories pointed at a temporary tree. Nothing in this
+/// file asserts by reading the rules.
+/// </para>
+/// </remarks>
+internal sealed class StagingProbe : IDisposable
+{
+    private static readonly TimeSpan _deadline = TimeSpan.FromMinutes(3);
+
+    private readonly string _base;
+    private readonly string _projectFile;
+    private readonly string _reportFile;
+    private readonly string _fingerprintFile;
+
+    private StagingProbe(string basePath)
+    {
+        _base = basePath;
+        _projectFile = Path.Combine(basePath, "StagingProbe.proj");
+        _reportFile = Path.Combine(basePath, "report.txt");
+        OutputDirectory = Path.Combine(basePath, "out");
+        _fingerprintFile = Path.Combine(basePath, "obj", "fixtures", "staging.fingerprint");
+        StageRoot = Path.Combine(OutputDirectory, "Fixtures");
+        ProbeRoot = Path.Combine(OutputDirectory, "FixtureHosts");
+    }
+
+    /// <summary>What the staging target decided about the tree as it stands.</summary>
+    internal sealed record Report(bool Stale, string Fingerprint);
+
+    private string OutputDirectory { get; }
+
+    /// <summary>Where the target stages plugin fixtures.</summary>
+    internal string StageRoot { get; }
+
+    /// <summary>Where the target stages the helper processes tests run.</summary>
+    internal string ProbeRoot { get; }
+
+    /// <summary>The staging rules under test, recorded into this assembly at build time.</summary>
+    internal static string TargetsFile { get; } =
+        typeof(StagingProbe)
+            .Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(metadata => metadata.Key == "PluginFixtureTargetsFile")
+            .Value!;
+
+    /// <summary>A loader source file, which the staging rules treat as an input.</summary>
+    internal static string LoaderSourceFile { get; } =
+        Path.GetFullPath(
+            Path.Combine(
+                Path.GetDirectoryName(TargetsFile)!,
+                "..",
+                "EdFi.Api.Plugins.Hosting",
+                "PluginLoader.cs"
+            )
+        );
+
+    internal static StagingProbe Create()
+    {
+        string basePath = Path.Combine(
+            Path.GetTempPath(),
+            "edfi-plugin-staging",
+            Guid.NewGuid().ToString("N")
+        );
+        Directory.CreateDirectory(basePath);
+
+        StagingProbe probe = new(basePath);
+
+        File.WriteAllText(
+            probe._projectFile,
+            """
+            <Project>
+                <Import Project="$(PluginFixtureTargetsFile)" />
+                <Target Name="ReportPluginFixtureStaging" DependsOnTargets="PrunePluginFixtureStaging">
+                    <WriteLinesToFile
+                        File="$(PluginFixtureStagingReportFile)"
+                        Overwrite="true"
+                        Lines="stale=$(PluginFixtureStagingIsStale);fingerprint=$(PluginFixtureFingerprint)"
+                    />
+                </Target>
+            </Project>
+
+            """
+        );
+
+        return probe;
+    }
+
+    /// <summary>Runs the staging rules over the tree as it stands and reports what they decided.</summary>
+    internal Report Run()
+    {
+        ProcessStartInfo start = new()
+        {
+            FileName = Environment.ProcessPath ?? "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        if (
+            !Path.GetFileNameWithoutExtension(start.FileName)
+                .Equals("dotnet", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            start.FileName = "dotnet";
+        }
+
+        start.ArgumentList.Add("msbuild");
+        start.ArgumentList.Add(_projectFile);
+        start.ArgumentList.Add("-nologo");
+        start.ArgumentList.Add("-verbosity:quiet");
+        start.ArgumentList.Add("-target:ReportPluginFixtureStaging");
+        start.ArgumentList.Add($"-property:PluginFixtureTargetsFile={TargetsFile}");
+        start.ArgumentList.Add($"-property:PluginFixtureStagingReportFile={_reportFile}");
+        start.ArgumentList.Add("-property:Configuration=Debug");
+        start.ArgumentList.Add($"-property:OutDir={OutputDirectory}{Path.DirectorySeparatorChar}");
+        start.ArgumentList.Add(
+            $"-property:IntermediateOutputPath={Path.Combine(_base, "obj")}{Path.DirectorySeparatorChar}"
+        );
+
+        ChildProcess.Result result = ChildProcess.Run(start, _deadline, "The staging probe");
+
+        if (result.ExitCode != 0 || !File.Exists(_reportFile))
+        {
+            throw new AssertionException($"The staging probe reported nothing. Output: {result.Output}");
+        }
+
+        Dictionary<string, string> reported = File.ReadAllLines(_reportFile)
+            .Select(line => line.Split('=', 2))
+            .Where(pair => pair.Length == 2)
+            .ToDictionary(pair => pair[0], pair => pair[1], StringComparer.Ordinal);
+
+        // The target sets its staleness property only when the tree is stale, so an absent or empty
+        // value is the fresh case rather than a missing answer.
+        return new Report(
+            reported.GetValueOrDefault("stale") == "true",
+            reported.GetValueOrDefault("fingerprint", string.Empty)
+        );
+    }
+
+    /// <summary>
+    /// Leaves the tree the seed describes, recorded as fresh, which is the state an ordinary build
+    /// finishes in.
+    /// </summary>
+    /// <remarks>
+    /// The freshness record is written by the publish, which is far too expensive to run here, so it is
+    /// produced the only other honest way: the tree is seeded, the rules are run over it to obtain the
+    /// fingerprint of exactly that tree, and the tree is seeded again because that first run removed it.
+    /// </remarks>
+    internal void SeedAndSeal(Action seed)
+    {
+        seed();
+
+        Report first = Run();
+
+        if (!first.Stale)
+        {
+            throw new AssertionException(
+                "A tree with no recorded fingerprint should be stale, so this probe is not measuring "
+                    + "what it claims to measure."
+            );
+        }
+
+        seed();
+
+        Directory.CreateDirectory(Path.GetDirectoryName(_fingerprintFile)!);
+        File.WriteAllText(_fingerprintFile, first.Fingerprint + Environment.NewLine);
+    }
+
+    /// <summary>Writes a file into the temporary tree, creating what it needs on the way.</summary>
+    internal static void WriteFile(string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "staged");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_base, recursive: true);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // Not worth failing a passing test over a temporary directory.
+        }
+    }
+}
+
+/// <summary>
+/// A staged tree nothing has changed since it was published.
+/// </summary>
+/// <remarks>
+/// The expensive mistake is here rather than in the stale case: a rule that classifies a directory it
+/// should have kept deletes the declared outputs of a tree that was up to date, so the next build
+/// republishes every fixture, every time, while reporting nothing at all.
+/// </remarks>
+[TestFixture]
+public class Given_a_staged_tree_that_has_not_changed
+{
+    private const string RemovedFixture = "Acme.Removed";
+    private const string RemovedHost = "Acme.RemovedHost";
+
+    private StagingProbe _probe = null!;
+    private StagingProbe.Report _report = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _probe = StagingProbe.Create();
+        _probe.SeedAndSeal(Seed);
+        _report = _probe.Run();
+    }
+
+    [TearDown]
+    public void TearDown() => _probe.Dispose();
+
+    private void Seed()
+    {
+        // One ordinary fixture, one portable fixture, one helper process, and one directory of each
+        // kind that no longer belongs to anything.
+        StagingProbe.WriteFile(
+            Path.Combine(_probe.StageRoot, PluginFixtures.Good, $"{PluginFixtures.Good}.dll")
+        );
+        StagingProbe.WriteFile(
+            Path.Combine(
+                _probe.StageRoot,
+                PluginFixtures.NativePortable,
+                $"{PluginFixtures.NativePortable}.deps.json"
+            )
+        );
+        StagingProbe.WriteFile(Path.Combine(_probe.StageRoot, RemovedFixture, "leftover.dll"));
+        StagingProbe.WriteFile(
+            Path.Combine(
+                _probe.ProbeRoot,
+                PluginFixtures.NativeProbeHostName,
+                $"{PluginFixtures.NativeProbeHostName}.runtimeconfig.json"
+            )
+        );
+        StagingProbe.WriteFile(Path.Combine(_probe.ProbeRoot, RemovedHost, "leftover.dll"));
+    }
+
+    [Test]
+    public void It_does_not_call_the_tree_stale()
+    {
+        _report.Stale.Should().BeFalse();
+    }
+
+    [Test]
+    public void It_keeps_an_ordinary_fixture_directory()
+    {
+        Directory.Exists(Path.Combine(_probe.StageRoot, PluginFixtures.Good)).Should().BeTrue();
+    }
+
+    [Test]
+    public void It_keeps_a_portable_fixture_directory()
+    {
+        // The portable fixture is staged by a list of its own, and a kind left out of the expected set
+        // is deleted here on every build however fresh the tree is. That removes the declared outputs
+        // the publish is skipped on, so the whole collection republishes each time.
+        Directory.Exists(Path.Combine(_probe.StageRoot, PluginFixtures.NativePortable)).Should().BeTrue();
+    }
+
+    [Test]
+    public void It_keeps_a_helper_process_directory()
+    {
+        Directory
+            .Exists(Path.Combine(_probe.ProbeRoot, PluginFixtures.NativeProbeHostName))
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    public void It_removes_a_fixture_directory_nothing_declares()
+    {
+        // The other half of the same rule, and the reason it exists: a fixture dropped from the list
+        // leaves a directory behind that a test enumerating the root would still find.
+        Directory.Exists(Path.Combine(_probe.StageRoot, RemovedFixture)).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_removes_a_helper_directory_nothing_declares()
+    {
+        Directory.Exists(Path.Combine(_probe.ProbeRoot, RemovedHost)).Should().BeFalse();
+    }
+}
+
+/// <summary>
+/// A staged helper process missing one of the files it was published with.
+/// </summary>
+/// <remarks>
+/// A helper is a whole published program, and losing one file from it leaves an entry assembly that
+/// still exists and still looks up to date while the process it belongs to can no longer start. The
+/// staged file set is in the fingerprint so that this is a stale tree rather than a mysterious failure
+/// in whatever test runs that helper.
+/// </remarks>
+[TestFixture]
+public class Given_a_staged_helper_process_has_lost_a_file
+{
+    private StagingProbe _probe = null!;
+    private StagingProbe.Report _report = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _probe = StagingProbe.Create();
+        _probe.SeedAndSeal(Seed);
+
+        File.Delete(
+            Path.Combine(
+                _probe.ProbeRoot,
+                PluginFixtures.NativeProbeHostName,
+                $"{PluginFixtures.NativeProbeHostName}.runtimeconfig.json"
+            )
+        );
+
+        _report = _probe.Run();
+    }
+
+    [TearDown]
+    public void TearDown() => _probe.Dispose();
+
+    private void Seed()
+    {
+        StagingProbe.WriteFile(
+            Path.Combine(
+                _probe.ProbeRoot,
+                PluginFixtures.NativeProbeHostName,
+                $"{PluginFixtures.NativeProbeHostName}.dll"
+            )
+        );
+        StagingProbe.WriteFile(
+            Path.Combine(
+                _probe.ProbeRoot,
+                PluginFixtures.NativeProbeHostName,
+                $"{PluginFixtures.NativeProbeHostName}.runtimeconfig.json"
+            )
+        );
+    }
+
+    [Test]
+    public void It_calls_the_tree_stale()
+    {
+        _report.Stale.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_removes_the_incomplete_helper_rather_than_leaving_it_to_be_run()
+    {
+        Directory
+            .Exists(Path.Combine(_probe.ProbeRoot, PluginFixtures.NativeProbeHostName))
+            .Should()
+            .BeFalse();
+    }
+}
+
+/// <summary>
+/// A loader source edited after the fixtures and helpers were staged.
+/// </summary>
+/// <remarks>
+/// A helper process references the loader by project, so its published copy answers with whatever the
+/// loader was when it was staged. A probe carrying an older loader does not fail; it answers a question
+/// nobody asked, which is why this has to be a stale tree.
+/// </remarks>
+[TestFixture]
+public class Given_a_loader_source_has_been_edited_since_staging
+{
+    private StagingProbe _probe = null!;
+    private StagingProbe.Report _report = null!;
+    private DateTime _originalWriteTime;
+
+    [SetUp]
+    public void Setup()
+    {
+        _probe = StagingProbe.Create();
+        _probe.SeedAndSeal(Seed);
+
+        // An edit as the staging rules see one: they carry the modification time of every input, so
+        // moving one is the smallest faithful way to make this file look edited. It is put back in the
+        // teardown, and no byte of it is read or written.
+        _originalWriteTime = File.GetLastWriteTimeUtc(StagingProbe.LoaderSourceFile);
+        File.SetLastWriteTimeUtc(StagingProbe.LoaderSourceFile, _originalWriteTime + TimeSpan.FromMinutes(1));
+
+        _report = _probe.Run();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        File.SetLastWriteTimeUtc(StagingProbe.LoaderSourceFile, _originalWriteTime);
+        _probe.Dispose();
+    }
+
+    private void Seed()
+    {
+        StagingProbe.WriteFile(
+            Path.Combine(_probe.StageRoot, PluginFixtures.Good, $"{PluginFixtures.Good}.dll")
+        );
+        StagingProbe.WriteFile(
+            Path.Combine(
+                _probe.ProbeRoot,
+                PluginFixtures.NativeProbeHostName,
+                $"{PluginFixtures.NativeProbeHostName}.dll"
+            )
+        );
+    }
+
+    [Test]
+    public void It_calls_the_tree_stale()
+    {
+        _report.Stale.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_removes_the_staged_helper_so_the_next_build_cannot_run_the_older_one()
+    {
+        Directory
+            .Exists(Path.Combine(_probe.ProbeRoot, PluginFixtures.NativeProbeHostName))
+            .Should()
+            .BeFalse();
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -58,6 +58,24 @@ internal static class PluginFixtures
     /// <summary>Touches an unmanifested higher version while the loader is constructing it.</summary>
     internal const string BackstopCtor = "Acme.BackstopCtor";
 
+    /// <summary>Touches the same unmanifested higher version from inside the contribution hook.</summary>
+    internal const string BackstopHook = "Acme.BackstopHook";
+
+    /// <summary>Ships the first major of a private third-party library the host does not carry.</summary>
+    internal const string LibV1 = "Acme.LibV1";
+
+    /// <summary>Ships the second major of that same library.</summary>
+    internal const string LibV2 = "Acme.LibV2";
+
+    /// <summary>Reads configuration and binds options, which is the IChangeToken regression.</summary>
+    internal const string Options = "Acme.Options";
+
+    /// <summary>Takes the hook signature's assemblies from the shared framework, not from packages.</summary>
+    internal const string FrameworkOnly = "Acme.FrameworkOnly";
+
+    /// <summary>Published portable over a package with runtime-identifier-specific managed assets.</summary>
+    internal const string RuntimeTargets = "Acme.RuntimeTargets";
+
     /// <summary>Ships a dependency the host does not carry, so its own copy is the one served.</summary>
     internal const string PrivateDependency = "Acme.PrivateDependency";
 
@@ -113,6 +131,12 @@ internal static class PluginFixtures
         NativePortable,
         Substitution,
         Localized,
+        BackstopHook,
+        LibV1,
+        LibV2,
+        Options,
+        FrameworkOnly,
+        RuntimeTargets,
     ];
 
     /// <summary>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// Where the fixture plugin directories are staged, and what they are called.
+/// </summary>
+/// <remarks>
+/// The fixture projects under Fixtures/ are published into the test output by
+/// PluginFixtures.targets, one directory each. Tests address them through this type rather than
+/// composing the path themselves, so that the staging layout is stated once.
+/// </remarks>
+internal static class PluginFixtures
+{
+    /// <summary>The staged plugin root, which is a real plugin root as far as the loader is concerned.</summary>
+    internal static string Root { get; } = Path.Combine(AppContext.BaseDirectory, "Fixtures");
+
+    /// <summary>The well-formed plugin.</summary>
+    internal const string Good = "Acme.Good";
+
+    /// <summary>A plugin directory whose entry assembly exposes no plugin type.</summary>
+    internal const string NoSubclass = "Acme.NoSubclass";
+
+    /// <summary>Every fixture the staging target is expected to produce.</summary>
+    internal static IReadOnlyList<string> All { get; } = [Good, NoSubclass];
+
+    internal static string DirectoryOf(string name) => Path.Combine(Root, name);
+
+    internal static string EntryAssemblyOf(string name) => Path.Combine(DirectoryOf(name), $"{name}.dll");
+
+    internal static string ManifestOf(string name) => Path.Combine(DirectoryOf(name), $"{name}.deps.json");
+}
+
+/// <summary>
+/// The staging target is infrastructure every later loader test rests on, so its output is asserted
+/// rather than assumed. A fixture that failed to publish would otherwise surface as a loader test
+/// failing for the wrong reason.
+/// </summary>
+[TestFixture]
+public class Given_the_fixture_plugins_have_been_staged
+{
+    [Test]
+    public void It_stages_them_under_a_single_plugin_root()
+    {
+        Directory.Exists(PluginFixtures.Root).Should().BeTrue();
+    }
+
+    [Test]
+    public void It_stages_exactly_the_declared_fixtures_and_nothing_left_over()
+    {
+        // A fixture removed from the target's list leaves its published directory behind, where a
+        // later test enumerating the root would still find it. This is what proves the staging prunes.
+        Directory
+            .GetDirectories(PluginFixtures.Root)
+            .Select(Path.GetFileName)
+            .Should()
+            .BeEquivalentTo(PluginFixtures.All);
+    }
+
+    [TestCaseSource(typeof(PluginFixtures), nameof(PluginFixtures.All))]
+    public void It_names_the_entry_assembly_for_the_directory(string name)
+    {
+        // The directory name, the entry assembly file name and the assembly's own name all have to be
+        // one string; this is the first of those equalities and the one staging is responsible for.
+        File.Exists(PluginFixtures.EntryAssemblyOf(name)).Should().BeTrue();
+    }
+
+    [TestCaseSource(typeof(PluginFixtures), nameof(PluginFixtures.All))]
+    public void It_publishes_a_dependency_manifest_beside_the_entry_assembly(string name)
+    {
+        File.Exists(PluginFixtures.ManifestOf(name)).Should().BeTrue();
+    }
+
+    [TestCaseSource(typeof(PluginFixtures), nameof(PluginFixtures.All))]
+    public void It_publishes_a_manifest_a_framework_dependent_publish_produces(string name)
+    {
+        using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(PluginFixtures.ManifestOf(name)));
+
+        // runtimeTarget naming the framework rather than a runtime pack is what distinguishes the
+        // publish the implementer guide prescribes from a self-contained one.
+        manifest
+            .RootElement.GetProperty("runtimeTarget")
+            .GetProperty("name")
+            .GetString()
+            .Should()
+            .StartWith(".NETCoreApp,Version=v10.0");
+    }
+
+    [Test]
+    public void It_carries_the_plugin_contract_into_the_plugin_directory()
+    {
+        // A published plugin brings its own copy of the contract, which is exactly the copy host-first
+        // resolution has to decline to use. The assertions about which copy is served need that file
+        // to be on disk, so its presence is pinned here rather than assumed there.
+        File.Exists(Path.Combine(PluginFixtures.DirectoryOf(PluginFixtures.Good), "EdFi.Api.Plugins.dll"))
+            .Should()
+            .BeTrue();
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -61,6 +61,9 @@ internal static class PluginFixtures
     /// <summary>Ships a dependency the host does not carry, so its own copy is the one served.</summary>
     internal const string PrivateDependency = "Acme.PrivateDependency";
 
+    /// <summary>Ships a satellite resource assembly under its culture's directory.</summary>
+    internal const string Localized = "Acme.Localized";
+
     /// <summary>Ships an older copy of an assembly the host carries.</summary>
     internal const string Substitution = "Acme.Substitution";
 
@@ -109,6 +112,7 @@ internal static class PluginFixtures
         Native,
         NativePortable,
         Substitution,
+        Localized,
     ];
 
     /// <summary>
@@ -122,13 +126,16 @@ internal static class PluginFixtures
 
     internal static string EntryAssemblyOf(string name) => Path.Combine(DirectoryOf(name), $"{name}.dll");
 
+    /// <summary>The staged name of the fresh-process probe, which is not a plugin.</summary>
+    internal const string NativeProbeHostName = "PluginNativeProbeHost";
+
     /// <summary>The fresh-process probe the native assertions run.</summary>
     internal static string NativeProbeHost { get; } =
         Path.Combine(
             AppContext.BaseDirectory,
             "FixtureHosts",
-            "PluginNativeProbeHost",
-            "PluginNativeProbeHost.dll"
+            NativeProbeHostName,
+            $"{NativeProbeHostName}.dll"
         );
 
     internal static string ManifestOf(string name) => Path.Combine(DirectoryOf(name), $"{name}.deps.json");

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -61,6 +61,12 @@ internal static class PluginFixtures
     /// <summary>Ships a dependency the host does not carry, so its own copy is the one served.</summary>
     internal const string PrivateDependency = "Acme.PrivateDependency";
 
+    /// <summary>Ships an older copy of an assembly the host carries.</summary>
+    internal const string Substitution = "Acme.Substitution";
+
+    /// <summary>Ships a native library and calls into it.</summary>
+    internal const string Native = "Acme.Native";
+
     /// <summary>A constructor overload naming a type from an unmanifested, skewed assembly.</summary>
     internal const string CtorSignatureSkew = "Acme.CtorSignatureSkew";
 
@@ -97,6 +103,8 @@ internal static class PluginFixtures
         ThrowingCtor,
         CtorSignatureSkew,
         CtorSignatureMissing,
+        Native,
+        Substitution,
     ];
 
     /// <summary>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -79,18 +79,56 @@ public class Given_the_fixture_plugins_have_been_staged
     }
 
     [TestCaseSource(typeof(PluginFixtures), nameof(PluginFixtures.All))]
-    public void It_publishes_a_manifest_a_framework_dependent_publish_produces(string name)
+    public void It_publishes_a_manifest_naming_the_target_framework(string name)
     {
         using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(PluginFixtures.ManifestOf(name)));
 
-        // runtimeTarget naming the framework rather than a runtime pack is what distinguishes the
-        // publish the implementer guide prescribes from a self-contained one.
+        // runtimeTarget names the framework the fixture was published for. It is deliberately not
+        // asserted to discriminate a self-contained publish, because it does not: a RID-specific
+        // framework-dependent publish names a runtime identifier here too, and a runtimepack entry
+        // among the libraries is what actually distinguishes the two.
         manifest
             .RootElement.GetProperty("runtimeTarget")
             .GetProperty("name")
             .GetString()
             .Should()
             .StartWith(".NETCoreApp,Version=v10.0");
+    }
+
+    [TestCaseSource(typeof(PluginFixtures), nameof(PluginFixtures.All))]
+    public void It_stages_every_managed_file_the_manifest_declares(string name)
+    {
+        // The entry assembly and the manifest are the staging target's declared outputs, so they are
+        // the two files a timestamp check can see. This asserts the rest of the closure, which is what
+        // a test over a half-staged fixture would otherwise fail on for the wrong reason.
+        using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(PluginFixtures.ManifestOf(name)));
+
+        string targetName = manifest
+            .RootElement.GetProperty("runtimeTarget")
+            .GetProperty("name")
+            .GetString()!;
+        JsonElement target = manifest.RootElement.GetProperty("targets").GetProperty(targetName);
+
+        List<string> declared = [];
+
+        foreach (JsonProperty library in target.EnumerateObject())
+        {
+            if (!library.Value.TryGetProperty("runtime", out JsonElement runtime))
+            {
+                continue;
+            }
+
+            // A portable framework-dependent publish flattens every runtime asset to the plugin
+            // directory root, so the declared path's file name is where the file actually sits. The
+            // fuller mapping, which a RID-specific publish needs, belongs with the loader's inventory.
+            declared.AddRange(runtime.EnumerateObject().Select(asset => Path.GetFileName(asset.Name)));
+        }
+
+        declared.Should().NotBeEmpty();
+        declared
+            .Where(file => !File.Exists(Path.Combine(PluginFixtures.DirectoryOf(name), file)))
+            .Should()
+            .BeEmpty();
     }
 
     [Test]

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -61,6 +61,15 @@ internal static class PluginFixtures
     /// <summary>Ships a dependency the host does not carry, so its own copy is the one served.</summary>
     internal const string PrivateDependency = "Acme.PrivateDependency";
 
+    /// <summary>Returns null from a property the contract declares non-nullable.</summary>
+    internal const string NullName = "Acme.NullName";
+
+    /// <summary>Throws when its Name is read.</summary>
+    internal const string ThrowingName = "Acme.ThrowingName";
+
+    /// <summary>Throws from its constructor.</summary>
+    internal const string ThrowingCtor = "Acme.ThrowingCtor";
+
     /// <summary>Every fixture the staging target is expected to produce.</summary>
     internal static IReadOnlyList<string> All { get; } =
     [
@@ -77,6 +86,9 @@ internal static class PluginFixtures
         DeclaredSkew,
         BackstopCtor,
         PrivateDependency,
+        NullName,
+        ThrowingName,
+        ThrowingCtor,
     ];
 
     /// <summary>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -64,6 +64,9 @@ internal static class PluginFixtures
     /// <summary>Ships an older copy of an assembly the host carries.</summary>
     internal const string Substitution = "Acme.Substitution";
 
+    /// <summary>Ships a native library under runtimes/, where only the override finds it.</summary>
+    internal const string NativePortable = "Acme.NativePortable";
+
     /// <summary>Ships a native library and calls into it.</summary>
     internal const string Native = "Acme.Native";
 
@@ -104,6 +107,7 @@ internal static class PluginFixtures
         CtorSignatureSkew,
         CtorSignatureMissing,
         Native,
+        NativePortable,
         Substitution,
     ];
 
@@ -112,11 +116,20 @@ internal static class PluginFixtures
     /// excluded because only its entry assembly and manifest are staged, deliberately.
     /// </summary>
     internal static IReadOnlyList<string> FullyStaged { get; } =
-        All.Where(name => name != SelfContained).ToArray();
+        All.Where(name => name != SelfContained && name != NativePortable).ToArray();
 
     internal static string DirectoryOf(string name) => Path.Combine(Root, name);
 
     internal static string EntryAssemblyOf(string name) => Path.Combine(DirectoryOf(name), $"{name}.dll");
+
+    /// <summary>The fresh-process probe the native assertions run.</summary>
+    internal static string NativeProbeHost { get; } =
+        Path.Combine(
+            AppContext.BaseDirectory,
+            "FixtureHosts",
+            "PluginNativeProbeHost",
+            "PluginNativeProbeHost.dll"
+        );
 
     internal static string ManifestOf(string name) => Path.Combine(DirectoryOf(name), $"{name}.deps.json");
 }

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -28,8 +28,63 @@ internal static class PluginFixtures
     /// <summary>A plugin directory whose entry assembly exposes no plugin type.</summary>
     internal const string NoSubclass = "Acme.NoSubclass";
 
+    /// <summary>Two constructible plugin types, so choosing between them would be arbitrary.</summary>
+    internal const string TwoSubclasses = "Acme.TwoSubclasses";
+
+    /// <summary>A plugin whose Name disagrees with its directory.</summary>
+    internal const string NameMismatch = "Acme.NameMismatch";
+
+    /// <summary>A plugin whose Name differs from its directory only in case.</summary>
+    internal const string CaseName = "Acme.CaseName";
+
+    /// <summary>One constructible type among several that are subclasses and not constructible.</summary>
+    internal const string NonCandidates = "Acme.NonCandidates";
+
+    /// <summary>Only subclasses the host cannot construct.</summary>
+    internal const string OnlyNonCandidates = "Acme.OnlyNonCandidates";
+
+    /// <summary>Published self-contained, so its manifest declares a runtime pack.</summary>
+    internal const string SelfContained = "Acme.SelfContained";
+
+    /// <summary>Published for a runtime identifier and framework-dependent, which has to load.</summary>
+    internal const string RidSpecific = "Acme.RidSpecific";
+
+    /// <summary>Built against a contract version this host does not carry.</summary>
+    internal const string NewerContract = "Acme.NewerContract";
+
+    /// <summary>Declares a higher version of an assembly the host carries, and never touches it.</summary>
+    internal const string DeclaredSkew = "Acme.DeclaredSkew";
+
+    /// <summary>Touches an unmanifested higher version while the loader is constructing it.</summary>
+    internal const string BackstopCtor = "Acme.BackstopCtor";
+
+    /// <summary>Ships a dependency the host does not carry, so its own copy is the one served.</summary>
+    internal const string PrivateDependency = "Acme.PrivateDependency";
+
     /// <summary>Every fixture the staging target is expected to produce.</summary>
-    internal static IReadOnlyList<string> All { get; } = [Good, NoSubclass];
+    internal static IReadOnlyList<string> All { get; } =
+    [
+        Good,
+        NoSubclass,
+        TwoSubclasses,
+        NameMismatch,
+        CaseName,
+        NonCandidates,
+        OnlyNonCandidates,
+        SelfContained,
+        RidSpecific,
+        NewerContract,
+        DeclaredSkew,
+        BackstopCtor,
+        PrivateDependency,
+    ];
+
+    /// <summary>
+    /// The fixtures whose staged directory is a whole published plugin. The self-contained fixture is
+    /// excluded because only its entry assembly and manifest are staged, deliberately.
+    /// </summary>
+    internal static IReadOnlyList<string> FullyStaged { get; } =
+        All.Where(name => name != SelfContained).ToArray();
 
     internal static string DirectoryOf(string name) => Path.Combine(Root, name);
 
@@ -95,7 +150,7 @@ public class Given_the_fixture_plugins_have_been_staged
             .StartWith(".NETCoreApp,Version=v10.0");
     }
 
-    [TestCaseSource(typeof(PluginFixtures), nameof(PluginFixtures.All))]
+    [TestCaseSource(typeof(PluginFixtures), nameof(PluginFixtures.FullyStaged))]
     public void It_stages_every_managed_file_the_manifest_declares(string name)
     {
         // The entry assembly and the manifest are the staging target's declared outputs, so they are

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -61,6 +61,12 @@ internal static class PluginFixtures
     /// <summary>Ships a dependency the host does not carry, so its own copy is the one served.</summary>
     internal const string PrivateDependency = "Acme.PrivateDependency";
 
+    /// <summary>A constructor overload naming a type from an unmanifested, skewed assembly.</summary>
+    internal const string CtorSignatureSkew = "Acme.CtorSignatureSkew";
+
+    /// <summary>A constructor overload naming a type from an assembly nothing carries.</summary>
+    internal const string CtorSignatureMissing = "Acme.CtorSignatureMissing";
+
     /// <summary>Returns null from a property the contract declares non-nullable.</summary>
     internal const string NullName = "Acme.NullName";
 
@@ -89,6 +95,8 @@ internal static class PluginFixtures
         NullName,
         ThrowingName,
         ThrowingCtor,
+        CtorSignatureSkew,
+        CtorSignatureMissing,
     ];
 
     /// <summary>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtureStagingTests.cs
@@ -76,6 +76,9 @@ internal static class PluginFixtures
     /// <summary>Published portable over a package with runtime-identifier-specific managed assets.</summary>
     internal const string RuntimeTargets = "Acme.RuntimeTargets";
 
+    /// <summary>Compiled against the real production contract at 1.0.0, for the 1.0-on-1.1 proof.</summary>
+    internal const string OldContract = "Acme.OldContract";
+
     /// <summary>Ships a dependency the host does not carry, so its own copy is the one served.</summary>
     internal const string PrivateDependency = "Acme.PrivateDependency";
 
@@ -137,6 +140,7 @@ internal static class PluginFixtures
         Options,
         FrameworkOnly,
         RuntimeTargets,
+        OldContract,
     ];
 
     /// <summary>
@@ -152,6 +156,19 @@ internal static class PluginFixtures
 
     /// <summary>The staged name of the fresh-process probe, which is not a plugin.</summary>
     internal const string NativeProbeHostName = "PluginNativeProbeHost";
+
+    /// <summary>The staged name of the 1.0-on-1.1 host, which is not a plugin either.</summary>
+    internal const string HostRunnerName = "PluginHostRunner";
+
+    /// <summary>The staged directory of the 1.0-on-1.1 host, which tests copy rather than run in place.</summary>
+    internal static string HostRunnerDirectory { get; } =
+        Path.Combine(AppContext.BaseDirectory, "FixtureHosts", HostRunnerName);
+
+    /// <summary>
+    /// The additive 1.1 contract assembly, staged beside the host runner it is substituted into.
+    /// </summary>
+    internal static string Contract11Assembly { get; } =
+        Path.Combine(HostRunnerDirectory, "contract-1.1", "EdFi.Api.Plugins.dll");
 
     /// <summary>The fresh-process probe the native assertions run.</summary>
     internal static string NativeProbeHost { get; } =

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -81,6 +81,29 @@
         <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.Substitution/Acme.Substitution.csproj">
             <StagedName>Acme.Substitution</StagedName>
         </PluginFixture>
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.BackstopHook/Acme.BackstopHook.csproj">
+            <StagedName>Acme.BackstopHook</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.LibV1/Acme.LibV1.csproj">
+            <StagedName>Acme.LibV1</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.LibV2/Acme.LibV2.csproj">
+            <StagedName>Acme.LibV2</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.Options/Acme.Options.csproj">
+            <StagedName>Acme.Options</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.FrameworkOnly/Acme.FrameworkOnly.csproj">
+            <StagedName>Acme.FrameworkOnly</StagedName>
+        </PluginFixture>
+        <!--
+            Portable on purpose, which is why it takes the default publish arguments rather than a
+            runtime identifier: the managed runtimeTargets rows this fixture exists to measure are only
+            emitted by a publish that resolves no identifier.
+        -->
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.RuntimeTargets/Acme.RuntimeTargets.csproj">
+            <StagedName>Acme.RuntimeTargets</StagedName>
+        </PluginFixture>
         <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.Native/Acme.Native.csproj">
             <StagedName>Acme.Native</StagedName>
             <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --no-self-contained</PublishArgs>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -44,11 +44,21 @@
     </ItemGroup>
 
     <!--
-        Staging is invalidated wholesale when the shape of the request changes rather than only its
-        content. The fingerprint carries the configuration, the runtime identifier and the set of
-        fixture names, so a Release build, a run on another operating system, or a fixture added or
-        removed cannot reuse a tree staged for something else. Timestamp comparison alone sees none of
-        those.
+        Freshness is decided by a recorded fingerprint rather than by timestamps alone, because the two
+        things most likely to go wrong here are both invisible to a timestamp comparison.
+
+        Removing a source file makes nothing newer, so an Inputs/Outputs check sees an up-to-date tree
+        and keeps serving an entry assembly built from source that no longer exists. The fingerprint
+        therefore carries the identity and modification time of every input, so a removal changes it.
+
+        Deleting a staged *dependency* leaves the staged entry assembly and manifest untouched, so an
+        Outputs check on those two files also sees an up-to-date tree while the fixture's closure is
+        incomplete and every test over it would fail for the wrong reason. The fingerprint therefore
+        also carries the whole staged file set.
+
+        The rest of the fingerprint is the shape of the request: the configuration, the runtime
+        identifier, and the fixture names. That is what stops a Release build, a run on another
+        operating system, or a fixture added or removed from reusing a tree staged for something else.
     -->
     <Target
         Name="PrunePluginFixtureStaging"
@@ -60,8 +70,19 @@
             <PluginFixtureStampDir
             >$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'fixtures'))</PluginFixtureStampDir>
             <PluginFixtureFingerprintFile>$(PluginFixtureStampDir)staging.fingerprint</PluginFixtureFingerprintFile>
+            <PluginFixtureInputList>@(PluginFixtureInput->'%(Identity)@%(ModifiedTime)', '|')</PluginFixtureInputList>
+            <PluginFixtureFingerprintPrefix
+            >$(Configuration)+$(NETCoreSdkRuntimeIdentifier)+@(PluginFixture->'%(StagedName)', '&amp;')+$([MSBuild]::StableStringHash($(PluginFixtureInputList)))</PluginFixtureFingerprintPrefix>
+        </PropertyGroup>
+
+        <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
+            <PluginFixtureStagedFile Include="$(PluginFixtureStageRoot)**/*" />
+        </ItemGroup>
+
+        <PropertyGroup>
+            <PluginFixtureStagedList>@(PluginFixtureStagedFile->'%(RecursiveDir)%(Filename)%(Extension)', '|')</PluginFixtureStagedList>
             <PluginFixtureFingerprint
-            >$(Configuration)|$(NETCoreSdkRuntimeIdentifier)|@(PluginFixture->'%(StagedName)', '+')</PluginFixtureFingerprint>
+            >$(PluginFixtureFingerprintPrefix)+$([MSBuild]::StableStringHash($(PluginFixtureStagedList)))</PluginFixtureFingerprint>
         </PropertyGroup>
 
         <ReadLinesFromFile
@@ -78,9 +99,16 @@
             >true</PluginFixtureStagingIsStale>
         </PropertyGroup>
 
+        <!--
+            A stale tree is removed wholesale rather than patched. That is what makes a removed
+            dependency, a removed fixture, and a directory left over from an earlier fixture set all
+            resolve the same way, and it is why the republish below cannot inherit a file from a
+            previous publish. The path is composed from OutDir and a literal, so it is always inside
+            this project's own output.
+        -->
         <RemoveDir
             Directories="$(PluginFixtureStageRoot)"
-            Condition="'$(PluginFixtureStagingIsStale)' == 'true' AND Exists('$(PluginFixtureStageRoot)')"
+            Condition="'$(PluginFixtureStagingIsStale)' == 'true' AND '$(PluginFixtureStageRoot)' != '' AND Exists('$(PluginFixtureStageRoot)')"
         />
         <Delete
             Files="$(PluginFixtureFingerprintFile)"
@@ -88,9 +116,9 @@
         />
 
         <!--
-            A fixture removed from the list above leaves its staged directory behind, where a test
-            enumerating the staged tree would still find it. The fingerprint already forces a full
-            re-stage in that case; this removes the directory the re-stage would not overwrite.
+            A directory carrying no files is invisible to the staged file set above, because the glob
+            matches files. That is the one leftover the fingerprint cannot see, so it is removed by
+            name. Each path is composed from the stage root and a literal fixture name.
         -->
         <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
             <PluginFixtureExpectedDir Include="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)')" />
@@ -106,9 +134,9 @@
     </Target>
 
     <!--
-        Outputs are the published entry assembly and manifest of each fixture rather than a stamp
-        file, so that deleting a staged directory by hand re-stages it instead of being reported as
-        up to date.
+        Outputs are each fixture's staged entry assembly and manifest. They are not the whole freshness
+        story, which is what the fingerprint above is for; they are what makes the common case cheap and
+        what re-runs this target once the prune has emptied the tree.
     -->
     <Target
         Name="PublishPluginFixtures"
@@ -119,6 +147,16 @@
         Outputs="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json')"
     >
         <!--
+            Each fixture's directory is emptied before it is published into, so that a file dropped from
+            a fixture's closure cannot survive as a leftover from the previous publish. dotnet publish
+            overwrites what it produces but removes nothing it no longer produces.
+        -->
+        <RemoveDir
+            Directories="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)')"
+            Condition="'$(PluginFixtureStageRoot)' != ''"
+        />
+
+        <!--
             BuildingPluginFixtures is passed down so that an inner publish can never re-enter this
             target, and each fixture project is named explicitly so that nothing walks back up to this
             test project.
@@ -128,10 +166,25 @@
             WorkingDirectory="$(MSBuildProjectDirectory)"
         />
 
+        <!--
+            The fingerprint is recorded from the tree that was just produced, so the next build compares
+            against what is actually staged rather than against what was staged when this target last
+            looked.
+        -->
+        <ItemGroup>
+            <PluginFixtureStagedFileAfterPublish Include="$(PluginFixtureStageRoot)**/*" />
+        </ItemGroup>
+
+        <PropertyGroup>
+            <PluginFixtureStagedListAfterPublish>@(PluginFixtureStagedFileAfterPublish->'%(RecursiveDir)%(Filename)%(Extension)', '|')</PluginFixtureStagedListAfterPublish>
+            <PluginFixtureFingerprintAfterPublish
+            >$(PluginFixtureFingerprintPrefix)+$([MSBuild]::StableStringHash($(PluginFixtureStagedListAfterPublish)))</PluginFixtureFingerprintAfterPublish>
+        </PropertyGroup>
+
         <MakeDir Directories="$(PluginFixtureStampDir)" />
         <WriteLinesToFile
             File="$(PluginFixtureFingerprintFile)"
-            Lines="$(PluginFixtureFingerprint)"
+            Lines="$(PluginFixtureFingerprintAfterPublish)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true"
         />

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -8,6 +8,19 @@
         The fixture tree is excluded from this project's compile, embedded-resource and None globs in
         the csproj; this file is the only thing that builds it.
     -->
+    <ItemDefinitionGroup>
+        <PluginFixture>
+            <!--
+                What the implementer guide tells a third party to publish. A fixture overrides this only
+                when the publish shape is itself the thing under test.
+            -->
+            <PublishArgs>--no-self-contained</PublishArgs>
+        </PluginFixture>
+        <PluginFixtureTrimmed>
+            <PublishArgs>--no-self-contained</PublishArgs>
+        </PluginFixtureTrimmed>
+    </ItemDefinitionGroup>
+
     <ItemGroup>
         <PluginFixture Include="Fixtures/Plugins/Acme.Good/Acme.Good.csproj">
             <StagedName>Acme.Good</StagedName>
@@ -15,6 +28,50 @@
         <PluginFixture Include="Fixtures/Plugins/Acme.NoSubclass/Acme.NoSubclass.csproj">
             <StagedName>Acme.NoSubclass</StagedName>
         </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.TwoSubclasses/Acme.TwoSubclasses.csproj">
+            <StagedName>Acme.TwoSubclasses</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.NameMismatch/Acme.NameMismatch.csproj">
+            <StagedName>Acme.NameMismatch</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.CaseName/Acme.CaseName.csproj">
+            <StagedName>Acme.CaseName</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.NonCandidates/Acme.NonCandidates.csproj">
+            <StagedName>Acme.NonCandidates</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.OnlyNonCandidates/Acme.OnlyNonCandidates.csproj">
+            <StagedName>Acme.OnlyNonCandidates</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.NewerContract/Acme.NewerContract.csproj">
+            <StagedName>Acme.NewerContract</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.DeclaredSkew/Acme.DeclaredSkew.csproj">
+            <StagedName>Acme.DeclaredSkew</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.BackstopCtor/Acme.BackstopCtor.csproj">
+            <StagedName>Acme.BackstopCtor</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.PrivateDependency/Acme.PrivateDependency.csproj">
+            <StagedName>Acme.PrivateDependency</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.RidSpecific/Acme.RidSpecific.csproj">
+            <StagedName>Acme.RidSpecific</StagedName>
+            <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --no-self-contained</PublishArgs>
+        </PluginFixture>
+    </ItemGroup>
+
+    <!--
+        Fixtures published somewhere else and staged as two files. A self-contained publish produces the
+        runtimepack declaration the refusal reads and several hundred megabytes beside it, none of which
+        the loader ever opens, so the publish lands in the intermediate output and only the entry
+        assembly and its manifest reach the staged tree.
+    -->
+    <ItemGroup>
+        <PluginFixtureTrimmed Include="Fixtures/Plugins/Acme.SelfContained/Acme.SelfContained.csproj">
+            <StagedName>Acme.SelfContained</StagedName>
+            <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --self-contained</PublishArgs>
+        </PluginFixtureTrimmed>
     </ItemGroup>
 
     <!--
@@ -71,8 +128,10 @@
             >$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'fixtures'))</PluginFixtureStampDir>
             <PluginFixtureFingerprintFile>$(PluginFixtureStampDir)staging.fingerprint</PluginFixtureFingerprintFile>
             <PluginFixtureInputList>@(PluginFixtureInput->'%(Identity)@%(ModifiedTime)', '|')</PluginFixtureInputList>
+            <PluginFixtureRawRoot
+            >$([MSBuild]::NormalizeDirectory('$(PluginFixtureStampDir)', 'raw'))</PluginFixtureRawRoot>
             <PluginFixtureFingerprintPrefix
-            >$(Configuration)+$(NETCoreSdkRuntimeIdentifier)+@(PluginFixture->'%(StagedName)', '&amp;')+$([MSBuild]::StableStringHash($(PluginFixtureInputList)))</PluginFixtureFingerprintPrefix>
+            >$(Configuration)+$(NETCoreSdkRuntimeIdentifier)+@(PluginFixture->'%(StagedName)', '&amp;')+@(PluginFixtureTrimmed->'%(StagedName)', '&amp;')+$([MSBuild]::StableStringHash($(PluginFixtureInputList)))</PluginFixtureFingerprintPrefix>
         </PropertyGroup>
 
         <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
@@ -122,6 +181,9 @@
         -->
         <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
             <PluginFixtureExpectedDir Include="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)')" />
+            <PluginFixtureExpectedDir
+                Include="@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)')"
+            />
             <PluginFixtureExistingDir
                 Include="$([System.IO.Directory]::GetDirectories('$(PluginFixtureStageRoot)'))"
             />
@@ -144,7 +206,7 @@
         DependsOnTargets="PrunePluginFixtureStaging"
         Condition="'$(BuildingPluginFixtures)' != 'true' AND '$(DesignTimeBuild)' != 'true'"
         Inputs="@(PluginFixtureInput)"
-        Outputs="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json')"
+        Outputs="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json')"
     >
         <!--
             Each fixture's directory is emptied before it is published into, so that a file dropped from
@@ -152,18 +214,45 @@
             overwrites what it produces but removes nothing it no longer produces.
         -->
         <RemoveDir
-            Directories="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)')"
-            Condition="'$(PluginFixtureStageRoot)' != ''"
+            Directories="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureRawRoot)%(StagedName)')"
+            Condition="'$(PluginFixtureStageRoot)' != '' AND '$(PluginFixtureRawRoot)' != ''"
         />
+
+        <PropertyGroup>
+            <PluginContractAssemblyPath
+            >$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(OutDir)', 'EdFi.Api.Plugins.dll'))</PluginContractAssemblyPath>
+        </PropertyGroup>
 
         <!--
             BuildingPluginFixtures is passed down so that an inner publish can never re-enter this
             target, and each fixture project is named explicitly so that nothing walks back up to this
             test project.
+
+            PluginContractAssemblyPath is passed down for the fixtures that are published for a runtime
+            identifier. Those cannot reference the contract by project: a runtime-specific publish
+            restores its project references with that identifier too, and NuGet then rewrites their lock
+            files to record it. Measured, one such publish added a win-x64 runtime-identifier section to
+            the plugin contract's committed lock file and broke the locked-mode restore of both
+            solutions. Fixture staging must not be able to edit a tracked production file, so those
+            fixtures reference the built contract assembly by path and their publishes never restore it.
         -->
         <Exec
-            Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixture.FullPath)&quot; --configuration $(Configuration) --no-self-contained --output &quot;$(PluginFixtureStageRoot)%(PluginFixture.StagedName)&quot; -p:BuildingPluginFixtures=true --nologo --verbosity quiet"
+            Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixture.FullPath)&quot; --configuration $(Configuration) %(PluginFixture.PublishArgs) --output &quot;$(PluginFixtureStageRoot)%(PluginFixture.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
             WorkingDirectory="$(MSBuildProjectDirectory)"
+        />
+
+        <Exec
+            Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixtureTrimmed.FullPath)&quot; --configuration $(Configuration) %(PluginFixtureTrimmed.PublishArgs) --output &quot;$(PluginFixtureRawRoot)%(PluginFixtureTrimmed.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
+            WorkingDirectory="$(MSBuildProjectDirectory)"
+        />
+
+        <Copy
+            SourceFiles="@(PluginFixtureTrimmed->'$(PluginFixtureRawRoot)%(StagedName)/%(StagedName).dll')"
+            DestinationFiles="@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll')"
+        />
+        <Copy
+            SourceFiles="@(PluginFixtureTrimmed->'$(PluginFixtureRawRoot)%(StagedName)/%(StagedName).deps.json')"
+            DestinationFiles="@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json')"
         />
 
         <!--

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -1,5 +1,10 @@
 <Project>
     <!--
+        Every path here is written relative to this file rather than to the importing project, so that
+        the freshness and pruning rules can be driven from a project somewhere else. That is what lets
+        the staging regressions run these targets against a temporary output tree instead of asserting
+        the rules by reading them.
+
         Publishes the fixture plugin projects under Fixtures/ into the test output as real plugin
         directories, because the loader's subject is a published directory and nothing smaller
         exercises it honestly. Each fixture is published on its own, so a deliberately malformed one
@@ -22,62 +27,65 @@
     </ItemDefinitionGroup>
 
     <ItemGroup>
-        <PluginFixture Include="Fixtures/Plugins/Acme.Good/Acme.Good.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.Good/Acme.Good.csproj">
             <StagedName>Acme.Good</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.NoSubclass/Acme.NoSubclass.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.NoSubclass/Acme.NoSubclass.csproj">
             <StagedName>Acme.NoSubclass</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.TwoSubclasses/Acme.TwoSubclasses.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.TwoSubclasses/Acme.TwoSubclasses.csproj">
             <StagedName>Acme.TwoSubclasses</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.NameMismatch/Acme.NameMismatch.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.NameMismatch/Acme.NameMismatch.csproj">
             <StagedName>Acme.NameMismatch</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.CaseName/Acme.CaseName.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.CaseName/Acme.CaseName.csproj">
             <StagedName>Acme.CaseName</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.NonCandidates/Acme.NonCandidates.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.NonCandidates/Acme.NonCandidates.csproj">
             <StagedName>Acme.NonCandidates</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.OnlyNonCandidates/Acme.OnlyNonCandidates.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.OnlyNonCandidates/Acme.OnlyNonCandidates.csproj">
             <StagedName>Acme.OnlyNonCandidates</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.NewerContract/Acme.NewerContract.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.NewerContract/Acme.NewerContract.csproj">
             <StagedName>Acme.NewerContract</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.DeclaredSkew/Acme.DeclaredSkew.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.DeclaredSkew/Acme.DeclaredSkew.csproj">
             <StagedName>Acme.DeclaredSkew</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.BackstopCtor/Acme.BackstopCtor.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.BackstopCtor/Acme.BackstopCtor.csproj">
             <StagedName>Acme.BackstopCtor</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.CtorSignatureSkew/Acme.CtorSignatureSkew.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.CtorSignatureSkew/Acme.CtorSignatureSkew.csproj">
             <StagedName>Acme.CtorSignatureSkew</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.CtorSignatureMissing/Acme.CtorSignatureMissing.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.CtorSignatureMissing/Acme.CtorSignatureMissing.csproj">
             <StagedName>Acme.CtorSignatureMissing</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.NullName/Acme.NullName.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.NullName/Acme.NullName.csproj">
             <StagedName>Acme.NullName</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.ThrowingName/Acme.ThrowingName.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.ThrowingName/Acme.ThrowingName.csproj">
             <StagedName>Acme.ThrowingName</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.ThrowingCtor/Acme.ThrowingCtor.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.ThrowingCtor/Acme.ThrowingCtor.csproj">
             <StagedName>Acme.ThrowingCtor</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.PrivateDependency/Acme.PrivateDependency.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.PrivateDependency/Acme.PrivateDependency.csproj">
             <StagedName>Acme.PrivateDependency</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.Substitution/Acme.Substitution.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.Localized/Acme.Localized.csproj">
+            <StagedName>Acme.Localized</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.Substitution/Acme.Substitution.csproj">
             <StagedName>Acme.Substitution</StagedName>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.Native/Acme.Native.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.Native/Acme.Native.csproj">
             <StagedName>Acme.Native</StagedName>
             <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --no-self-contained</PublishArgs>
         </PluginFixture>
-        <PluginFixture Include="Fixtures/Plugins/Acme.RidSpecific/Acme.RidSpecific.csproj">
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.RidSpecific/Acme.RidSpecific.csproj">
             <StagedName>Acme.RidSpecific</StagedName>
             <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --no-self-contained</PublishArgs>
         </PluginFixture>
@@ -88,7 +96,7 @@
         root a test configures; it is a program the tests run.
     -->
     <ItemGroup>
-        <PluginProbeHost Include="Fixtures/Hosts/PluginNativeProbeHost/PluginNativeProbeHost.csproj">
+        <PluginProbeHost Include="$(MSBuildThisFileDirectory)Fixtures/Hosts/PluginNativeProbeHost/PluginNativeProbeHost.csproj">
             <StagedName>PluginNativeProbeHost</StagedName>
         </PluginProbeHost>
     </ItemGroup>
@@ -106,13 +114,13 @@
         carry is the eighty megabytes of libraries for identifiers this process could never load.
     -->
     <ItemGroup>
-        <PluginFixturePortable Include="Fixtures/Plugins/Acme.NativePortable/Acme.NativePortable.csproj">
+        <PluginFixturePortable Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.NativePortable/Acme.NativePortable.csproj">
             <StagedName>Acme.NativePortable</StagedName>
         </PluginFixturePortable>
     </ItemGroup>
 
     <ItemGroup>
-        <PluginFixtureTrimmed Include="Fixtures/Plugins/Acme.SelfContained/Acme.SelfContained.csproj">
+        <PluginFixtureTrimmed Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.SelfContained/Acme.SelfContained.csproj">
             <StagedName>Acme.SelfContained</StagedName>
             <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --self-contained</PublishArgs>
         </PluginFixtureTrimmed>
@@ -120,27 +128,35 @@
 
     <!--
         Everything a fixture's published bytes can depend on. The plugin contract is listed because
-        every fixture references it by project, so a change to the contract has to re-publish them;
-        the loader assembly deliberately is not, because no fixture references it and listing it would
-        re-publish the whole tree on every edit to the code under test. It joins this list with the
-        story that adds a fixture host process, which does reference it.
+        every fixture references it by project. The loader assembly is listed too, now that a fixture
+        host references it by project: an edit to the loader changes what that probe does, and a probe
+        staged from older sources would answer a question nobody asked. It costs a re-publish of the
+        fixture tree on every loader edit, which is the price of the probe being trustworthy.
+
+        Every file under Fixtures counts, not a list of the extensions a fixture happens to use today.
+        A fixture's published bytes can come from any of them: a .resx becomes a satellite assembly, and
+        naming .cs and .csproj alone meant a resource edited or removed left the satellite as it was.
+        An enumeration of kinds silently omits the next kind somebody adds; the directory does not.
 
         bin/ and obj/ are excluded so that generated sources, which change on every build, cannot make
         the staging permanently out of date.
     -->
     <ItemGroup>
         <PluginFixtureInput Include="$(MSBuildThisFileFullPath)" />
-        <PluginFixtureInput Include="Fixtures/Directory.Build.props" />
         <PluginFixtureInput
-            Include="Fixtures/**/*.cs;Fixtures/**/*.csproj"
-            Exclude="Fixtures/**/bin/**;Fixtures/**/obj/**"
+            Include="$(MSBuildThisFileDirectory)Fixtures/**/*"
+            Exclude="$(MSBuildThisFileDirectory)Fixtures/**/bin/**;$(MSBuildThisFileDirectory)Fixtures/**/obj/**"
         />
         <PluginFixtureInput
-            Include="../EdFi.Api.Plugins/**/*.cs;../EdFi.Api.Plugins/*.csproj"
-            Exclude="../EdFi.Api.Plugins/bin/**;../EdFi.Api.Plugins/obj/**"
+            Include="$(MSBuildThisFileDirectory)../EdFi.Api.Plugins/**/*.cs;$(MSBuildThisFileDirectory)../EdFi.Api.Plugins/*.csproj"
+            Exclude="$(MSBuildThisFileDirectory)../EdFi.Api.Plugins/bin/**;$(MSBuildThisFileDirectory)../EdFi.Api.Plugins/obj/**"
         />
         <PluginFixtureInput
-            Include="../Directory.Build.props;../../Directory.Packages.props;../../nuget.config"
+            Include="$(MSBuildThisFileDirectory)../EdFi.Api.Plugins.Hosting/**/*.cs;$(MSBuildThisFileDirectory)../EdFi.Api.Plugins.Hosting/*.csproj"
+            Exclude="$(MSBuildThisFileDirectory)../EdFi.Api.Plugins.Hosting/bin/**;$(MSBuildThisFileDirectory)../EdFi.Api.Plugins.Hosting/obj/**"
+        />
+        <PluginFixtureInput
+            Include="$(MSBuildThisFileDirectory)../Directory.Build.props;$(MSBuildThisFileDirectory)../../Directory.Packages.props;$(MSBuildThisFileDirectory)../../nuget.config"
         />
     </ItemGroup>
 
@@ -167,21 +183,24 @@
     >
         <PropertyGroup>
             <PluginFixtureStageRoot
-            >$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutDir)', 'Fixtures'))</PluginFixtureStageRoot>
+            >$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '$(OutDir)', 'Fixtures'))</PluginFixtureStageRoot>
             <PluginFixtureStampDir
-            >$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'fixtures'))</PluginFixtureStampDir>
+            >$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '$(IntermediateOutputPath)', 'fixtures'))</PluginFixtureStampDir>
             <PluginFixtureFingerprintFile>$(PluginFixtureStampDir)staging.fingerprint</PluginFixtureFingerprintFile>
             <PluginFixtureInputList>@(PluginFixtureInput->'%(Identity)@%(ModifiedTime)', '|')</PluginFixtureInputList>
             <PluginFixtureRawRoot
             >$([MSBuild]::NormalizeDirectory('$(PluginFixtureStampDir)', 'raw'))</PluginFixtureRawRoot>
             <PluginFixtureProbeRoot
-            >$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutDir)', 'FixtureHosts'))</PluginFixtureProbeRoot>
+            >$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '$(OutDir)', 'FixtureHosts'))</PluginFixtureProbeRoot>
             <PluginFixtureFingerprintPrefix
             >$(Configuration)+$(NETCoreSdkRuntimeIdentifier)+@(PluginFixture->'%(StagedName)', '&amp;')+@(PluginFixtureTrimmed->'%(StagedName)', '&amp;')+@(PluginProbeHost->'%(StagedName)', '&amp;')+@(PluginFixturePortable->'%(StagedName)', '&amp;')+$([MSBuild]::StableStringHash($(PluginFixtureInputList)))</PluginFixtureFingerprintPrefix>
         </PropertyGroup>
 
         <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
             <PluginFixtureStagedFile Include="$(PluginFixtureStageRoot)**/*" />
+        </ItemGroup>
+        <ItemGroup Condition="Exists('$(PluginFixtureProbeRoot)')">
+            <PluginFixtureStagedFile Include="$(PluginFixtureProbeRoot)**/*" />
         </ItemGroup>
 
         <PropertyGroup>
@@ -215,6 +234,10 @@
             Directories="$(PluginFixtureStageRoot)"
             Condition="'$(PluginFixtureStagingIsStale)' == 'true' AND '$(PluginFixtureStageRoot)' != '' AND Exists('$(PluginFixtureStageRoot)')"
         />
+        <RemoveDir
+            Directories="$(PluginFixtureProbeRoot)"
+            Condition="'$(PluginFixtureStagingIsStale)' == 'true' AND '$(PluginFixtureProbeRoot)' != '' AND Exists('$(PluginFixtureProbeRoot)')"
+        />
         <Delete
             Files="$(PluginFixtureFingerprintFile)"
             Condition="'$(PluginFixtureStagingIsStale)' == 'true'"
@@ -223,12 +246,21 @@
         <!--
             A directory carrying no files is invisible to the staged file set above, because the glob
             matches files. That is the one leftover the fingerprint cannot see, so it is removed by
-            name. Each path is composed from the stage root and a literal fixture name.
+            name, in the helper root as well as the fixture root. Each path is composed from a root this
+            target derived and a literal staged name.
+
+            Every fixture kind has to appear among the expected directories, portable included. A kind
+            left out is classified stale and deleted on every build, which removes the declared outputs
+            of a tree that was up to date and republishes the whole collection each time. Deleting a
+            directory here must mean it is genuinely unaccounted for.
         -->
         <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
             <PluginFixtureExpectedDir Include="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)')" />
             <PluginFixtureExpectedDir
                 Include="@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)')"
+            />
+            <PluginFixtureExpectedDir
+                Include="@(PluginFixturePortable->'$(PluginFixtureStageRoot)%(StagedName)')"
             />
             <PluginFixtureExistingDir
                 Include="$([System.IO.Directory]::GetDirectories('$(PluginFixtureStageRoot)'))"
@@ -238,13 +270,40 @@
                 Exclude="@(PluginFixtureExpectedDir)"
             />
         </ItemGroup>
+        <ItemGroup Condition="Exists('$(PluginFixtureProbeRoot)')">
+            <PluginFixtureExpectedProbeDir
+                Include="@(PluginProbeHost->'$(PluginFixtureProbeRoot)%(StagedName)')"
+            />
+            <PluginFixtureExistingProbeDir
+                Include="$([System.IO.Directory]::GetDirectories('$(PluginFixtureProbeRoot)'))"
+            />
+            <PluginFixtureStaleDir
+                Include="@(PluginFixtureExistingProbeDir)"
+                Exclude="@(PluginFixtureExpectedProbeDir)"
+            />
+        </ItemGroup>
         <RemoveDir Directories="@(PluginFixtureStaleDir)" />
     </Target>
 
     <!--
-        Outputs are each fixture's staged entry assembly and manifest. They are not the whole freshness
-        story, which is what the fingerprint above is for; they are what makes the common case cheap and
-        what re-runs this target once the prune has emptied the tree.
+        The single output is the fingerprint file, and the inputs are the same ones the fingerprint is
+        built from.
+
+        Comparing the inputs against the staged files themselves does not work and cannot be made to. A
+        publish copies files, a copy carries the source file's modification time, and a staged file is
+        therefore as old as whatever produced it: routinely older than an input that has just been
+        edited, and older still than one edited since. Measured against the previous form of this
+        target, every build after any edit to any input found the staged tree out of date forever and
+        re-entered a target whose two dozen publishes each turned out to have nothing to do, for fifty
+        seconds in which not one staged byte changed.
+
+        The fingerprint file is written by this target when it finishes and deleted by the prune above
+        when the tree is stale, so its timestamp is genuinely the moment the staged tree was last
+        produced, and its absence is genuinely a tree that has to be produced again. Both halves of the
+        up-to-date check then mean what they say.
+
+        A condition on this target cannot do the same job: a target whose condition is false is skipped
+        along with the targets it depends on, so the prune that decides staleness would never run.
     -->
     <Target
         Name="PublishPluginFixtures"
@@ -252,7 +311,7 @@
         DependsOnTargets="PrunePluginFixtureStaging"
         Condition="'$(BuildingPluginFixtures)' != 'true' AND '$(DesignTimeBuild)' != 'true'"
         Inputs="@(PluginFixtureInput)"
-        Outputs="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json');@(PluginProbeHost->'$(PluginFixtureProbeRoot)%(StagedName)/%(StagedName).dll');@(PluginFixturePortable->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json')"
+        Outputs="$(PluginFixtureFingerprintFile)"
     >
         <!--
             Each fixture's directory is emptied before it is published into, so that a file dropped from
@@ -266,7 +325,7 @@
 
         <PropertyGroup>
             <PluginContractAssemblyPath
-            >$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(OutDir)', 'EdFi.Api.Plugins.dll'))</PluginContractAssemblyPath>
+            >$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '$(OutDir)', 'EdFi.Api.Plugins.dll'))</PluginContractAssemblyPath>
         </PropertyGroup>
 
         <!--
@@ -285,25 +344,25 @@
         <Exec
             Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixture.FullPath)&quot; --configuration $(Configuration) %(PluginFixture.PublishArgs) --output &quot;$(PluginFixtureStageRoot)%(PluginFixture.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
             EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
-            WorkingDirectory="$(MSBuildProjectDirectory)"
+            WorkingDirectory="$(MSBuildThisFileDirectory)"
         />
 
         <Exec
             Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixtureTrimmed.FullPath)&quot; --configuration $(Configuration) %(PluginFixtureTrimmed.PublishArgs) --output &quot;$(PluginFixtureRawRoot)%(PluginFixtureTrimmed.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
             EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
-            WorkingDirectory="$(MSBuildProjectDirectory)"
+            WorkingDirectory="$(MSBuildThisFileDirectory)"
         />
 
         <Exec
             Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginProbeHost.FullPath)&quot; --configuration $(Configuration) --no-self-contained --output &quot;$(PluginFixtureProbeRoot)%(PluginProbeHost.StagedName)&quot; -p:BuildingPluginFixtures=true --nologo --verbosity quiet"
             EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
-            WorkingDirectory="$(MSBuildProjectDirectory)"
+            WorkingDirectory="$(MSBuildThisFileDirectory)"
         />
 
         <Exec
             Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixturePortable.FullPath)&quot; --configuration $(Configuration) --no-self-contained --output &quot;$(PluginFixtureRawRoot)%(PluginFixturePortable.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
             EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
-            WorkingDirectory="$(MSBuildProjectDirectory)"
+            WorkingDirectory="$(MSBuildThisFileDirectory)"
         />
 
         <!--
@@ -344,6 +403,7 @@
         -->
         <ItemGroup>
             <PluginFixtureStagedFileAfterPublish Include="$(PluginFixtureStageRoot)**/*" />
+            <PluginFixtureStagedFileAfterPublish Include="$(PluginFixtureProbeRoot)**/*" />
         </ItemGroup>
 
         <PropertyGroup>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -70,6 +70,13 @@
         <PluginFixture Include="Fixtures/Plugins/Acme.PrivateDependency/Acme.PrivateDependency.csproj">
             <StagedName>Acme.PrivateDependency</StagedName>
         </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.Substitution/Acme.Substitution.csproj">
+            <StagedName>Acme.Substitution</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.Native/Acme.Native.csproj">
+            <StagedName>Acme.Native</StagedName>
+            <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --no-self-contained</PublishArgs>
+        </PluginFixture>
         <PluginFixture Include="Fixtures/Plugins/Acme.RidSpecific/Acme.RidSpecific.csproj">
             <StagedName>Acme.RidSpecific</StagedName>
             <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --no-self-contained</PublishArgs>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -104,6 +104,9 @@
         <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.RuntimeTargets/Acme.RuntimeTargets.csproj">
             <StagedName>Acme.RuntimeTargets</StagedName>
         </PluginFixture>
+        <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.OldContract/Acme.OldContract.csproj">
+            <StagedName>Acme.OldContract</StagedName>
+        </PluginFixture>
         <PluginFixture Include="$(MSBuildThisFileDirectory)Fixtures/Plugins/Acme.Native/Acme.Native.csproj">
             <StagedName>Acme.Native</StagedName>
             <PublishArgs>--runtime $(NETCoreSdkRuntimeIdentifier) --no-self-contained</PublishArgs>
@@ -122,6 +125,25 @@
         <PluginProbeHost Include="$(MSBuildThisFileDirectory)Fixtures/Hosts/PluginNativeProbeHost/PluginNativeProbeHost.csproj">
             <StagedName>PluginNativeProbeHost</StagedName>
         </PluginProbeHost>
+        <!--
+            The 1.0-on-1.1 host, staged whole and read-only. Each test copies it into a temporary
+            directory of its own before replacing that copy's contract assembly, so the staged tree is
+            never the thing whose identity is rewritten.
+        -->
+        <PluginProbeHost Include="$(MSBuildThisFileDirectory)Fixtures/Hosts/PluginHostRunner/PluginHostRunner.csproj">
+            <StagedName>PluginHostRunner</StagedName>
+        </PluginProbeHost>
+    </ItemGroup>
+
+    <!--
+        The additive 1.1 contract, built rather than published: what a test needs from it is the single
+        assembly it substitutes into a copy of the runner's output, and a publish would bring a manifest
+        and a runtimeconfig that nothing reads.
+    -->
+    <ItemGroup>
+        <PluginContractBuild Include="$(MSBuildThisFileDirectory)Fixtures/Contracts/Contract_1_1/EdFi.Api.Plugins.v1_1.csproj">
+            <StagedName>Contract_1_1</StagedName>
+        </PluginContractBuild>
     </ItemGroup>
 
     <!--
@@ -216,7 +238,7 @@
             <PluginFixtureProbeRoot
             >$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '$(OutDir)', 'FixtureHosts'))</PluginFixtureProbeRoot>
             <PluginFixtureFingerprintPrefix
-            >$(Configuration)+$(NETCoreSdkRuntimeIdentifier)+@(PluginFixture->'%(StagedName)', '&amp;')+@(PluginFixtureTrimmed->'%(StagedName)', '&amp;')+@(PluginProbeHost->'%(StagedName)', '&amp;')+@(PluginFixturePortable->'%(StagedName)', '&amp;')+$([MSBuild]::StableStringHash($(PluginFixtureInputList)))</PluginFixtureFingerprintPrefix>
+            >$(Configuration)+$(NETCoreSdkRuntimeIdentifier)+@(PluginFixture->'%(StagedName)', '&amp;')+@(PluginFixtureTrimmed->'%(StagedName)', '&amp;')+@(PluginProbeHost->'%(StagedName)', '&amp;')+@(PluginFixturePortable->'%(StagedName)', '&amp;')+@(PluginContractBuild->'%(StagedName)', '&amp;')+$([MSBuild]::StableStringHash($(PluginFixtureInputList)))</PluginFixtureFingerprintPrefix>
         </PropertyGroup>
 
         <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
@@ -342,7 +364,7 @@
             overwrites what it produces but removes nothing it no longer produces.
         -->
         <RemoveDir
-            Directories="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureRawRoot)%(StagedName)');@(PluginProbeHost->'$(PluginFixtureProbeRoot)%(StagedName)');@(PluginFixturePortable->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixturePortable->'$(PluginFixtureRawRoot)%(StagedName)')"
+            Directories="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureRawRoot)%(StagedName)');@(PluginProbeHost->'$(PluginFixtureProbeRoot)%(StagedName)');@(PluginFixturePortable->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixturePortable->'$(PluginFixtureRawRoot)%(StagedName)');@(PluginContractBuild->'$(PluginFixtureRawRoot)%(StagedName)')"
             Condition="'$(PluginFixtureStageRoot)' != '' AND '$(PluginFixtureRawRoot)' != '' AND '$(PluginFixtureProbeRoot)' != ''"
         />
 
@@ -380,6 +402,27 @@
             Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginProbeHost.FullPath)&quot; --configuration $(Configuration) --no-self-contained --output &quot;$(PluginFixtureProbeRoot)%(PluginProbeHost.StagedName)&quot; -p:BuildingPluginFixtures=true --nologo --verbosity quiet"
             EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
             WorkingDirectory="$(MSBuildThisFileDirectory)"
+        />
+
+        <!--
+            The additive 1.1 contract, to the intermediate output. Only one file of it is wanted, so it
+            is not staged where a test could mistake it for a plugin or a host.
+        -->
+        <Exec
+            Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginContractBuild.FullPath)&quot; --configuration $(Configuration) --output &quot;$(PluginFixtureRawRoot)%(PluginContractBuild.StagedName)&quot; -p:BuildingPluginFixtures=true --nologo --verbosity quiet"
+            EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
+            WorkingDirectory="$(MSBuildThisFileDirectory)"
+        />
+
+        <!--
+            Placed inside the runner's own staged directory, in a subdirectory named for what it is. The
+            runner never loads it: a test copies the whole staged directory to a temporary tree and then
+            overwrites that copy's own contract assembly with this one. Living here means the staged
+            file set already covers it, so deleting it makes the tree stale like any other staged file.
+        -->
+        <Copy
+            SourceFiles="@(PluginContractBuild->'$(PluginFixtureRawRoot)%(StagedName)/EdFi.Api.Plugins.dll')"
+            DestinationFiles="@(PluginContractBuild->'$(PluginFixtureProbeRoot)PluginHostRunner/contract-1.1/EdFi.Api.Plugins.dll')"
         />
 
         <Exec

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -52,6 +52,12 @@
         <PluginFixture Include="Fixtures/Plugins/Acme.BackstopCtor/Acme.BackstopCtor.csproj">
             <StagedName>Acme.BackstopCtor</StagedName>
         </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.CtorSignatureSkew/Acme.CtorSignatureSkew.csproj">
+            <StagedName>Acme.CtorSignatureSkew</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.CtorSignatureMissing/Acme.CtorSignatureMissing.csproj">
+            <StagedName>Acme.CtorSignatureMissing</StagedName>
+        </PluginFixture>
         <PluginFixture Include="Fixtures/Plugins/Acme.NullName/Acme.NullName.csproj">
             <StagedName>Acme.NullName</StagedName>
         </PluginFixture>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -84,11 +84,33 @@
     </ItemGroup>
 
     <!--
+        The fresh-process probe, staged whole. It is not a plugin and never appears under the plugin
+        root a test configures; it is a program the tests run.
+    -->
+    <ItemGroup>
+        <PluginProbeHost Include="Fixtures/Hosts/PluginNativeProbeHost/PluginNativeProbeHost.csproj">
+            <StagedName>PluginNativeProbeHost</StagedName>
+        </PluginProbeHost>
+    </ItemGroup>
+
+    <!--
         Fixtures published somewhere else and staged as two files. A self-contained publish produces the
         runtimepack declaration the refusal reads and several hundred megabytes beside it, none of which
         the loader ever opens, so the publish lands in the intermediate output and only the entry
         assembly and its manifest reach the staged tree.
     -->
+    <!--
+        Published to the intermediate output and staged selectively: the top level, plus only the running
+        runtime identifier's runtimes subtree. The manifest that reaches the staged tree is a real
+        portable manifest declaring every identifier the package ships; what the staged tree does not
+        carry is the eighty megabytes of libraries for identifiers this process could never load.
+    -->
+    <ItemGroup>
+        <PluginFixturePortable Include="Fixtures/Plugins/Acme.NativePortable/Acme.NativePortable.csproj">
+            <StagedName>Acme.NativePortable</StagedName>
+        </PluginFixturePortable>
+    </ItemGroup>
+
     <ItemGroup>
         <PluginFixtureTrimmed Include="Fixtures/Plugins/Acme.SelfContained/Acme.SelfContained.csproj">
             <StagedName>Acme.SelfContained</StagedName>
@@ -152,8 +174,10 @@
             <PluginFixtureInputList>@(PluginFixtureInput->'%(Identity)@%(ModifiedTime)', '|')</PluginFixtureInputList>
             <PluginFixtureRawRoot
             >$([MSBuild]::NormalizeDirectory('$(PluginFixtureStampDir)', 'raw'))</PluginFixtureRawRoot>
+            <PluginFixtureProbeRoot
+            >$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutDir)', 'FixtureHosts'))</PluginFixtureProbeRoot>
             <PluginFixtureFingerprintPrefix
-            >$(Configuration)+$(NETCoreSdkRuntimeIdentifier)+@(PluginFixture->'%(StagedName)', '&amp;')+@(PluginFixtureTrimmed->'%(StagedName)', '&amp;')+$([MSBuild]::StableStringHash($(PluginFixtureInputList)))</PluginFixtureFingerprintPrefix>
+            >$(Configuration)+$(NETCoreSdkRuntimeIdentifier)+@(PluginFixture->'%(StagedName)', '&amp;')+@(PluginFixtureTrimmed->'%(StagedName)', '&amp;')+@(PluginProbeHost->'%(StagedName)', '&amp;')+@(PluginFixturePortable->'%(StagedName)', '&amp;')+$([MSBuild]::StableStringHash($(PluginFixtureInputList)))</PluginFixtureFingerprintPrefix>
         </PropertyGroup>
 
         <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
@@ -228,7 +252,7 @@
         DependsOnTargets="PrunePluginFixtureStaging"
         Condition="'$(BuildingPluginFixtures)' != 'true' AND '$(DesignTimeBuild)' != 'true'"
         Inputs="@(PluginFixtureInput)"
-        Outputs="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json')"
+        Outputs="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json');@(PluginProbeHost->'$(PluginFixtureProbeRoot)%(StagedName)/%(StagedName).dll');@(PluginFixturePortable->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json')"
     >
         <!--
             Each fixture's directory is emptied before it is published into, so that a file dropped from
@@ -236,8 +260,8 @@
             overwrites what it produces but removes nothing it no longer produces.
         -->
         <RemoveDir
-            Directories="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureRawRoot)%(StagedName)')"
-            Condition="'$(PluginFixtureStageRoot)' != '' AND '$(PluginFixtureRawRoot)' != ''"
+            Directories="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixtureTrimmed->'$(PluginFixtureRawRoot)%(StagedName)');@(PluginProbeHost->'$(PluginFixtureProbeRoot)%(StagedName)');@(PluginFixturePortable->'$(PluginFixtureStageRoot)%(StagedName)');@(PluginFixturePortable->'$(PluginFixtureRawRoot)%(StagedName)')"
+            Condition="'$(PluginFixtureStageRoot)' != '' AND '$(PluginFixtureRawRoot)' != '' AND '$(PluginFixtureProbeRoot)' != ''"
         />
 
         <PropertyGroup>
@@ -268,6 +292,40 @@
             Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixtureTrimmed.FullPath)&quot; --configuration $(Configuration) %(PluginFixtureTrimmed.PublishArgs) --output &quot;$(PluginFixtureRawRoot)%(PluginFixtureTrimmed.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
             EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
             WorkingDirectory="$(MSBuildProjectDirectory)"
+        />
+
+        <Exec
+            Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginProbeHost.FullPath)&quot; --configuration $(Configuration) --no-self-contained --output &quot;$(PluginFixtureProbeRoot)%(PluginProbeHost.StagedName)&quot; -p:BuildingPluginFixtures=true --nologo --verbosity quiet"
+            EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
+            WorkingDirectory="$(MSBuildProjectDirectory)"
+        />
+
+        <Exec
+            Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixturePortable.FullPath)&quot; --configuration $(Configuration) --no-self-contained --output &quot;$(PluginFixtureRawRoot)%(PluginFixturePortable.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
+            EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
+            WorkingDirectory="$(MSBuildProjectDirectory)"
+        />
+
+        <!--
+            Literal paths rather than an item transform, because a transform does not glob: the one
+            portable fixture is named here as well as in its item above.
+        -->
+        <ItemGroup>
+            <PluginPortableTopLevelFile
+                Include="$(PluginFixtureRawRoot)Acme.NativePortable/*.*"
+            />
+            <PluginPortableRuntimeFile
+                Include="$(PluginFixtureRawRoot)Acme.NativePortable/runtimes/$(NETCoreSdkRuntimeIdentifier)/**/*.*"
+            />
+        </ItemGroup>
+
+        <Copy
+            SourceFiles="@(PluginPortableTopLevelFile)"
+            DestinationFolder="$(PluginFixtureStageRoot)Acme.NativePortable"
+        />
+        <Copy
+            SourceFiles="@(PluginPortableRuntimeFile)"
+            DestinationFiles="@(PluginPortableRuntimeFile->'$(PluginFixtureStageRoot)Acme.NativePortable/runtimes/$(NETCoreSdkRuntimeIdentifier)/%(RecursiveDir)%(Filename)%(Extension)')"
         />
 
         <Copy

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -1,0 +1,139 @@
+<Project>
+    <!--
+        Publishes the fixture plugin projects under Fixtures/ into the test output as real plugin
+        directories, because the loader's subject is a published directory and nothing smaller
+        exercises it honestly. Each fixture is published on its own, so a deliberately malformed one
+        cannot disturb the others.
+
+        The fixture tree is excluded from this project's compile, embedded-resource and None globs in
+        the csproj; this file is the only thing that builds it.
+    -->
+    <ItemGroup>
+        <PluginFixture Include="Fixtures/Plugins/Acme.Good/Acme.Good.csproj">
+            <StagedName>Acme.Good</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.NoSubclass/Acme.NoSubclass.csproj">
+            <StagedName>Acme.NoSubclass</StagedName>
+        </PluginFixture>
+    </ItemGroup>
+
+    <!--
+        Everything a fixture's published bytes can depend on. The plugin contract is listed because
+        every fixture references it by project, so a change to the contract has to re-publish them;
+        the loader assembly deliberately is not, because no fixture references it and listing it would
+        re-publish the whole tree on every edit to the code under test. It joins this list with the
+        story that adds a fixture host process, which does reference it.
+
+        bin/ and obj/ are excluded so that generated sources, which change on every build, cannot make
+        the staging permanently out of date.
+    -->
+    <ItemGroup>
+        <PluginFixtureInput Include="$(MSBuildThisFileFullPath)" />
+        <PluginFixtureInput Include="Fixtures/Directory.Build.props" />
+        <PluginFixtureInput
+            Include="Fixtures/**/*.cs;Fixtures/**/*.csproj"
+            Exclude="Fixtures/**/bin/**;Fixtures/**/obj/**"
+        />
+        <PluginFixtureInput
+            Include="../EdFi.Api.Plugins/**/*.cs;../EdFi.Api.Plugins/*.csproj"
+            Exclude="../EdFi.Api.Plugins/bin/**;../EdFi.Api.Plugins/obj/**"
+        />
+        <PluginFixtureInput
+            Include="../Directory.Build.props;../../Directory.Packages.props;../../nuget.config"
+        />
+    </ItemGroup>
+
+    <!--
+        Staging is invalidated wholesale when the shape of the request changes rather than only its
+        content. The fingerprint carries the configuration, the runtime identifier and the set of
+        fixture names, so a Release build, a run on another operating system, or a fixture added or
+        removed cannot reuse a tree staged for something else. Timestamp comparison alone sees none of
+        those.
+    -->
+    <Target
+        Name="PrunePluginFixtureStaging"
+        Condition="'$(BuildingPluginFixtures)' != 'true' AND '$(DesignTimeBuild)' != 'true'"
+    >
+        <PropertyGroup>
+            <PluginFixtureStageRoot
+            >$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutDir)', 'Fixtures'))</PluginFixtureStageRoot>
+            <PluginFixtureStampDir
+            >$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'fixtures'))</PluginFixtureStampDir>
+            <PluginFixtureFingerprintFile>$(PluginFixtureStampDir)staging.fingerprint</PluginFixtureFingerprintFile>
+            <PluginFixtureFingerprint
+            >$(Configuration)|$(NETCoreSdkRuntimeIdentifier)|@(PluginFixture->'%(StagedName)', '+')</PluginFixtureFingerprint>
+        </PropertyGroup>
+
+        <ReadLinesFromFile
+            File="$(PluginFixtureFingerprintFile)"
+            Condition="Exists('$(PluginFixtureFingerprintFile)')"
+        >
+            <Output TaskParameter="Lines" ItemName="PluginFixturePreviousFingerprintLine" />
+        </ReadLinesFromFile>
+
+        <PropertyGroup>
+            <PluginFixturePreviousFingerprint>@(PluginFixturePreviousFingerprintLine)</PluginFixturePreviousFingerprint>
+            <PluginFixtureStagingIsStale
+                Condition="'$(PluginFixturePreviousFingerprint)' != '$(PluginFixtureFingerprint)'"
+            >true</PluginFixtureStagingIsStale>
+        </PropertyGroup>
+
+        <RemoveDir
+            Directories="$(PluginFixtureStageRoot)"
+            Condition="'$(PluginFixtureStagingIsStale)' == 'true' AND Exists('$(PluginFixtureStageRoot)')"
+        />
+        <Delete
+            Files="$(PluginFixtureFingerprintFile)"
+            Condition="'$(PluginFixtureStagingIsStale)' == 'true'"
+        />
+
+        <!--
+            A fixture removed from the list above leaves its staged directory behind, where a test
+            enumerating the staged tree would still find it. The fingerprint already forces a full
+            re-stage in that case; this removes the directory the re-stage would not overwrite.
+        -->
+        <ItemGroup Condition="Exists('$(PluginFixtureStageRoot)')">
+            <PluginFixtureExpectedDir Include="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)')" />
+            <PluginFixtureExistingDir
+                Include="$([System.IO.Directory]::GetDirectories('$(PluginFixtureStageRoot)'))"
+            />
+            <PluginFixtureStaleDir
+                Include="@(PluginFixtureExistingDir)"
+                Exclude="@(PluginFixtureExpectedDir)"
+            />
+        </ItemGroup>
+        <RemoveDir Directories="@(PluginFixtureStaleDir)" />
+    </Target>
+
+    <!--
+        Outputs are the published entry assembly and manifest of each fixture rather than a stamp
+        file, so that deleting a staged directory by hand re-stages it instead of being reported as
+        up to date.
+    -->
+    <Target
+        Name="PublishPluginFixtures"
+        AfterTargets="Build"
+        DependsOnTargets="PrunePluginFixtureStaging"
+        Condition="'$(BuildingPluginFixtures)' != 'true' AND '$(DesignTimeBuild)' != 'true'"
+        Inputs="@(PluginFixtureInput)"
+        Outputs="@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).dll');@(PluginFixture->'$(PluginFixtureStageRoot)%(StagedName)/%(StagedName).deps.json')"
+    >
+        <!--
+            BuildingPluginFixtures is passed down so that an inner publish can never re-enter this
+            target, and each fixture project is named explicitly so that nothing walks back up to this
+            test project.
+        -->
+        <Exec
+            Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixture.FullPath)&quot; --configuration $(Configuration) --no-self-contained --output &quot;$(PluginFixtureStageRoot)%(PluginFixture.StagedName)&quot; -p:BuildingPluginFixtures=true --nologo --verbosity quiet"
+            WorkingDirectory="$(MSBuildProjectDirectory)"
+        />
+
+        <MakeDir Directories="$(PluginFixtureStampDir)" />
+        <WriteLinesToFile
+            File="$(PluginFixtureFingerprintFile)"
+            Lines="$(PluginFixtureFingerprint)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true"
+        />
+    </Target>
+</Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginFixtures.targets
@@ -52,6 +52,15 @@
         <PluginFixture Include="Fixtures/Plugins/Acme.BackstopCtor/Acme.BackstopCtor.csproj">
             <StagedName>Acme.BackstopCtor</StagedName>
         </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.NullName/Acme.NullName.csproj">
+            <StagedName>Acme.NullName</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.ThrowingName/Acme.ThrowingName.csproj">
+            <StagedName>Acme.ThrowingName</StagedName>
+        </PluginFixture>
+        <PluginFixture Include="Fixtures/Plugins/Acme.ThrowingCtor/Acme.ThrowingCtor.csproj">
+            <StagedName>Acme.ThrowingCtor</StagedName>
+        </PluginFixture>
         <PluginFixture Include="Fixtures/Plugins/Acme.PrivateDependency/Acme.PrivateDependency.csproj">
             <StagedName>Acme.PrivateDependency</StagedName>
         </PluginFixture>
@@ -238,11 +247,13 @@
         -->
         <Exec
             Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixture.FullPath)&quot; --configuration $(Configuration) %(PluginFixture.PublishArgs) --output &quot;$(PluginFixtureStageRoot)%(PluginFixture.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
+            EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
             WorkingDirectory="$(MSBuildProjectDirectory)"
         />
 
         <Exec
             Command="&quot;$(DOTNET_HOST_PATH)&quot; publish &quot;%(PluginFixtureTrimmed.FullPath)&quot; --configuration $(Configuration) %(PluginFixtureTrimmed.PublishArgs) --output &quot;$(PluginFixtureRawRoot)%(PluginFixtureTrimmed.StagedName)&quot; -p:BuildingPluginFixtures=true -p:PluginContractAssemblyPath=&quot;$(PluginContractAssemblyPath)&quot; --nologo --verbosity quiet"
+            EnvironmentVariables="DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1;MSBUILDDISABLENODEREUSE=1"
             WorkingDirectory="$(MSBuildProjectDirectory)"
         />
 

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginInventoryTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginInventoryTests.cs
@@ -427,3 +427,175 @@ public class Given_a_well_formed_plugin_whose_declarations_all_agree_with_the_ho
             );
     }
 }
+
+/// <summary>
+/// A declared path is a string a third party wrote, and <c>Path.Combine</c> discards its first argument
+/// for a rooted second, so a declared path could select a file outside the plugin directory and have
+/// those bytes hashed and reported as one the plugin shipped.
+/// </summary>
+/// <remarks>
+/// The boundary is lexical on purpose. It decides only whether a declared string may select a file, not
+/// whether an assembly may load, so it does not touch the symlinked-file case the loader documents as a
+/// deferred limit.
+/// </remarks>
+[TestFixture]
+public class Given_a_declared_path_that_points_outside_the_plugin_directory
+{
+    private const string SentinelContent = "sentinel bytes that no plugin ever shipped";
+    private const string SentinelFileName = "Sentinel.dll";
+
+    private TemporaryPluginRoot _root = null!;
+    private string _sentinel = null!;
+    private string _sentinelDigest = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+        _sentinel = TemporaryPluginRoot.WriteFile(
+            Path.Combine(_root.CreateDirectoryOutsideRoot("outside"), SentinelFileName),
+            SentinelContent
+        );
+        _sentinelDigest = IndependentDigest.Of(_sentinel);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    private IReadOnlyList<PluginInventoryRow> Load()
+    {
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Good);
+
+        run.Failure.Should().BeNull();
+        return run.Result!.Plugins[0].MaterializeInventory();
+    }
+
+    private void ItIsAbsentAndNothingCarriesTheSentinelsBytes(string fileName)
+    {
+        IReadOnlyList<PluginInventoryRow> inventory = Load();
+        PluginInventoryRow row = inventory.Single(candidate => candidate.FileName == fileName);
+
+        row.Availability.Should().Be(PluginFileAvailability.Absent);
+        row.ResolvedRelativePath.Should().BeNull();
+        row.Sha256.Should().BeNull();
+
+        // The digest is the part that matters. An inventory that never carries these bytes is one an
+        // incident responder cannot be misled by, whatever the row says about itself.
+        inventory.Should().NotContain(candidate => candidate.Sha256 == _sentinelDigest);
+    }
+
+    [Test]
+    public void It_does_not_inventory_a_file_named_by_a_rooted_declared_path()
+    {
+        // A manifest writes forward slashes whatever the platform, so the rooted path is presented the
+        // way a manifest would present it.
+        _root.AddDeclaredRuntimeAsset(
+            PluginFixtures.Good,
+            _sentinel.Replace(Path.DirectorySeparatorChar, '/')
+        );
+
+        ItIsAbsentAndNothingCarriesTheSentinelsBytes(SentinelFileName);
+    }
+
+    [Test]
+    public void It_does_not_inventory_a_file_a_declared_path_traverses_to()
+    {
+        _root.AddDeclaredRuntimeAsset(PluginFixtures.Good, $"../../outside/{SentinelFileName}");
+
+        ItIsAbsentAndNothingCarriesTheSentinelsBytes(SentinelFileName);
+    }
+
+    [Test]
+    public void It_does_not_treat_a_sibling_directory_sharing_the_prefix_as_inside()
+    {
+        // "<root>/Acme.GoodEvil" starts with "<root>/Acme.Good" as a string, so only the separator that
+        // terminates the boundary keeps the two apart.
+        TemporaryPluginRoot.WriteFile(
+            Path.Combine(_root.RootPath, $"{PluginFixtures.Good}Evil", SentinelFileName),
+            SentinelContent
+        );
+
+        _root.AddDeclaredRuntimeAsset(
+            PluginFixtures.Good,
+            $"../{PluginFixtures.Good}Evil/{SentinelFileName}"
+        );
+
+        ItIsAbsentAndNothingCarriesTheSentinelsBytes(SentinelFileName);
+    }
+
+    [Test]
+    public void It_reports_a_path_the_platform_cannot_normalize_as_absent_rather_than_failing()
+    {
+        // Path.GetFullPath throws for a path carrying a NUL where File.Exists simply answered false, so
+        // normalizing before probing must not turn a candidate that selects nothing into a new fatal.
+        _root.AddDeclaredRuntimeAsset(PluginFixtures.Good, "lib/net10.0/a\u0000b.dll");
+
+        IReadOnlyList<PluginInventoryRow> inventory = Load();
+
+        inventory
+            .Single(row => row.DeclaredPath.Contains('\u0000'))
+            .Availability.Should()
+            .Be(PluginFileAvailability.Absent);
+    }
+
+    [Test]
+    public void It_still_resolves_a_declared_path_nested_inside_the_plugin_directory()
+    {
+        // The guard rail for all of the above: the boundary must reject what leaves the directory
+        // without rejecting the nested shapes a real publish writes.
+        TemporaryPluginRoot.WriteFile(
+            Path.Combine(_root.RootPath, PluginFixtures.Good, "lib", "net10.0", "Nested.dll"),
+            "nested bytes"
+        );
+
+        _root.AddDeclaredRuntimeAsset(PluginFixtures.Good, "lib/net10.0/Nested.dll");
+
+        PluginInventoryRow row = Load().Single(candidate => candidate.FileName == "Nested.dll");
+
+        row.Availability.Should().Be(PluginFileAvailability.Present);
+        row.ResolvedRelativePath.Should().Be(Path.Combine("lib", "net10.0", "Nested.dll"));
+        row.Sha256.Should().NotBeNull();
+    }
+}
+
+/// <summary>
+/// The locale a resource declaration carries composes a candidate path of its own, so it is a third
+/// input to the same resolution and is bounded by the same rule.
+/// </summary>
+[TestFixture]
+public class Given_a_resource_declaration_whose_locale_leaves_the_plugin_directory
+{
+    private const string SatelliteFileName = "Acme.Localized.resources.dll";
+    private const string PublishedPath = "fr/" + SatelliteFileName;
+
+    [Test]
+    public void It_does_not_inventory_a_file_the_locale_traverses_to()
+    {
+        using TemporaryPluginRoot root = TemporaryPluginRoot.Create();
+        root.Add(PluginFixtures.Localized);
+
+        // The declared path is moved to one the publish did not write, so the declared-path candidate
+        // misses and the locale-derived candidate is the one under test. The satellite's file name
+        // alone is not at the plugin root either, which the satellite fixture already establishes.
+        string declaredPath = $"lib/net10.0/{SatelliteFileName}";
+        root.SetResourceDeclaredPath(PluginFixtures.Localized, PublishedPath, declaredPath);
+        root.SetResourceLocale(PluginFixtures.Localized, declaredPath, "../outside");
+
+        string sentinel = TemporaryPluginRoot.WriteFile(
+            Path.Combine(root.RootPath, "outside", SatelliteFileName),
+            "sentinel bytes that no plugin ever shipped"
+        );
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(root.RootPath, PluginFixtures.Localized);
+        run.Failure.Should().BeNull();
+
+        IReadOnlyList<PluginInventoryRow> inventory = run.Result!.Plugins[0].MaterializeInventory();
+
+        inventory
+            .Single(row => row.Kind == PluginFileKind.Resource)
+            .Availability.Should()
+            .Be(PluginFileAvailability.Absent);
+        inventory.Should().NotContain(row => row.Sha256 == IndependentDigest.Of(sentinel));
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginInventoryTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginInventoryTests.cs
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Security.Cryptography;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// Digests the test computes for itself, by a different route from the one the loader takes, so that a
+/// row's digest is checked rather than compared against the same code that produced it.
+/// </summary>
+internal static class IndependentDigest
+{
+    internal static string Of(string path) =>
+        Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path))).ToLowerInvariant();
+}
+
+/// <summary>
+/// Finds the native rows of an inventory, and among them the one the runtime can actually load.
+/// </summary>
+/// <remarks>
+/// A plugin can ship more than one native file for one library, and the measured case is exactly that:
+/// the SQLite package publishes a shared library and a static archive side by side for its Linux
+/// runtime identifiers, and only a shared library for Windows. Both are files the plugin shipped, so
+/// both are inventory rows; only one of them is the thing a P/Invoke resolves.
+/// </remarks>
+internal static class NativeRows
+{
+    internal static string SharedLibraryExtension
+    {
+        get
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return ".dll";
+            }
+
+            return OperatingSystem.IsMacOS() ? ".dylib" : ".so";
+        }
+    }
+
+    internal static IEnumerable<PluginInventoryRow> Of(IEnumerable<PluginInventoryRow> inventory) =>
+        inventory.Where(row => row.Kind == PluginFileKind.Native);
+
+    internal static PluginInventoryRow SharedLibrary(IEnumerable<PluginInventoryRow> inventory) =>
+        Of(inventory).Single(row => row.FileName.EndsWith(SharedLibraryExtension, StringComparison.Ordinal));
+}
+
+[TestFixture]
+public class Given_a_plugin_that_ships_a_private_dependency_inventory
+{
+    private TemporaryPluginRoot _root = null!;
+    private LoadedPlugin _plugin = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.PrivateDependency);
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.PrivateDependency);
+        run.Failure.Should().BeNull();
+        _plugin = run.Result!.Plugins[0];
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_lists_the_entry_assembly_and_the_private_dependency()
+    {
+        // Built from the declaration rather than from the context's assembly list, so a dependency
+        // nothing has touched is in the inventory rather than missing from it.
+        _plugin
+            .MaterializeInventory()
+            .Select(row => row.FileName)
+            .Should()
+            .Contain([$"{PluginFixtures.PrivateDependency}.dll", "Acme.Private.dll"]);
+    }
+
+    [Test]
+    public void It_reports_the_entry_assembly_version_as_coming_from_the_assembly()
+    {
+        // A framework-dependent publish writes no version for the project's own entry, so the row has no
+        // declared version and takes its effective one from the assembly the process loaded. Reporting
+        // that null as 0.0.0.0, or dropping the row for want of a version, are the two things this keeps
+        // anybody from doing later.
+        PluginInventoryRow entry = _plugin
+            .MaterializeInventory()
+            .Single(row => row.FileName == $"{PluginFixtures.PrivateDependency}.dll");
+
+        entry.DeclaredAssemblyVersion.Should().BeNull();
+        entry.EffectiveVersion.Should().Be(_plugin.EntryAssemblyVersion);
+        entry.EffectiveVersionSource.Should().Be(PluginVersionSource.LoadedAssembly);
+    }
+
+    [Test]
+    public void It_hashes_the_file_that_is_actually_in_the_plugin_directory()
+    {
+        PluginInventoryRow dependency = _plugin
+            .MaterializeInventory()
+            .Single(row => row.FileName == "Acme.Private.dll");
+
+        dependency.Availability.Should().Be(PluginFileAvailability.Present);
+        dependency
+            .Sha256.Should()
+            .Be(IndependentDigest.Of(Path.Combine(_plugin.Directory, dependency.ResolvedRelativePath!)));
+        dependency.DeclaredAssemblyVersion.Should().Be(new Version(1, 0, 0, 0));
+        dependency.EffectiveVersionSource.Should().Be(PluginVersionSource.DepsJsonDeclaration);
+    }
+
+    [Test]
+    public void It_reads_the_load_state_when_the_inventory_is_materialized_rather_than_when_loading_finished()
+    {
+        // The assertion that proves the read is late-bound. A flag captured when loading finished would
+        // report this dependency as unloaded for the life of the process, including while the process
+        // was running it.
+        _plugin
+            .MaterializeInventory()
+            .Single(row => row.FileName == "Acme.Private.dll")
+            .LoadState.Should()
+            .Be(PluginFileLoadState.NotLoaded);
+
+        Type pluginType = _plugin.Instance.GetType();
+        pluginType.GetMethod("DescribePrivateDependency")!.Invoke(null, null);
+
+        _plugin
+            .MaterializeInventory()
+            .Single(row => row.FileName == "Acme.Private.dll")
+            .LoadState.Should()
+            .Be(PluginFileLoadState.Loaded);
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_that_ships_a_native_library
+{
+    private TemporaryPluginRoot _root = null!;
+    private LoadedPlugin _plugin = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Native);
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Native);
+        run.Failure.Should().BeNull();
+        _plugin = run.Result!.Plugins[0];
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_resolves_the_native_library_and_calls_into_it()
+    {
+        // Nothing in the managed Load override reaches a native library, so this only works because the
+        // context answers for unmanaged dependencies too. The value is SQLite's own version number,
+        // which is a real answer from real native code rather than a resolution that returned a path.
+        int version = (int)
+            _plugin
+                .Instance.GetType()
+                .Assembly.GetType("Acme.Native.NativePlugin")!
+                .GetMethod("NativeLibraryVersion")!
+                .Invoke(null, null)!;
+
+        version.Should().BeGreaterThan(3_000_000);
+    }
+
+    [Test]
+    public void It_lists_the_native_library_with_a_digest_and_no_version()
+    {
+        IReadOnlyList<PluginInventoryRow> inventory = _plugin.MaterializeInventory();
+        PluginInventoryRow native = NativeRows.SharedLibrary(inventory);
+
+        native.FileName.Should().Contain("e_sqlite3");
+        native.Availability.Should().Be(PluginFileAvailability.Present);
+        native
+            .Sha256.Should()
+            .Be(IndependentDigest.Of(Path.Combine(_plugin.Directory, native.ResolvedRelativePath!)));
+
+        // A native asset carries no assembly version anywhere, and saying so is the point: the row is
+        // listed with an explicit no-declaration source rather than dropped or filled in. This holds for
+        // every native file the plugin shipped, not only the one a P/Invoke resolves.
+        NativeRows
+            .Of(inventory)
+            .Should()
+            .OnlyContain(row =>
+                row.DeclaredAssemblyVersion == null
+                && row.EffectiveVersion == null
+                && row.EffectiveVersionSource == PluginVersionSource.NotDeclared
+            );
+    }
+
+    [Test]
+    public void It_reports_the_native_load_state_as_unknown_rather_than_guessing()
+    {
+        // The runtime exposes no way to enumerate the native libraries a context has resolved. Reporting
+        // this one as not loaded would be a claim nobody checked, and it would be wrong here: the test
+        // above called into it.
+        NativeRows
+            .Of(_plugin.MaterializeInventory())
+            .Should()
+            .OnlyContain(row => row.LoadState == PluginFileLoadState.Unknown);
+    }
+
+    [Test]
+    public void It_finds_the_native_library_where_the_publish_put_it_rather_than_where_the_manifest_says()
+    {
+        // The manifest declares it under runtimes/<rid>/native/ and a runtime-specific publish relocates
+        // it to the plugin directory root. Both paths are recorded, which is what lets a responder match
+        // a row to the package it came from as well as to the file on disk.
+        PluginInventoryRow native = NativeRows.SharedLibrary(_plugin.MaterializeInventory());
+
+        native.DeclaredPath.Should().Contain("runtimes/");
+        native.ResolvedRelativePath.Should().NotContain("runtimes");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_whose_native_library_is_missing
+{
+    private TemporaryPluginRoot _root = null!;
+    private LoadedPlugin _plugin = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Native);
+
+        // The design records a missing native asset as a lazy first-use failure rather than a load-time
+        // check, because .deps.json describes native assets per runtime identifier and the runtime
+        // resolves them lazily. This removes the file the publish actually placed.
+        foreach (
+            string nativeFile in Directory.EnumerateFiles(
+                Path.Combine(_root.RootPath, PluginFixtures.Native),
+                "*e_sqlite3*",
+                SearchOption.AllDirectories
+            )
+        )
+        {
+            File.Delete(nativeFile);
+        }
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Native);
+        run.Failure.Should().BeNull();
+        _plugin = run.Result!.Plugins[0];
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_still_loads_because_native_resolution_is_lazy()
+    {
+        _plugin.Name.Should().Be(PluginFixtures.Native);
+    }
+
+    [Test]
+    public void It_lists_the_declaration_with_no_digest_rather_than_dropping_it()
+    {
+        // A declared file that is not there is still something the plugin said it shipped, and an
+        // inventory that quietly omitted it would be silent exactly where a responder is looking.
+        // Nothing hashes empty bytes to fill the column.
+        IEnumerable<PluginInventoryRow> native = NativeRows.Of(_plugin.MaterializeInventory());
+
+        native.Should().NotBeEmpty();
+        native
+            .Should()
+            .OnlyContain(row =>
+                row.Availability == PluginFileAvailability.Absent
+                && row.Sha256 == null
+                && row.ResolvedRelativePath == null
+                && row.DeclaredPath.Contains("e_sqlite3")
+            );
+    }
+
+    [Test]
+    public void It_offers_the_runtime_nothing_and_defers_to_the_default_probing()
+    {
+        // The loader's half of "not detected at load": the plugin shipped no such file, so the context
+        // has no path to give and returns zero, which is how the override says to probe as usual. What
+        // happens next is the runtime's business, and by design it is a DllNotFoundException at first
+        // use rather than a refusal here.
+        //
+        // That last step is deliberately not asserted in this process. Windows and Linux both resolve a
+        // native module by name once it is loaded, so a sibling fixture that has already loaded a module
+        // of this name satisfies the call regardless of what this plugin ships, and an assertion here
+        // would pass or fail on test order rather than on behaviour. The assertion that does hold
+        // everywhere is the one below.
+        PluginLoadContext context = new(
+            PluginFixtures.Native,
+            Path.Combine(_plugin.Directory, $"{PluginFixtures.Native}.dll")
+        );
+
+        MethodInfo loadUnmanagedDll = typeof(PluginLoadContext).GetMethod(
+            "LoadUnmanagedDll",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        )!;
+
+        loadUnmanagedDll.Invoke(context, ["e_sqlite3"]).Should().Be(IntPtr.Zero);
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_shipping_an_older_copy_of_an_assembly_the_host_carries
+{
+    private TemporaryPluginRoot _root = null!;
+    private LoadedPlugin _plugin = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Substitution);
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Substitution);
+        run.Failure.Should().BeNull();
+        _plugin = run.Result!.Plugins[0];
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_records_nothing_until_the_assembly_is_actually_resolved()
+    {
+        // The record is of resolutions that happened. A preflight knows this plugin declares an older
+        // copy and could predict a substitution from that, but predicting one for a dependency nothing
+        // has asked for would report a substitution that has not occurred.
+        _plugin.MaterializeSubstitutions().Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_records_the_substitution_once_the_assembly_is_resolved()
+    {
+        string described = (string)
+            _plugin
+                .Instance.GetType()
+                .Assembly.GetType("Acme.Substitution.SubstitutionPlugin")!
+                .GetMethod("DescribeHostShared")!
+                .Invoke(null, null)!;
+
+        // The host's copy answered, not the plugin's, which is the substitution itself.
+        described.Should().Be("Acme.HostShared 1.0.0");
+
+        HostFirstSubstitution substitution = _plugin.MaterializeSubstitutions().Single();
+
+        substitution.AssemblyName.Should().Be("Acme.HostShared");
+        substitution.HostVersion.Should().Be(new Version(1, 0, 0, 0));
+
+        // The manifest declaration is the comparison that matters, because it is what the plugin
+        // shipped. The reference version is a separate fact and is carried separately rather than
+        // standing in for it.
+        substitution.DeclaredVersion.Should().Be(new Version(0, 5, 0, 0));
+        substitution.RequestedVersion.Should().Be(new Version(0, 5, 0, 0));
+    }
+
+    [Test]
+    public void It_reports_the_plugins_own_copy_as_not_loaded()
+    {
+        _plugin
+            .Instance.GetType()
+            .Assembly.GetType("Acme.Substitution.SubstitutionPlugin")!
+            .GetMethod("DescribeHostShared")!
+            .Invoke(null, null);
+
+        // The plugin's own file is on disk and was never used, so the truthful load state is that it is
+        // not loaded. Where it went instead is what the substitution record is for.
+        _plugin
+            .MaterializeInventory()
+            .Single(row => row.FileName == "Acme.HostShared.dll")
+            .LoadState.Should()
+            .Be(PluginFileLoadState.NotLoaded);
+    }
+}
+
+[TestFixture]
+public class Given_a_well_formed_plugin_whose_declarations_all_agree_with_the_host
+{
+    private TemporaryPluginRoot _root = null!;
+    private LoadedPlugin _plugin = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Good);
+        run.Failure.Should().BeNull();
+        _plugin = run.Result!.Plugins[0];
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_records_no_substitution_when_the_host_serves_the_same_version()
+    {
+        // Host-first serves this plugin the host's contract copy, and the versions agree, so nothing was
+        // substituted in any sense worth reporting. A record here would be noise in the one event an
+        // operator reads to find real ones.
+        _plugin.MaterializeSubstitutions().Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_gives_every_present_file_a_digest_and_no_absent_file_one()
+    {
+        IReadOnlyList<PluginInventoryRow> inventory = _plugin.MaterializeInventory();
+
+        // Stated as one invariant rather than two filtered assertions, so that it still says something
+        // when a fixture happens to have no absent files at all.
+        inventory.Should().NotBeEmpty();
+        inventory
+            .Should()
+            .OnlyContain(row =>
+                (row.Availability == PluginFileAvailability.Present)
+                == (row.Sha256 != null && row.Sha256.Length == 64)
+            );
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderContainmentTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderContainmentTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// The containment check resolves symbolic links rather than normalizing lexically, and it composes the
+/// plugin path against the resolved root. All three of these cases are required together: an
+/// implementation that passes any one of them alone is a plausible wrong answer.
+/// </summary>
+[TestFixture]
+public class Given_a_plugin_directory_that_is_a_link_out_of_the_root
+{
+    private TemporaryPluginRoot _root = null!;
+    private string _outside = null!;
+    private string _link = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _outside = _root.CreateDirectoryOutsideRoot("outside");
+        TemporaryPluginRoot.AddTo(_outside, PluginFixtures.Good, asName: "Acme.Escape");
+
+        _link = TemporaryPluginRoot.CreateDirectoryLink(
+            Path.Combine(_root.RootPath, "Acme.Escape"),
+            Path.Combine(_outside, "Acme.Escape")
+        );
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_the_plugin()
+    {
+        // The name rule cannot see this: "Acme.Escape" is a perfectly good single path segment.
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, "Acme.Escape");
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.EscapesPluginRoot);
+    }
+
+    [Test]
+    public void It_names_both_resolved_paths()
+    {
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, "Acme.Escape");
+
+        run.Failure!.Message.Should().Contain(Path.Combine(_outside, "Acme.Escape"));
+        run.Failure!.Message.Should().Contain(_root.RootPath);
+    }
+
+    [Test]
+    public void It_is_a_case_a_lexical_check_would_pass()
+    {
+        // Path.GetFullPath normalizes lexically and never reads the filesystem, so the composed path
+        // starts with the root while the assembly that would load is the one outside it. This asserts
+        // the fixture really is that case, so the test above cannot pass for the wrong reason.
+        string composed = Path.GetFullPath(Path.Combine(_root.RootPath, "Acme.Escape"));
+        composed.Should().StartWith(_root.RootPath);
+
+        string resolved = Directory.ResolveLinkTarget(_link, returnFinalTarget: true)!.FullName;
+        resolved.Should().NotStartWith(_root.RootPath);
+    }
+}
+
+[TestFixture]
+public class Given_a_well_formed_plugin_under_a_root_that_is_itself_a_link
+{
+    private TemporaryPluginRoot _root = null!;
+    private string _linkedRoot = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create(rootName: "realplugins");
+        _root.Add(PluginFixtures.Good);
+
+        _linkedRoot = TemporaryPluginRoot.CreateDirectoryLink(
+            Path.Combine(Path.GetDirectoryName(_root.RootPath)!, "app-plugins"),
+            _root.RootPath
+        );
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_loads_the_plugin()
+    {
+        // Composing against the configured root rather than the resolved one rejects this: the resolved
+        // root is .../realplugins while the composed path is .../app-plugins/Acme.Good, and the ordinary
+        // plugin gets reported as escaping. Resolving the root once and composing against it is what
+        // makes both this and the escape case come out right.
+        PluginLoaderRun run = PluginLoaderProbe.Run(_linkedRoot, PluginFixtures.Good);
+
+        run.Failure.Should().BeNull();
+        run.Result!.Plugins.Select(plugin => plugin.Name).Should().Equal(PluginFixtures.Good);
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_directory_that_is_a_link_out_of_a_linked_root
+{
+    private TemporaryPluginRoot _root = null!;
+    private string _linkedRoot = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create(rootName: "realplugins");
+
+        string outside = _root.CreateDirectoryOutsideRoot("outside");
+        TemporaryPluginRoot.AddTo(outside, PluginFixtures.Good, asName: "Acme.Escape");
+
+        TemporaryPluginRoot.CreateDirectoryLink(
+            Path.Combine(_root.RootPath, "Acme.Escape"),
+            Path.Combine(outside, "Acme.Escape")
+        );
+
+        _linkedRoot = TemporaryPluginRoot.CreateDirectoryLink(
+            Path.Combine(Path.GetDirectoryName(_root.RootPath)!, "app-plugins"),
+            _root.RootPath
+        );
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_the_plugin()
+    {
+        // The combination neither of the other two cases reaches: both the root and the plugin directory
+        // are links, so an implementation that resolves only one of them gets this wrong.
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(_linkedRoot, "Acme.Escape");
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.EscapesPluginRoot);
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderDiscoveryTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderDiscoveryTests.cs
@@ -358,17 +358,19 @@ public class Given_a_staged_name_that_differs_only_in_case
     private const string WrongCaseManifest = "acme.good.deps.json";
 
     private TemporaryPluginRoot _root = null!;
+    private bool _foldsCase;
 
     [SetUp]
     public void Setup()
     {
         _root = TemporaryPluginRoot.Create();
+        _foldsCase = _root.FilesystemFoldsCase();
 
         // Recorded as evidence rather than asserted, and measured in this tree rather than inferred from
         // the operating system's name. Where it is false the wrong-cased staging below could never have
         // been opened at all, and these cases refuse for that reason instead; the refusal being the same
         // either way is what the correction is for.
-        TestContext.Out.WriteLine($"filesystem folds case: {_root.FilesystemFoldsCase()}");
+        TestContext.Out.WriteLine($"filesystem folds case: {_foldsCase}");
     }
 
     [TearDown]
@@ -391,11 +393,21 @@ public class Given_a_staged_name_that_differs_only_in_case
     {
         PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.Good);
 
+        // The reason, the named plugin and the single line are the portable assertions: the outcome is
+        // the same on both kinds of filesystem, which is the whole point of the correction.
         run.Failure!.Reason.Should().Be(reason);
-        run.Failure!.Message.Should().Contain(actualSpelling);
         run.Failure!.Message.Should().Contain(PluginFixtures.Good);
         run.DiagnosticLines.Should().ContainSingle();
         run.DiagnosticLines[0].Should().StartWith($"plugin '{PluginFixtures.Good}' failed:");
+
+        if (_foldsCase)
+        {
+            // Only where the filesystem folded case does the wrong-cased entry survive the existence
+            // check and reach the spelling check, which is the refusal that can name what is actually
+            // there. Where it does not fold, the earlier check refuses first with the established
+            // missing-path message, which names only the spelling that was asked for and is left alone.
+            run.Failure!.Message.Should().Contain(actualSpelling);
+        }
     }
 
     [Test]

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderDiscoveryTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderDiscoveryTests.cs
@@ -343,3 +343,107 @@ public class Given_an_allowlist_whose_later_entry_is_invalid
         run.DiagnosticLines[0].Should().StartWith("plugins:");
     }
 }
+
+/// <summary>
+/// A filesystem answers <c>Directory.Exists</c> and <c>File.Exists</c>, and a case-insensitive one
+/// answers true for a name that is not the name it was asked about. The three names the loader composes
+/// from an allowlist entry therefore have to be read back from the directory and compared ordinally,
+/// like every other identity comparison here.
+/// </summary>
+[TestFixture]
+public class Given_a_staged_name_that_differs_only_in_case
+{
+    private const string WrongCaseDirectory = "acme.good";
+    private const string WrongCaseEntryAssembly = "acme.good.dll";
+    private const string WrongCaseManifest = "acme.good.deps.json";
+
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+
+        // Recorded as evidence rather than asserted, and measured in this tree rather than inferred from
+        // the operating system's name. Where it is false the wrong-cased staging below could never have
+        // been opened at all, and these cases refuse for that reason instead; the refusal being the same
+        // either way is what the correction is for.
+        TestContext.Out.WriteLine($"filesystem folds case: {_root.FilesystemFoldsCase()}");
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    /// <summary>
+    /// Asserts the staging actually produced the spelling the case is about.
+    /// </summary>
+    /// <remarks>
+    /// A case-only rename is a no-op on some filesystems. Without this, such a case would pass for the
+    /// wrong reason: the loader would be refusing a name that is not there at all rather than one that
+    /// is there under another spelling.
+    /// </remarks>
+    private static void RequirePhysicalEntry(string parent, string expected)
+    {
+        Directory.EnumerateFileSystemEntries(parent).Select(Path.GetFileName).Should().Contain(expected);
+    }
+
+    private void ItRefusesWithOneLine(PluginLoadFailure reason, string actualSpelling)
+    {
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.Good);
+
+        run.Failure!.Reason.Should().Be(reason);
+        run.Failure!.Message.Should().Contain(actualSpelling);
+        run.Failure!.Message.Should().Contain(PluginFixtures.Good);
+        run.DiagnosticLines.Should().ContainSingle();
+        run.DiagnosticLines[0].Should().StartWith($"plugin '{PluginFixtures.Good}' failed:");
+    }
+
+    [Test]
+    public void It_refuses_a_plugin_directory_spelled_differently()
+    {
+        // The self-contradiction this removes: the run used to load this directory and then announce, on
+        // the same channel, that it was ignoring a directory not in the allowlist, naming the very one it
+        // had just loaded.
+        _root.AddUnderDirectoryName(PluginFixtures.Good, WrongCaseDirectory);
+        RequirePhysicalEntry(_root.RootPath, WrongCaseDirectory);
+
+        ItRefusesWithOneLine(PluginLoadFailure.PluginDirectoryMissing, WrongCaseDirectory);
+    }
+
+    [Test]
+    public void It_refuses_an_entry_assembly_spelled_differently()
+    {
+        // This one used to load and then report EntryAssemblyFileName as the allowlist spelling, which is
+        // a file name that is not on disk.
+        _root.Add(PluginFixtures.Good);
+        _root.RenameFileInPlugin(PluginFixtures.Good, $"{PluginFixtures.Good}.dll", WrongCaseEntryAssembly);
+        RequirePhysicalEntry(Path.Combine(_root.RootPath, PluginFixtures.Good), WrongCaseEntryAssembly);
+
+        ItRefusesWithOneLine(PluginLoadFailure.EntryAssemblyMissing, WrongCaseEntryAssembly);
+    }
+
+    [Test]
+    public void It_refuses_a_dependency_manifest_spelled_differently()
+    {
+        _root.Add(PluginFixtures.Good);
+        _root.RenameFileInPlugin(PluginFixtures.Good, $"{PluginFixtures.Good}.deps.json", WrongCaseManifest);
+        RequirePhysicalEntry(Path.Combine(_root.RootPath, PluginFixtures.Good), WrongCaseManifest);
+
+        ItRefusesWithOneLine(PluginLoadFailure.DepsJsonMissing, WrongCaseManifest);
+    }
+
+    [Test]
+    public void It_still_loads_when_every_name_is_exact()
+    {
+        // The control, without which the three refusals above would be satisfied by a loader that had
+        // simply stopped accepting plugins.
+        _root.Add(PluginFixtures.Good);
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Good);
+
+        run.Failure.Should().BeNull();
+        run.Result!.Plugins.Should().ContainSingle();
+        run.Result!.Plugins[0].EntryAssemblyFileName.Should().Be($"{PluginFixtures.Good}.dll");
+        run.DiagnosticLines.Should().ContainSingle();
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderDiscoveryTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderDiscoveryTests.cs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+[TestFixture]
+public class Given_a_plugin_root_that_does_not_exist_and_an_empty_allowlist
+{
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _run = PluginLoaderProbe.Run(
+            Path.Combine(Path.GetTempPath(), "edfi-plugin-tests", Guid.NewGuid().ToString("N")),
+            allowed: string.Empty
+        );
+    }
+
+    [Test]
+    public void It_returns_no_plugins()
+    {
+        // The shipped default, and the case that has to keep working for every deployment whose image
+        // never created a plugin directory.
+        _run.Failure.Should().BeNull();
+        _run.Result!.Plugins.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_writes_nothing_at_all()
+    {
+        _run.Diagnostics.Should().BeEmpty();
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_root_that_does_not_exist_and_a_populated_allowlist
+{
+    private string _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "edfi-plugin-tests", Guid.NewGuid().ToString("N"));
+        _run = PluginLoaderProbe.RunExpectingFailure(_root, PluginFixtures.Good);
+    }
+
+    [Test]
+    public void It_refuses_because_plugins_were_asked_for_and_cannot_be_delivered()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.PluginRootMissing);
+    }
+
+    [Test]
+    public void It_names_the_root_the_operator_has_to_create()
+    {
+        _run.Failure!.Message.Should().Contain(_root);
+    }
+
+    [Test]
+    public void It_does_not_surface_the_raw_resolution_failure()
+    {
+        // Directory.ResolveLinkTarget throws DirectoryNotFoundException for a path that does not exist,
+        // so resolving the root before checking that it exists would produce that instead of a message
+        // naming the path. The order is the criterion, and this is what pins it.
+        _run.Failure.Should().NotBeOfType<DirectoryNotFoundException>();
+        _run.Failure!.InnerException.Should().BeNull();
+    }
+}
+
+[TestFixture]
+public class Given_a_misspelled_allowlist_entry
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, "Acme.Godo");
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_with_the_missing_directory_failure()
+    {
+        // Not a raw DirectoryNotFoundException out of the resolution step, which is what a check that
+        // resolved before testing for existence would produce.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.PluginDirectoryMissing);
+        _run.Failure!.InnerException.Should().BeNull();
+    }
+
+    [Test]
+    public void It_names_the_path_it_expected()
+    {
+        _run.Failure!.Message.Should().Contain(Path.Combine(_root.RootPath, "Acme.Godo"));
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_directory_missing_its_entry_assembly
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+        _root.Remove(PluginFixtures.Good, $"{PluginFixtures.Good}.dll");
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_and_names_the_expected_path()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.EntryAssemblyMissing);
+        _run.Failure!.Message.Should().Contain($"{PluginFixtures.Good}.dll");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_directory_missing_its_dependency_manifest
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+        _root.Remove(PluginFixtures.Good, $"{PluginFixtures.Good}.deps.json");
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_rather_than_letting_the_closure_fail_at_first_use()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.DepsJsonMissing);
+        _run.Failure!.Message.Should().Contain($"{PluginFixtures.Good}.deps.json");
+    }
+}
+
+[TestFixture]
+public class Given_two_well_formed_plugins_in_allowlist_order
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+        _root.Add(PluginFixtures.NonCandidates);
+
+        // Written in the reverse of alphabetical order, so a sorted result would be visibly wrong.
+        _run = PluginLoaderProbe.Run(_root.RootPath, $"{PluginFixtures.NonCandidates},{PluginFixtures.Good}");
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_returns_one_instance_each_in_the_order_written()
+    {
+        _run.Failure.Should().BeNull();
+        _run.Result!.Plugins.Select(plugin => plugin.Name)
+            .Should()
+            .Equal(PluginFixtures.NonCandidates, PluginFixtures.Good);
+    }
+
+    [Test]
+    public void It_returns_the_plugin_instance_the_directory_names()
+    {
+        _run.Result!.Plugins.Select(plugin => plugin.Instance.Name)
+            .Should()
+            .Equal(PluginFixtures.NonCandidates, PluginFixtures.Good);
+    }
+
+    [Test]
+    public void It_writes_one_line_per_allowlisted_name_in_order()
+    {
+        _run.DiagnosticLines.Should().HaveCount(2);
+        _run.DiagnosticLines[0].Should().Contain(PluginFixtures.NonCandidates).And.Contain("loaded from");
+        _run.DiagnosticLines[1].Should().Contain(PluginFixtures.Good).And.Contain("loaded from");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_that_fails_after_one_has_loaded
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+        _root.Add(PluginFixtures.NoSubclass);
+
+        _run = PluginLoaderProbe.RunExpectingFailure(
+            _root.RootPath,
+            $"{PluginFixtures.Good},{PluginFixtures.NoSubclass}"
+        );
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_reports_the_outcome_of_every_name_it_reached()
+    {
+        _run.DiagnosticLines.Should().HaveCount(2);
+        _run.DiagnosticLines[0].Should().Contain(PluginFixtures.Good).And.Contain("loaded from");
+        _run.DiagnosticLines[1].Should().Contain(PluginFixtures.NoSubclass).And.Contain("failed:");
+    }
+
+    [Test]
+    public void It_stops_at_the_failing_entry()
+    {
+        // An allowlisted plugin that does not load is fatal, so nothing after it is reached. That is
+        // inherent rather than incidental, and it is why the channel carries no third line.
+        _run.Failure!.PluginName.Should().Be(PluginFixtures.NoSubclass);
+    }
+}
+
+[TestFixture]
+public class Given_a_directory_nobody_allowlisted
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+        _root.Add(PluginFixtures.NameMismatch, asName: "Acme.NobodyAsked");
+
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_loads_only_what_was_allowlisted()
+    {
+        _run.Failure.Should().BeNull();
+        _run.Result!.Plugins.Select(plugin => plugin.Name).Should().Equal(PluginFixtures.Good);
+    }
+
+    [Test]
+    public void It_warns_and_names_the_directory_it_ignored()
+    {
+        // The directory holds a plugin whose Name disagrees with its directory, so if anything inside it
+        // had been opened the run would have failed rather than warned. That is the assertion: discovery
+        // is driven by the allowlist, and an unasked-for directory is never opened, probed, or read.
+        _run.DiagnosticLines.Should().HaveCount(2);
+        _run.DiagnosticLines[1].Should().Contain("ignoring directories not in the allowlist");
+        _run.DiagnosticLines[1].Should().Contain("Acme.NobodyAsked");
+    }
+}
+
+/// <summary>
+/// The allowlist is validated in full before anything touches the filesystem. Each case here would fail
+/// differently if it were not.
+/// </summary>
+[TestFixture]
+public class Given_an_allowlist_whose_later_entry_is_invalid
+{
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_the_entry_without_loading_the_valid_one_before_it()
+    {
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(
+            _root.RootPath,
+            $"{PluginFixtures.Good},../sibling"
+        );
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.InvalidAllowlistName);
+
+        // Nothing was loaded and no per-name line was written, so the well-formed first entry was never
+        // processed. A loader that validated entry by entry would have loaded it and written its line.
+        run.DiagnosticLines.Should().ContainSingle();
+        run.DiagnosticLines[0].Should().StartWith("plugins:");
+    }
+
+    [Test]
+    public void It_refuses_the_entry_without_asking_whether_the_root_exists()
+    {
+        // Against a root that does not exist, a loader that probed the filesystem before validating the
+        // allowlist would report the missing root. Reporting the entry instead is what proves the order.
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(
+            Path.Combine(Path.GetTempPath(), "edfi-plugin-tests", Guid.NewGuid().ToString("N")),
+            $"{PluginFixtures.Good},sub/dir"
+        );
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.InvalidAllowlistName);
+    }
+
+    [Test]
+    public void It_refuses_a_later_duplicate_without_loading_the_first_entry()
+    {
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(
+            _root.RootPath,
+            $"{PluginFixtures.Good},acme.good"
+        );
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.DuplicateAllowlistEntry);
+        run.DiagnosticLines.Should().ContainSingle();
+        run.DiagnosticLines[0].Should().StartWith("plugins:");
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderIsolationTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderIsolationTests.cs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Runtime.Loader;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// A host configuration for the hook to read, separate from the one that configures the loader.
+/// </summary>
+/// <remarks>
+/// The loader's own configuration carries the <c>Plugins</c> section and nothing a plugin should see.
+/// What a plugin is handed is the host's whole configuration, so these cases build one of their own
+/// rather than reusing the loader's.
+/// </remarks>
+internal static class HostConfiguration
+{
+    internal static IConfiguration WithSection(string section, IReadOnlyDictionary<string, string?> values)
+    {
+        Dictionary<string, string?> prefixed = new(StringComparer.Ordinal);
+
+        foreach (KeyValuePair<string, string?> value in values)
+        {
+            prefixed[$"{section}:{value.Key}"] = value.Value;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(prefixed).Build();
+    }
+}
+
+/// <summary>
+/// Two plugins carrying different majors of one library the host does not have.
+/// </summary>
+/// <remarks>
+/// This is what host-first keeps. It gives up a plugin overriding an assembly the host carries; what
+/// it does not give up is the case real collisions live in, where two vendors ship different versions
+/// of the same third-party library and the host has no opinion because it has no copy.
+/// </remarks>
+[TestFixture]
+public class Given_two_plugins_shipping_different_majors_of_one_private_dependency
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+    private Type _libV1 = null!;
+    private Type _libV2 = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.LibV1);
+        _root.Add(PluginFixtures.LibV2);
+
+        _run = PluginLoaderProbe.Run(_root.RootPath, $"{PluginFixtures.LibV1},{PluginFixtures.LibV2}");
+
+        _run.Failure.Should().BeNull();
+
+        _libV1 = _run.Result!.Plugins.Single(plugin => plugin.Name == PluginFixtures.LibV1)
+            .Instance.GetType();
+        _libV2 = _run.Result!.Plugins.Single(plugin => plugin.Name == PluginFixtures.LibV2)
+            .Instance.GetType();
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    private static string Describe(Type pluginType) =>
+        (string)pluginType.GetMethod("DescribeSharedDependency")!.Invoke(null, null)!;
+
+    private static Type SharedMarkerType(Type pluginType) =>
+        (Type)pluginType.GetMethod("SharedMarkerType")!.Invoke(null, null)!;
+
+    [Test]
+    public void It_is_a_library_the_host_carries_at_no_version()
+    {
+        // The premise, asserted rather than assumed. If the host carried Acme.Shared at any version,
+        // host-first would serve that copy to both plugins and every assertion below would be about
+        // something else entirely.
+        HostAssemblies.TryLoad("Acme.Shared", out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_serves_each_plugin_the_copy_that_plugin_shipped()
+    {
+        Describe(_libV1).Should().Be("Acme.Shared 1.0.0");
+        Describe(_libV2).Should().Be("Acme.Shared 2.0.0");
+    }
+
+    [Test]
+    public void It_gives_the_two_copies_separate_type_identities()
+    {
+        // Both types have the same full name, so a comparison by name would report one type. The Type
+        // objects are what the runtime actually uses, and there are two of them.
+        Type first = SharedMarkerType(_libV1);
+        Type second = SharedMarkerType(_libV2);
+
+        first.FullName.Should().Be(second.FullName);
+        first.Should().NotBeSameAs(second);
+        first.Assembly.Should().NotBeSameAs(second.Assembly);
+    }
+
+    [Test]
+    public void It_resolves_each_copy_inside_the_context_of_the_plugin_that_shipped_it()
+    {
+        AssemblyLoadContext firstContext = AssemblyLoadContext.GetLoadContext(
+            SharedMarkerType(_libV1).Assembly
+        )!;
+        AssemblyLoadContext secondContext = AssemblyLoadContext.GetLoadContext(
+            SharedMarkerType(_libV2).Assembly
+        )!;
+
+        // Named for the plugin that owns it, which is what makes a runtime diagnostic say where an
+        // assembly came from, and neither is the default context.
+        firstContext.Name.Should().Be(PluginFixtures.LibV1);
+        secondContext.Name.Should().Be(PluginFixtures.LibV2);
+        firstContext.Should().NotBeSameAs(secondContext);
+        firstContext.Should().NotBeSameAs(AssemblyLoadContext.Default);
+        secondContext.Should().NotBeSameAs(AssemblyLoadContext.Default);
+    }
+
+    [Test]
+    public void It_records_the_two_copies_as_separate_versions()
+    {
+        SharedMarkerType(_libV1).Assembly.GetName().Version.Should().Be(new Version(1, 0, 0, 0));
+        SharedMarkerType(_libV2).Assembly.GetName().Version.Should().Be(new Version(2, 0, 0, 0));
+    }
+
+    [Test]
+    public void It_carries_both_versions_through_one_container()
+    {
+        // The half a host cares about: both hooks contribute to one collection, and each contribution
+        // carries the version its own copy reported. Isolation that only held while nothing was
+        // registered would not be isolation a host could use.
+        ServiceCollection services = [];
+        IConfiguration configuration = HostConfiguration.WithSection(
+            "Acme",
+            new Dictionary<string, string?>()
+        );
+
+        foreach (LoadedPlugin plugin in _run.Result!.Plugins)
+        {
+            plugin.Instance.ContributeServices(services, configuration);
+        }
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        object first = provider.GetRequiredService(_libV1.Assembly.GetType("Acme.LibV1.LibV1Marker")!);
+        object second = provider.GetRequiredService(_libV2.Assembly.GetType("Acme.LibV2.LibV2Marker")!);
+
+        first.GetType().GetProperty("SharedVersion")!.GetValue(first).Should().Be("Acme.Shared 1.0.0");
+        second.GetType().GetProperty("SharedVersion")!.GetValue(second).Should().Be("Acme.Shared 2.0.0");
+    }
+}
+
+/// <summary>
+/// The plugin that reads configuration and binds options, loaded by the real loader.
+/// </summary>
+/// <remarks>
+/// design.md calls this the regression test for the <c>IChangeToken</c> split, because it is the most
+/// ordinary plugin there is and it is the one an enumerated shared set breaks. The control that breaks
+/// it is asserted in the fixture below; this one asserts that host-first does not.
+/// </remarks>
+[TestFixture]
+public class Given_a_plugin_that_binds_options_through_the_hosts_container
+{
+    private TemporaryPluginRoot _root = null!;
+    private ServiceProvider _provider = null!;
+    private Type _pluginType = null!;
+    private Type _optionsType = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Options);
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Options);
+        run.Failure.Should().BeNull();
+
+        LoadedPlugin plugin = run.Result!.Plugins.Single();
+        _pluginType = plugin.Instance.GetType();
+        _optionsType = _pluginType.Assembly.GetType("Acme.Options.AcmeOptions")!;
+
+        ServiceCollection services = [];
+
+        // Invoked directly on the returned instance. The production loader does not call the hook -
+        // the story that adds the recording wrapper owns invocation - so a test that wants the hook's
+        // behaviour calls it, which is also how design.md defines this regression.
+        plugin.Instance.ContributeServices(
+            services,
+            HostConfiguration.WithSection(
+                "Acme",
+                new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    ["Greeting"] = "from the host's configuration",
+                }
+            )
+        );
+
+        _provider = services.BuildServiceProvider();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _provider.Dispose();
+        _root.Dispose();
+    }
+
+    private object BoundValue()
+    {
+        Type optionsInterface = typeof(IOptions<>).MakeGenericType(_optionsType);
+
+        return optionsInterface
+            .GetProperty("Value")!
+            .GetValue(_provider.GetRequiredService(optionsInterface))!;
+    }
+
+    [Test]
+    public void It_binds_the_hosts_value_over_the_plugins_own_default()
+    {
+        _optionsType
+            .GetProperty("Greeting")!
+            .GetValue(BoundValue())
+            .Should()
+            .Be("from the host's configuration");
+    }
+
+    [Test]
+    public void It_keeps_the_plugins_own_default_where_the_host_says_nothing()
+    {
+        // The plugin composed this layer from its own configuration builder, so a value surviving here
+        // is evidence its own Microsoft.Extensions.Configuration copy did real work rather than merely
+        // sitting in the plugin directory.
+        _optionsType.GetProperty("Retries")!.GetValue(BoundValue()).Should().Be(3);
+    }
+
+    [Test]
+    public void It_serves_one_identity_for_the_type_the_enumerated_set_would_split()
+    {
+        // IChangeToken as the plugin's own assembly resolves it, against IChangeToken as this host
+        // holds it. One assembly instance, so nothing can be split.
+        Type asThePluginSeesIt = (Type)_pluginType.GetMethod("ChangeTokenType")!.Invoke(null, null)!;
+
+        asThePluginSeesIt.Should().BeSameAs(typeof(IChangeToken));
+    }
+
+    [Test]
+    public void It_produces_a_reload_token_the_host_can_consume()
+    {
+        // The change-token source the plugin's own Options.ConfigurationExtensions copy registered when
+        // it bound the host's section. Its GetChangeToken calls IConfiguration.GetReloadToken, which is
+        // the exact call the enumerated set splits, and it returns whichever IChangeToken that copy
+        // resolved. Resolving and invoking it is what makes this a live assertion rather than a
+        // registration count.
+        Type sourceInterface = typeof(IOptionsChangeTokenSource<>).MakeGenericType(_optionsType);
+        object[] sources = (
+            (IEnumerable<object>)
+                _provider.GetRequiredService(typeof(IEnumerable<>).MakeGenericType(sourceInterface))
+        ).ToArray();
+
+        sources.Should().NotBeEmpty();
+
+        foreach (object source in sources)
+        {
+            object token = sourceInterface.GetMethod("GetChangeToken")!.Invoke(source, null)!;
+
+            token.Should().BeAssignableTo<IChangeToken>();
+        }
+    }
+}
+
+/// <summary>
+/// The same plugin, the same bytes, under the enumerated shared set instead of host-first.
+/// </summary>
+/// <remarks>
+/// design.md rejects an enumerated set on the strength of a measurement, and this is that measurement
+/// kept where a change to the decision has to argue with it. The control lives only in this test
+/// assembly; nothing in the loader can be configured into it.
+/// </remarks>
+[TestFixture]
+public class Given_the_same_plugin_under_an_enumerated_shared_set
+{
+    private TemporaryPluginRoot _root = null!;
+    private Exception? _failure;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Options);
+
+        _failure = EnumeratedSharedSetContext.InvokeContributeServices(
+            Path.Combine(_root.RootPath, PluginFixtures.Options),
+            PluginFixtures.Options,
+            HostConfiguration.WithSection(
+                "Acme",
+                new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    ["Greeting"] = "from the host's configuration",
+                }
+            )
+        );
+
+        TestContext.Out.WriteLine($"enumerated shared set: {_failure?.ToString() ?? "no failure"}");
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_ships_its_own_copies_of_the_assemblies_the_enumerated_set_leaves_out()
+    {
+        // The premise of the whole comparison: these are real files in the plugin directory, so a
+        // strategy that does not prefer the host's copies has something else to serve.
+        string directory = Path.Combine(_root.RootPath, PluginFixtures.Options);
+
+        File.Exists(Path.Combine(directory, "Microsoft.Extensions.Primitives.dll")).Should().BeTrue();
+        File.Exists(Path.Combine(directory, "Microsoft.Extensions.Options.dll")).Should().BeTrue();
+        File.Exists(Path.Combine(directory, "Microsoft.Extensions.Configuration.dll")).Should().BeTrue();
+    }
+
+    [Test]
+    public void It_loads_cleanly_and_fails_only_when_the_hook_runs()
+    {
+        // Loading is not where an enumerated set goes wrong, which is what makes it such a plausible
+        // wrong answer: it looks correct until an ordinary plugin's hook runs.
+        _failure.Should().NotBeNull();
+    }
+
+    [Test]
+    public void It_fails_on_the_change_token_the_enumerated_set_split()
+    {
+        _failure.Should().BeOfType<TypeLoadException>();
+        _failure!.Message.Should().Contain("GetReloadToken");
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderMalformedInputTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderMalformedInputTests.cs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// A dependency manifest is a file a third party produced and an operator dropped into a directory, so
+/// anything about its shape can be wrong. Every case here goes through the public loader path rather
+/// than through the reader directly, because what matters is that an operator gets the named refusal
+/// and one line on the channel, not that a parser method returns something.
+/// </summary>
+[TestFixture]
+public class Given_a_dependency_manifest_of_the_wrong_shape
+{
+    private static readonly object[] Malformed =
+    [
+        new object[] { "a JSON array rather than an object", "[]" },
+        new object[] { "a null runtimeTarget", """{"runtimeTarget": null, "targets": {}}""" },
+        new object[]
+        {
+            "a runtimeTarget name that is not a string",
+            """{"runtimeTarget": {"name": 10}, "targets": {}}""",
+        },
+        new object[]
+        {
+            "targets that are not an object",
+            """{"runtimeTarget": {"name": "t"}, "targets": "t"}""",
+        },
+        new object[]
+        {
+            "a selected target that is not an object",
+            """{"runtimeTarget": {"name": "t"}, "targets": {"t": 3}}""",
+        },
+        new object[]
+        {
+            "a library that is not an object",
+            """{"runtimeTarget": {"name": "t"}, "targets": {"t": {"a/1.0.0": 3}}}""",
+        },
+        new object[]
+        {
+            "a runtime section that is not an object",
+            """{"runtimeTarget": {"name": "t"}, "targets": {"t": {"a/1.0.0": {"runtime": 3}}}}""",
+        },
+        new object[]
+        {
+            "libraries that are not an object",
+            """{"runtimeTarget": {"name": "t"}, "targets": {"t": {}}, "libraries": 3}""",
+        },
+    ];
+
+    [TestCaseSource(nameof(Malformed))]
+    public void It_refuses_with_the_named_manifest_failure(string description, string manifest)
+    {
+        using TemporaryPluginRoot root = TemporaryPluginRoot.Create();
+        root.Add(PluginFixtures.Good);
+        root.WriteManifest(PluginFixtures.Good, manifest);
+
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(root.RootPath, PluginFixtures.Good);
+
+        // Reading a value of the wrong JSON kind throws InvalidOperationException, which would leave the
+        // loader with an unlabelled exception and an empty channel. This is the case described as
+        // '{description}'.
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.DepsJsonUnreadable, description);
+        run.Failure!.Message.Should().Contain(PluginFixtures.Good);
+    }
+
+    [TestCaseSource(nameof(Malformed))]
+    public void It_writes_exactly_one_failure_line(string description, string manifest)
+    {
+        using TemporaryPluginRoot root = TemporaryPluginRoot.Create();
+        root.Add(PluginFixtures.Good);
+        root.WriteManifest(PluginFixtures.Good, manifest);
+
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(root.RootPath, PluginFixtures.Good);
+
+        run.DiagnosticLines.Should().ContainSingle(description);
+        run.DiagnosticLines[0].Should().StartWith($"plugin '{PluginFixtures.Good}' failed:");
+    }
+}
+
+[TestFixture]
+public class Given_a_declared_assembly_version_that_is_not_a_version
+{
+    [Test]
+    public void It_refuses_a_version_that_does_not_parse()
+    {
+        using TemporaryPluginRoot root = TemporaryPluginRoot.Create();
+        root.Add(PluginFixtures.Good);
+        root.ReplaceFirstDeclaredAssemblyVersion(PluginFixtures.Good, JsonValue.Create("not-a-version"));
+
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(root.RootPath, PluginFixtures.Good);
+
+        // Dropping it silently would take an assembly out of the skew preflight with nobody told, which
+        // is the one outcome the preflight exists to prevent: the plugin would load and the comparison
+        // it was supposed to fail would simply never have happened.
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.DepsJsonUnreadable);
+        run.Failure!.Message.Should().Contain("not-a-version");
+    }
+
+    [Test]
+    public void It_refuses_a_version_that_is_not_even_a_string()
+    {
+        using TemporaryPluginRoot root = TemporaryPluginRoot.Create();
+        root.Add(PluginFixtures.Good);
+        root.ReplaceFirstDeclaredAssemblyVersion(PluginFixtures.Good, JsonValue.Create(10));
+
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(root.RootPath, PluginFixtures.Good);
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.DepsJsonUnreadable);
+    }
+
+    [Test]
+    public void It_refuses_a_version_written_as_a_json_null()
+    {
+        // Present and not a version, which is the same case as the two above: a null is a value the
+        // manifest chose to write, not an absence.
+        using TemporaryPluginRoot root = TemporaryPluginRoot.Create();
+        root.Add(PluginFixtures.Good);
+        root.ReplaceFirstDeclaredAssemblyVersion(PluginFixtures.Good, null);
+
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(root.RootPath, PluginFixtures.Good);
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.DepsJsonUnreadable);
+    }
+
+    [Test]
+    public void It_still_accepts_a_declaration_that_carries_no_version_at_all()
+    {
+        // An absent assemblyVersion is legitimate and common: a framework-dependent publish writes none
+        // for the project's own entry, so treating absence as malformed would refuse every plugin. This
+        // is what keeps the three refusals above from being a blanket rule about the field.
+        using TemporaryPluginRoot root = TemporaryPluginRoot.Create();
+        root.Add(PluginFixtures.Good);
+        root.ReplaceFirstDeclaredAssemblyVersion(PluginFixtures.Good, null, remove: true);
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(root.RootPath, PluginFixtures.Good);
+
+        run.Failure.Should().BeNull();
+        run.Result!.Plugins.Should().ContainSingle();
+    }
+}
+
+/// <summary>
+/// The contract declares <c>Name</c> non-nullable and a third-party assembly is not constrained by that
+/// at runtime, so every plugin-controlled boundary the loader reads has to be treated as something a
+/// careless implementer can get wrong.
+/// </summary>
+[TestFixture]
+public class Given_a_plugin_that_returns_null_from_its_name
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.NullName);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.NullName);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_with_the_named_mismatch_rather_than_dereferencing_it()
+    {
+        // A null is a name that is not the directory name. Quoting it for the message is what used to
+        // throw, replacing the refusal an operator needs with an exception from inside the loader.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.PluginNameMismatch);
+        _run.Failure.Should().BeOfType<PluginLoadException>();
+    }
+
+    [Test]
+    public void It_renders_the_null_truthfully()
+    {
+        _run.Failure!.Message.Should().Contain("<null>").And.Contain(PluginFixtures.NullName);
+    }
+
+    [Test]
+    public void It_writes_exactly_one_failure_line()
+    {
+        _run.DiagnosticLines.Should().ContainSingle();
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_that_throws_when_its_name_is_read
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.ThrowingName);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.ThrowingName);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_reports_the_plugins_own_message_and_keeps_the_cause()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.PluginNameUnavailable);
+        _run.Failure!.Message.Should().Contain("refuses to say its name");
+        _run.Failure!.InnerException.Should().BeOfType<InvalidOperationException>();
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_that_throws_from_its_constructor
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.ThrowingCtor);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.ThrowingCtor);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_reports_the_plugins_own_message_rather_than_the_reflection_wrapper()
+    {
+        // Activator wraps anything a constructor throws in a TargetInvocationException whose own message
+        // says only that an invocation target threw, which tells an operator nothing about the plugin.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.PluginActivationFailed);
+        _run.Failure!.Message.Should().Contain("refuses to be constructed");
+        _run.Failure!.InnerException.Should().BeOfType<InvalidOperationException>();
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderMalformedInputTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderMalformedInputTests.cs
@@ -216,6 +216,100 @@ public class Given_a_plugin_that_throws_when_its_name_is_read
     }
 }
 
+/// <summary>
+/// Discovery is reflection over a third party's assembly from end to end, and every step of it can
+/// bind another assembly. Asking a type for its parameterless constructor makes the runtime resolve
+/// the parameter types of that type's other constructors, so an overload naming a type the runtime
+/// cannot resolve fails there rather than at enumeration or at activation.
+/// </summary>
+[TestFixture]
+public class Given_a_constructor_overload_naming_a_skewed_assembly
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.CtorSignatureSkew);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.CtorSignatureSkew);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_reports_the_named_skew_rather_than_escaping_unlabelled()
+    {
+        // The plugin shape is ordinary: a parameterless constructor beside an overload that takes a
+        // dependency. Before the whole of discovery sat inside the classified handler, this escaped the
+        // loader as a raw FileLoadException with nothing at all on the diagnostic channel.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.DependencyVersionSkew);
+        _run.Failure!.Message.Should().Contain("Acme.HostShared");
+        _run.Failure!.Message.Should().Contain("2.0.0").And.Contain("1.0.0");
+    }
+
+    [Test]
+    public void It_writes_exactly_one_failure_line()
+    {
+        _run.DiagnosticLines.Should().ContainSingle();
+        _run.DiagnosticLines[0].Should().StartWith($"plugin '{PluginFixtures.CtorSignatureSkew}' failed:");
+    }
+
+    [Test]
+    public void It_fails_at_constructor_resolution_rather_than_at_type_enumeration()
+    {
+        // Without this the two assertions above would pass just as well if the fixture happened to fail
+        // at enumeration, which the handler already covered before this case existed. Enumerating this
+        // assembly's exported types succeeds, because no type's own signature names the skewed
+        // assembly; only asking a type for its parameterless constructor makes the runtime resolve the
+        // parameter types of that type's other constructors.
+        string entryAssemblyPath = Path.Combine(
+            _root.RootPath,
+            PluginFixtures.CtorSignatureSkew,
+            $"{PluginFixtures.CtorSignatureSkew}.dll"
+        );
+
+        PluginLoadContext context = new(PluginFixtures.CtorSignatureSkew, entryAssemblyPath);
+        Type[] exported = context.LoadFromAssemblyPath(entryAssemblyPath).GetExportedTypes();
+
+        exported.Should().Contain(type => type.Name == "CtorSignatureSkewPlugin");
+
+        Type pluginType = exported.Single(type => type.Name == "CtorSignatureSkewPlugin");
+
+        Assert.Throws<FileLoadException>(() => pluginType.GetConstructor(Type.EmptyTypes));
+    }
+}
+
+[TestFixture]
+public class Given_a_constructor_overload_naming_an_assembly_nothing_carries
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.CtorSignatureMissing);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.CtorSignatureMissing);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_reports_the_unresolvable_type_rather_than_escaping_unlabelled()
+    {
+        // The general branch beside the skew one: nothing is version-skewed here, the assembly is simply
+        // not there, and the refusal still has to name the plugin and say what could not be resolved.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.PluginTypesUnloadable);
+        _run.Failure!.Message.Should().Contain(PluginFixtures.CtorSignatureMissing);
+        _run.Failure!.Message.Should().Contain("Acme.Private");
+    }
+}
+
 [TestFixture]
 public class Given_a_plugin_that_throws_from_its_constructor
 {

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderMalformedInputTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderMalformedInputTests.cs
@@ -52,6 +52,16 @@ public class Given_a_dependency_manifest_of_the_wrong_shape
             "libraries that are not an object",
             """{"runtimeTarget": {"name": "t"}, "targets": {"t": {}}, "libraries": 3}""",
         },
+        new object[]
+        {
+            "a runtime asset key that names no assembly",
+            """{"runtimeTarget": {"name": "t"}, "targets": {"t": {"a/1.0.0": {"runtime": {"lib/net10.0/.dll": {"assemblyVersion": "1.0.0.0"}}}}}}""",
+        },
+        new object[]
+        {
+            "a runtime asset key whose assembly name is only whitespace",
+            """{"runtimeTarget": {"name": "t"}, "targets": {"t": {"a/1.0.0": {"runtime": {"lib/net10.0/   .dll": {"assemblyVersion": "1.0.0.0"}}}}}}""",
+        },
     ];
 
     [TestCaseSource(nameof(Malformed))]
@@ -63,9 +73,10 @@ public class Given_a_dependency_manifest_of_the_wrong_shape
 
         PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(root.RootPath, PluginFixtures.Good);
 
-        // Reading a value of the wrong JSON kind throws InvalidOperationException, which would leave the
-        // loader with an unlabelled exception and an empty channel. This is the case described as
-        // '{description}'.
+        // Each of these would otherwise leave the loader with an unlabelled exception and an empty
+        // channel. Reading a value of the wrong JSON kind throws InvalidOperationException, and an
+        // asset key that names no assembly throws out of the runtime's own assembly-name parsing when
+        // the skew preflight reaches it. This is the case described as '{description}'.
         run.Failure!.Reason.Should().Be(PluginLoadFailure.DepsJsonUnreadable, description);
         run.Failure!.Message.Should().Contain(PluginFixtures.Good);
     }

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// A plugin root of this test's own, built from the staged fixtures.
+/// </summary>
+/// <remarks>
+/// Tests do not point the loader at the staged tree directly. Each one assembles the root it needs, so
+/// that a case can name a fixture something else, remove a file from it, or sit beside a symbolic link,
+/// and so that one test's root cannot describe another test's expectations.
+/// </remarks>
+internal sealed class TemporaryPluginRoot : IDisposable
+{
+    private readonly string _base;
+
+    private TemporaryPluginRoot(string basePath, string rootPath)
+    {
+        _base = basePath;
+        RootPath = rootPath;
+    }
+
+    /// <summary>The plugin root to configure.</summary>
+    internal string RootPath { get; }
+
+    /// <summary>Creates an empty root inside a temporary tree of its own.</summary>
+    internal static TemporaryPluginRoot Create(string rootName = "plugins")
+    {
+        string basePath = Path.Combine(Path.GetTempPath(), "edfi-plugin-tests", Guid.NewGuid().ToString("N"));
+        string rootPath = Path.Combine(basePath, rootName);
+        Directory.CreateDirectory(rootPath);
+
+        return new TemporaryPluginRoot(basePath, rootPath);
+    }
+
+    /// <summary>A directory inside the temporary tree but outside the plugin root.</summary>
+    internal string CreateDirectoryOutsideRoot(string name)
+    {
+        string path = Path.Combine(_base, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    /// <summary>Copies a staged fixture into the root, optionally under another name.</summary>
+    internal string Add(string fixtureName, string? asName = null) => AddTo(RootPath, fixtureName, asName);
+
+    /// <summary>Copies a staged fixture into an arbitrary directory, optionally under another name.</summary>
+    internal static string AddTo(string destinationRoot, string fixtureName, string? asName = null)
+    {
+        string stagedName = asName ?? fixtureName;
+        string destination = Path.Combine(destinationRoot, stagedName);
+
+        CopyDirectory(PluginFixtures.DirectoryOf(fixtureName), destination);
+
+        if (!string.Equals(stagedName, fixtureName, StringComparison.Ordinal))
+        {
+            // The loader resolves <directory>/<directory>.dll, so a fixture staged under another name
+            // has to carry files named for it. Renaming rather than rebuilding is the point of several
+            // of these cases: the entry assembly's own name then disagrees with the directory.
+            Rename(destination, $"{fixtureName}.dll", $"{stagedName}.dll");
+            Rename(destination, $"{fixtureName}.deps.json", $"{stagedName}.deps.json");
+        }
+
+        return destination;
+    }
+
+    /// <summary>Removes a file from a plugin directory in the root.</summary>
+    internal void Remove(string pluginName, string fileName)
+    {
+        File.Delete(Path.Combine(RootPath, pluginName, fileName));
+    }
+
+    /// <summary>Writes bytes that are not a managed assembly where an entry assembly belongs.</summary>
+    internal string AddCorruptPlugin(string pluginName)
+    {
+        string directory = Path.Combine(RootPath, pluginName);
+        Directory.CreateDirectory(directory);
+
+        File.WriteAllText(
+            Path.Combine(directory, $"{pluginName}.dll"),
+            "This is not a managed assembly. It is deliberately not a PE file at all.",
+            Encoding.UTF8
+        );
+
+        // A manifest of the shape a publish produces, so the run reaches the entry assembly rather than
+        // stopping at a missing manifest. It is written here rather than committed, because a corrupt
+        // binary does not belong in source control.
+        File.WriteAllText(
+            Path.Combine(directory, $"{pluginName}.deps.json"),
+            JsonSerializer.Serialize(
+                new
+                {
+                    runtimeTarget = new { name = ".NETCoreApp,Version=v10.0", signature = "" },
+                    compilationOptions = new { },
+                    targets = new Dictionary<string, object>
+                    {
+                        [".NETCoreApp,Version=v10.0"] = new Dictionary<string, object>
+                        {
+                            [$"{pluginName}/1.0.0"] = new
+                            {
+                                runtime = new Dictionary<string, object> { [$"{pluginName}.dll"] = new { } },
+                            },
+                        },
+                    },
+                    libraries = new Dictionary<string, object>
+                    {
+                        [$"{pluginName}/1.0.0"] = new { type = "project", serviceable = false },
+                    },
+                },
+                new JsonSerializerOptions { WriteIndented = true }
+            ),
+            Encoding.UTF8
+        );
+
+        return directory;
+    }
+
+    /// <summary>
+    /// Creates a directory symbolic link, or ends the test as inconclusive when the platform refuses.
+    /// </summary>
+    /// <remarks>
+    /// Windows requires elevation or developer mode to create one. Ending the test as inconclusive with
+    /// a message that says so keeps a run on such a machine visibly incomplete rather than falsely
+    /// green; the case is covered for real on Linux.
+    /// </remarks>
+    internal static string CreateDirectoryLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+            return linkPath;
+        }
+        catch (Exception exception)
+            when (exception is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+        {
+            Assert.Inconclusive(
+                "This platform refused to create a directory symbolic link "
+                    + $"({exception.GetType().Name}: {exception.Message}). The containment checks that "
+                    + "need one are covered on a platform that permits it; this run does not cover them."
+            );
+
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_base, recursive: true);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // A loaded plugin assembly is held by a non-collectible context for the life of the
+            // process, so its file can still be locked. Leaving a temporary directory behind is not
+            // worth failing a passing test over.
+        }
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+
+        foreach (string file in Directory.EnumerateFiles(source))
+        {
+            File.Copy(file, Path.Combine(destination, Path.GetFileName(file)));
+        }
+
+        foreach (string directory in Directory.EnumerateDirectories(source))
+        {
+            CopyDirectory(directory, Path.Combine(destination, Path.GetFileName(directory)));
+        }
+    }
+
+    private static void Rename(string directory, string from, string to)
+    {
+        string source = Path.Combine(directory, from);
+
+        if (File.Exists(source))
+        {
+            File.Move(source, Path.Combine(directory, to));
+        }
+    }
+}
+
+/// <summary>What one loader run produced, including everything it wrote to its diagnostic channel.</summary>
+internal sealed record PluginLoaderRun(
+    LoadedPlugins? Result,
+    PluginLoadException? Failure,
+    string Diagnostics
+)
+{
+    internal IReadOnlyList<string> DiagnosticLines =>
+        Diagnostics.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}
+
+/// <summary>
+/// Runs the real loader against a root, capturing its channel rather than redirecting the process's own.
+/// </summary>
+internal static class PluginLoaderProbe
+{
+    /// <summary>The contract set a host normally passes: assembly names, never package ids.</summary>
+    internal static readonly string[] Contracts = ["EdFi.Api.Plugins"];
+
+    internal static PluginLoaderRun Run(
+        string root,
+        string allowed,
+        IReadOnlyCollection<string>? contracts = null
+    )
+    {
+        StringWriter diagnostics = new();
+
+        try
+        {
+            LoadedPlugins result = PluginLoader.Load(
+                Configuration(root, allowed),
+                contracts ?? Contracts,
+                diagnostics
+            );
+
+            return new PluginLoaderRun(result, null, diagnostics.ToString());
+        }
+        catch (PluginLoadException exception)
+        {
+            return new PluginLoaderRun(null, exception, diagnostics.ToString());
+        }
+    }
+
+    /// <summary>Runs and asserts the load failed, returning the run so the reason can be inspected.</summary>
+    internal static PluginLoaderRun RunExpectingFailure(
+        string root,
+        string allowed,
+        IReadOnlyCollection<string>? contracts = null
+    )
+    {
+        PluginLoaderRun run = Run(root, allowed, contracts);
+
+        if (run.Failure is null)
+        {
+            throw new AssertionException(
+                "Expected a PluginLoadException, but the load succeeded with "
+                    + $"[{string.Join(", ", run.Result!.Plugins.Select(plugin => plugin.Name))}]. "
+                    + $"Channel: {run.Diagnostics}"
+            );
+        }
+
+        return run;
+    }
+
+    private static IConfiguration Configuration(string root, string allowed) =>
+        new ConfigurationBuilder()
+            .AddJsonStream(
+                new MemoryStream(
+                    Encoding.UTF8.GetBytes(
+                        "{\"Plugins\": {\"Directory\": "
+                            + JsonSerializer.Serialize(root)
+                            + ", \"Allowed\": "
+                            + JsonSerializer.Serialize(allowed)
+                            + "}}"
+                    )
+                )
+            )
+            .Build();
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
@@ -134,6 +134,96 @@ internal sealed class TemporaryPluginRoot : IDisposable
         );
     }
 
+    /// <summary>
+    /// Moves a declared managed dependency out of the top-level <c>runtime</c> section and into a
+    /// <c>runtimeTargets</c> row, with the version given.
+    /// </summary>
+    /// <remarks>
+    /// This is the shape a package with runtime-identifier-specific managed assets produces, and it is
+    /// the one the skew preflight deliberately does not read. The record of what the host served is a
+    /// different question from what to refuse, so a declaration made only here still has to reach it.
+    /// </remarks>
+    internal void MoveDeclarationToRuntimeTargets(string pluginName, string simpleName, string version)
+    {
+        JsonNode manifest = JsonNode.Parse(File.ReadAllText(ManifestPathOf(pluginName)))!;
+        string targetName = manifest["runtimeTarget"]!["name"]!.GetValue<string>();
+
+        foreach (KeyValuePair<string, JsonNode?> library in manifest["targets"]![targetName]!.AsObject())
+        {
+            if (library.Value is not JsonObject entry || entry["runtime"] is not JsonObject runtime)
+            {
+                continue;
+            }
+
+            string? declaredPath = runtime
+                .Select(asset => asset.Key)
+                .FirstOrDefault(path =>
+                    Path.GetFileNameWithoutExtension(path).Equals(simpleName, StringComparison.Ordinal)
+                );
+
+            if (declaredPath is null)
+            {
+                continue;
+            }
+
+            runtime.Remove(declaredPath);
+
+            if (runtime.Count == 0)
+            {
+                entry.Remove("runtime");
+            }
+
+            entry["runtimeTargets"] = new JsonObject
+            {
+                [declaredPath] = new JsonObject
+                {
+                    ["rid"] = "any",
+                    ["assetType"] = "runtime",
+                    ["assemblyVersion"] = version,
+                    ["fileVersion"] = version,
+                },
+            };
+
+            WriteManifest(pluginName, manifest.ToJsonString());
+            return;
+        }
+
+        throw new AssertionException(
+            $"Fixture '{pluginName}' declares no runtime asset named '{simpleName}'."
+        );
+    }
+
+    /// <summary>Sets the declared version of one managed dependency, wherever it is declared.</summary>
+    internal void SetDeclaredVersion(string pluginName, string simpleName, string version)
+    {
+        JsonNode manifest = JsonNode.Parse(File.ReadAllText(ManifestPathOf(pluginName)))!;
+        string targetName = manifest["runtimeTarget"]!["name"]!.GetValue<string>();
+
+        foreach (KeyValuePair<string, JsonNode?> library in manifest["targets"]![targetName]!.AsObject())
+        {
+            if (library.Value?["runtime"] is not JsonObject runtime)
+            {
+                continue;
+            }
+
+            foreach (KeyValuePair<string, JsonNode?> asset in runtime)
+            {
+                if (
+                    Path.GetFileNameWithoutExtension(asset.Key).Equals(simpleName, StringComparison.Ordinal)
+                    && asset.Value is JsonObject declaration
+                    && declaration.ContainsKey("assemblyVersion")
+                )
+                {
+                    declaration["assemblyVersion"] = version;
+                    WriteManifest(pluginName, manifest.ToJsonString());
+                    return;
+                }
+            }
+        }
+
+        throw new AssertionException($"Fixture '{pluginName}' declares no version for '{simpleName}'.");
+    }
+
     /// <summary>Writes bytes that are not a managed assembly where an entry assembly belongs.</summary>
     internal string AddCorruptPlugin(string pluginName)
     {

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
@@ -224,6 +224,42 @@ internal sealed class TemporaryPluginRoot : IDisposable
         throw new AssertionException($"Fixture '{pluginName}' declares no version for '{simpleName}'.");
     }
 
+    /// <summary>
+    /// Rewrites the declared path of a resource asset, keeping the file where the publish put it.
+    /// </summary>
+    /// <remarks>
+    /// A satellite that comes from a project reference is declared at the same path the publish writes,
+    /// so it is found by the declared path alone. One that comes from a package is declared at its
+    /// package-relative path, <c>lib/&lt;tfm&gt;/&lt;culture&gt;/...</c>, while the publish writes it
+    /// under the culture directory only. This produces that second shape from a real publish, which is
+    /// the only thing that exercises the culture branch of the mapping.
+    /// </remarks>
+    internal void SetResourceDeclaredPath(string pluginName, string fromPath, string toPath)
+    {
+        JsonNode manifest = JsonNode.Parse(File.ReadAllText(ManifestPathOf(pluginName)))!;
+        string targetName = manifest["runtimeTarget"]!["name"]!.GetValue<string>();
+
+        foreach (KeyValuePair<string, JsonNode?> library in manifest["targets"]![targetName]!.AsObject())
+        {
+            if (library.Value is not JsonObject entry || entry["resources"] is not JsonObject resources)
+            {
+                continue;
+            }
+
+            if (resources[fromPath] is not JsonNode declaration)
+            {
+                continue;
+            }
+
+            resources.Remove(fromPath);
+            resources[toPath] = declaration.DeepClone();
+            WriteManifest(pluginName, manifest.ToJsonString());
+            return;
+        }
+
+        throw new AssertionException($"Fixture '{pluginName}' declares no resource asset at '{fromPath}'.");
+    }
+
     /// <summary>Writes bytes that are not a managed assembly where an entry assembly belongs.</summary>
     internal string AddCorruptPlugin(string pluginName)
     {

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
@@ -50,6 +50,14 @@ internal sealed class TemporaryPluginRoot : IDisposable
         return path;
     }
 
+    /// <summary>Writes a file wherever the caller asks, creating the directories above it.</summary>
+    internal static string WriteFile(string path, string content)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
     /// <summary>Copies a staged fixture into the root, optionally under another name.</summary>
     internal string Add(string fixtureName, string? asName = null) => AddTo(RootPath, fixtureName, asName);
 
@@ -190,6 +198,70 @@ internal sealed class TemporaryPluginRoot : IDisposable
 
         throw new AssertionException(
             $"Fixture '{pluginName}' declares no runtime asset named '{simpleName}'."
+        );
+    }
+
+    /// <summary>
+    /// Declares one more runtime asset at a path of the caller's choosing, in the first library that
+    /// already declares runtime assets.
+    /// </summary>
+    /// <remarks>
+    /// The declared path is the whole point, so it is written verbatim rather than composed from a file
+    /// name: what these cases are about is which file a declared string may select, and which name that
+    /// string presents to the host lookup.
+    /// </remarks>
+    internal void AddDeclaredRuntimeAsset(
+        string pluginName,
+        string declaredPath,
+        string? assemblyVersion = null
+    )
+    {
+        JsonNode manifest = JsonNode.Parse(File.ReadAllText(ManifestPathOf(pluginName)))!;
+        string targetName = manifest["runtimeTarget"]!["name"]!.GetValue<string>();
+
+        foreach (KeyValuePair<string, JsonNode?> library in manifest["targets"]![targetName]!.AsObject())
+        {
+            if (library.Value?["runtime"] is not JsonObject runtime)
+            {
+                continue;
+            }
+
+            JsonObject declaration = [];
+
+            if (assemblyVersion is not null)
+            {
+                declaration["assemblyVersion"] = assemblyVersion;
+            }
+
+            runtime[declaredPath] = declaration;
+            WriteManifest(pluginName, manifest.ToJsonString());
+            return;
+        }
+
+        throw new AssertionException($"Fixture '{pluginName}' declares no runtime assets.");
+    }
+
+    /// <summary>Rewrites the locale a resource declaration carries, leaving its file where it is.</summary>
+    internal void SetResourceLocale(string pluginName, string declaredPath, string locale)
+    {
+        JsonNode manifest = JsonNode.Parse(File.ReadAllText(ManifestPathOf(pluginName)))!;
+        string targetName = manifest["runtimeTarget"]!["name"]!.GetValue<string>();
+
+        foreach (KeyValuePair<string, JsonNode?> library in manifest["targets"]![targetName]!.AsObject())
+        {
+            if (
+                library.Value?["resources"] is JsonObject resources
+                && resources[declaredPath] is JsonObject declaration
+            )
+            {
+                declaration["locale"] = locale;
+                WriteManifest(pluginName, manifest.ToJsonString());
+                return;
+            }
+        }
+
+        throw new AssertionException(
+            $"Fixture '{pluginName}' declares no resource asset at '{declaredPath}'."
         );
     }
 

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
@@ -5,6 +5,7 @@
 
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 
@@ -76,6 +77,61 @@ internal sealed class TemporaryPluginRoot : IDisposable
     internal void Remove(string pluginName, string fileName)
     {
         File.Delete(Path.Combine(RootPath, pluginName, fileName));
+    }
+
+    /// <summary>The staged plugin's dependency manifest.</summary>
+    internal string ManifestPathOf(string pluginName) =>
+        Path.Combine(RootPath, pluginName, $"{pluginName}.deps.json");
+
+    /// <summary>Replaces a staged plugin's dependency manifest with the given text.</summary>
+    internal void WriteManifest(string pluginName, string json)
+    {
+        File.WriteAllText(ManifestPathOf(pluginName), json);
+    }
+
+    /// <summary>
+    /// Rewrites the first declared <c>assemblyVersion</c> in a staged plugin's manifest, keeping every
+    /// other byte of a real published manifest intact.
+    /// </summary>
+    /// <remarks>
+    /// The point is to change exactly one value in a file a publish produced, so that a test about a
+    /// malformed version is about that version rather than about a hand-written manifest that differs
+    /// from a real one in ways nobody enumerated.
+    /// </remarks>
+    internal void ReplaceFirstDeclaredAssemblyVersion(string pluginName, JsonNode? value, bool remove = false)
+    {
+        JsonNode manifest = JsonNode.Parse(File.ReadAllText(ManifestPathOf(pluginName)))!;
+        string targetName = manifest["runtimeTarget"]!["name"]!.GetValue<string>();
+
+        foreach (KeyValuePair<string, JsonNode?> library in manifest["targets"]![targetName]!.AsObject())
+        {
+            if (library.Value?["runtime"] is not JsonObject runtime)
+            {
+                continue;
+            }
+
+            foreach (KeyValuePair<string, JsonNode?> asset in runtime)
+            {
+                if (asset.Value is JsonObject declaration && declaration.ContainsKey("assemblyVersion"))
+                {
+                    if (remove)
+                    {
+                        declaration.Remove("assemblyVersion");
+                    }
+                    else
+                    {
+                        declaration["assemblyVersion"] = value;
+                    }
+
+                    WriteManifest(pluginName, manifest.ToJsonString());
+                    return;
+                }
+            }
+        }
+
+        throw new AssertionException(
+            $"Fixture '{pluginName}' declares no assemblyVersion, so there is nothing to rewrite."
+        );
     }
 
     /// <summary>Writes bytes that are not a managed assembly where an entry assembly belongs.</summary>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
@@ -225,6 +225,71 @@ internal sealed class TemporaryPluginRoot : IDisposable
     }
 
     /// <summary>
+    /// Lowers every top-level declared <c>assemblyVersion</c> that is higher than the copy this host
+    /// carries, so a fixture built over a real package can be loaded in this process, and reports what
+    /// it changed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This exists because of a measurement, not a convenience. A fixture referencing
+    /// Microsoft.Data.SqlClient declares that package's closure, and the preflight correctly refuses
+    /// it here: measured, the manifest declares <c>System.Configuration.ConfigurationManager</c>
+    /// 9.0.0.0 while this test process carries 4.0.0.0, which arrives with the test platform. That is
+    /// the designed refusal working on a genuine package rather than a defect, and a real host that
+    /// serves SqlClient's closure would not hit it.
+    /// </para>
+    /// <para>
+    /// A fixture whose subject is the <em>shape</em> of a manifest therefore reads the staged manifest
+    /// untouched, and only a case that has to get the plugin loaded applies this. Nothing here invents
+    /// a version: each rewritten value is the version this host actually carries, and the returned list
+    /// names every change so a test can report exactly what it stood on.
+    /// </para>
+    /// </remarks>
+    internal IReadOnlyList<string> LowerDeclarationsAboveHostVersions(string pluginName)
+    {
+        JsonNode manifest = JsonNode.Parse(File.ReadAllText(ManifestPathOf(pluginName)))!;
+        string targetName = manifest["runtimeTarget"]!["name"]!.GetValue<string>();
+        List<string> lowered = [];
+
+        foreach (KeyValuePair<string, JsonNode?> library in manifest["targets"]![targetName]!.AsObject())
+        {
+            if (library.Value?["runtime"] is not JsonObject runtime)
+            {
+                continue;
+            }
+
+            foreach (KeyValuePair<string, JsonNode?> asset in runtime)
+            {
+                if (
+                    asset.Value is not JsonObject declaration
+                    || declaration["assemblyVersion"]?.GetValue<string>() is not { } declaredText
+                    || !Version.TryParse(declaredText, out Version? declared)
+                )
+                {
+                    continue;
+                }
+
+                string simpleName = Path.GetFileNameWithoutExtension(asset.Key);
+
+                if (
+                    !HostAssemblies.TryGetVersion(simpleName, out Version hostVersion)
+                    || hostVersion >= declared
+                )
+                {
+                    continue;
+                }
+
+                declaration["assemblyVersion"] = hostVersion.ToString();
+                lowered.Add($"{simpleName} {declared} -> {hostVersion}");
+            }
+        }
+
+        WriteManifest(pluginName, manifest.ToJsonString());
+
+        return lowered;
+    }
+
+    /// <summary>
     /// Rewrites the declared path of a resource asset, keeping the file where the publish put it.
     /// </summary>
     /// <remarks>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
@@ -50,6 +50,33 @@ internal sealed class TemporaryPluginRoot : IDisposable
         return path;
     }
 
+    /// <summary>
+    /// Whether this tree's filesystem folds case, measured in the tree itself rather than inferred from
+    /// the operating system's name.
+    /// </summary>
+    internal bool FilesystemFoldsCase()
+    {
+        Directory.CreateDirectory(Path.Combine(_base, "CaseFoldProbe"));
+
+        return Directory.Exists(Path.Combine(_base, "casefoldprobe"));
+    }
+
+    /// <summary>
+    /// Copies a staged fixture under a directory name of the caller's choosing, renaming nothing inside
+    /// it, so that the directory's spelling can differ from the files' on its own.
+    /// </summary>
+    internal string AddUnderDirectoryName(string fixtureName, string directoryName)
+    {
+        string destination = Path.Combine(RootPath, directoryName);
+        CopyDirectory(PluginFixtures.DirectoryOf(fixtureName), destination);
+
+        return destination;
+    }
+
+    /// <summary>Renames one file inside a staged plugin directory.</summary>
+    internal void RenameFileInPlugin(string pluginName, string fromFileName, string toFileName) =>
+        Rename(Path.Combine(RootPath, pluginName), fromFileName, toFileName);
+
     /// <summary>Writes a file wherever the caller asks, creating the directories above it.</summary>
     internal static string WriteFile(string path, string content)
     {

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderProbe.cs
@@ -460,7 +460,8 @@ internal static class PluginLoaderProbe
     internal static PluginLoaderRun Run(
         string root,
         string allowed,
-        IReadOnlyCollection<string>? contracts = null
+        IReadOnlyCollection<string>? contracts = null,
+        HostResolutionObserver? observer = null
     )
     {
         StringWriter diagnostics = new();
@@ -470,7 +471,8 @@ internal static class PluginLoaderProbe
             LoadedPlugins result = PluginLoader.Load(
                 Configuration(root, allowed),
                 contracts ?? Contracts,
-                diagnostics
+                diagnostics,
+                observer
             );
 
             return new PluginLoaderRun(result, null, diagnostics.ToString());

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderTypeDiscoveryTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderTypeDiscoveryTests.cs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+[TestFixture]
+public class Given_an_entry_assembly_with_no_plugin_type
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.NoSubclass);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.NoSubclass);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_because_the_operator_allowlisted_something_that_contributes_nothing()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.NoPluginType);
+    }
+
+    [Test]
+    public void It_throws_rather_than_logging_and_continuing()
+    {
+        _run.Result.Should().BeNull();
+    }
+}
+
+[TestFixture]
+public class Given_an_entry_assembly_with_two_plugin_types
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.TwoSubclasses);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.TwoSubclasses);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_because_choosing_between_them_would_be_arbitrary()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.MultiplePluginTypes);
+    }
+
+    [Test]
+    public void It_names_what_it_found()
+    {
+        _run.Failure!.Message.Should().Contain("FirstPlugin").And.Contain("SecondPlugin");
+    }
+}
+
+[TestFixture]
+public class Given_an_entry_assembly_whose_only_other_subclasses_cannot_be_constructed
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.NonCandidates);
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.NonCandidates);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_loads_the_one_type_the_host_can_construct()
+    {
+        // An abstract type, an open generic, a type with no public parameterless constructor and a type
+        // that is not exported are each impossible for the host to construct and call. Counting any of
+        // them would turn this into a multiple-plugin-types failure.
+        _run.Failure.Should().BeNull();
+        _run.Result!.Plugins.Should().ContainSingle();
+        _run.Result!.Plugins[0].Instance.GetType().Name.Should().Be("TheOnePlugin");
+    }
+}
+
+[TestFixture]
+public class Given_an_entry_assembly_whose_subclasses_all_cannot_be_constructed
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.OnlyNonCandidates);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.OnlyNonCandidates);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_reports_that_none_was_found_rather_than_that_several_were()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.NoPluginType);
+    }
+
+    [Test]
+    public void It_names_the_subclasses_it_could_not_use()
+    {
+        // Without this an implementer whose only subclass is abstract reads "no plugin type" and has
+        // nothing to act on.
+        _run.Failure!.Message.Should().Contain("AbstractPlugin");
+        _run.Failure!.Message.Should().Contain("GenericPlugin");
+        _run.Failure!.Message.Should().Contain("ParameterizedPlugin");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_whose_name_disagrees_with_its_directory
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.NameMismatch);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.NameMismatch);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_and_names_both()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.PluginNameMismatch);
+        _run.Failure!.Message.Should().Contain(PluginFixtures.NameMismatch).And.Contain("Some.Other.Name");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_whose_name_differs_from_its_directory_only_in_case
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.CaseName);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.CaseName);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_because_the_comparison_is_ordinal()
+    {
+        // A plugin's identity must not depend on which filesystem the image happened to be built on, so
+        // the comparison is ordinal even where the filesystem is not.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.PluginNameMismatch);
+        _run.Failure!.Message.Should().Contain("acme.casename");
+    }
+}
+
+[TestFixture]
+public class Given_an_entry_assembly_published_under_a_different_file_name
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        // The directory and the file name agree, and the assembly's own name does not. That is the one
+        // of the four equalities the file name cannot prove, and a plugin shaped this way satisfies
+        // every other check.
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good, asName: "Acme.Renamed");
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, "Acme.Renamed");
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_and_names_both()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.AssemblyNameMismatch);
+        _run.Failure!.Message.Should().Contain("Acme.Renamed").And.Contain(PluginFixtures.Good);
+    }
+}
+
+[TestFixture]
+public class Given_an_entry_assembly_that_is_not_a_managed_assembly
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.AddCorruptPlugin("Acme.Corrupt");
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, "Acme.Corrupt");
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_with_the_load_failure_rather_than_letting_it_escape_raw()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.EntryAssemblyUnreadable);
+        _run.Failure!.InnerException.Should().NotBeNull();
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderVersionTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderVersionTests.cs
@@ -390,35 +390,42 @@ public class Given_a_plugin_carrying_its_own_copy_of_the_contract
 public class Given_the_default_context_is_asked_for_an_assembly_it_cannot_serve
 {
     [Test]
-    public void It_gives_a_caller_no_way_to_tell_absent_from_older()
+    public void It_throws_the_same_exception_for_an_absent_assembly_and_for_an_older_shared_framework_one()
     {
         Exception? absent = Capture("Acme.NoSuchAssembly.ThisHostHasNever.HeardOf");
         Exception? olderFramework = Capture("System.Runtime, Version=99.0.0.0");
-        Exception? olderApplication = Capture("Acme.HostShared, Version=99.0.0.0");
 
         TestContext.Out.WriteLine($"absent: {Describe(absent)}");
         TestContext.Out.WriteLine($"older, shared framework: {Describe(olderFramework)}");
+
+        // The measurement the loader's approach rests on, pinned exactly rather than loosely: the two
+        // cases that need opposite treatment produce the identical exception, so a catch cannot tell
+        // "the host does not have it" from "the host has an older one". If a future runtime makes them
+        // distinguishable, this fails and the simple-name approach is revisited deliberately rather
+        // than silently.
+        absent.Should().BeOfType<FileNotFoundException>();
+        olderFramework.Should().BeOfType<FileNotFoundException>();
+    }
+
+    [Test]
+    public void It_quietly_serves_an_older_copy_of_an_application_dependency()
+    {
+        // A separate measurement, and a different shape from the one above. For an assembly the
+        // application's own manifest declares, a higher-version request does not fail at all: the host
+        // returns the copy it has. A loader that asked with a version and trusted the answer would be
+        // handed an assembly older than the reference declared with nothing at all to catch, which is
+        // the second reason the loader asks without a version and compares for itself.
+        Exception? olderApplication = Capture("Acme.HostShared, Version=99.0.0.0");
+
         TestContext.Out.WriteLine($"older, application dependency: {Describe(olderApplication)}");
 
-        // Asking for something the host has never heard of is the only case that reliably throws.
-        absent.Should().BeOfType<FileNotFoundException>();
-        Type absentType = absent!.GetType();
+        olderApplication.Should().BeNull();
 
-        // Asking for a higher version of something the host does carry gives a caller nothing to
-        // branch on: it either throws the same exception as the absent case, or it quietly hands back
-        // the older copy. Both outcomes defeat a catch that means to say "the host does not have it":
-        // the first hands a version-skewed plugin its own private copy, and the second serves an
-        // assembly older than the reference declared without anybody being told. That is why the loader
-        // asks by simple name, which carries no version to fail on, and does the comparison itself.
-        foreach (Exception? older in new[] { olderFramework, olderApplication })
-        {
-            (older is null || older.GetType() == absentType)
-                .Should()
-                .BeTrue(
-                    "a higher-version request must not be distinguishable from an absent assembly by "
-                        + $"exception type, but this one produced {Describe(older)}"
-                );
-        }
+        AssemblyLoadContext
+            .Default.LoadFromAssemblyName(new AssemblyName("Acme.HostShared, Version=99.0.0.0"))
+            .GetName()
+            .Version.Should()
+            .Be(new Version(1, 0, 0, 0));
     }
 
     /// <summary>

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderVersionTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderVersionTests.cs
@@ -1,0 +1,456 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.Loader;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+[TestFixture]
+public class Given_a_plugin_published_self_contained
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.SelfContained);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.SelfContained);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_the_publish_shape()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.SelfContainedPublish);
+        _run.Failure!.Message.Should().Contain("--no-self-contained");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_published_for_a_runtime_identifier
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.RidSpecific);
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.RidSpecific);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_loads_because_the_discriminator_is_the_runtime_pack_and_not_the_runtime_identifier()
+    {
+        // A RID-specific framework-dependent publish names the runtime identifier in runtimeTarget and
+        // is how a plugin ships native assets, so keying the refusal on that would refuse a legitimate
+        // publish.
+        _run.Failure.Should().BeNull();
+        _run.Result!.Plugins.Should().ContainSingle();
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_built_against_a_newer_contract_than_the_host_carries
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.NewerContract);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.NewerContract);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_and_names_the_contract_and_both_versions()
+    {
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.ContractVersionSkew);
+        _run.Failure!.Message.Should().Contain("EdFi.Api.Plugins").And.Contain("2.0.0").And.Contain("1.0.0");
+    }
+
+    [Test]
+    public void It_refuses_from_the_metadata_read_rather_than_from_a_type_load()
+    {
+        // The fixture also exposes a type whose load fails with a recognizable error naming
+        // Acme.HostShared. Its absence from the message is what proves the check ran before any type
+        // was loaded, which is where it has to run for the message to be actionable.
+        _run.Failure!.Message.Should().NotContain("Acme.HostShared");
+        _run.Failure!.InnerException.Should().BeNull();
+    }
+}
+
+[TestFixture]
+public class Given_a_contract_set_naming_a_second_contract
+{
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.DeclaredSkew);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_catches_a_plugin_skewed_on_the_second_entry_and_names_it()
+    {
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(
+            _root.RootPath,
+            PluginFixtures.DeclaredSkew,
+            contracts: ["EdFi.Api.Plugins", "Acme.HostShared"]
+        );
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.ContractVersionSkew);
+        run.Failure!.Message.Should().Contain("Acme.HostShared");
+    }
+
+    [Test]
+    public void It_catches_nothing_from_a_set_carrying_a_package_id_where_an_assembly_name_belongs()
+    {
+        // What an assembly reference carries is a simple assembly name, so a package id in the contract
+        // set matches nothing. The plugin is still refused, by the manifest preflight, and the different
+        // failure is exactly the evidence: the contract check saw nothing.
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(
+            _root.RootPath,
+            PluginFixtures.DeclaredSkew,
+            contracts: ["EdFi.Api.Plugins", "Acme.HostShared.Package"]
+        );
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.DependencyVersionSkew);
+    }
+
+    [Test]
+    public void It_does_not_manufacture_a_failure_from_a_contract_the_plugin_never_references()
+    {
+        // A caller entry the plugin does not reference is never probed, so naming one the host could not
+        // resolve changes nothing: the failure is still the skew on the contract the plugin does
+        // reference.
+        PluginLoaderRun run = PluginLoaderProbe.RunExpectingFailure(
+            _root.RootPath,
+            PluginFixtures.DeclaredSkew,
+            contracts: ["Acme.HostShared", "Acme.NoSuchContract.ThisHostHasNever.HeardOf"]
+        );
+
+        run.Failure!.Reason.Should().Be(PluginLoadFailure.ContractVersionSkew);
+        run.Failure!.Message.Should().Contain("Acme.HostShared");
+    }
+}
+
+[TestFixture]
+public class Given_a_declared_contract_the_plugin_references_and_the_host_cannot_resolve
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Acme.Private is shipped by the plugin and carried by no host, so naming it as a contract is a
+        // host that declares something it cannot serve.
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.PrivateDependency);
+        _run = PluginLoaderProbe.RunExpectingFailure(
+            _root.RootPath,
+            PluginFixtures.PrivateDependency,
+            contracts: ["EdFi.Api.Plugins", "Acme.Private"]
+        );
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_and_names_the_contract()
+    {
+        // Skipping the comparison would leave the declaration silently unenforced, which is the exact
+        // blindness the contract check exists to prevent.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.ContractAssemblyMissing);
+        _run.Failure!.Message.Should().Contain("Acme.Private");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_shipping_a_dependency_the_host_does_not_carry
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.PrivateDependency);
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.PrivateDependency);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_loads_and_resolves_the_dependency_from_the_plugin_directory()
+    {
+        // What host-first gives up is a plugin overriding an assembly the host has. What it keeps is
+        // this: a plugin still gets its own copy of anything the host does not carry, which is where
+        // real collisions live.
+        _run.Failure.Should().BeNull();
+
+        Type pluginType = _run.Result!.Plugins[0].Instance.GetType();
+        string described = (string)pluginType.GetMethod("DescribePrivateDependency")!.Invoke(null, null)!;
+
+        described.Should().Be("Acme.Private 1.0.0");
+    }
+
+    [Test]
+    public void It_resolves_that_dependency_inside_the_plugins_own_context()
+    {
+        Type pluginType = _run.Result!.Plugins[0].Instance.GetType();
+        pluginType.GetMethod("DescribePrivateDependency")!.Invoke(null, null);
+
+        AssemblyLoadContext pluginContext = AssemblyLoadContext.GetLoadContext(pluginType.Assembly)!;
+
+        pluginContext.Assemblies.Select(assembly => assembly.GetName().Name).Should().Contain("Acme.Private");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_declaring_a_higher_version_of_an_assembly_the_host_carries
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.DeclaredSkew);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.DeclaredSkew);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_refuses_even_though_no_executed_code_path_touches_it()
+    {
+        // The Load override is called when a type resolution first needs an assembly, so a dependency no
+        // hook happens to touch would otherwise be discovered on a request rather than at startup, and
+        // "fatal at load" would be a promise this design does not keep.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.DependencyVersionSkew);
+        _run.Failure!.Message.Should().Contain("Acme.HostShared").And.Contain("2.0.0").And.Contain("1.0.0");
+    }
+
+    [Test]
+    public void It_refuses_before_the_plugin_is_constructed()
+    {
+        // Nothing was returned and the plugin's own copy was never served, which is the identity split
+        // host-first resolution exists to prevent.
+        _run.Result.Should().BeNull();
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_whose_skewed_reference_the_manifest_does_not_declare
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.BackstopCtor);
+        _run = PluginLoaderProbe.RunExpectingFailure(_root.RootPath, PluginFixtures.BackstopCtor);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_is_a_reference_the_preflight_cannot_see()
+    {
+        // The manifest declares nothing for it and the file is not in the plugin directory, which is
+        // what makes this the Load override's case rather than the preflight's. This models the shared
+        // framework, whose assemblies a framework-dependent publish also leaves undeclared.
+        string manifest = File.ReadAllText(
+            Path.Combine(
+                _root.RootPath,
+                PluginFixtures.BackstopCtor,
+                $"{PluginFixtures.BackstopCtor}.deps.json"
+            )
+        );
+
+        manifest.Should().NotContain("Acme.HostShared");
+        File.Exists(Path.Combine(_root.RootPath, PluginFixtures.BackstopCtor, "Acme.HostShared.dll"))
+            .Should()
+            .BeFalse();
+    }
+
+    [Test]
+    public void It_reports_the_named_skew_rather_than_the_runtime_wrapper()
+    {
+        // The runtime wraps anything thrown from inside the Load override in a FileLoadException whose
+        // own message names only the version the host carries. An operator reading that would have no
+        // idea what the plugin asked for, so the loader unwraps it.
+        _run.Failure!.Reason.Should().Be(PluginLoadFailure.DependencyVersionSkew);
+        _run.Failure!.Message.Should().Contain("requires Acme.HostShared >= 2.0.0");
+        _run.Failure!.Message.Should().Contain("host carries 1.0.0");
+        _run.Failure!.Message.Should().NotContain("0x80131500");
+    }
+
+    [Test]
+    public void It_keeps_the_runtime_failure_as_the_cause()
+    {
+        _run.Failure!.InnerException.Should().NotBeNull();
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_carrying_its_own_copy_of_the_contract
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_really_does_carry_one()
+    {
+        // Every published plugin brings its own copy, so the assertion below is about which of two real
+        // files was used rather than about a file that is not there.
+        File.Exists(Path.Combine(_root.RootPath, PluginFixtures.Good, "EdFi.Api.Plugins.dll"))
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    public void It_is_served_the_host_copy_instead()
+    {
+        // The same assembly instance, not merely the same version. Two identities for the contract would
+        // mean the host could not see the plugin as an EdFiApiPlugin at all.
+        _run.Failure.Should().BeNull();
+
+        Assembly contractTheHostCarries = typeof(EdFiApiPlugin).Assembly;
+        Assembly contractThePluginGot = _run.Result!.Plugins[0].Instance.GetType().BaseType!.Assembly;
+
+        contractThePluginGot.Should().BeSameAs(contractTheHostCarries);
+    }
+
+    [Test]
+    public void It_loads_the_plugin_into_a_non_collectible_context_named_for_it()
+    {
+        AssemblyLoadContext context = AssemblyLoadContext.GetLoadContext(
+            _run.Result!.Plugins[0].Instance.GetType().Assembly
+        )!;
+
+        // Named for the plugin so a diagnostic taken from the runtime says which plugin an assembly
+        // came from, and non-collectible because nothing unloads a plugin.
+        context.Name.Should().Be(PluginFixtures.Good);
+        context.IsCollectible.Should().BeFalse();
+        context.Should().NotBeSameAs(AssemblyLoadContext.Default);
+    }
+}
+
+/// <summary>
+/// Records what the default context actually does, so the loader's simple-name approach rests on a
+/// measurement rather than on an assumed exception type. If a future runtime makes the two
+/// distinguishable, this fails and the approach is revisited deliberately rather than silently.
+/// </summary>
+[TestFixture]
+public class Given_the_default_context_is_asked_for_an_assembly_it_cannot_serve
+{
+    [Test]
+    public void It_gives_a_caller_no_way_to_tell_absent_from_older()
+    {
+        Exception? absent = Capture("Acme.NoSuchAssembly.ThisHostHasNever.HeardOf");
+        Exception? olderFramework = Capture("System.Runtime, Version=99.0.0.0");
+        Exception? olderApplication = Capture("Acme.HostShared, Version=99.0.0.0");
+
+        TestContext.Out.WriteLine($"absent: {Describe(absent)}");
+        TestContext.Out.WriteLine($"older, shared framework: {Describe(olderFramework)}");
+        TestContext.Out.WriteLine($"older, application dependency: {Describe(olderApplication)}");
+
+        // Asking for something the host has never heard of is the only case that reliably throws.
+        absent.Should().BeOfType<FileNotFoundException>();
+        Type absentType = absent!.GetType();
+
+        // Asking for a higher version of something the host does carry gives a caller nothing to
+        // branch on: it either throws the same exception as the absent case, or it quietly hands back
+        // the older copy. Both outcomes defeat a catch that means to say "the host does not have it":
+        // the first hands a version-skewed plugin its own private copy, and the second serves an
+        // assembly older than the reference declared without anybody being told. That is why the loader
+        // asks by simple name, which carries no version to fail on, and does the comparison itself.
+        foreach (Exception? older in new[] { olderFramework, olderApplication })
+        {
+            (older is null || older.GetType() == absentType)
+                .Should()
+                .BeTrue(
+                    "a higher-version request must not be distinguishable from an absent assembly by "
+                        + $"exception type, but this one produced {Describe(older)}"
+                );
+        }
+    }
+
+    /// <summary>
+    /// Asks the default context and reports what came back, including nothing at all. NUnit's Assert
+    /// helpers all insist an exception was thrown, and "it did not throw" is one of the outcomes this
+    /// measurement exists to record.
+    /// </summary>
+    private static Exception? Capture(string displayName)
+    {
+        try
+        {
+            AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(displayName));
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+
+    private static string Describe(Exception? exception) =>
+        exception is null ? "no exception" : exception.GetType().Name;
+
+    [Test]
+    public void It_serves_the_host_copy_when_asked_by_simple_name_alone()
+    {
+        // Which is why the loader asks this way and compares versions itself: a request carrying a
+        // version cannot fail on version grounds if it carries none.
+        AssemblyLoadContext
+            .Default.LoadFromAssemblyName(new AssemblyName("Acme.HostShared"))
+            .GetName()
+            .Version.Should()
+            .Be(new Version(1, 0, 0, 0));
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderVersionTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginLoaderVersionTests.cs
@@ -461,3 +461,65 @@ public class Given_the_default_context_is_asked_for_an_assembly_it_cannot_serve
             .Be(new Version(1, 0, 0, 0));
     }
 }
+
+/// <summary>
+/// A declared asset's file name is a string a third party wrote, and the skew preflight presents it to
+/// the host as a simple assembly name. It has to be asked for as a name and never parsed as a display
+/// name.
+/// </summary>
+[TestFixture]
+public class Given_a_declared_asset_whose_file_name_is_not_a_plain_assembly_name
+{
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Good);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [TestCase("lib/net10.0/a,b.dll", TestName = "It_loads_the_plugin_when_the_name_carries_a_comma")]
+    [TestCase("lib/net10.0/a=1.dll", TestName = "It_loads_the_plugin_when_the_name_carries_an_equals")]
+    [TestCase("lib/net10.0/a\"b.dll", TestName = "It_loads_the_plugin_when_the_name_carries_a_quote")]
+    public void It_loads_the_plugin(string declaredPath)
+    {
+        // Each of these makes the display-name parser throw FileLoadException. That is neither a
+        // PluginLoadException nor the FileNotFoundException a missing assembly produces, so it escaped
+        // the loader entirely and left the diagnostic channel empty. Asked for as a name, the host
+        // simply carries nothing called that, which is true, and the plugin's own copy is used.
+        _root.AddDeclaredRuntimeAsset(PluginFixtures.Good, declaredPath, "1.0.0.0");
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Good);
+
+        run.Failure.Should().BeNull();
+        run.Result!.Plugins.Should().ContainSingle();
+        run.DiagnosticLines.Should().ContainSingle();
+        run.DiagnosticLines[0].Should().StartWith($"plugin '{PluginFixtures.Good}' loaded from");
+    }
+
+    [Test]
+    public void It_does_not_let_a_declared_path_impersonate_another_assembly()
+    {
+        // The case that decides the shape of the fix, because it is not a throw. The display-name
+        // parser reads this file name as System.Text.Json carrying a version constraint, so the host's
+        // real System.Text.Json was bound and its version compared against a declaration that was never
+        // about it: measured, host 10.0.0.0 against a declared 99.0.0.0, a skew fatal naming an
+        // assembly this plugin does not ship. Nothing the plugin declared is called System.Text.Json,
+        // so the truthful answer is that the host carries no such assembly and there is nothing to
+        // compare.
+        _root.AddDeclaredRuntimeAsset(
+            PluginFixtures.Good,
+            "lib/net10.0/System.Text.Json, Version=1.0.0.0.dll",
+            "99.0.0.0"
+        );
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Good);
+
+        run.Failure.Should().BeNull();
+        run.Result!.Plugins.Should().ContainSingle();
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginNativeResolutionTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginNativeResolutionTests.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Diagnostics;
-using System.Text;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -21,9 +20,20 @@ namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
 /// </remarks>
 internal static class NativeProbe
 {
-    internal sealed record Result(int ExitCode, string Output);
+    /// <summary>How long a probe may run before the runner ends it.</summary>
+    /// <remarks>
+    /// Generous, because the work is starting a process and loading a plugin and a build machine can be
+    /// slow at both. It bounds a hang; it is not a performance assertion. A case about the bound itself
+    /// passes a short one.
+    /// </remarks>
+    private static readonly TimeSpan _defaultDeadline = TimeSpan.FromMinutes(2);
 
-    internal static Result Run(string pluginRoot, string pluginName, string mode)
+    internal static ChildProcess.Result Run(
+        string pluginRoot,
+        string pluginName,
+        string mode,
+        TimeSpan? deadline = null
+    )
     {
         ProcessStartInfo start = new()
         {
@@ -48,20 +58,85 @@ internal static class NativeProbe
         start.ArgumentList.Add(pluginName);
         start.ArgumentList.Add(mode);
 
-        using Process process =
-            Process.Start(start) ?? throw new AssertionException("The native probe did not start.");
+        return ChildProcess.Run(start, deadline ?? _defaultDeadline, "The native probe");
+    }
+}
 
-        StringBuilder output = new();
-        output.Append(process.StandardOutput.ReadToEnd());
-        output.Append(process.StandardError.ReadToEnd());
+/// <summary>
+/// The runner's own two failure modes, which every native assertion here depends on not having.
+/// </summary>
+/// <remarks>
+/// Both belong to the runner rather than to the loader, and both are invisible in a passing run: a
+/// probe that hangs and a probe that fills a pipe look exactly like a slow one until the suite itself
+/// stops. They are asserted against a child that really behaves that way, with a short deadline so the
+/// cases cost seconds.
+/// </remarks>
+[TestFixture]
+public class Given_a_probe_process_the_runner_cannot_simply_read_to_the_end
+{
+    [Test]
+    public void It_ends_a_probe_that_never_finishes_at_the_deadline()
+    {
+        Stopwatch elapsed = Stopwatch.StartNew();
 
-        if (!process.WaitForExit(TimeSpan.FromMinutes(2)))
-        {
-            process.Kill(entireProcessTree: true);
-            throw new AssertionException($"The native probe did not finish. Output so far: {output}");
-        }
+        AssertionException failure = Assert.Throws<AssertionException>(() =>
+            NativeProbe.Run(
+                PluginFixtures.Root,
+                PluginFixtures.Good,
+                mode: "stall",
+                deadline: TimeSpan.FromSeconds(5)
+            )
+        )!;
 
-        return new Result(process.ExitCode, output.ToString());
+        elapsed.Stop();
+
+        failure.Message.Should().Contain("did not finish within its deadline");
+
+        // The claim is that the deadline is what ended it. Well below the runner's own default, so a
+        // slow machine cannot make this pass for the wrong reason.
+        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(60));
+    }
+
+    [Test]
+    public void It_stops_waiting_for_streams_a_departed_probe_left_open()
+    {
+        // The probe exits immediately, having started a process that inherited its streams. Waiting for
+        // the streams to end rather than for the process to exit is what makes the captured output
+        // complete, and waiting for them without a bound is what makes that wait never return.
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        AssertionException failure = Assert.Throws<AssertionException>(() =>
+            NativeProbe.Run(
+                PluginFixtures.Root,
+                PluginFixtures.Good,
+                mode: "linger",
+                deadline: TimeSpan.FromSeconds(5)
+            )
+        )!;
+
+        elapsed.Stop();
+
+        failure.Message.Should().Contain("held its streams open past the deadline");
+
+        // What it did manage to read is reported rather than thrown away.
+        failure.Message.Should().Contain("LINGER STARTED");
+        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(60));
+    }
+
+    [Test]
+    public void It_finishes_a_probe_that_fills_its_error_stream_before_writing_its_output()
+    {
+        // Two megabytes of error output ahead of a single line of ordinary output, which is far more
+        // than a pipe holds. A runner that reads output to its end first never sees that line.
+        ChildProcess.Result result = NativeProbe.Run(
+            PluginFixtures.Root,
+            PluginFixtures.Good,
+            mode: "spew",
+            deadline: TimeSpan.FromSeconds(60)
+        );
+
+        result.ExitCode.Should().Be(0);
+        result.Output.Should().Contain("SPEW DONE");
     }
 }
 
@@ -88,7 +163,7 @@ public class Given_a_plugin_whose_native_asset_sits_where_its_manifest_declares_
     [Test]
     public void It_resolves_and_calls_the_library_through_the_loader()
     {
-        NativeProbe.Result result = NativeProbe.Run(
+        ChildProcess.Result result = NativeProbe.Run(
             _root.RootPath,
             PluginFixtures.NativePortable,
             mode: "loader"
@@ -106,7 +181,7 @@ public class Given_a_plugin_whose_native_asset_sits_where_its_manifest_declares_
         // layout, and a context that resolves managed assemblies host-first exactly as the real one
         // does while overriding nothing for unmanaged ones: the call fails. That is what shows the
         // override is doing the work rather than the runtime's default probing.
-        NativeProbe.Result result = NativeProbe.Run(
+        ChildProcess.Result result = NativeProbe.Run(
             _root.RootPath,
             PluginFixtures.NativePortable,
             mode: "plain"
@@ -139,7 +214,7 @@ public class Given_a_plugin_whose_native_asset_was_flattened_beside_the_entry_as
         // native asset to the plugin root, where the runtime's own probing finds it, so a passing call
         // against this layout says nothing about whether the override ran. This is the measurement that
         // makes the declared-layout tests above the load-bearing ones.
-        NativeProbe.Result result = NativeProbe.Run(_root.RootPath, PluginFixtures.Native, mode: "plain");
+        ChildProcess.Result result = NativeProbe.Run(_root.RootPath, PluginFixtures.Native, mode: "plain");
 
         result.Output.Should().Contain("LOAD SUCCEEDED");
         result.Output.Should().Contain("NATIVE RESULT 3");
@@ -179,7 +254,7 @@ public class Given_a_plugin_whose_declared_native_asset_is_not_there
         // check, because a manifest describes native assets per runtime identifier and the runtime
         // resolves them lazily. Both halves of that are asserted here, in a process where no module of
         // this name has been loaded, which is the only place the second half means anything.
-        NativeProbe.Result result = NativeProbe.Run(_root.RootPath, PluginFixtures.Native, mode: "loader");
+        ChildProcess.Result result = NativeProbe.Run(_root.RootPath, PluginFixtures.Native, mode: "loader");
 
         result.Output.Should().Contain("LOAD SUCCEEDED");
         result.Output.Should().Contain("NATIVE FAILURE System.DllNotFoundException");

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginNativeResolutionTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginNativeResolutionTests.cs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Diagnostics;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// Runs the native probe in a process that has loaded no native module before it starts.
+/// </summary>
+/// <remarks>
+/// Both platforms resolve a native module by name once it is loaded, so any assertion about a native
+/// library failing to resolve is meaningless in a process where a sibling test has already loaded a
+/// module of that name: it would turn on test order rather than on behaviour. A fresh process per case
+/// is the only way to make these claims honestly.
+/// </remarks>
+internal static class NativeProbe
+{
+    internal sealed record Result(int ExitCode, string Output);
+
+    internal static Result Run(string pluginRoot, string pluginName, string mode)
+    {
+        ProcessStartInfo start = new()
+        {
+            FileName = Environment.ProcessPath ?? "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        // The test host is itself dotnet, so its own path runs the probe. Falling back to the name on
+        // PATH covers a host that is something else.
+        if (
+            !Path.GetFileNameWithoutExtension(start.FileName)
+                .Equals("dotnet", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            start.FileName = "dotnet";
+        }
+
+        start.ArgumentList.Add(PluginFixtures.NativeProbeHost);
+        start.ArgumentList.Add(pluginRoot);
+        start.ArgumentList.Add(pluginName);
+        start.ArgumentList.Add(mode);
+
+        using Process process =
+            Process.Start(start) ?? throw new AssertionException("The native probe did not start.");
+
+        StringBuilder output = new();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+
+        if (!process.WaitForExit(TimeSpan.FromMinutes(2)))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new AssertionException($"The native probe did not finish. Output so far: {output}");
+        }
+
+        return new Result(process.ExitCode, output.ToString());
+    }
+}
+
+/// <summary>
+/// The override exists for a native asset that sits where the manifest declares it. A copy flattened
+/// beside the entry assembly is found by the runtime's own probing either way, so a call that succeeds
+/// against that layout proves nothing about the override.
+/// </summary>
+[TestFixture]
+public class Given_a_plugin_whose_native_asset_sits_where_its_manifest_declares_it
+{
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.NativePortable);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_resolves_and_calls_the_library_through_the_loader()
+    {
+        NativeProbe.Result result = NativeProbe.Run(
+            _root.RootPath,
+            PluginFixtures.NativePortable,
+            mode: "loader"
+        );
+
+        result.Output.Should().Contain("LOAD SUCCEEDED");
+        result.Output.Should().Contain("NATIVE RESULT 3");
+        result.ExitCode.Should().Be(0);
+    }
+
+    [Test]
+    public void It_cannot_resolve_the_library_without_the_unmanaged_override()
+    {
+        // The control, and the reason the case above is worth anything. The same plugin, the same
+        // layout, and a context that resolves managed assemblies host-first exactly as the real one
+        // does while overriding nothing for unmanaged ones: the call fails. That is what shows the
+        // override is doing the work rather than the runtime's default probing.
+        NativeProbe.Result result = NativeProbe.Run(
+            _root.RootPath,
+            PluginFixtures.NativePortable,
+            mode: "plain"
+        );
+
+        result.Output.Should().Contain("LOAD SUCCEEDED");
+        result.Output.Should().Contain("NATIVE FAILURE System.DllNotFoundException");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_whose_native_asset_was_flattened_beside_the_entry_assembly
+{
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Native);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_resolves_without_the_override_too_which_is_why_this_layout_proves_nothing_about_it()
+    {
+        // Recorded rather than assumed. A runtime-specific publish relocates the running identifier's
+        // native asset to the plugin root, where the runtime's own probing finds it, so a passing call
+        // against this layout says nothing about whether the override ran. This is the measurement that
+        // makes the declared-layout tests above the load-bearing ones.
+        NativeProbe.Result result = NativeProbe.Run(_root.RootPath, PluginFixtures.Native, mode: "plain");
+
+        result.Output.Should().Contain("LOAD SUCCEEDED");
+        result.Output.Should().Contain("NATIVE RESULT 3");
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_whose_declared_native_asset_is_not_there
+{
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Native);
+
+        foreach (
+            string nativeFile in Directory.EnumerateFiles(
+                Path.Combine(_root.RootPath, PluginFixtures.Native),
+                "*e_sqlite3*",
+                SearchOption.AllDirectories
+            )
+        )
+        {
+            File.Delete(nativeFile);
+        }
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_loads_and_then_fails_at_first_use()
+    {
+        // The design records a missing native asset as a lazy first-use failure rather than a load-time
+        // check, because a manifest describes native assets per runtime identifier and the runtime
+        // resolves them lazily. Both halves of that are asserted here, in a process where no module of
+        // this name has been loaded, which is the only place the second half means anything.
+        NativeProbe.Result result = NativeProbe.Run(_root.RootPath, PluginFixtures.Native, mode: "loader");
+
+        result.Output.Should().Contain("LOAD SUCCEEDED");
+        result.Output.Should().Contain("NATIVE FAILURE System.DllNotFoundException");
+        result.ExitCode.Should().Be(0);
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginResourceInventoryTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginResourceInventoryTests.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// A satellite resource assembly is the one asset kind whose published location its file name alone
+/// cannot find, because a publish puts it under its culture's directory.
+/// </summary>
+[TestFixture]
+public class Given_a_plugin_that_ships_a_satellite_resource_assembly
+{
+    private const string SatelliteFileName = "Acme.Localized.resources.dll";
+    private const string PublishedPath = "fr/" + SatelliteFileName;
+
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Localized);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    private LoadedPlugin Load()
+    {
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Localized);
+        run.Failure.Should().BeNull();
+        return run.Result!.Plugins[0];
+    }
+
+    [Test]
+    public void It_lists_the_satellite_as_a_resource_with_a_digest()
+    {
+        PluginInventoryRow resource = Load()
+            .MaterializeInventory()
+            .Single(row => row.Kind == PluginFileKind.Resource);
+
+        resource.FileName.Should().Be(SatelliteFileName);
+        resource.Availability.Should().Be(PluginFileAvailability.Present);
+        resource.Sha256.Should().NotBeNull();
+
+        // A satellite carries no assembly version in the manifest, so the row says so rather than
+        // inventing one, exactly as a native row does.
+        resource.DeclaredAssemblyVersion.Should().BeNull();
+        resource.EffectiveVersionSource.Should().Be(PluginVersionSource.NotDeclared);
+    }
+
+    [Test]
+    public void It_is_a_real_satellite_the_plugin_can_read_from()
+    {
+        // Without this the row above could be describing a file that is a satellite in name only.
+        LoadedPlugin plugin = Load();
+
+        string greeting = (string)
+            plugin
+                .Instance.GetType()
+                .Assembly.GetType("Acme.Localized.LocalizedPlugin")!
+                .GetMethod("FrenchGreeting")!
+                .Invoke(null, null)!;
+
+        greeting.Should().Be("bonjour");
+    }
+
+    [Test]
+    public void It_finds_a_satellite_declared_at_its_package_relative_path()
+    {
+        // The case the culture branch of the mapping exists for. A satellite from a project reference is
+        // declared where the publish writes it, so the declared path alone finds it; one from a package
+        // is declared under lib/<tfm>/<culture>/ while the publish writes it under the culture directory
+        // only. This produces that second shape from a real publish.
+        _root.SetResourceDeclaredPath(
+            PluginFixtures.Localized,
+            PublishedPath,
+            $"lib/net10.0/{PublishedPath}"
+        );
+
+        // The file name alone is not at the plugin root, so the last-resort candidate cannot be what
+        // finds it either. Only the culture directory can.
+        File.Exists(Path.Combine(_root.RootPath, PluginFixtures.Localized, SatelliteFileName))
+            .Should()
+            .BeFalse();
+
+        PluginInventoryRow resource = Load()
+            .MaterializeInventory()
+            .Single(row => row.Kind == PluginFileKind.Resource);
+
+        resource.DeclaredPath.Should().Be($"lib/net10.0/{PublishedPath}");
+        resource.Availability.Should().Be(PluginFileAvailability.Present);
+        resource.ResolvedRelativePath.Should().Be(PublishedPath.Replace('/', Path.DirectorySeparatorChar));
+    }
+}
+
+/// <summary>
+/// The control context in the native probe only means something if the probe's own directory cannot
+/// satisfy the call by accident.
+/// </summary>
+[TestFixture]
+public class Given_the_native_probe_host
+{
+    [Test]
+    public void It_carries_no_native_library_of_its_own()
+    {
+        // If the probe shipped a copy of the library beside itself, the runtime's default probing would
+        // find it and the no-override control would pass for a reason that has nothing to do with the
+        // plugin under test.
+        string probeDirectory = Path.GetDirectoryName(PluginFixtures.NativeProbeHost)!;
+
+        Directory
+            .EnumerateFiles(probeDirectory, "*e_sqlite3*", SearchOption.AllDirectories)
+            .Should()
+            .BeEmpty();
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginRuntimeTargetsTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginRuntimeTargetsTests.cs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>One managed asset declaration read out of a real published manifest.</summary>
+internal sealed record ManagedDeclaration(string Library, string SimpleName, string? AssemblyVersion);
+
+/// <summary>
+/// The managed declarations of one published manifest, separated by where they are declared.
+/// </summary>
+/// <remarks>
+/// Read here rather than in each test because the two collections answer the same question from
+/// opposite sides: what a per-identifier row says, and what the top-level entry the skew preflight
+/// reads says about the same simple name.
+/// </remarks>
+internal sealed record ManagedDeclarations(
+    string TargetName,
+    IReadOnlyList<ManagedDeclaration> RuntimeTargetsRows,
+    IReadOnlyDictionary<string, IReadOnlyDictionary<string, string?>> TopLevelRowsByLibrary
+)
+{
+    internal static ManagedDeclarations Read(string manifestPath)
+    {
+        using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+
+        string targetName = manifest
+            .RootElement.GetProperty("runtimeTarget")
+            .GetProperty("name")
+            .GetString()!;
+
+        JsonElement target = manifest.RootElement.GetProperty("targets").GetProperty(targetName);
+
+        List<ManagedDeclaration> runtimeTargetsRows = [];
+        Dictionary<string, IReadOnlyDictionary<string, string?>> topLevel = new(StringComparer.Ordinal);
+
+        foreach (JsonProperty library in target.EnumerateObject())
+        {
+            topLevel[library.Name] = TopLevelRowsOf(library.Value);
+            runtimeTargetsRows.AddRange(RuntimeTargetsRowsOf(library));
+        }
+
+        return new ManagedDeclarations(targetName, runtimeTargetsRows, topLevel);
+    }
+
+    /// <summary>The top-level <c>runtime</c> declarations of one library, by simple name.</summary>
+    internal IReadOnlyDictionary<string, string?> TopLevelRowsIn(string library) =>
+        TopLevelRowsByLibrary[library];
+
+    private static IReadOnlyDictionary<string, string?> TopLevelRowsOf(JsonElement library)
+    {
+        Dictionary<string, string?> rows = new(StringComparer.Ordinal);
+
+        if (!library.TryGetProperty("runtime", out JsonElement runtime))
+        {
+            return rows;
+        }
+
+        foreach (JsonProperty asset in runtime.EnumerateObject())
+        {
+            rows[Path.GetFileNameWithoutExtension(asset.Name)] = DeclaredVersionOf(asset.Value);
+        }
+
+        return rows;
+    }
+
+    private static IEnumerable<ManagedDeclaration> RuntimeTargetsRowsOf(JsonProperty library)
+    {
+        if (!library.Value.TryGetProperty("runtimeTargets", out JsonElement runtimeTargets))
+        {
+            yield break;
+        }
+
+        foreach (JsonProperty row in runtimeTargets.EnumerateObject())
+        {
+            // assetType is the discriminator, not the path: a native asset also lives under runtimes/
+            // and carries no assembly version, and treating the two alike would compare a managed
+            // declaration against something that has none.
+            if (
+                !row.Value.TryGetProperty("assetType", out JsonElement assetType)
+                || assetType.GetString() != "runtime"
+            )
+            {
+                continue;
+            }
+
+            yield return new ManagedDeclaration(
+                library.Name,
+                Path.GetFileNameWithoutExtension(row.Name),
+                DeclaredVersionOf(row.Value)
+            );
+        }
+    }
+
+    private static string? DeclaredVersionOf(JsonElement declaration) =>
+        declaration.TryGetProperty("assemblyVersion", out JsonElement version) ? version.GetString() : null;
+}
+
+/// <summary>
+/// The publish shape the skew preflight's sufficiency rests on, measured rather than assumed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The preflight reads top-level <c>runtime</c> entries only. That is safe to the extent that a
+/// managed <c>runtimeTargets</c> row repeats a top-level declaration of the same simple name at the
+/// same <c>assemblyVersion</c>, because then nothing a per-identifier row could say is new. This
+/// fixture is the measurement of that claim against a real package with runtime-identifier-specific
+/// managed assets, published portable so the rows exist at all.
+/// </para>
+/// <para>
+/// It is also where the claim's limit is recorded. Measured on Microsoft.Data.SqlClient 6.1.4, the
+/// repetition holds for every managed row whose simple name appears at the top level, and there is at
+/// least one managed row whose simple name appears nowhere at the top level. The preflight is
+/// therefore incomplete rather than equivalent, and that is stated here instead of being hidden by an
+/// assertion written only over the rows that happen to match.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class Given_a_plugin_shipping_runtime_identifier_specific_managed_assets
+{
+    private ManagedDeclarations _declarations = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _declarations = ManagedDeclarations.Read(PluginFixtures.ManifestOf(PluginFixtures.RuntimeTargets));
+
+        foreach (ManagedDeclaration row in _declarations.RuntimeTargetsRows)
+        {
+            TestContext.Out.WriteLine($"{row.Library}: {row.SimpleName} {row.AssemblyVersion}");
+        }
+    }
+
+    [Test]
+    public void It_is_published_portable_rather_than_for_one_identifier()
+    {
+        // The shape the criterion measures. A publish carrying a runtime identifier resolves the
+        // per-identifier assets and emits no managed runtimeTargets rows at all, so a fixture built
+        // that way would satisfy every assertion below over an empty collection.
+        _declarations.TargetName.Should().Be(".NETCoreApp,Version=v10.0");
+    }
+
+    [Test]
+    public void It_really_does_declare_managed_runtime_targets_rows()
+    {
+        _declarations.RuntimeTargetsRows.Should().NotBeEmpty();
+        _declarations
+            .RuntimeTargetsRows.Should()
+            .Contain(row => row.SimpleName == "Microsoft.Data.SqlClient");
+    }
+
+    [Test]
+    public void It_repeats_the_top_level_version_for_every_row_the_top_level_also_declares()
+    {
+        // The invariant the preflight's sufficiency actually rests on. Asserted per row rather than in
+        // aggregate, so a single divergent declaration is named instead of being averaged away.
+        List<ManagedDeclaration> matched = [];
+
+        foreach (ManagedDeclaration row in _declarations.RuntimeTargetsRows)
+        {
+            if (!_declarations.TopLevelRowsIn(row.Library).TryGetValue(row.SimpleName, out string? topLevel))
+            {
+                continue;
+            }
+
+            row.AssemblyVersion.Should()
+                .Be(
+                    topLevel,
+                    $"the runtimeTargets row for {row.SimpleName} in {row.Library} must not declare a "
+                        + "version the top-level runtime entry does not, or the preflight's top-level "
+                        + "read would miss a skew the manifest states"
+                );
+
+            matched.Add(row);
+        }
+
+        // Otherwise the loop above proves nothing: no matched row means no comparison happened.
+        matched.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void It_also_declares_a_managed_row_the_top_level_does_not_mention_at_all()
+    {
+        // The limit of the claim, kept as a measurement. Such a row is declared per identifier and
+        // nowhere else, so the preflight cannot see its version at all: the top-level read is
+        // incomplete rather than equivalent, which is a documented policy about what to refuse and not
+        // an oversight. The inventory, a different question, still carries these rows.
+        ManagedDeclaration[] unmatched =
+        [
+            .. _declarations.RuntimeTargetsRows.Where(row =>
+                !_declarations.TopLevelRowsIn(row.Library).ContainsKey(row.SimpleName)
+            ),
+        ];
+
+        foreach (ManagedDeclaration row in unmatched)
+        {
+            TestContext.Out.WriteLine(
+                $"declared only per identifier: {row.Library}: {row.SimpleName} {row.AssemblyVersion}"
+            );
+        }
+
+        unmatched.Should().NotBeEmpty();
+    }
+}
+
+/// <summary>
+/// The same manifest, read by the loader rather than by the test.
+/// </summary>
+/// <remarks>
+/// What the preflight declines to read, the inventory still reports. The two answer different
+/// questions - what to refuse, and what the directory contains - and the second is not narrowed to the
+/// first.
+/// </remarks>
+[TestFixture]
+public class Given_the_loader_inventories_runtime_identifier_specific_managed_assets
+{
+    private TemporaryPluginRoot _root = null!;
+    private ManagedDeclarations _declarations = null!;
+    private IReadOnlyList<PluginInventoryRow> _inventory = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _declarations = ManagedDeclarations.Read(PluginFixtures.ManifestOf(PluginFixtures.RuntimeTargets));
+
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.RuntimeTargets);
+
+        // The one case over this fixture that has to get the plugin loaded, and the only one that
+        // touches the manifest. Measured, this process carries System.Configuration.ConfigurationManager
+        // 4.0.0.0 from the test platform while the package's closure declares 9.0.0.0, so the preflight
+        // refuses the plugin exactly as designed. Lowering that declaration to the version this host
+        // really carries is what a host serving SqlClient's closure would present, and it leaves every
+        // runtimeTargets row untouched.
+        foreach (string change in _root.LowerDeclarationsAboveHostVersions(PluginFixtures.RuntimeTargets))
+        {
+            TestContext.Out.WriteLine($"lowered to this host's version: {change}");
+        }
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.RuntimeTargets);
+        run.Failure.Should().BeNull();
+
+        _inventory = run.Result!.Plugins.Single().MaterializeInventory();
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_carries_every_managed_runtime_targets_declaration()
+    {
+        foreach (ManagedDeclaration row in _declarations.RuntimeTargetsRows)
+        {
+            _inventory
+                .Should()
+                .Contain(
+                    entry =>
+                        entry.Kind == PluginFileKind.Managed
+                        && Path.GetFileNameWithoutExtension(entry.FileName) == row.SimpleName,
+                    $"the manifest declares {row.SimpleName} as a managed asset"
+                );
+        }
+    }
+
+    [Test]
+    public void It_carries_the_row_the_preflight_cannot_see()
+    {
+        // Named as its own case because it is the one the two questions actually diverge on: declared
+        // per identifier and nowhere else, invisible to the preflight, and present in the inventory.
+        ManagedDeclaration[] unmatched =
+        [
+            .. _declarations.RuntimeTargetsRows.Where(row =>
+                !_declarations.TopLevelRowsIn(row.Library).ContainsKey(row.SimpleName)
+            ),
+        ];
+
+        unmatched.Should().NotBeEmpty();
+
+        foreach (ManagedDeclaration row in unmatched)
+        {
+            _inventory
+                .Should()
+                .Contain(entry => Path.GetFileNameWithoutExtension(entry.FileName) == row.SimpleName);
+        }
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginRuntimeTargetsTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginRuntimeTargetsTests.cs
@@ -115,15 +115,22 @@ internal sealed record ManagedDeclarations(
 /// </para>
 /// <para>
 /// It is also where the claim's limit is recorded. Measured on Microsoft.Data.SqlClient 6.1.4, the
-/// repetition holds for every managed row whose simple name appears at the top level, and there is at
-/// least one managed row whose simple name appears nowhere at the top level. The preflight is
-/// therefore incomplete rather than equivalent, and that is stated here instead of being hidden by an
-/// assertion written only over the rows that happen to match.
+/// repetition holds for every managed row whose simple name appears at the top level, and one managed
+/// row appears nowhere at the top level at all: <c>System.Diagnostics.EventLog.Messages</c>, from the
+/// transitive <c>System.Diagnostics.EventLog/9.0.11</c>, declared at 9.0.0.0 in a <c>win</c> row and
+/// in no top-level entry, beside a <c>System.Diagnostics.EventLog</c> row that does have one. The
+/// preflight's top-level read is therefore incomplete rather than equivalent. That is a documented
+/// policy about what to refuse, it is asserted below rather than hidden by a sweep written only over
+/// the rows that happen to match, and it is not a reason to widen the production preflight past the
+/// approved design.
 /// </para>
 /// </remarks>
 [TestFixture]
 public class Given_a_plugin_shipping_runtime_identifier_specific_managed_assets
 {
+    /// <summary>The package whose publish shape this fixture exists to measure.</summary>
+    private const string SubjectPackage = "Microsoft.Data.SqlClient";
+
     private ManagedDeclarations _declarations = null!;
 
     [SetUp]
@@ -150,9 +157,30 @@ public class Given_a_plugin_shipping_runtime_identifier_specific_managed_assets
     public void It_really_does_declare_managed_runtime_targets_rows()
     {
         _declarations.RuntimeTargetsRows.Should().NotBeEmpty();
-        _declarations
-            .RuntimeTargetsRows.Should()
-            .Contain(row => row.SimpleName == "Microsoft.Data.SqlClient");
+    }
+
+    [Test]
+    public void It_repeats_the_top_level_version_for_the_package_this_fixture_is_built_on()
+    {
+        // The acceptance case, pinned to the package rather than left to the sweep below. That sweep
+        // skips a row with no top-level counterpart, so on its own it would still pass if this package
+        // lost its counterpart while some other library kept one, and the fixture would then measure
+        // an invariant over somebody else's declarations.
+        ManagedDeclaration[] rows =
+        [
+            .. _declarations.RuntimeTargetsRows.Where(row => row.SimpleName == SubjectPackage),
+        ];
+
+        rows.Should().NotBeEmpty();
+
+        foreach (ManagedDeclaration row in rows)
+        {
+            IReadOnlyDictionary<string, string?> topLevel = _declarations.TopLevelRowsIn(row.Library);
+
+            row.AssemblyVersion.Should().NotBeNull();
+            topLevel.Should().ContainKey(SubjectPackage);
+            row.AssemblyVersion.Should().Be(topLevel[SubjectPackage]);
+        }
     }
 
     [Test]

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSharedFrameworkTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSharedFrameworkTests.cs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// A plugin taking the hook signature's assemblies from the shared framework rather than packages.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The evidence boundary matters more here than anywhere else in this suite, so it is stated rather
+/// than left to be inferred. What this fixture proves is <em>provenance and resolution</em>: those
+/// assemblies appear nowhere in the manifest and nowhere in the plugin directory, so the skew
+/// preflight cannot see them, and when the plugin uses them it is the host's own assembly instances it
+/// gets.
+/// </para>
+/// <para>
+/// What it does not prove is a <em>refusal</em>. A genuine shared-framework version skew would need a
+/// plugin compiled against a newer shared framework than the host runs, and with one installed runtime
+/// there is no such compilation. The refusal half belongs to
+/// <c>Given_a_plugin_whose_skewed_reference_the_manifest_does_not_declare</c> in
+/// PluginLoaderVersionTests, over Acme.BackstopCtor, whose suppressed manifest row reproduces the one
+/// property that matters - a reference the preflight cannot see - on an ordinary assembly. Neither
+/// fixture is evidence for the other's claim.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class Given_a_plugin_taking_the_hook_signature_from_the_shared_framework
+{
+    /// <summary>The two assemblies the hook signature names, which this plugin does not ship.</summary>
+    private static readonly string[] SignatureAssemblies =
+    [
+        "Microsoft.Extensions.DependencyInjection.Abstractions",
+        "Microsoft.Extensions.Configuration.Abstractions",
+    ];
+
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+    private Type _pluginType = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.FrameworkOnly);
+
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.FrameworkOnly);
+        _run.Failure.Should().BeNull();
+
+        _pluginType = _run.Result!.Plugins.Single().Instance.GetType();
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    private static IEnumerable<string> DeclaredRuntimeSimpleNames(string manifestPath)
+    {
+        using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+
+        string targetName = manifest
+            .RootElement.GetProperty("runtimeTarget")
+            .GetProperty("name")
+            .GetString()!;
+
+        foreach (
+            JsonProperty library in manifest
+                .RootElement.GetProperty("targets")
+                .GetProperty(targetName)
+                .EnumerateObject()
+        )
+        {
+            if (!library.Value.TryGetProperty("runtime", out JsonElement runtime))
+            {
+                continue;
+            }
+
+            foreach (JsonProperty asset in runtime.EnumerateObject())
+            {
+                yield return Path.GetFileNameWithoutExtension(asset.Name);
+            }
+        }
+    }
+
+    [Test]
+    public void It_declares_neither_of_them_in_its_manifest()
+    {
+        // Not "the manifest has one library": this fixture references the contract by project, so the
+        // contract is a manifest entry and whatever else the publish emits is enumerated here rather
+        // than assumed. The precise fact is that these two names are not among the declarations.
+        string[] declared = DeclaredRuntimeSimpleNames(
+                PluginFixtures.ManifestOf(PluginFixtures.FrameworkOnly)
+            )
+            .ToArray();
+
+        TestContext.Out.WriteLine($"declared runtime assets: {string.Join(", ", declared)}");
+
+        declared.Should().NotBeEmpty();
+        declared.Should().NotContain(SignatureAssemblies);
+    }
+
+    [TestCaseSource(nameof(SignatureAssemblies))]
+    public void It_ships_no_file_for_them_either(string simpleName)
+    {
+        // A declaration the preflight cannot see and a file the resolver could still find would be a
+        // different situation, so both halves are asserted.
+        File.Exists(Path.Combine(_root.RootPath, PluginFixtures.FrameworkOnly, $"{simpleName}.dll"))
+            .Should()
+            .BeFalse();
+    }
+
+    [Test]
+    public void It_is_served_the_hosts_own_instances_when_it_uses_them()
+    {
+        // Resolved from inside the plugin: each method body carries a type reference in the plugin
+        // assembly's own metadata, so the answer is what the plugin's context produced rather than
+        // what this test project happens to hold.
+        Type serviceCollection = (Type)_pluginType.GetMethod("ServiceCollectionType")!.Invoke(null, null)!;
+        Type configuration = (Type)_pluginType.GetMethod("ConfigurationType")!.Invoke(null, null)!;
+
+        serviceCollection.Should().BeSameAs(typeof(IServiceCollection));
+        configuration.Should().BeSameAs(typeof(IConfiguration));
+    }
+
+    [TestCaseSource(nameof(SignatureAssemblies))]
+    public void It_takes_them_from_the_default_context_rather_than_its_own(string simpleName)
+    {
+        // The provenance claim stated exactly. Both the loader's Load override and, had it declined,
+        // the runtime's own fallback would end at the default context for an assembly the plugin does
+        // not ship, so this asserts where the assembly came from and not which of those two produced
+        // it. That the override is genuinely consulted for an undeclared reference is Acme.BackstopCtor's
+        // evidence, where declining would have produced a private copy instead of a refusal.
+        Assembly resolved = _pluginType
+            .Assembly.GetReferencedAssemblies()
+            .Where(reference => reference.Name == simpleName)
+            .Select(reference =>
+                AssemblyLoadContext.GetLoadContext(_pluginType.Assembly)!.LoadFromAssemblyName(reference)
+            )
+            .Single();
+
+        AssemblyLoadContext.GetLoadContext(resolved).Should().BeSameAs(AssemblyLoadContext.Default);
+    }
+
+    [Test]
+    public void It_runs_its_hook_against_the_shared_types()
+    {
+        ServiceCollection services = [];
+
+        _run.Result!.Plugins.Single()
+            .Instance.ContributeServices(services, new ConfigurationBuilder().Build());
+
+        // One registration, of a plugin type, added through the host's own IServiceCollection. A split
+        // identity for either signature assembly would have failed before this point.
+        services.Should().ContainSingle();
+    }
+}
+
+/// <summary>
+/// The same suppressed manifest row as Acme.BackstopCtor, touched after the loader has returned.
+/// </summary>
+/// <remarks>
+/// The characterisation this fixture exists for is a negative one: there is no loader frame above a
+/// contribution hook, so nothing unwraps the runtime's <c>FileLoadException</c> and no friendly
+/// message naming both versions is produced. Claiming otherwise would be false, and the loader is not
+/// changed to reach into a call it does not make. Draft 03 owns invocation and is where a diagnostic
+/// for this case would belong.
+/// </remarks>
+[TestFixture]
+public class Given_a_skewed_reference_first_touched_after_the_loader_returned
+{
+    private TemporaryPluginRoot _root = null!;
+    private PluginLoaderRun _run = null!;
+    private Exception _failure = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.BackstopHook);
+
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.BackstopHook);
+
+        // Called directly rather than through reflection, so what the assertions see is the exception
+        // the runtime raised and not a TargetInvocationException wrapped around it. Captured rather
+        // than asserted here, because the exception's own type is one of the facts under test.
+        try
+        {
+            _run.Result!.Plugins.Single()
+                .Instance.ContributeServices(new ServiceCollection(), new ConfigurationBuilder().Build());
+
+            throw new AssertionException(
+                "Expected the hook to fail on the skewed reference, and it returned normally."
+            );
+        }
+        catch (Exception exception) when (exception is not AssertionException)
+        {
+            _failure = exception;
+        }
+
+        TestContext.Out.WriteLine($"after the loader returned: {_failure}");
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_loads_without_complaint()
+    {
+        // The preflight reads the manifest and the manifest says nothing about this reference, so there
+        // is nothing to refuse at load. That is the same blind spot Acme.BackstopCtor has; the only
+        // difference is when the reference is first needed.
+        _run.Failure.Should().BeNull();
+        _run.DiagnosticLines.Should()
+            .Contain(line => line.Contains($"plugin '{PluginFixtures.BackstopHook}' loaded"));
+    }
+
+    [Test]
+    public void It_fails_with_the_runtimes_own_wrapper_rather_than_a_loader_diagnostic()
+    {
+        // The honest characterisation. The refusal still happens - host-first has not been bypassed -
+        // but the caller is the hook, not the loader, so what reaches it is the runtime's wrapper.
+        _failure.Should().BeOfType<FileLoadException>();
+        _failure.Message.Should().Contain("Acme.HostShared");
+    }
+
+    [Test]
+    public void It_carries_the_named_skew_only_as_an_inner_cause()
+    {
+        // The information an operator wants is present but unformatted, which is exactly the gap. No
+        // loader-time friendly report exists for this case and none is claimed.
+        _failure.InnerException.Should().BeOfType<PluginVersionSkewException>();
+        _failure.Message.Should().NotContain("requires Acme.HostShared >= 2.0.0");
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSharedFrameworkTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSharedFrameworkTests.cs
@@ -3,7 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Reflection;
 using System.Runtime.Loader;
 using System.Text.Json;
 using FluentAssertions;
@@ -19,34 +18,49 @@ namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
 /// <remarks>
 /// <para>
 /// The evidence boundary matters more here than anywhere else in this suite, so it is stated rather
-/// than left to be inferred. What this fixture proves is <em>provenance and resolution</em>: those
-/// assemblies appear nowhere in the manifest and nowhere in the plugin directory, so the skew
-/// preflight cannot see them, and when the plugin uses them it is the host's own assembly instances it
-/// gets.
+/// than left to be inferred. What this fixture proves is that those assemblies appear nowhere in the
+/// manifest and nowhere in the plugin directory, so the skew preflight cannot see them; that the
+/// loader's own <c>Load</c> override is what answers for each of them rather than the runtime's
+/// fallback; and that what it serves is the host's own assembly instance out of the default context.
 /// </para>
 /// <para>
-/// What it does not prove is a <em>refusal</em>. A genuine shared-framework version skew would need a
-/// plugin compiled against a newer shared framework than the host runs, and with one installed runtime
-/// there is no such compilation. The refusal half belongs to
-/// <c>Given_a_plugin_whose_skewed_reference_the_manifest_does_not_declare</c> in
+/// What it does not prove is a <em>refusal</em>, and it is not evidence of a directly measured
+/// shared-framework version skew. That would need a plugin compiled against a newer shared framework
+/// than the host runs, and with one installed runtime there is no such compilation. The refusal half
+/// belongs to <c>Given_a_plugin_whose_skewed_reference_the_manifest_does_not_declare</c> in
 /// PluginLoaderVersionTests, over Acme.BackstopCtor, whose suppressed manifest row reproduces the one
-/// property that matters - a reference the preflight cannot see - on an ordinary assembly. Neither
-/// fixture is evidence for the other's claim.
+/// property that matters - a reference the preflight cannot see - on an ordinary assembly, and to the
+/// hook case below. Neither fixture is evidence for the other's claim.
 /// </para>
 /// </remarks>
 [TestFixture]
 public class Given_a_plugin_taking_the_hook_signature_from_the_shared_framework
 {
+    private const string ServiceCollectionAssembly = "Microsoft.Extensions.DependencyInjection.Abstractions";
+
+    private const string ConfigurationAssembly = "Microsoft.Extensions.Configuration.Abstractions";
+
     /// <summary>The two assemblies the hook signature names, which this plugin does not ship.</summary>
-    private static readonly string[] SignatureAssemblies =
+    private static readonly string[] SignatureAssemblies = [ServiceCollectionAssembly, ConfigurationAssembly];
+
+    /// <summary>
+    /// The same two, each paired with the plugin method whose body resolves a type out of it.
+    /// </summary>
+    /// <remarks>
+    /// The method matters as much as the name. Resolution has to be driven by the plugin's own code,
+    /// because asking the context to load the assembly directly would be the test resolving it rather
+    /// than the plugin, and the claim is about the plugin's first use.
+    /// </remarks>
+    private static readonly object[] SignatureAssemblyUses =
     [
-        "Microsoft.Extensions.DependencyInjection.Abstractions",
-        "Microsoft.Extensions.Configuration.Abstractions",
+        new object[] { ServiceCollectionAssembly, "ServiceCollectionType" },
+        new object[] { ConfigurationAssembly, "ConfigurationType" },
     ];
 
     private TemporaryPluginRoot _root = null!;
     private PluginLoaderRun _run = null!;
     private Type _pluginType = null!;
+    private PluginLoadContext _context = null!;
 
     [SetUp]
     public void Setup()
@@ -58,6 +72,10 @@ public class Given_a_plugin_taking_the_hook_signature_from_the_shared_framework
         _run.Failure.Should().BeNull();
 
         _pluginType = _run.Result!.Plugins.Single().Instance.GetType();
+
+        // The context the production loader built, reached the way anything holding a loaded plugin
+        // assembly would reach it. Nothing here creates a context or chooses its policy.
+        _context = (PluginLoadContext)AssemblyLoadContext.GetLoadContext(_pluginType.Assembly)!;
     }
 
     [TearDown]
@@ -91,16 +109,20 @@ public class Given_a_plugin_taking_the_hook_signature_from_the_shared_framework
         }
     }
 
+    /// <summary>Runs the plugin's own accessor, which is what forces the resolution.</summary>
+    private Type ResolvedByThePlugin(string accessor) =>
+        (Type)_pluginType.GetMethod(accessor)!.Invoke(null, null)!;
+
     [Test]
     public void It_declares_neither_of_them_in_its_manifest()
     {
         // Not "the manifest has one library": this fixture references the contract by project, so the
         // contract is a manifest entry and whatever else the publish emits is enumerated here rather
         // than assumed. The precise fact is that these two names are not among the declarations.
-        string[] declared = DeclaredRuntimeSimpleNames(
-                PluginFixtures.ManifestOf(PluginFixtures.FrameworkOnly)
-            )
-            .ToArray();
+        string[] declared =
+        [
+            .. DeclaredRuntimeSimpleNames(PluginFixtures.ManifestOf(PluginFixtures.FrameworkOnly)),
+        ];
 
         TestContext.Out.WriteLine($"declared runtime assets: {string.Join(", ", declared)}");
 
@@ -124,30 +146,69 @@ public class Given_a_plugin_taking_the_hook_signature_from_the_shared_framework
         // Resolved from inside the plugin: each method body carries a type reference in the plugin
         // assembly's own metadata, so the answer is what the plugin's context produced rather than
         // what this test project happens to hold.
-        Type serviceCollection = (Type)_pluginType.GetMethod("ServiceCollectionType")!.Invoke(null, null)!;
-        Type configuration = (Type)_pluginType.GetMethod("ConfigurationType")!.Invoke(null, null)!;
-
-        serviceCollection.Should().BeSameAs(typeof(IServiceCollection));
-        configuration.Should().BeSameAs(typeof(IConfiguration));
+        ResolvedByThePlugin("ServiceCollectionType").Should().BeSameAs(typeof(IServiceCollection));
+        ResolvedByThePlugin("ConfigurationType").Should().BeSameAs(typeof(IConfiguration));
     }
 
-    [TestCaseSource(nameof(SignatureAssemblies))]
-    public void It_takes_them_from_the_default_context_rather_than_its_own(string simpleName)
+    [TestCaseSource(nameof(SignatureAssemblyUses))]
+    public void It_reaches_the_loaders_own_override(string simpleName, string accessor)
     {
-        // The provenance claim stated exactly. Both the loader's Load override and, had it declined,
-        // the runtime's own fallback would end at the default context for an assembly the plugin does
-        // not ship, so this asserts where the assembly came from and not which of those two produced
-        // it. That the override is genuinely consulted for an undeclared reference is Acme.BackstopCtor's
-        // evidence, where declining would have produced a private copy instead of a refusal.
-        Assembly resolved = _pluginType
-            .Assembly.GetReferencedAssemblies()
-            .Where(reference => reference.Name == simpleName)
-            .Select(reference =>
-                AssemblyLoadContext.GetLoadContext(_pluginType.Assembly)!.LoadFromAssemblyName(reference)
-            )
-            .Single();
+        // The half a comment cannot stand in for. An assembly the plugin does not ship would arrive
+        // from the default context whether this context's override answered for it or declined and let
+        // the runtime fall back, so provenance alone cannot say which happened. Asking the context the
+        // production loader built whether its own override served the name can.
+        //
+        // Measured, and not what I first assumed: both names are already served by the time Load
+        // returns, so the assertion is not a false-then-true transition. The immediate cause is that
+        // this plugin overrides ContributeServices, and matching an override to its base virtual slot
+        // resolves the override's parameter types when the type is loaded - which the loader's own
+        // candidate scan does, before the plugin is ever used. The fact required is the same either
+        // way, and it holds across the plugin's own use as well.
+        _context.HasServedFromHost(simpleName).Should().BeTrue();
 
-        AssemblyLoadContext.GetLoadContext(resolved).Should().BeSameAs(AssemblyLoadContext.Default);
+        ResolvedByThePlugin(accessor);
+
+        _context.HasServedFromHost(simpleName).Should().BeTrue();
+    }
+
+    [Test]
+    public void It_reports_nothing_for_a_name_this_context_was_never_asked_for()
+    {
+        // The control that makes the assertions above mean something. A predicate that answered yes to
+        // anything would satisfy them without observing a thing, so a name this plugin does not
+        // reference and one nothing anywhere carries both have to come back no.
+        _context.HasServedFromHost("Acme.HostShared").Should().BeFalse();
+        _context.HasServedFromHost("Acme.NoSuchAssembly.ThisPluginHasNever.HeardOf").Should().BeFalse();
+    }
+
+    [TestCaseSource(nameof(SignatureAssemblyUses))]
+    public void It_still_declares_nothing_for_them_after_serving_them(string simpleName, string accessor)
+    {
+        // The two facts have to hold together, or the fixture would prove the override was consulted
+        // for something the preflight could have caught instead. Nothing the resolution does adds a
+        // declaration or a substitution row: there is no manifest version to have differed from.
+        ResolvedByThePlugin(accessor);
+
+        _run.Result!.Plugins.Single()
+            .DeclaredFiles.Should()
+            .NotContain(file => Path.GetFileNameWithoutExtension(file.FileName) == simpleName);
+
+        _run.Result!.Plugins.Single()
+            .MaterializeSubstitutions()
+            .Should()
+            .NotContain(substitution => substitution.AssemblyName == simpleName);
+    }
+
+    [TestCaseSource(nameof(SignatureAssemblyUses))]
+    public void It_takes_them_from_the_default_context_rather_than_its_own(string simpleName, string accessor)
+    {
+        // Provenance, read off the assembly the plugin's own resolution produced rather than off one
+        // this test asked for. simpleName is asserted too, so a fixture whose accessor stopped naming
+        // the assembly it is paired with fails here instead of passing on the other one.
+        Type resolved = ResolvedByThePlugin(accessor);
+
+        resolved.Assembly.GetName().Name.Should().Be(simpleName);
+        AssemblyLoadContext.GetLoadContext(resolved.Assembly).Should().BeSameAs(AssemblyLoadContext.Default);
     }
 
     [Test]

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSharedFrameworkTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSharedFrameworkTests.cs
@@ -57,10 +57,19 @@ public class Given_a_plugin_taking_the_hook_signature_from_the_shared_framework
         new object[] { ConfigurationAssembly, "ConfigurationType" },
     ];
 
+    /// <summary>
+    /// A name this plugin does not reference, watched alongside the two that matter.
+    /// </summary>
+    /// <remarks>
+    /// The control. An observer that reported every watched name as served would satisfy the two
+    /// assertions below without observing anything, so one watched name has to come back unserved.
+    /// </remarks>
+    private const string UnusedAssembly = "Acme.HostShared";
+
     private TemporaryPluginRoot _root = null!;
     private PluginLoaderRun _run = null!;
     private Type _pluginType = null!;
-    private PluginLoadContext _context = null!;
+    private HostResolutionObserver _observer = null!;
 
     [SetUp]
     public void Setup()
@@ -68,14 +77,15 @@ public class Given_a_plugin_taking_the_hook_signature_from_the_shared_framework
         _root = TemporaryPluginRoot.Create();
         _root.Add(PluginFixtures.FrameworkOnly);
 
-        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.FrameworkOnly);
+        // Named by this test and nothing wider: the two assemblies the hook signature carries, plus one
+        // the plugin never asks for. The production loader creates its contexts with no observer at
+        // all, so nothing outside this run records anything.
+        _observer = new HostResolutionObserver([.. SignatureAssemblies, UnusedAssembly]);
+
+        _run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.FrameworkOnly, observer: _observer);
         _run.Failure.Should().BeNull();
 
         _pluginType = _run.Result!.Plugins.Single().Instance.GetType();
-
-        // The context the production loader built, reached the way anything holding a loaded plugin
-        // assembly would reach it. Nothing here creates a context or chooses its policy.
-        _context = (PluginLoadContext)AssemblyLoadContext.GetLoadContext(_pluginType.Assembly)!;
     }
 
     [TearDown]
@@ -154,31 +164,39 @@ public class Given_a_plugin_taking_the_hook_signature_from_the_shared_framework
     public void It_reaches_the_loaders_own_override(string simpleName, string accessor)
     {
         // The half a comment cannot stand in for. An assembly the plugin does not ship would arrive
-        // from the default context whether this context's override answered for it or declined and let
-        // the runtime fall back, so provenance alone cannot say which happened. Asking the context the
-        // production loader built whether its own override served the name can.
+        // from the default context whether the override answered for it or declined and let the runtime
+        // fall back, and it leaves no substitution row either, because there is no declared version for
+        // the host's to have differed from. Only the override itself can say, so this run asks it.
         //
         // Measured, and not what I first assumed: both names are already served by the time Load
-        // returns, so the assertion is not a false-then-true transition. The immediate cause is that
-        // this plugin overrides ContributeServices, and matching an override to its base virtual slot
-        // resolves the override's parameter types when the type is loaded - which the loader's own
-        // candidate scan does, before the plugin is ever used. The fact required is the same either
-        // way, and it holds across the plugin's own use as well.
-        _context.HasServedFromHost(simpleName).Should().BeTrue();
+        // returns, so this is not a false-then-true transition and no such condition is manufactured.
+        // The cause is that this plugin overrides ContributeServices, and matching an override to its
+        // base virtual slot resolves the override's parameter types when the type is loaded, which the
+        // loader's own candidate scan does before the plugin is constructed. The fact required is the
+        // same either way, and it holds across the plugin's own use as well.
+        _observer.HasServed(simpleName).Should().BeTrue();
 
         ResolvedByThePlugin(accessor);
 
-        _context.HasServedFromHost(simpleName).Should().BeTrue();
+        _observer.HasServed(simpleName).Should().BeTrue();
     }
 
     [Test]
-    public void It_reports_nothing_for_a_name_this_context_was_never_asked_for()
+    public void It_reports_nothing_for_a_watched_name_the_plugin_never_asked_for()
     {
-        // The control that makes the assertions above mean something. A predicate that answered yes to
-        // anything would satisfy them without observing a thing, so a name this plugin does not
-        // reference and one nothing anywhere carries both have to come back no.
-        _context.HasServedFromHost("Acme.HostShared").Should().BeFalse();
-        _context.HasServedFromHost("Acme.NoSuchAssembly.ThisPluginHasNever.HeardOf").Should().BeFalse();
+        // Same observer, same run, a name the plugin does not reference: unserved. Without this an
+        // observer that said yes to everything would pass the cases above.
+        _observer.HasServed(UnusedAssembly).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_refuses_to_answer_about_a_name_it_was_not_watching()
+    {
+        // A quiet false for an unwatched name would let a caller read "never observed" as "never
+        // resolved", which is the one wrong answer this observation must not give.
+        Assert.Throws<InvalidOperationException>(() =>
+            _observer.HasServed("Microsoft.Extensions.Primitives")
+        );
     }
 
     [TestCaseSource(nameof(SignatureAssemblyUses))]

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSubstitutionSourceTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSubstitutionSourceTests.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// Where the substitution record gets the declaration it compares against.
+/// </summary>
+/// <remarks>
+/// The skew preflight reads top-level <c>runtime</c> entries only, which is a policy about what to
+/// refuse and is documented as a limitation. The record is a different question: it says what the
+/// plugin declared for an assembly the host actually served. Deriving it from the preflight's narrower
+/// set would report no declaration for a version the manifest plainly states, which is what these
+/// cases exist to prevent.
+/// </remarks>
+[TestFixture]
+public class Given_a_declaration_the_skew_preflight_does_not_read
+{
+    private TemporaryPluginRoot _root = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Substitution);
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    private static HostFirstSubstitution ResolveAndRecord(LoadedPlugin plugin)
+    {
+        plugin
+            .Instance.GetType()
+            .Assembly.GetType("Acme.Substitution.SubstitutionPlugin")!
+            .GetMethod("DescribeHostShared")!
+            .Invoke(null, null);
+
+        return plugin.MaterializeSubstitutions().Single(record => record.AssemblyName == "Acme.HostShared");
+    }
+
+    [Test]
+    public void It_still_reaches_the_record_when_declared_only_in_a_runtime_targets_row()
+    {
+        // The manifest declares the version here and nowhere else. Reporting no declaration would be
+        // untrue of the file, and it is exactly what deriving the record from the preflight's set does.
+        _root.MoveDeclarationToRuntimeTargets(PluginFixtures.Substitution, "Acme.HostShared", "0.1.0.0");
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Substitution);
+        run.Failure.Should().BeNull();
+
+        HostFirstSubstitution substitution = ResolveAndRecord(run.Result!.Plugins[0]);
+
+        substitution.DeclaredVersion.Should().Be(new Version(0, 1, 0, 0));
+        substitution.HostVersion.Should().Be(new Version(1, 0, 0, 0));
+    }
+
+    [Test]
+    public void It_keeps_the_declaration_and_the_reference_apart_when_they_disagree()
+    {
+        // The reference the entry assembly carries says 0.5.0.0 and the manifest says 0.1.0.0. Both are
+        // real and neither stands in for the other, so both are on the record.
+        _root.SetDeclaredVersion(PluginFixtures.Substitution, "Acme.HostShared", "0.1.0.0");
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Substitution);
+        run.Failure.Should().BeNull();
+
+        HostFirstSubstitution substitution = ResolveAndRecord(run.Result!.Plugins[0]);
+
+        substitution.DeclaredVersion.Should().Be(new Version(0, 1, 0, 0));
+        substitution.RequestedVersion.Should().Be(new Version(0, 5, 0, 0));
+        substitution.HostVersion.Should().Be(new Version(1, 0, 0, 0));
+    }
+
+    [Test]
+    public void It_records_nothing_when_the_host_serves_exactly_what_the_manifest_declared()
+    {
+        // The mirror case, and the one that pins which comparison is being made. The reference still
+        // says 0.5.0.0, so a record keyed on the reference would appear here; the manifest says the host
+        // served precisely what the plugin shipped, so nothing was substituted and nothing is reported.
+        _root.SetDeclaredVersion(PluginFixtures.Substitution, "Acme.HostShared", "1.0.0.0");
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Substitution);
+        run.Failure.Should().BeNull();
+
+        LoadedPlugin plugin = run.Result!.Plugins[0];
+
+        plugin
+            .Instance.GetType()
+            .Assembly.GetType("Acme.Substitution.SubstitutionPlugin")!
+            .GetMethod("DescribeHostShared")!
+            .Invoke(null, null);
+
+        plugin
+            .MaterializeSubstitutions()
+            .Should()
+            .NotContain(record => record.AssemblyName == "Acme.HostShared");
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSubstitutionSourceTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginSubstitutionSourceTests.cs
@@ -102,3 +102,63 @@ public class Given_a_declaration_the_skew_preflight_does_not_read
             .NotContain(record => record.AssemblyName == "Acme.HostShared");
     }
 }
+
+/// <summary>
+/// A reference that asks for exactly the version the host carries, over a manifest that declares
+/// something else.
+/// </summary>
+/// <remarks>
+/// The case a record keyed on the reference cannot see at all. The plugin was published against one
+/// version of a shared assembly and compiled against another, which is ordinary: a reference records
+/// the version the compiler bound to, and the manifest records what the publish actually shipped. What
+/// the plugin's author tested against is the copy in the package, so a host serving something else has
+/// substituted, whatever the reference happens to say.
+/// </remarks>
+[TestFixture]
+public class Given_a_reference_asking_for_the_version_the_host_carries
+{
+    private TemporaryPluginRoot _root = null!;
+    private HostFirstSubstitution _substitution = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = TemporaryPluginRoot.Create();
+        _root.Add(PluginFixtures.Substitution);
+
+        // The contract, which every plugin references at the host's own version and which the publish
+        // declares at that same version. Moving the declaration alone leaves the reference asking for
+        // precisely what the host serves.
+        _root.SetDeclaredVersion(PluginFixtures.Substitution, "EdFi.Api.Plugins", "0.1.0.0");
+
+        PluginLoaderRun run = PluginLoaderProbe.Run(_root.RootPath, PluginFixtures.Substitution);
+        run.Failure.Should().BeNull();
+
+        _substitution = run.Result!.Plugins[0]
+            .MaterializeSubstitutions()
+            .Single(record => record.AssemblyName == "EdFi.Api.Plugins");
+    }
+
+    [TearDown]
+    public void TearDown() => _root.Dispose();
+
+    [Test]
+    public void It_records_the_declaration_the_manifest_makes()
+    {
+        _substitution.DeclaredVersion.Should().Be(new Version(0, 1, 0, 0));
+    }
+
+    [Test]
+    public void It_records_a_request_the_host_satisfied_exactly()
+    {
+        // The half that makes the case: nothing about this resolution differs from what the reference
+        // asked for, so a record derived from the reference would not exist.
+        _substitution.RequestedVersion.Should().Be(_substitution.HostVersion);
+    }
+
+    [Test]
+    public void It_records_the_version_the_host_actually_served()
+    {
+        _substitution.HostVersion.Should().Be(new Version(1, 0, 0, 0));
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginsConfigurationBindingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginsConfigurationBindingTests.cs
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
+
+/// <summary>
+/// Builds an <see cref="IConfiguration"/> the way a host does, from JSON, so that the binder is
+/// exercised through real configuration rather than through a hand-made options instance.
+/// </summary>
+internal static class PluginsConfigurationFrom
+{
+    internal static IConfiguration Json(string json) =>
+        new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json))).Build();
+
+    internal static IConfiguration Allowed(string allowed) =>
+        Json("{\"Plugins\": {\"Allowed\": " + JsonSerializer.Serialize(allowed) + "}}");
+
+    internal static IConfiguration Directory(string directory) =>
+        Json("{\"Plugins\": {\"Directory\": " + JsonSerializer.Serialize(directory) + "}}");
+}
+
+[TestFixture]
+public class Given_a_configuration_with_no_plugins_section
+{
+    private PluginsConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Json("{}"));
+    }
+
+    [Test]
+    public void It_allows_no_plugins()
+    {
+        _configuration.AllowedNames.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_uses_the_default_plugin_root()
+    {
+        // The shipped default is /app/plugins. On a platform where that is rooted but not fully
+        // qualified it acquires the base directory's volume, so the assertion is on the tail rather
+        // than on the whole string.
+        _configuration.ResolvedRoot.Replace('\\', '/').Should().EndWith("/app/plugins");
+    }
+
+    [Test]
+    public void It_resolves_the_root_to_a_fully_qualified_path()
+    {
+        Path.IsPathFullyQualified(_configuration.ResolvedRoot).Should().BeTrue();
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_written_out_of_order_with_whitespace_and_empty_entries
+{
+    private PluginsConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _configuration = PluginsConfigurationBinder.Bind(
+            PluginsConfigurationFrom.Allowed("  Zulu.Plugin , ,Alpha.Plugin,   ,Mike.Plugin  ")
+        );
+    }
+
+    [Test]
+    public void It_keeps_the_order_the_operator_wrote()
+    {
+        // Order is contractual for the composition phases, so a sorted result would be wrong even
+        // though it contains the same names.
+        _configuration.AllowedNames.Should().Equal("Zulu.Plugin", "Alpha.Plugin", "Mike.Plugin");
+    }
+
+    [Test]
+    public void It_drops_empty_entries()
+    {
+        _configuration.AllowedNames.Should().HaveCount(3);
+    }
+
+    [Test]
+    public void It_trims_surrounding_whitespace_from_every_entry()
+    {
+        _configuration.AllowedNames.Should().OnlyContain(name => name == name.Trim());
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_of_one_name
+{
+    private PluginsConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed("Acme.Good"));
+    }
+
+    [Test]
+    public void It_allows_that_one_name()
+    {
+        _configuration.AllowedNames.Should().Equal("Acme.Good");
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_that_is_only_separators_and_whitespace
+{
+    private PluginsConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed(" , , "));
+    }
+
+    [Test]
+    public void It_allows_no_plugins()
+    {
+        // Indistinguishable from an absent allowlist, which is the continue-silently case rather than
+        // a list of empty names.
+        _configuration.AllowedNames.Should().BeEmpty();
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_naming_one_plugin_twice
+{
+    private PluginLoadException _exception = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(
+                PluginsConfigurationFrom.Allowed("Acme.Good,Other.Plugin,Acme.Good")
+            )
+        );
+    }
+
+    [Test]
+    public void It_refuses_the_ambiguous_allowlist()
+    {
+        _exception.Reason.Should().Be(PluginLoadFailure.DuplicateAllowlistEntry);
+    }
+
+    [Test]
+    public void It_names_the_duplicate()
+    {
+        _exception.PluginName.Should().Be("Acme.Good");
+        _exception.Message.Should().Contain("Acme.Good");
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_whose_duplicate_appears_only_after_trimming
+{
+    private PluginLoadException _exception = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed("Acme.Good,  Acme.Good  "))
+        );
+    }
+
+    [Test]
+    public void It_refuses_the_ambiguous_allowlist()
+    {
+        _exception.Reason.Should().Be(PluginLoadFailure.DuplicateAllowlistEntry);
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_whose_entries_differ_only_in_case
+{
+    private PluginLoadException _exception = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed("Acme.Good,acme.good"))
+        );
+    }
+
+    [Test]
+    public void It_refuses_the_pair_as_ambiguous()
+    {
+        // Two spellings of one name would resolve to one directory on a case-insensitive filesystem
+        // and to two on the image's, so the operator's intent cannot be recovered from the list.
+        _exception.Reason.Should().Be(PluginLoadFailure.DuplicateAllowlistEntry);
+    }
+
+    [Test]
+    public void It_names_the_second_spelling()
+    {
+        _exception.PluginName.Should().Be("acme.good");
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_entry_that_is_not_a_single_path_segment
+{
+    private static readonly string[] Rejected =
+    [
+        "/etc/passwd",
+        @"C:\Windows",
+        "..",
+        "../sibling",
+        @"..\sibling",
+        "sub/dir",
+        @"sub\dir",
+        ".hidden",
+        "-leading-dash",
+        "_leading_underscore",
+        "has space",
+        "quote'name",
+    ];
+
+    [TestCaseSource(nameof(Rejected))]
+    public void It_refuses_the_entry_and_names_the_rule(string entry)
+    {
+        PluginLoadException exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed(entry))
+        );
+
+        exception.Reason.Should().Be(PluginLoadFailure.InvalidAllowlistName);
+        exception.PluginName.Should().Be(entry);
+        exception.Message.Should().Contain(PluginsConfigurationBinder.AllowedNameRule);
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_entry_of_the_permitted_shape
+{
+    private static readonly string[] Accepted =
+    [
+        "A",
+        "0",
+        "Acme.Good",
+        "Acme_Plugin",
+        "Acme-Plugin",
+        "Acme.Dms.Identity",
+        "acme.good",
+    ];
+
+    [TestCaseSource(nameof(Accepted))]
+    public void It_accepts_the_entry(string entry)
+    {
+        PluginsConfigurationBinder
+            .Bind(PluginsConfigurationFrom.Allowed(entry))
+            .AllowedNames.Should()
+            .Equal(entry);
+    }
+}
+
+[TestFixture]
+public class Given_a_valid_allowlist_entry_followed_by_an_invalid_one
+{
+    private PluginLoadException _exception = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed("Acme.Good,../sibling"))
+        );
+    }
+
+    [Test]
+    public void It_refuses_the_whole_allowlist_rather_than_acting_on_the_valid_entry()
+    {
+        // The shape rule runs over every entry before anything is done with any of them, so a well
+        // formed first entry cannot buy the list a partial pass.
+        _exception.Reason.Should().Be(PluginLoadFailure.InvalidAllowlistName);
+        _exception.PluginName.Should().Be("../sibling");
+    }
+}
+
+[TestFixture]
+public class Given_a_valid_allowlist_entry_followed_by_a_duplicate
+{
+    private PluginLoadException _exception = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(
+                PluginsConfigurationFrom.Allowed("Acme.Good,Other.Plugin,other.plugin")
+            )
+        );
+    }
+
+    [Test]
+    public void It_refuses_the_whole_allowlist()
+    {
+        _exception.Reason.Should().Be(PluginLoadFailure.DuplicateAllowlistEntry);
+        _exception.PluginName.Should().Be("other.plugin");
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_entry_that_is_both_duplicated_and_malformed
+{
+    private PluginLoadException _exception = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed("sub/dir,sub/dir"))
+        );
+    }
+
+    [Test]
+    public void It_reports_the_ambiguity_first()
+    {
+        // Both rules apply, so the order they run in is observable and is pinned here: ambiguity is
+        // settled before shape, so the message an operator reads does not depend on which entry the
+        // implementation happened to examine first.
+        _exception.Reason.Should().Be(PluginLoadFailure.DuplicateAllowlistEntry);
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_entry_carrying_a_line_break
+{
+    private PluginLoadException _exception = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed("Acme\r\nplugins: forged line"))
+        );
+    }
+
+    [Test]
+    public void It_refuses_the_entry()
+    {
+        _exception.Reason.Should().Be(PluginLoadFailure.InvalidAllowlistName);
+    }
+
+    [Test]
+    public void It_escapes_the_line_break_rather_than_reproducing_it()
+    {
+        // The loader's messages go to a line-oriented channel and are re-emitted through the host's
+        // logger, so a configuration value carrying a line break would otherwise forge a line in both.
+        _exception.Message.Should().NotContain("\n");
+        _exception.Message.Should().NotContain("\r");
+        _exception.Message.Should().Contain(@"Acme\r\nplugins: forged line");
+    }
+}
+
+[TestFixture]
+public class Given_a_relative_plugin_directory
+{
+    private PluginsConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Directory("local-plugins"));
+    }
+
+    [Test]
+    public void It_resolves_the_directory_against_the_application_base_directory()
+    {
+        _configuration.ResolvedRoot.Should().Be(Path.GetFullPath("local-plugins", AppContext.BaseDirectory));
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_directory_that_needs_normalizing
+{
+    private PluginsConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        string unnormalized = Path.Combine(AppContext.BaseDirectory, "a", "..", "b");
+
+        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Directory(unnormalized));
+    }
+
+    [Test]
+    public void It_normalizes_the_directory()
+    {
+        _configuration.ResolvedRoot.Should().Be(Path.Combine(AppContext.BaseDirectory, "b"));
+    }
+}
+
+[TestFixture]
+public class Given_a_plugin_directory_that_is_present_but_empty
+{
+    private PluginLoadException _exception = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Directory("   "))
+        );
+    }
+
+    [Test]
+    public void It_refuses_rather_than_falling_back_to_the_default_root()
+    {
+        // An operator who cleared the setting did not ask for /app/plugins to be read, so silently
+        // restoring the default would load plugins nobody asked for.
+        _exception.Reason.Should().Be(PluginLoadFailure.PluginPathUnresolvable);
+    }
+}
+
+/// <summary>
+/// Captures the loader failure a call is expected to produce, so that every fixture asserts on the
+/// same shape rather than each spelling its own try/catch.
+/// </summary>
+internal static class CaptureLoadFailure
+{
+    internal static PluginLoadException From(Func<PluginsConfiguration> act)
+    {
+        try
+        {
+            PluginsConfiguration configuration = act();
+
+            throw new AssertionException(
+                "Expected a PluginLoadException, but the configuration bound successfully to "
+                    + $"root '{configuration.ResolvedRoot}' with "
+                    + $"[{string.Join(", ", configuration.AllowedNames)}]."
+            );
+        }
+        catch (PluginLoadException exception)
+        {
+            return exception;
+        }
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginsConfigurationBindingTests.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/PluginsConfigurationBindingTests.cs
@@ -12,19 +12,33 @@ using NUnit.Framework;
 namespace EdFi.Api.Plugins.Hosting.Tests.Unit;
 
 /// <summary>
-/// Builds an <see cref="IConfiguration"/> the way a host does, from JSON, so that the binder is
-/// exercised through real configuration rather than through a hand-made options instance.
+/// Builds an <see cref="IConfiguration"/> the way a host does, from real providers, so that the binder
+/// is exercised through configuration rather than through a hand-made options instance. The JSON
+/// provider is used deliberately: it is the one that can put a null where a property initializer put a
+/// default, which a hand-made instance can never reproduce.
 /// </summary>
 internal static class PluginsConfigurationFrom
 {
+    /// <summary>A directory value no platform can turn into a path.</summary>
+    internal const string MalformedDirectory = "bad\u0000path";
+
     internal static IConfiguration Json(string json) =>
         new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json))).Build();
 
     internal static IConfiguration Allowed(string allowed) =>
         Json("{\"Plugins\": {\"Allowed\": " + JsonSerializer.Serialize(allowed) + "}}");
 
-    internal static IConfiguration Directory(string directory) =>
-        Json("{\"Plugins\": {\"Directory\": " + JsonSerializer.Serialize(directory) + "}}");
+    internal static IConfiguration AllowedAndDirectory(string allowed, string directory) =>
+        Json(
+            "{\"Plugins\": {\"Allowed\": "
+                + JsonSerializer.Serialize(allowed)
+                + ", \"Directory\": "
+                + JsonSerializer.Serialize(directory)
+                + "}}"
+        );
+
+    /// <summary>A section that writes a literal JSON null for the named key.</summary>
+    internal static IConfiguration NullValued(string key) => Json("{\"Plugins\": {\"" + key + "\": null}}");
 }
 
 [TestFixture]
@@ -45,18 +59,42 @@ public class Given_a_configuration_with_no_plugins_section
     }
 
     [Test]
+    public void It_resolves_no_plugin_root()
+    {
+        // The shipped default asks for nothing, so there is nothing to read and no root to resolve.
+        // Reporting a root here would make "no plugins were asked for" indistinguishable from "the
+        // plugin root happens to be missing", which are different rows in the failure semantics.
+        _configuration.TryGetResolvedRoot(out string? root).Should().BeFalse();
+        root.Should().BeNull();
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_and_no_configured_directory
+{
+    private PluginsConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed("Acme.Good"));
+    }
+
+    [Test]
     public void It_uses_the_default_plugin_root()
     {
         // The shipped default is /app/plugins. On a platform where that is rooted but not fully
         // qualified it acquires the base directory's volume, so the assertion is on the tail rather
         // than on the whole string.
-        _configuration.ResolvedRoot.Replace('\\', '/').Should().EndWith("/app/plugins");
+        _configuration.TryGetResolvedRoot(out string? root).Should().BeTrue();
+        root!.Replace('\\', '/').Should().EndWith("/app/plugins");
     }
 
     [Test]
     public void It_resolves_the_root_to_a_fully_qualified_path()
     {
-        Path.IsPathFullyQualified(_configuration.ResolvedRoot).Should().BeTrue();
+        _configuration.TryGetResolvedRoot(out string? root).Should().BeTrue();
+        Path.IsPathFullyQualified(root!).Should().BeTrue();
     }
 }
 
@@ -129,6 +167,151 @@ public class Given_an_allowlist_that_is_only_separators_and_whitespace
         // Indistinguishable from an absent allowlist, which is the continue-silently case rather than
         // a list of empty names.
         _configuration.AllowedNames.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_resolves_no_plugin_root()
+    {
+        _configuration.TryGetResolvedRoot(out _).Should().BeFalse();
+    }
+}
+
+[TestFixture]
+public class Given_an_allowlist_written_as_a_json_null
+{
+    private PluginsConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Configuration binding assigns a null straight over a property initializer, so this is the one
+        // input a hand-made options instance cannot reproduce, and the one that reached the split as a
+        // null reference before this case existed.
+        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.NullValued("Allowed"));
+    }
+
+    [Test]
+    public void It_reads_as_asking_for_no_plugins()
+    {
+        _configuration.AllowedNames.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_resolves_no_plugin_root()
+    {
+        _configuration.TryGetResolvedRoot(out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_binds_a_json_null_over_the_property_default()
+    {
+        // Pins the runtime behaviour the two cases above exist for, so neither of them can pass
+        // vacuously: if binding left the initializer in place, the null handling in the binder would be
+        // unreachable and these assertions would prove nothing.
+        PluginsConfigurationFrom
+            .NullValued("Allowed")
+            .GetSection(PluginsConfigurationBinder.SectionName)
+            .Get<PluginsOptions>()!
+            .Allowed.Should()
+            .BeNull();
+
+        PluginsConfigurationFrom
+            .NullValued("Directory")
+            .GetSection(PluginsConfigurationBinder.SectionName)
+            .Get<PluginsOptions>()!
+            .Directory.Should()
+            .BeNull();
+    }
+}
+
+[TestFixture]
+public class Given_no_plugins_are_asked_for_and_the_directory_is_unusable
+{
+    private static readonly string[] UnusableDirectories =
+    [
+        "",
+        "   ",
+        PluginsConfigurationFrom.MalformedDirectory,
+    ];
+
+    [TestCaseSource(nameof(UnusableDirectories))]
+    public void It_still_asks_for_no_plugins(string directory)
+    {
+        // The shipped default is an empty allowlist, so a deployment that adopts nothing has to boot
+        // whatever Plugins:Directory says. Validating an unused setting would turn every such
+        // deployment's stray value into a startup failure.
+        PluginsConfiguration configuration = PluginsConfigurationBinder.Bind(
+            PluginsConfigurationFrom.AllowedAndDirectory(string.Empty, directory)
+        );
+
+        configuration.AllowedNames.Should().BeEmpty();
+        configuration.TryGetResolvedRoot(out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_still_asks_for_no_plugins_when_the_directory_is_a_json_null()
+    {
+        PluginsConfiguration configuration = PluginsConfigurationBinder.Bind(
+            PluginsConfigurationFrom.NullValued("Directory")
+        );
+
+        configuration.AllowedNames.Should().BeEmpty();
+        configuration.TryGetResolvedRoot(out _).Should().BeFalse();
+    }
+}
+
+[TestFixture]
+public class Given_plugins_are_asked_for_and_the_directory_is_unusable
+{
+    private static readonly string[] UnusableDirectories =
+    [
+        "",
+        "   ",
+        PluginsConfigurationFrom.MalformedDirectory,
+    ];
+
+    [TestCaseSource(nameof(UnusableDirectories))]
+    public void It_refuses_with_a_named_failure(string directory)
+    {
+        // Once a plugin has been asked for, the root is load-bearing, so an unusable value is fatal
+        // rather than quietly replaced by the default.
+        PluginLoadException exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(
+                PluginsConfigurationFrom.AllowedAndDirectory("Acme.Good", directory)
+            )
+        );
+
+        exception.Reason.Should().Be(PluginLoadFailure.PluginPathUnresolvable);
+        exception.PluginName.Should().BeNull();
+    }
+
+    [Test]
+    public void It_refuses_a_directory_written_as_a_json_null()
+    {
+        PluginLoadException exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(
+                PluginsConfigurationFrom.Json(
+                    "{\"Plugins\": {\"Allowed\": \"Acme.Good\", \"Directory\": null}}"
+                )
+            )
+        );
+
+        exception.Reason.Should().Be(PluginLoadFailure.PluginPathUnresolvable);
+    }
+
+    [Test]
+    public void It_escapes_a_control_character_in_the_refused_directory()
+    {
+        PluginLoadException exception = CaptureLoadFailure.From(() =>
+            PluginsConfigurationBinder.Bind(
+                PluginsConfigurationFrom.AllowedAndDirectory(
+                    "Acme.Good",
+                    PluginsConfigurationFrom.MalformedDirectory
+                )
+            )
+        );
+
+        exception.Message.Should().Contain(@"bad\u0000path");
     }
 }
 
@@ -372,13 +555,16 @@ public class Given_a_relative_plugin_directory
     [SetUp]
     public void Setup()
     {
-        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Directory("local-plugins"));
+        _configuration = PluginsConfigurationBinder.Bind(
+            PluginsConfigurationFrom.AllowedAndDirectory("Acme.Good", "local-plugins")
+        );
     }
 
     [Test]
     public void It_resolves_the_directory_against_the_application_base_directory()
     {
-        _configuration.ResolvedRoot.Should().Be(Path.GetFullPath("local-plugins", AppContext.BaseDirectory));
+        _configuration.TryGetResolvedRoot(out string? root).Should().BeTrue();
+        root.Should().Be(Path.GetFullPath("local-plugins", AppContext.BaseDirectory));
     }
 }
 
@@ -392,41 +578,77 @@ public class Given_a_plugin_directory_that_needs_normalizing
     {
         string unnormalized = Path.Combine(AppContext.BaseDirectory, "a", "..", "b");
 
-        _configuration = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Directory(unnormalized));
+        _configuration = PluginsConfigurationBinder.Bind(
+            PluginsConfigurationFrom.AllowedAndDirectory("Acme.Good", unnormalized)
+        );
     }
 
     [Test]
     public void It_normalizes_the_directory()
     {
-        _configuration.ResolvedRoot.Should().Be(Path.Combine(AppContext.BaseDirectory, "b"));
-    }
-}
-
-[TestFixture]
-public class Given_a_plugin_directory_that_is_present_but_empty
-{
-    private PluginLoadException _exception = null!;
-
-    [SetUp]
-    public void Setup()
-    {
-        _exception = CaptureLoadFailure.From(() =>
-            PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Directory("   "))
-        );
-    }
-
-    [Test]
-    public void It_refuses_rather_than_falling_back_to_the_default_root()
-    {
-        // An operator who cleared the setting did not ask for /app/plugins to be read, so silently
-        // restoring the default would load plugins nobody asked for.
-        _exception.Reason.Should().Be(PluginLoadFailure.PluginPathUnresolvable);
+        _configuration.TryGetResolvedRoot(out string? root).Should().BeTrue();
+        root.Should().Be(Path.Combine(AppContext.BaseDirectory, "b"));
     }
 }
 
 /// <summary>
-/// Captures the loader failure a call is expected to produce, so that every fixture asserts on the
-/// same shape rather than each spelling its own try/catch.
+/// The environment-variable form is the one deployments actually use, so it is asserted against the
+/// JSON form rather than assumed equivalent.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class Given_the_allowlist_supplied_as_an_environment_variable
+{
+    private const string VariableName = "Plugins__Allowed";
+    private const string Written = "  Zulu.Plugin , ,Alpha.Plugin,Mike.Plugin  ";
+
+    private string? _previousValue;
+    private PluginsConfiguration _fromEnvironment = null!;
+    private PluginsConfiguration _fromJson = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _previousValue = Environment.GetEnvironmentVariable(VariableName);
+        Environment.SetEnvironmentVariable(VariableName, Written);
+
+        _fromEnvironment = PluginsConfigurationBinder.Bind(
+            new ConfigurationBuilder().AddEnvironmentVariables().Build()
+        );
+        _fromJson = PluginsConfigurationBinder.Bind(PluginsConfigurationFrom.Allowed(Written));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // Restores whatever was there, which for an absent variable means null and therefore removal.
+        // Deleting unconditionally would discard a value this process did not own.
+        Environment.SetEnvironmentVariable(VariableName, _previousValue);
+    }
+
+    [Test]
+    public void It_binds_to_the_same_ordered_list_as_the_json_form()
+    {
+        _fromEnvironment.AllowedNames.Should().Equal(_fromJson.AllowedNames);
+    }
+
+    [Test]
+    public void It_keeps_the_order_the_operator_wrote()
+    {
+        _fromEnvironment.AllowedNames.Should().Equal("Zulu.Plugin", "Alpha.Plugin", "Mike.Plugin");
+    }
+
+    [Test]
+    public void It_resolves_the_default_plugin_root()
+    {
+        _fromEnvironment.TryGetResolvedRoot(out string? root).Should().BeTrue();
+        root!.Replace('\\', '/').Should().EndWith("/app/plugins");
+    }
+}
+
+/// <summary>
+/// Captures the loader failure a call is expected to produce, so that every fixture asserts on the same
+/// shape rather than each spelling its own try/catch.
 /// </summary>
 internal static class CaptureLoadFailure
 {
@@ -435,11 +657,11 @@ internal static class CaptureLoadFailure
         try
         {
             PluginsConfiguration configuration = act();
+            configuration.TryGetResolvedRoot(out string? root);
 
             throw new AssertionException(
-                "Expected a PluginLoadException, but the configuration bound successfully to "
-                    + $"root '{configuration.ResolvedRoot}' with "
-                    + $"[{string.Join(", ", configuration.AllowedNames)}]."
+                "Expected a PluginLoadException, but the configuration bound successfully to root "
+                    + $"'{root ?? "<none>"}' with [{string.Join(", ", configuration.AllowedNames)}]."
             );
         }
         catch (PluginLoadException exception)

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/packages.lock.json
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/packages.lock.json
@@ -172,6 +172,9 @@
         "resolved": "4.4.0",
         "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
       },
+      "Acme.HostShared": {
+        "type": "Project"
+      },
       "edfi.api.plugins": {
         "type": "Project",
         "dependencies": {

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/packages.lock.json
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/packages.lock.json
@@ -1,0 +1,216 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.2, )",
+        "resolved": "6.0.2",
+        "contentHash": "bJShQ6uWRTQ100ZeyiMqcFlhP7WJ+bCuabUs885dJiBEzMsJMSFr7BOyeCw4rgvQokteGi5rKQTlkhfQPUXg2A=="
+      },
+      "coverlet.msbuild": {
+        "type": "Direct",
+        "requested": "[6.0.2, )",
+        "resolved": "6.0.2",
+        "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
+      },
+      "FluentAssertions": {
+        "type": "Direct",
+        "requested": "[6.12.1, )",
+        "resolved": "6.12.1",
+        "contentHash": "hciWwryyLw3eonfqhFpOMTXyM1/auJChYslEBA+iGJyuBs5O3t/kA8YaeH4iRo/2Fe3ElSYL86C0miivtZ0f3g==",
+        "dependencies": {
+          "System.Configuration.ConfigurationManager": "4.4.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.CodeStyle": {
+        "type": "Direct",
+        "requested": "[4.12.0, )",
+        "resolved": "4.12.0",
+        "contentHash": "5S+LHLhm0am4MWQQMN0O3VyKA/St5JCqH1yv+1YGZl2klIJlLlmNA/KTLCVJSC1kZPIKR1MFF/3g9FqsyzIyCQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "csD8Eps3HQ3yc0x6NhgTV+aIFKSs3qVlVCtFnMHz/JOjnv7eEj/qSXKXiK9LzBzB1qSfAVqFnB5iaX2nUmagIQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "0zW3eYBJlRctmgqk5s0kFIi5o5y2g80mvGCD8bkYxREPQlKUnr0ndU/Sop+UDIhyWN0fIi4RW63vo7BKTi7ncA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.11.1, )",
+        "resolved": "17.11.1",
+        "contentHash": "U3Ty4BaGoEu+T2bwSko9tWqWUOU16WzSFkq6U8zve75oRBMSLTBdMAZrVNNz1Tq12aCdDom9fcOcM9QZaFHqFg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.11.1",
+          "Microsoft.TestPlatform.TestHost": "17.11.1"
+        }
+      },
+      "NUnit": {
+        "type": "Direct",
+        "requested": "[4.2.2, )",
+        "resolved": "4.2.2",
+        "contentHash": "mon0OPko28yZ/foVXrhiUvq1LReaGsBdziumyyYGxV/pOE4q92fuYeN+AF+gEU5pCjzykcdBt5l7xobTaiBjsg=="
+      },
+      "NUnit.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "Ki4p1XrmnYil64HE9VkJSuo6KBr8vg7Mut43atYvItDp3HwIcRY5hi+n5o8GaX1IBCwYLaJgW5ZfZuBVPYXEkg=="
+      },
+      "NUnit3TestAdapter": {
+        "type": "Direct",
+        "requested": "[4.6.0, )",
+        "resolved": "4.6.0",
+        "contentHash": "R7e1+a4vuV/YS+ItfL7f//rG+JBvVeVLX4mHzFEZo4W1qEKl8Zz27AqvQSAqo+BtIzUCo4aAJMYa56VXS4hudw=="
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[9.32.0.97167, )",
+        "resolved": "9.32.0.97167",
+        "contentHash": "Yxk86RV+8ynJpUhku1Yw2hITFmnmXKkXJ73cIFSy85ol5SnWREQg9RuTyV8nI7V7+pyLKpCfRmD7P0widsgjkg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.11.1",
+        "contentHash": "nPJqrcA5iX+Y0kqoT3a+pD/8lrW/V7ayqnEJQsTonSoPz59J8bmoQhcSN4G8+UJ64Hkuf0zuxnfuj2lkHOq4cA=="
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "N/6GiwiZFCBFZDk3vg1PhHW3zMqqu5WWpmeZAA9VTXv7Q8pr8NZR/EQsH0DjzqydDksJtY6EQBsu81d5okQOlA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "+b3DligYSZuoWltU5YdbMpIEUHNZPgPrzWfNiIuDkMdqOl93UxYB5KzS3lgpRfTXJhTNpo/CZ8w/sTkDTPDdxQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "4bxzGXIzZnz0Bf7czQ72jGvpOqJsRW/44PS7YLFXTTnu6cNcPvmSREDvBoH0ZVP2hAbMfL4sUoCUn54k70jPWw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "49dFvGJjLSwGn76eHnP1gBvCJkL8HRYpCrG0DCvsP6wRpEQRLN2Fq8rTxbP+6jS7jmYKCnSVO5C65v4mT3rzeA=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.11.1",
+        "contentHash": "E2jZqAU6JeWEVsyOEOrSW1o1bpHLgb25ypvKNB/moBXPVsFYBPd/Jwi7OrYahG50J83LfHzezYI+GaEkpAotiA=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.11.1",
+        "contentHash": "DnG+GOqJXO/CkoqlJWeDFTgPhqD/V6VqUIL3vINizCWZ3X+HshCtbbyDdSHQQEjrc2Sl/K3yaxX6s+5LFEdYuw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.11.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gWwQv/Ug1qWJmHCmN17nAbxJYmQBM/E94QxKLksvUiiKB1Ld3Sc/eK1lgmbSjDFxkQhVuayI/cGFZhpBSodLrg==",
+        "dependencies": {
+          "System.Security.Cryptography.ProtectedData": "4.4.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
+      },
+      "edfi.api.plugins": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )"
+        }
+      },
+      "edfi.api.plugins.hosting": {
+        "type": "Project",
+        "dependencies": {
+          "EdFi.Api.Plugins": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.1, )"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Lp4CZIuTVXtlvkAnTq6QvMSW7+H62gX2cU2vdFxHQUxvrWTpi7LwYI3X+YAyIS0r12/p7gaosco7efIxL4yFNw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
+      }
+    }
+  }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/packages.lock.json
+++ b/src/plugins/EdFi.Api.Plugins.Hosting.Tests.Unit/packages.lock.json
@@ -61,6 +61,25 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1"
         }
       },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "G6VVwywpJI4XIobetGHwg7wDOYC2L2XBYdtskxLaKF/Ynb5QBwLl7Q//wxAR2aVCLkMpoQrjSP9VoORkyddsNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.11.1, )",

--- a/src/plugins/EdFi.Api.Plugins.Hosting/EdFi.Api.Plugins.Hosting.csproj
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/EdFi.Api.Plugins.Hosting.csproj
@@ -10,13 +10,25 @@
         -->
         <IsPackable>false</IsPackable>
     </PropertyGroup>
-    <!--
-        Deliberately empty. This project exists now so that the solution entries and the committed
-        lock files for both production projects are settled by the story that creates src/plugins,
-        rather than arriving with the loader. The loader, its discovery and load-isolation code, and
-        this project's unit test project are added by the story that follows.
-    -->
     <ItemGroup>
         <ProjectReference Include="..\EdFi.Api.Plugins\EdFi.Api.Plugins.csproj" />
+    </ItemGroup>
+    <!--
+        The binder is what turns the Plugins section into PluginsOptions. IConfiguration itself
+        arrives from the contract's Microsoft.Extensions.Configuration.Abstractions reference; the
+        Get<T> extension lives in the Binder package and is the only reason it is here. It is a host
+        assembly dependency and not a contract one, so it places no obligation on a plugin author.
+    -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    </ItemGroup>
+    <!--
+        The loader's collaborators are the filesystem, the dependency manifest, and the runtime's own
+        binder, so the types that model them are internal: they are implementation, not a surface a
+        host composes against. The unit test project therefore needs access to them to assert the
+        rules directly rather than only through what Load happens to expose.
+    -->
+    <ItemGroup>
+        <InternalsVisibleTo Include="EdFi.Api.Plugins.Hosting.Tests.Unit" />
     </ItemGroup>
 </Project>

--- a/src/plugins/EdFi.Api.Plugins.Hosting/EntryAssemblyReferences.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/EntryAssemblyReferences.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Reads an entry assembly's assembly references from metadata, without loading it.
+/// </summary>
+/// <remarks>
+/// The contract-skew check has to run before any type is loaded, so that a plugin built against a newer
+/// contract than the host is refused with a message naming both versions rather than surfacing later as
+/// a type-load error from somewhere an operator cannot act on. Reading metadata is what makes that
+/// ordering possible.
+/// </remarks>
+internal static class EntryAssemblyReferences
+{
+    /// <summary>Reads the simple name and version of every assembly the entry assembly references.</summary>
+    /// <exception cref="PluginLoadException">The file is not a readable managed assembly.</exception>
+    internal static IReadOnlyList<(string Name, Version Version)> Read(
+        string pluginName,
+        string entryAssemblyPath
+    )
+    {
+        try
+        {
+            using FileStream stream = File.OpenRead(entryAssemblyPath);
+            using PEReader peReader = new(stream);
+
+            if (!peReader.HasMetadata)
+            {
+                throw Unreadable(pluginName, entryAssemblyPath, innerException: null);
+            }
+
+            MetadataReader metadata = peReader.GetMetadataReader();
+            List<(string, Version)> references = [];
+
+            foreach (AssemblyReferenceHandle handle in metadata.AssemblyReferences)
+            {
+                AssemblyReference reference = metadata.GetAssemblyReference(handle);
+                references.Add((metadata.GetString(reference.Name), reference.Version));
+            }
+
+            return references;
+        }
+        catch (Exception exception)
+            when (exception
+                    is BadImageFormatException
+                        or InvalidOperationException
+                        or IOException
+                        or UnauthorizedAccessException
+            )
+        {
+            throw Unreadable(pluginName, entryAssemblyPath, exception);
+        }
+    }
+
+    private static PluginLoadException Unreadable(
+        string pluginName,
+        string entryAssemblyPath,
+        Exception? innerException
+    ) =>
+        new(
+            PluginLoadFailure.EntryAssemblyUnreadable,
+            pluginName,
+            $"plugin '{PluginDiagnosticText.Quote(pluginName)}' has an entry assembly at "
+                + $"'{PluginDiagnosticText.Quote(entryAssemblyPath)}' whose metadata could not be read. "
+                + "It has to be the managed assembly a dotnet publish of the plugin produced.",
+            innerException
+        );
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/HostAssemblies.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/HostAssemblies.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Asks the host what it carries, by simple name.
+/// </summary>
+/// <remarks>
+/// The simple name is the whole point. <see cref="AssemblyLoadContext.LoadFromAssemblyName"/> throws
+/// <see cref="FileNotFoundException"/> both when the host has nothing by that name and when the host
+/// has an older version than the request declares, so a request carrying a version cannot tell the two
+/// apart and a fall-through on that exception would hand a version-skewed plugin its private copy
+/// silently. Asking without a version carries no constraint the binder can fail on, which leaves the
+/// comparison to the loader, where it can be reported.
+/// </remarks>
+internal static class HostAssemblies
+{
+    /// <summary>
+    /// Loads the host's copy of <paramref name="simpleName"/>, or returns <see langword="false"/> when
+    /// the host carries nothing by that name.
+    /// </summary>
+    internal static bool TryLoad(string simpleName, out Assembly assembly)
+    {
+        try
+        {
+            assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(simpleName));
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            assembly = null!;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads the <c>AssemblyVersion</c> the host carries for <paramref name="simpleName"/>, when it
+    /// carries one at all and that copy declares a version.
+    /// </summary>
+    internal static bool TryGetVersion(string simpleName, out Version version)
+    {
+        if (TryLoad(simpleName, out Assembly assembly) && assembly.GetName().Version is { } hostVersion)
+        {
+            version = hostVersion;
+            return true;
+        }
+
+        version = null!;
+        return false;
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/HostAssemblies.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/HostAssemblies.cs
@@ -29,7 +29,15 @@ internal static class HostAssemblies
     {
         try
         {
-            assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(simpleName));
+            // Built by property rather than by parsing. The AssemblyName(string) constructor is the
+            // display-name parser: a name carrying ", Version=" is read as a different assembly plus a
+            // version constraint, and the host's copy of that other assembly comes back in its place,
+            // while a name carrying a comma, an equals sign or a quotation mark is rejected outright
+            // with an exception that is not the FileNotFoundException below. Both are reachable,
+            // because this name is derived from a path a third party wrote. A simple name is a name.
+            assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(
+                new AssemblyName { Name = simpleName }
+            );
             return true;
         }
         catch (FileNotFoundException)

--- a/src/plugins/EdFi.Api.Plugins.Hosting/HostResolutionObserver.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/HostResolutionObserver.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Watches a finite, caller-supplied set of assembly names and records which of them a load context's
+/// host-first override actually served.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because one claim about the loader cannot be observed from its results. For an assembly
+/// a framework-dependent publish does not declare, the default context is where the assembly comes
+/// from whether the override served it or declined and let the runtime fall back, and there is no
+/// substitution row either, because there is no declared version for the host's to have differed from.
+/// The only way to tell the two apart is to ask the override.
+/// </para>
+/// <para>
+/// It is deliberately not a log of what a context was asked for. The caller names the assemblies it
+/// wants to know about, nothing outside that set is retained, and no ordering or repeat count is kept.
+/// A context created without one records nothing at all, which is what the public loader path does, so
+/// an ordinary host run carries no observation state.
+/// </para>
+/// </remarks>
+internal sealed class HostResolutionObserver
+{
+    private readonly HashSet<string> _watched;
+    private readonly HashSet<string> _served = new(StringComparer.Ordinal);
+    private readonly Lock _gate = new();
+
+    /// <summary>Watches exactly <paramref name="simpleNames"/> and nothing else.</summary>
+    internal HostResolutionObserver(IReadOnlyCollection<string> simpleNames)
+    {
+        ArgumentNullException.ThrowIfNull(simpleNames);
+
+        _watched = new HashSet<string>(simpleNames, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Notes that the override served <paramref name="simpleName"/> from the host, when that name is
+    /// watched.
+    /// </summary>
+    internal void Record(string simpleName)
+    {
+        // Filtered here rather than at the call site, so the context stays free of any knowledge of
+        // what is being watched and an unwatched name costs a set lookup and nothing else.
+        lock (_gate)
+        {
+            if (_watched.Contains(simpleName))
+            {
+                _served.Add(simpleName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether the override served <paramref name="simpleName"/>, which must be one of the watched
+    /// names.
+    /// </summary>
+    /// <remarks>
+    /// Asking about an unwatched name throws rather than answering <see langword="false"/>. A quiet
+    /// false would let a caller believe it had observed the absence of a resolution that was simply
+    /// never being watched for, which is the one wrong answer this type must not give.
+    /// </remarks>
+    internal bool HasServed(string simpleName)
+    {
+        lock (_gate)
+        {
+            if (!_watched.Contains(simpleName))
+            {
+                throw new InvalidOperationException(
+                    $"'{simpleName}' is not among the watched names [{string.Join(", ", _watched)}], "
+                        + "so nothing was recorded about it either way."
+                );
+            }
+
+            return _served.Contains(simpleName);
+        }
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/LoadedPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/LoadedPlugin.cs
@@ -137,9 +137,16 @@ public sealed record LoadedPlugin
         _loadContext.MaterializeSubstitutions();
 
     /// <summary>
-    /// The version the process actually has for a file, which for the entry assembly comes from the
-    /// loaded assembly because a framework-dependent publish declares none for it.
+    /// The version to report for a file: the manifest's declaration where there is one, and for the
+    /// entry assembly, which a framework-dependent publish declares no version for, the version read
+    /// from the assembly the process loaded.
     /// </summary>
+    /// <remarks>
+    /// For a row other than the entry assembly this is the declared version rather than an independent
+    /// reading of the file, and the source on the row says so. Calling it the version the process has
+    /// would overstate it: an assembly the host served instead is a version this row does not describe,
+    /// which is what the substitution record covers.
+    /// </remarks>
     private Version? EffectiveVersionOf(PluginDeclaredFile file) =>
         file.DeclaredAssemblyVersion ?? (IsEntryAssembly(file) ? EntryAssemblyVersion : null);
 

--- a/src/plugins/EdFi.Api.Plugins.Hosting/LoadedPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/LoadedPlugin.cs
@@ -3,7 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Runtime.Loader;
+using System.Reflection;
 
 namespace EdFi.Api.Plugins.Hosting;
 
@@ -18,19 +18,25 @@ namespace EdFi.Api.Plugins.Hosting;
 /// </remarks>
 public sealed record LoadedPlugin
 {
+    private readonly PluginLoadContext _loadContext;
+
     internal LoadedPlugin(
         string name,
         EdFiApiPlugin instance,
         string directory,
         Version entryAssemblyVersion,
-        AssemblyLoadContext loadContext
+        string entryAssemblyFileName,
+        IReadOnlyList<PluginDeclaredFile> declaredFiles,
+        PluginLoadContext loadContext
     )
     {
         Name = name;
         Instance = instance;
         Directory = directory;
         EntryAssemblyVersion = entryAssemblyVersion;
-        LoadContext = loadContext;
+        EntryAssemblyFileName = entryAssemblyFileName;
+        DeclaredFiles = declaredFiles;
+        _loadContext = loadContext;
     }
 
     /// <summary>
@@ -52,9 +58,122 @@ public sealed record LoadedPlugin
     /// </summary>
     public Version EntryAssemblyVersion { get; }
 
+    /// <summary>The entry assembly's file name, which is how its inventory row is recognised.</summary>
+    public string EntryAssemblyFileName { get; }
+
     /// <summary>
-    /// The plugin's own load context, held so that later work can read from it at the moment it asks
-    /// rather than from a snapshot taken when loading finished.
+    /// Every file the plugin's dependency manifest declares, with its digest where it is present.
     /// </summary>
-    internal AssemblyLoadContext LoadContext { get; }
+    /// <remarks>
+    /// Fixed when the plugin loaded, because it comes from the declaration and from bytes sitting in a
+    /// directory nothing may write. What is not fixed is whether each file has since been loaded, which
+    /// is why the load state lives on <see cref="MaterializeInventory"/> instead.
+    /// </remarks>
+    public IReadOnlyList<PluginDeclaredFile> DeclaredFiles { get; }
+
+    /// <summary>
+    /// The inventory as it stands now, with each file's load state read from the plugin's own context
+    /// at this moment.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The load state is read here rather than stored, and the difference is the whole point. An
+    /// assembly first touched inside a contribution hook loads after the loader's work is over, so a
+    /// flag captured at the end of loading would report a file as unloaded while the process was
+    /// already running it.
+    /// </para>
+    /// <para>
+    /// A managed row is <see cref="PluginFileLoadState.Loaded"/> only when that file's own bytes are in
+    /// the plugin's context. An assembly the host served instead reports
+    /// <see cref="PluginFileLoadState.NotLoaded"/>, which is the truthful answer: the plugin's copy was
+    /// never used, and <see cref="MaterializeSubstitutions"/> is where that shows up. A native row is
+    /// <see cref="PluginFileLoadState.Unknown"/>, because the runtime exposes no way to ask.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<PluginInventoryRow> MaterializeInventory()
+    {
+        // Compared ordinally, like every other comparison in this loader, and normalized first because
+        // one side comes from a path this loader composed and the other from what the runtime recorded.
+        HashSet<string> loadedLocations = new(
+            _loadContext
+                .Assemblies.Select(assembly => assembly.Location)
+                .Where(location => location.Length > 0)
+                .Select(Path.GetFullPath),
+            StringComparer.Ordinal
+        );
+
+        List<PluginInventoryRow> rows = [];
+
+        foreach (PluginDeclaredFile file in DeclaredFiles)
+        {
+            rows.Add(
+                new PluginInventoryRow(
+                    file.FileName,
+                    file.DeclaredPath,
+                    file.ResolvedRelativePath,
+                    file.Kind,
+                    file.DeclaredAssemblyVersion,
+                    EffectiveVersionOf(file),
+                    EffectiveVersionSourceOf(file),
+                    file.Availability,
+                    file.Sha256,
+                    LoadStateOf(file, loadedLocations)
+                )
+            );
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Every assembly the host has actually served this plugin in place of its own, as it stands now.
+    /// </summary>
+    /// <remarks>
+    /// Read at this moment for the same reason as the inventory: a substitution that happens inside a
+    /// hook happens after loading finished. These are resolutions the context performed, never
+    /// predictions about a dependency nothing has asked for yet.
+    /// </remarks>
+    public IReadOnlyList<HostFirstSubstitution> MaterializeSubstitutions() =>
+        _loadContext.MaterializeSubstitutions();
+
+    /// <summary>
+    /// The version the process actually has for a file, which for the entry assembly comes from the
+    /// loaded assembly because a framework-dependent publish declares none for it.
+    /// </summary>
+    private Version? EffectiveVersionOf(PluginDeclaredFile file) =>
+        file.DeclaredAssemblyVersion ?? (IsEntryAssembly(file) ? EntryAssemblyVersion : null);
+
+    private PluginVersionSource EffectiveVersionSourceOf(PluginDeclaredFile file)
+    {
+        if (file.DeclaredAssemblyVersion is not null)
+        {
+            return PluginVersionSource.DepsJsonDeclaration;
+        }
+
+        // The entry assembly is the one file a framework-dependent publish declares no version for, so
+        // its effective version comes from the assembly the process loaded and says so.
+        return IsEntryAssembly(file) ? PluginVersionSource.LoadedAssembly : PluginVersionSource.NotDeclared;
+    }
+
+    private bool IsEntryAssembly(PluginDeclaredFile file) =>
+        string.Equals(file.FileName, EntryAssemblyFileName, StringComparison.Ordinal);
+
+    private PluginFileLoadState LoadStateOf(PluginDeclaredFile file, HashSet<string> loadedLocations)
+    {
+        if (file.Kind == PluginFileKind.Native)
+        {
+            // The runtime exposes no way to enumerate the native libraries a context has resolved, so
+            // reporting anything else here would be a claim nobody checked.
+            return PluginFileLoadState.Unknown;
+        }
+
+        if (file.Availability == PluginFileAvailability.Absent)
+        {
+            return PluginFileLoadState.NotLoaded;
+        }
+
+        return loadedLocations.Contains(Path.GetFullPath(Path.Combine(Directory, file.ResolvedRelativePath!)))
+            ? PluginFileLoadState.Loaded
+            : PluginFileLoadState.NotLoaded;
+    }
 }

--- a/src/plugins/EdFi.Api.Plugins.Hosting/LoadedPlugin.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/LoadedPlugin.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Runtime.Loader;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// One plugin the loader constructed, with what a caller needs to invoke and to report it.
+/// </summary>
+/// <remarks>
+/// Read-only to everyone outside this assembly: the loader is the only thing that can produce one,
+/// because every value here is a fact it established while loading. A record a caller could construct
+/// would be a record a caller could construct wrongly, and the four equalities this type asserts by
+/// existing would then mean nothing.
+/// </remarks>
+public sealed record LoadedPlugin
+{
+    internal LoadedPlugin(
+        string name,
+        EdFiApiPlugin instance,
+        string directory,
+        Version entryAssemblyVersion,
+        AssemblyLoadContext loadContext
+    )
+    {
+        Name = name;
+        Instance = instance;
+        Directory = directory;
+        EntryAssemblyVersion = entryAssemblyVersion;
+        LoadContext = loadContext;
+    }
+
+    /// <summary>
+    /// The plugin's name, which equals its directory name, its entry assembly's file name, and the
+    /// entry assembly's own name. All four are checked, so the loader never returns an instance for
+    /// which they disagree.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>The single plugin type the entry assembly exposes, constructed.</summary>
+    public EdFiApiPlugin Instance { get; }
+
+    /// <summary>The plugin directory the entry assembly was loaded from, resolved.</summary>
+    public string Directory { get; }
+
+    /// <summary>
+    /// The entry assembly's version, read from the loaded assembly rather than from the manifest,
+    /// because a framework-dependent publish records no version for the project's own entry.
+    /// </summary>
+    public Version EntryAssemblyVersion { get; }
+
+    /// <summary>
+    /// The plugin's own load context, held so that later work can read from it at the moment it asks
+    /// rather than from a snapshot taken when loading finished.
+    /// </summary>
+    internal AssemblyLoadContext LoadContext { get; }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/LoadedPlugins.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/LoadedPlugins.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Every plugin the loader returned, in allowlist order.
+/// </summary>
+/// <remarks>
+/// An aggregate rather than a bare list because the composition phases are added to it later: the
+/// service contribution phase by the story that invokes hooks, and the configuration phase by the
+/// secrets foundation story. Both need somewhere to live that a caller already holds.
+/// </remarks>
+public sealed class LoadedPlugins
+{
+    /// <summary>
+    /// Creates an aggregate over the given plugins, in allowlist order. Internal because the loader is
+    /// the only thing that has plugins to put in one.
+    /// </summary>
+    internal LoadedPlugins(IReadOnlyList<LoadedPlugin> plugins)
+    {
+        Plugins = plugins;
+    }
+
+    /// <summary>
+    /// The value returned when no plugin was asked for, which is the shipped default.
+    /// </summary>
+    public static LoadedPlugins Empty { get; } = new([]);
+
+    /// <summary>
+    /// The loaded plugins, in the order the operator wrote them, which is the invocation order for
+    /// both composition phases.
+    /// </summary>
+    public IReadOnlyList<LoadedPlugin> Plugins { get; }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginDepsManifest.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginDepsManifest.cs
@@ -262,13 +262,28 @@ internal sealed class PluginDepsManifest
                     );
                 }
 
-                declared.Add(
-                    new PluginDeclaredAssembly(
-                        Path.GetFileNameWithoutExtension(asset.Name),
-                        version,
-                        library.Name
-                    )
-                );
+                string simpleName = Path.GetFileNameWithoutExtension(asset.Name);
+
+                // The simple name goes on to the skew preflight, which asks the runtime for the host's
+                // copy by that name, and the runtime's own assembly-name parsing throws on an empty or
+                // whitespace one before any binding is attempted. That throw is neither a
+                // PluginLoadException nor the FileNotFoundException a missing assembly produces, so it
+                // would leave the operator an unlabelled exception and a silent channel. Refused here
+                // rather than skipped, for the same reason an unparseable version is: a declaration
+                // dropped for want of a usable name is a declaration taken out of the preflight with
+                // nobody told.
+                if (string.IsNullOrWhiteSpace(simpleName))
+                {
+                    throw Unreadable(
+                        pluginName,
+                        manifestPath,
+                        $"'{PluginDiagnosticText.Quote($"{library.Name}.runtime.{asset.Name}")}' declares "
+                            + "a version for a path that names no assembly",
+                        innerException: null
+                    );
+                }
+
+                declared.Add(new PluginDeclaredAssembly(simpleName, version, library.Name));
             }
         }
 

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginDepsManifest.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginDepsManifest.cs
@@ -19,9 +19,19 @@ internal sealed record PluginDeclaredAssembly(string SimpleName, Version Declare
 /// The parts of a plugin's <c>.deps.json</c> the loader reads before it constructs the plugin.
 /// </summary>
 /// <remarks>
-/// No new manifest format is introduced anywhere in this design: the file <c>dotnet publish</c> already
-/// emits is the dependency manifest. This type reads only what the load-time checks need. The fuller
-/// file-by-file reading the inventory needs is a separate concern and is not done here.
+/// <para>
+/// No new manifest format is introduced anywhere in this design: the file <c>dotnet publish</c>
+/// already emits is the dependency manifest. This type reads only what the load-time checks need. The
+/// fuller file-by-file reading the inventory needs is a separate concern and is not done here.
+/// </para>
+/// <para>
+/// Every read checks the JSON kind before it reads a value. A manifest is a file a third party
+/// produced and an operator dropped into a directory, so anything about its shape can be wrong, and
+/// <see cref="JsonElement"/>'s accessors throw <see cref="InvalidOperationException"/> rather than
+/// returning null when the kind is not what was asked for. A manifest that is a JSON array, or whose
+/// <c>runtimeTarget</c> is null, is an ordinary malformed plugin rather than an unforeseen host
+/// failure, and it has to arrive as the named refusal this loader promises.
+/// </para>
 /// </remarks>
 internal sealed class PluginDepsManifest
 {
@@ -62,81 +72,218 @@ internal sealed class PluginDepsManifest
             // and JsonDocument.Parse over raw bytes does not, so a manifest carrying one would be
             // reported as unreadable when it is perfectly good JSON.
             using JsonDocument document = JsonDocument.Parse(File.ReadAllText(manifestPath));
-            JsonElement root = document.RootElement;
+
+            JsonElement root = Require(
+                document.RootElement,
+                JsonValueKind.Object,
+                pluginName,
+                manifestPath,
+                "the document"
+            );
 
             // The target is selected by name rather than by taking the only entry: a RID-specific
             // manifest can carry both a framework target and a framework/RID target, and reading the
             // wrong one would silently miss every declaration in the other.
-            if (
-                !root.TryGetProperty("runtimeTarget", out JsonElement runtimeTarget)
-                || !runtimeTarget.TryGetProperty("name", out JsonElement targetNameElement)
-                || targetNameElement.GetString() is not { } targetName
-                || !root.TryGetProperty("targets", out JsonElement targets)
-                || !targets.TryGetProperty(targetName, out JsonElement target)
-            )
+            JsonElement runtimeTarget = Require(
+                root,
+                "runtimeTarget",
+                JsonValueKind.Object,
+                pluginName,
+                manifestPath
+            );
+            JsonElement targetName = Require(
+                runtimeTarget,
+                "name",
+                JsonValueKind.String,
+                pluginName,
+                manifestPath,
+                "runtimeTarget."
+            );
+            JsonElement targets = Require(root, "targets", JsonValueKind.Object, pluginName, manifestPath);
+
+            if (!targets.TryGetProperty(targetName.GetString()!, out JsonElement target))
             {
                 throw Unreadable(
                     pluginName,
                     manifestPath,
-                    "it does not name a runtime target that its targets section declares",
+                    $"its targets section declares no '{PluginDiagnosticText.Quote(targetName.GetString()!)}', "
+                        + "which is the runtime target it names",
                     innerException: null
                 );
             }
 
-            return new PluginDepsManifest(ReadDeclaresRuntimePack(root), ReadDeclaredAssemblies(target));
+            return new PluginDepsManifest(
+                ReadDeclaresRuntimePack(root, pluginName, manifestPath),
+                ReadDeclaredAssemblies(
+                    Require(target, JsonValueKind.Object, pluginName, manifestPath, "the selected target"),
+                    pluginName,
+                    manifestPath
+                )
+            );
         }
         catch (Exception exception)
-            when (exception is JsonException or IOException or UnauthorizedAccessException)
+            when (exception
+                    is JsonException
+                        or InvalidOperationException
+                        or IOException
+                        or UnauthorizedAccessException
+            )
         {
             throw Unreadable(pluginName, manifestPath, "it could not be read as JSON", exception);
         }
     }
 
-    private static bool ReadDeclaresRuntimePack(JsonElement root)
+    private static bool ReadDeclaresRuntimePack(JsonElement root, string pluginName, string manifestPath)
     {
+        // An absent libraries section is not malformed: it simply declares no runtime pack.
         if (!root.TryGetProperty("libraries", out JsonElement libraries))
         {
             return false;
         }
 
-        return libraries
-            .EnumerateObject()
-            .Any(library =>
-                library.Value.TryGetProperty("type", out JsonElement type)
-                && string.Equals(type.GetString(), "runtimepack", StringComparison.Ordinal)
+        Require(libraries, JsonValueKind.Object, pluginName, manifestPath, "libraries");
+
+        foreach (JsonProperty library in libraries.EnumerateObject())
+        {
+            Require(
+                library.Value,
+                JsonValueKind.Object,
+                pluginName,
+                manifestPath,
+                $"libraries.{library.Name}"
             );
+
+            if (
+                library.Value.TryGetProperty("type", out JsonElement type)
+                && Require(
+                        type,
+                        JsonValueKind.String,
+                        pluginName,
+                        manifestPath,
+                        $"libraries.{library.Name}.type"
+                    )
+                    .ValueEquals("runtimepack")
+            )
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    private static IReadOnlyList<PluginDeclaredAssembly> ReadDeclaredAssemblies(JsonElement target)
+    private static IReadOnlyList<PluginDeclaredAssembly> ReadDeclaredAssemblies(
+        JsonElement target,
+        string pluginName,
+        string manifestPath
+    )
     {
         List<PluginDeclaredAssembly> declared = [];
 
         foreach (JsonProperty library in target.EnumerateObject())
         {
+            Require(library.Value, JsonValueKind.Object, pluginName, manifestPath, library.Name);
+
+            // A library with no runtime assets declares nothing to compare, which is ordinary.
             if (!library.Value.TryGetProperty("runtime", out JsonElement runtime))
             {
                 continue;
             }
 
+            Require(runtime, JsonValueKind.Object, pluginName, manifestPath, $"{library.Name}.runtime");
+
             foreach (JsonProperty asset in runtime.EnumerateObject())
             {
-                if (
-                    asset.Value.TryGetProperty("assemblyVersion", out JsonElement declaredVersion)
-                    && Version.TryParse(declaredVersion.GetString(), out Version? version)
-                )
+                Require(
+                    asset.Value,
+                    JsonValueKind.Object,
+                    pluginName,
+                    manifestPath,
+                    $"{library.Name}.runtime.{asset.Name}"
+                );
+
+                // An absent assemblyVersion is legitimate and common: a framework-dependent publish
+                // writes none for the project's own entry. A present one that is not a version is not
+                // legitimate, and dropping it silently would remove an assembly from the skew preflight
+                // without anybody being told, which is the one outcome this check exists to prevent.
+                if (!asset.Value.TryGetProperty("assemblyVersion", out JsonElement declaredVersion))
                 {
-                    declared.Add(
-                        new PluginDeclaredAssembly(
-                            Path.GetFileNameWithoutExtension(asset.Name),
-                            version,
-                            library.Name
-                        )
+                    continue;
+                }
+
+                string location = $"{library.Name}.runtime.{asset.Name}.assemblyVersion";
+
+                Require(declaredVersion, JsonValueKind.String, pluginName, manifestPath, location);
+
+                if (!Version.TryParse(declaredVersion.GetString(), out Version? version))
+                {
+                    throw Unreadable(
+                        pluginName,
+                        manifestPath,
+                        $"'{PluginDiagnosticText.Quote(location)}' is "
+                            + $"'{PluginDiagnosticText.Quote(declaredVersion.GetString())}', which is not "
+                            + "an assembly version",
+                        innerException: null
                     );
                 }
+
+                declared.Add(
+                    new PluginDeclaredAssembly(
+                        Path.GetFileNameWithoutExtension(asset.Name),
+                        version,
+                        library.Name
+                    )
+                );
             }
         }
 
         return declared;
+    }
+
+    /// <summary>Requires a property of the given kind, naming where it was expected when it is not.</summary>
+    private static JsonElement Require(
+        JsonElement parent,
+        string propertyName,
+        JsonValueKind kind,
+        string pluginName,
+        string manifestPath,
+        string locationPrefix = ""
+    )
+    {
+        if (!parent.TryGetProperty(propertyName, out JsonElement property))
+        {
+            throw Unreadable(
+                pluginName,
+                manifestPath,
+                $"it declares no '{locationPrefix}{propertyName}'",
+                innerException: null
+            );
+        }
+
+        return Require(property, kind, pluginName, manifestPath, $"{locationPrefix}{propertyName}");
+    }
+
+    /// <summary>Requires a value of the given kind, naming where it was expected when it is not.</summary>
+    private static JsonElement Require(
+        JsonElement element,
+        JsonValueKind kind,
+        string pluginName,
+        string manifestPath,
+        string location
+    )
+    {
+        if (element.ValueKind != kind)
+        {
+            throw Unreadable(
+                pluginName,
+                manifestPath,
+                $"'{PluginDiagnosticText.Quote(location)}' is {element.ValueKind} where "
+                    + $"{kind} was expected",
+                innerException: null
+            );
+        }
+
+        return element;
     }
 
     private static PluginLoadException Unreadable(
@@ -149,8 +296,9 @@ internal sealed class PluginDepsManifest
             PluginLoadFailure.DepsJsonUnreadable,
             pluginName,
             $"plugin '{PluginDiagnosticText.Quote(pluginName)}' has a dependency manifest at "
-                + $"'{PluginDiagnosticText.Quote(manifestPath)}' that {reason}. It has to be the "
-                + ".deps.json a dotnet publish of the plugin produced.",
+                + $"'{PluginDiagnosticText.Quote(manifestPath)}' that is not the shape a publish "
+                + $"produces: {reason}. It has to be the .deps.json a dotnet publish of the plugin "
+                + "produced.",
             innerException
         );
 }

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginDepsManifest.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginDepsManifest.cs
@@ -16,6 +16,23 @@ namespace EdFi.Api.Plugins.Hosting;
 internal sealed record PluginDeclaredAssembly(string SimpleName, Version DeclaredVersion, string Library);
 
 /// <summary>
+/// One asset a plugin's dependency manifest declares, before anything has looked for it on disk.
+/// </summary>
+/// <param name="DeclaredPath">The path the manifest wrote, which is package-relative.</param>
+/// <param name="Kind">Which section of the manifest declared it.</param>
+/// <param name="DeclaredVersion">The declared assembly version, when the section carries one.</param>
+/// <param name="Locale">
+/// The culture a resource assembly belongs to, which is where a publish puts it and is therefore part
+/// of finding it.
+/// </param>
+internal sealed record PluginDeclaredAsset(
+    string DeclaredPath,
+    PluginFileKind Kind,
+    Version? DeclaredVersion,
+    string? Locale
+);
+
+/// <summary>
 /// The parts of a plugin's <c>.deps.json</c> the loader reads before it constructs the plugin.
 /// </summary>
 /// <remarks>
@@ -37,11 +54,13 @@ internal sealed class PluginDepsManifest
 {
     private PluginDepsManifest(
         bool declaresRuntimePack,
-        IReadOnlyList<PluginDeclaredAssembly> declaredAssemblies
+        IReadOnlyList<PluginDeclaredAssembly> declaredAssemblies,
+        IReadOnlyList<PluginDeclaredAsset> declaredAssets
     )
     {
         DeclaresRuntimePack = declaresRuntimePack;
         DeclaredAssemblies = declaredAssemblies;
+        DeclaredAssets = declaredAssets;
     }
 
     /// <summary>
@@ -59,6 +78,17 @@ internal sealed class PluginDepsManifest
     /// compares against the host.
     /// </summary>
     internal IReadOnlyList<PluginDeclaredAssembly> DeclaredAssemblies { get; }
+
+    /// <summary>
+    /// Every asset the manifest declares, managed, native and resource alike, which is the set the
+    /// inventory is built from.
+    /// </summary>
+    /// <remarks>
+    /// A native asset carries no version and is still a file the plugin shipped, so it is listed rather
+    /// than dropped for want of one. Dropping it would leave the inventory silent about exactly the
+    /// files an incident responder is most likely to ask about.
+    /// </remarks>
+    internal IReadOnlyList<PluginDeclaredAsset> DeclaredAssets { get; }
 
     /// <summary>Reads the manifest at <paramref name="manifestPath"/>.</summary>
     /// <exception cref="PluginLoadException">
@@ -112,13 +142,18 @@ internal sealed class PluginDepsManifest
                 );
             }
 
+            JsonElement selectedTarget = Require(
+                target,
+                JsonValueKind.Object,
+                pluginName,
+                manifestPath,
+                "the selected target"
+            );
+
             return new PluginDepsManifest(
                 ReadDeclaresRuntimePack(root, pluginName, manifestPath),
-                ReadDeclaredAssemblies(
-                    Require(target, JsonValueKind.Object, pluginName, manifestPath, "the selected target"),
-                    pluginName,
-                    manifestPath
-                )
+                ReadDeclaredAssemblies(selectedTarget, pluginName, manifestPath),
+                ReadDeclaredAssets(selectedTarget, pluginName, manifestPath)
             );
         }
         catch (Exception exception)
@@ -284,6 +319,138 @@ internal sealed class PluginDepsManifest
         }
 
         return element;
+    }
+
+    /// <summary>
+    /// Reads every asset the selected target declares: the managed assemblies under <c>runtime</c>, the
+    /// satellite assemblies under <c>resources</c>, the native libraries under <c>native</c>, and the
+    /// RID-specific assets under <c>runtimeTargets</c>, whose kind comes from their own asset type.
+    /// </summary>
+    private static IReadOnlyList<PluginDeclaredAsset> ReadDeclaredAssets(
+        JsonElement target,
+        string pluginName,
+        string manifestPath
+    )
+    {
+        List<PluginDeclaredAsset> assets = [];
+
+        foreach (JsonElement library in target.EnumerateObject().Select(entry => entry.Value))
+        {
+            ReadSection(library, "runtime", PluginFileKind.Managed);
+            ReadSection(library, "native", PluginFileKind.Native);
+            ReadSection(library, "resources", PluginFileKind.Resource);
+            ReadRuntimeTargets(library);
+        }
+
+        return assets;
+
+        void ReadSection(JsonElement libraryValue, string sectionName, PluginFileKind kind)
+        {
+            if (!libraryValue.TryGetProperty(sectionName, out JsonElement section))
+            {
+                return;
+            }
+
+            Require(section, JsonValueKind.Object, pluginName, manifestPath, sectionName);
+
+            foreach (JsonProperty asset in section.EnumerateObject())
+            {
+                string location = $"{sectionName}.{asset.Name}";
+
+                Require(asset.Value, JsonValueKind.Object, pluginName, manifestPath, location);
+
+                assets.Add(
+                    new PluginDeclaredAsset(
+                        asset.Name,
+                        kind,
+                        ReadVersion(asset.Value, location),
+                        ReadLocale(asset.Value, location)
+                    )
+                );
+            }
+        }
+
+        void ReadRuntimeTargets(JsonElement libraryValue)
+        {
+            if (!libraryValue.TryGetProperty("runtimeTargets", out JsonElement runtimeTargets))
+            {
+                return;
+            }
+
+            Require(runtimeTargets, JsonValueKind.Object, pluginName, manifestPath, "runtimeTargets");
+
+            foreach (JsonProperty asset in runtimeTargets.EnumerateObject())
+            {
+                string location = $"runtimeTargets.{asset.Name}";
+
+                Require(asset.Value, JsonValueKind.Object, pluginName, manifestPath, location);
+
+                // The asset type is what says whether a RID-specific asset is managed or native. A
+                // native one carries no assemblyVersion, which is the known gap rather than a fault.
+                PluginFileKind kind =
+                    asset.Value.TryGetProperty("assetType", out JsonElement assetType)
+                    && Require(
+                            assetType,
+                            JsonValueKind.String,
+                            pluginName,
+                            manifestPath,
+                            $"{location}.assetType"
+                        )
+                        .ValueEquals("native")
+                        ? PluginFileKind.Native
+                        : PluginFileKind.Managed;
+
+                assets.Add(
+                    new PluginDeclaredAsset(
+                        asset.Name,
+                        kind,
+                        ReadVersion(asset.Value, location),
+                        ReadLocale(asset.Value, location)
+                    )
+                );
+            }
+        }
+
+        Version? ReadVersion(JsonElement declaration, string location)
+        {
+            if (!declaration.TryGetProperty("assemblyVersion", out JsonElement declaredVersion))
+            {
+                return null;
+            }
+
+            Require(
+                declaredVersion,
+                JsonValueKind.String,
+                pluginName,
+                manifestPath,
+                $"{location}.assemblyVersion"
+            );
+
+            if (!Version.TryParse(declaredVersion.GetString(), out Version? version))
+            {
+                throw Unreadable(
+                    pluginName,
+                    manifestPath,
+                    $"'{PluginDiagnosticText.Quote(location)}.assemblyVersion' is "
+                        + $"'{PluginDiagnosticText.Quote(declaredVersion.GetString())}', which is not an "
+                        + "assembly version",
+                    innerException: null
+                );
+            }
+
+            return version;
+        }
+
+        string? ReadLocale(JsonElement declaration, string location)
+        {
+            if (!declaration.TryGetProperty("locale", out JsonElement locale))
+            {
+                return null;
+            }
+
+            return Require(locale, JsonValueKind.String, pluginName, manifestPath, $"{location}.locale")
+                .GetString();
+        }
     }
 
     private static PluginLoadException Unreadable(

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginDepsManifest.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginDepsManifest.cs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// A managed assembly a plugin's dependency manifest declares, with the version it declares for it.
+/// </summary>
+/// <param name="SimpleName">The assembly's simple name, taken from the declared file name.</param>
+/// <param name="DeclaredVersion">The <c>assemblyVersion</c> the manifest records.</param>
+/// <param name="Library">The manifest library the declaration belongs to, for diagnostics.</param>
+internal sealed record PluginDeclaredAssembly(string SimpleName, Version DeclaredVersion, string Library);
+
+/// <summary>
+/// The parts of a plugin's <c>.deps.json</c> the loader reads before it constructs the plugin.
+/// </summary>
+/// <remarks>
+/// No new manifest format is introduced anywhere in this design: the file <c>dotnet publish</c> already
+/// emits is the dependency manifest. This type reads only what the load-time checks need. The fuller
+/// file-by-file reading the inventory needs is a separate concern and is not done here.
+/// </remarks>
+internal sealed class PluginDepsManifest
+{
+    private PluginDepsManifest(
+        bool declaresRuntimePack,
+        IReadOnlyList<PluginDeclaredAssembly> declaredAssemblies
+    )
+    {
+        DeclaresRuntimePack = declaresRuntimePack;
+        DeclaredAssemblies = declaredAssemblies;
+    }
+
+    /// <summary>
+    /// Whether the manifest declares a runtime pack, which is what a self-contained publish produces.
+    /// </summary>
+    /// <remarks>
+    /// The discriminator is deliberately the library entry rather than a runtime identifier in
+    /// <c>runtimeTarget</c>: a RID-specific framework-dependent publish names a runtime identifier
+    /// there too, and that publish is legitimate. It is how a plugin ships native assets.
+    /// </remarks>
+    internal bool DeclaresRuntimePack { get; }
+
+    /// <summary>
+    /// Every managed assembly the manifest declares a version for, which is the set the skew preflight
+    /// compares against the host.
+    /// </summary>
+    internal IReadOnlyList<PluginDeclaredAssembly> DeclaredAssemblies { get; }
+
+    /// <summary>Reads the manifest at <paramref name="manifestPath"/>.</summary>
+    /// <exception cref="PluginLoadException">
+    /// The file is not readable as the shape a publish produces.
+    /// </exception>
+    internal static PluginDepsManifest Read(string pluginName, string manifestPath)
+    {
+        try
+        {
+            // Read as text rather than as bytes: File.ReadAllText detects and strips a byte order mark,
+            // and JsonDocument.Parse over raw bytes does not, so a manifest carrying one would be
+            // reported as unreadable when it is perfectly good JSON.
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            JsonElement root = document.RootElement;
+
+            // The target is selected by name rather than by taking the only entry: a RID-specific
+            // manifest can carry both a framework target and a framework/RID target, and reading the
+            // wrong one would silently miss every declaration in the other.
+            if (
+                !root.TryGetProperty("runtimeTarget", out JsonElement runtimeTarget)
+                || !runtimeTarget.TryGetProperty("name", out JsonElement targetNameElement)
+                || targetNameElement.GetString() is not { } targetName
+                || !root.TryGetProperty("targets", out JsonElement targets)
+                || !targets.TryGetProperty(targetName, out JsonElement target)
+            )
+            {
+                throw Unreadable(
+                    pluginName,
+                    manifestPath,
+                    "it does not name a runtime target that its targets section declares",
+                    innerException: null
+                );
+            }
+
+            return new PluginDepsManifest(ReadDeclaresRuntimePack(root), ReadDeclaredAssemblies(target));
+        }
+        catch (Exception exception)
+            when (exception is JsonException or IOException or UnauthorizedAccessException)
+        {
+            throw Unreadable(pluginName, manifestPath, "it could not be read as JSON", exception);
+        }
+    }
+
+    private static bool ReadDeclaresRuntimePack(JsonElement root)
+    {
+        if (!root.TryGetProperty("libraries", out JsonElement libraries))
+        {
+            return false;
+        }
+
+        return libraries
+            .EnumerateObject()
+            .Any(library =>
+                library.Value.TryGetProperty("type", out JsonElement type)
+                && string.Equals(type.GetString(), "runtimepack", StringComparison.Ordinal)
+            );
+    }
+
+    private static IReadOnlyList<PluginDeclaredAssembly> ReadDeclaredAssemblies(JsonElement target)
+    {
+        List<PluginDeclaredAssembly> declared = [];
+
+        foreach (JsonProperty library in target.EnumerateObject())
+        {
+            if (!library.Value.TryGetProperty("runtime", out JsonElement runtime))
+            {
+                continue;
+            }
+
+            foreach (JsonProperty asset in runtime.EnumerateObject())
+            {
+                if (
+                    asset.Value.TryGetProperty("assemblyVersion", out JsonElement declaredVersion)
+                    && Version.TryParse(declaredVersion.GetString(), out Version? version)
+                )
+                {
+                    declared.Add(
+                        new PluginDeclaredAssembly(
+                            Path.GetFileNameWithoutExtension(asset.Name),
+                            version,
+                            library.Name
+                        )
+                    );
+                }
+            }
+        }
+
+        return declared;
+    }
+
+    private static PluginLoadException Unreadable(
+        string pluginName,
+        string manifestPath,
+        string reason,
+        Exception? innerException
+    ) =>
+        new(
+            PluginLoadFailure.DepsJsonUnreadable,
+            pluginName,
+            $"plugin '{PluginDiagnosticText.Quote(pluginName)}' has a dependency manifest at "
+                + $"'{PluginDiagnosticText.Quote(manifestPath)}' that {reason}. It has to be the "
+                + ".deps.json a dotnet publish of the plugin produced.",
+            innerException
+        );
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginDiagnosticText.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginDiagnosticText.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Renders externally supplied values for inclusion in a loader message.
+/// </summary>
+/// <remarks>
+/// Loader messages quote configuration entries and filesystem paths, both of which arrive from
+/// outside the process, and those messages are written to a line-oriented diagnostic channel and are
+/// re-emitted through the host's logger afterwards. A value carrying a line break would forge a line
+/// on that channel and in the log, so control characters are escaped rather than reproduced. The
+/// escaping is applied at the point a value enters a message, so no caller has to remember to do it.
+/// </remarks>
+internal static class PluginDiagnosticText
+{
+    /// <summary>
+    /// Returns <paramref name="value"/> with every control character replaced by a printable escape.
+    /// </summary>
+    internal static string Quote(string value)
+    {
+        if (!value.Any(char.IsControl))
+        {
+            return value;
+        }
+
+        StringBuilder escaped = new(value.Length + 8);
+
+        foreach (char character in value)
+        {
+            switch (character)
+            {
+                case '\r':
+                    escaped.Append("\\r");
+                    break;
+                case '\n':
+                    escaped.Append("\\n");
+                    break;
+                case '\t':
+                    escaped.Append("\\t");
+                    break;
+                default:
+                    if (char.IsControl(character))
+                    {
+                        escaped.Append(CultureInfo.InvariantCulture, $"\\u{(int)character:x4}");
+                    }
+                    else
+                    {
+                        escaped.Append(character);
+                    }
+
+                    break;
+            }
+        }
+
+        return escaped.ToString();
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginDiagnosticText.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginDiagnosticText.cs
@@ -23,8 +23,20 @@ internal static class PluginDiagnosticText
     /// <summary>
     /// Returns <paramref name="value"/> with every control character replaced by a printable escape.
     /// </summary>
-    internal static string Quote(string value)
+    /// <remarks>
+    /// Accepts null and renders it as <c>&lt;null&gt;</c>. The values quoted here come from a plugin a
+    /// third party wrote, and nullable annotations do not constrain a third-party assembly at runtime:
+    /// a plugin can return null from a non-nullable property. Throwing here would replace the named
+    /// refusal an operator needs with a NullReferenceException from inside the loader, which is the one
+    /// outcome a diagnostic helper must never produce.
+    /// </remarks>
+    internal static string Quote(string? value)
     {
+        if (value is null)
+        {
+            return "<null>";
+        }
+
         if (!value.Any(char.IsControl))
         {
             return value;

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginFileInventory.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginFileInventory.cs
@@ -96,17 +96,63 @@ internal static class PluginFileInventory
     /// </summary>
     private static string? TryResolve(string pluginDirectory, PluginDeclaredAsset asset, string fileName)
     {
+        string root = Path.GetFullPath(pluginDirectory);
+        string prefix = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
         foreach (string candidate in Candidates(asset, fileName))
         {
             string normalized = candidate.Replace('/', Path.DirectorySeparatorChar);
 
-            if (File.Exists(Path.Combine(pluginDirectory, normalized)))
+            if (IsInside(root, prefix, normalized) && File.Exists(Path.Combine(root, normalized)))
             {
                 return normalized;
             }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Whether a candidate stays inside the plugin directory, judged lexically.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every part a candidate is composed from is text a third party wrote: the declared path, the file
+    /// name taken from it, and the locale a resource declaration carries. <c>Path.Combine</c> discards
+    /// its first argument for a rooted second, and a traversing one climbs out, so without this a
+    /// declared path could select a file outside the plugin directory and those bytes would be hashed
+    /// and reported as a file the plugin shipped. The boundary carries its trailing separator so that a
+    /// sibling directory whose name merely begins with the plugin's is outside it.
+    /// </para>
+    /// <para>
+    /// Lexical on purpose, and deliberately unlike the loader's containment check, which resolves
+    /// symbolic links because it decides whether an assembly may load. This one decides only whether a
+    /// declared string may select a file, so it leaves the symlinked-file boundary where the design
+    /// puts it.
+    /// </para>
+    /// </remarks>
+    private static bool IsInside(string root, string prefix, string relativePath)
+    {
+        try
+        {
+            return Path.GetFullPath(Path.Combine(root, relativePath))
+                .StartsWith(prefix, StringComparison.Ordinal);
+        }
+        catch (Exception exception)
+            when (exception
+                    is ArgumentException
+                        or NotSupportedException
+                        or PathTooLongException
+                        or IOException
+            )
+        {
+            // A path string the platform cannot normalize is a candidate that selects nothing, which is
+            // exactly what File.Exists answered for it before anything normalized it. Normalizing first
+            // must not turn that quiet miss into a fatal an operator cannot act on.
+            return false;
+        }
     }
 
     private static IEnumerable<string> Candidates(PluginDeclaredAsset asset, string fileName)

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginFileInventory.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginFileInventory.cs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Turns what a manifest declares into what is actually in the plugin directory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A manifest names assets by their package-relative path, and a publish flattens them, so the
+/// declared path and the published path are rarely the same string. Two candidates cover both shapes a
+/// plugin can ship: a portable framework-dependent publish leaves <c>runtimes/&lt;rid&gt;/...</c> in
+/// place and flattens the rest to the root, and a runtime-specific publish relocates the running RID's
+/// assets to the root while the manifest goes on writing their package-relative paths. A resource
+/// assembly gets a third candidate under its own culture directory, which is where a publish puts it.
+/// </para>
+/// <para>
+/// Nothing here fabricates. A declared file that is not there is an absent row with no digest, because
+/// a missing native asset is a lazy first-use failure by design rather than a load-time refusal, and
+/// because a digest of nothing is not a digest. A file that is there and cannot be read is a refusal,
+/// because an unreadable file is not an absent one and laundering the difference would hide a real
+/// problem.
+/// </para>
+/// </remarks>
+internal static class PluginFileInventory
+{
+    /// <summary>Builds the declared-file inventory for one plugin directory.</summary>
+    /// <exception cref="PluginLoadException">A file that is present could not be read.</exception>
+    internal static IReadOnlyList<PluginDeclaredFile> Build(
+        string pluginName,
+        string pluginDirectory,
+        PluginDepsManifest manifest
+    )
+    {
+        List<PluginDeclaredFile> files = [];
+
+        // Two declarations of one published file are one row: a library's top-level runtime entry and
+        // its runtimeTargets row for the running RID commonly resolve to the same bytes. Two
+        // declarations that resolve nowhere stay separate, because nothing has shown them to be the
+        // same file and merging them would drop a declaration the plugin made.
+        HashSet<string> seenResolved = new(StringComparer.Ordinal);
+        HashSet<string> seenDeclared = new(StringComparer.Ordinal);
+
+        foreach (PluginDeclaredAsset asset in manifest.DeclaredAssets)
+        {
+            string fileName = Path.GetFileName(asset.DeclaredPath);
+
+            if (fileName.Length == 0)
+            {
+                continue;
+            }
+
+            if (TryResolve(pluginDirectory, asset, fileName) is { } resolvedRelativePath)
+            {
+                if (!seenResolved.Add(resolvedRelativePath))
+                {
+                    continue;
+                }
+
+                files.Add(
+                    PluginDeclaredFile.Present(
+                        fileName,
+                        asset.DeclaredPath,
+                        resolvedRelativePath,
+                        asset.Kind,
+                        asset.DeclaredVersion,
+                        ComputeSha256(
+                            pluginName,
+                            Path.Combine(pluginDirectory, resolvedRelativePath),
+                            resolvedRelativePath
+                        )
+                    )
+                );
+
+                continue;
+            }
+
+            if (seenDeclared.Add(asset.DeclaredPath))
+            {
+                files.Add(
+                    PluginDeclaredFile.Absent(fileName, asset.DeclaredPath, asset.Kind, asset.DeclaredVersion)
+                );
+            }
+        }
+
+        return files;
+    }
+
+    /// <summary>
+    /// Finds where a declared asset actually sits, relative to the plugin directory.
+    /// </summary>
+    private static string? TryResolve(string pluginDirectory, PluginDeclaredAsset asset, string fileName)
+    {
+        foreach (string candidate in Candidates(asset, fileName))
+        {
+            string normalized = candidate.Replace('/', Path.DirectorySeparatorChar);
+
+            if (File.Exists(Path.Combine(pluginDirectory, normalized)))
+            {
+                return normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> Candidates(PluginDeclaredAsset asset, string fileName)
+    {
+        // The path as the manifest wrote it, which is where a portable publish leaves a RID-specific
+        // asset.
+        yield return asset.DeclaredPath;
+
+        // A satellite assembly lives under its culture, which is the one place its file name alone
+        // would not find it and the one thing that keeps two cultures' copies apart.
+        if (asset.Kind == PluginFileKind.Resource && !string.IsNullOrEmpty(asset.Locale))
+        {
+            yield return $"{asset.Locale}/{fileName}";
+        }
+
+        // Flattened to the plugin directory root, which is where a publish puts a top-level asset and
+        // where a runtime-specific publish relocates the running RID's assets.
+        yield return fileName;
+    }
+
+    private static string ComputeSha256(string pluginName, string path, string relativePath)
+    {
+        try
+        {
+            using FileStream stream = File.OpenRead(path);
+            return Convert.ToHexStringLower(SHA256.HashData(stream));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw new PluginLoadException(
+                PluginLoadFailure.PluginFileUnreadable,
+                pluginName,
+                $"plugin '{PluginDiagnosticText.Quote(pluginName)}' declares "
+                    + $"'{PluginDiagnosticText.Quote(relativePath)}', which is present and could not be "
+                    + $"read: {PluginDiagnosticText.Quote(exception.Message)}. A file that cannot be read "
+                    + "is not a file that is absent, and the inventory will not report it as one.",
+                exception
+            );
+        }
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginInventory.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginInventory.cs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>What kind of asset a plugin's dependency manifest declared.</summary>
+public enum PluginFileKind
+{
+    /// <summary>A managed assembly.</summary>
+    Managed,
+
+    /// <summary>A native library, which carries no assembly version and is resolved lazily.</summary>
+    Native,
+
+    /// <summary>A satellite resource assembly, which lives under its culture's directory.</summary>
+    Resource,
+}
+
+/// <summary>Whether a file the manifest declared is actually in the plugin directory.</summary>
+public enum PluginFileAvailability
+{
+    /// <summary>The file was found, and therefore has a digest.</summary>
+    Present,
+
+    /// <summary>The file was declared and is not there, so there is nothing to hash.</summary>
+    Absent,
+}
+
+/// <summary>Where a version on an inventory row came from.</summary>
+/// <remarks>
+/// Kept separate from the version itself so that nobody later reads a missing declaration as
+/// <c>0.0.0.0</c> or drops a row for want of a version. A framework-dependent publish records no
+/// version for the project's own entry and none at all for a native asset, and both of those are
+/// ordinary rather than faults.
+/// </remarks>
+public enum PluginVersionSource
+{
+    /// <summary>The manifest declared it.</summary>
+    DepsJsonDeclaration,
+
+    /// <summary>The manifest declared none, so it was read from the assembly the process loaded.</summary>
+    LoadedAssembly,
+
+    /// <summary>Nothing declares one and nothing can supply one.</summary>
+    NotDeclared,
+}
+
+/// <summary>Whether a declared file had been loaded when the inventory was materialized.</summary>
+/// <remarks>
+/// <see cref="Unknown"/> is not a failure to look. The runtime exposes no way to enumerate the native
+/// libraries a load context has resolved, so a native row cannot be answered either way and reporting
+/// <see cref="NotLoaded"/> for it would be a claim nobody checked.
+/// </remarks>
+public enum PluginFileLoadState
+{
+    /// <summary>This file's own bytes are loaded in the plugin's context.</summary>
+    Loaded,
+
+    /// <summary>This file is not loaded. For a managed assembly the host served instead, this is the
+    /// truthful answer: the plugin's copy was never used.</summary>
+    NotLoaded,
+
+    /// <summary>Not answerable, which is the case for every native asset.</summary>
+    Unknown,
+}
+
+/// <summary>
+/// One file a plugin's dependency manifest declares, as it stands on disk.
+/// </summary>
+/// <remarks>
+/// The inventory is built from the declaration rather than from the load context's assembly list,
+/// because assemblies load lazily: an enumeration taken at any single moment omits every request-path
+/// assembly and every native library, and an inventory that goes quiet exactly where the interesting
+/// code lives is worse than one that admits its edges. The declaration is the complete set of files
+/// the plugin shipped, so a responder can match a running process to a published artifact whether or
+/// not a given assembly has been touched.
+/// </remarks>
+public sealed record PluginDeclaredFile
+{
+    private PluginDeclaredFile(
+        string fileName,
+        string declaredPath,
+        string? resolvedRelativePath,
+        PluginFileKind kind,
+        Version? declaredAssemblyVersion,
+        PluginVersionSource declaredVersionSource,
+        PluginFileAvailability availability,
+        string? sha256
+    )
+    {
+        FileName = fileName;
+        DeclaredPath = declaredPath;
+        ResolvedRelativePath = resolvedRelativePath;
+        Kind = kind;
+        DeclaredAssemblyVersion = declaredAssemblyVersion;
+        DeclaredVersionSource = declaredVersionSource;
+        Availability = availability;
+        Sha256 = sha256;
+    }
+
+    /// <summary>The file's name as it was published.</summary>
+    public string FileName { get; }
+
+    /// <summary>The path the manifest wrote, which is package-relative rather than published.</summary>
+    public string DeclaredPath { get; }
+
+    /// <summary>
+    /// Where the file was found, relative to the plugin directory, or <see langword="null"/> when it
+    /// was not found at all.
+    /// </summary>
+    public string? ResolvedRelativePath { get; }
+
+    /// <summary>What kind of asset the manifest declared.</summary>
+    public PluginFileKind Kind { get; }
+
+    /// <summary>The version the manifest declared, or <see langword="null"/> when it declared none.</summary>
+    public Version? DeclaredAssemblyVersion { get; }
+
+    /// <summary>Whether a declared version exists at all.</summary>
+    public PluginVersionSource DeclaredVersionSource { get; }
+
+    /// <summary>Whether the declared file is in the plugin directory.</summary>
+    public PluginFileAvailability Availability { get; }
+
+    /// <summary>
+    /// The SHA-256 of the file as it sits in the plugin directory, lower-case hexadecimal. Non-null if
+    /// and only if <see cref="Availability"/> is <see cref="PluginFileAvailability.Present"/>: nothing
+    /// hashes empty bytes, and no digest-of-nothing is ever presented as a file's digest.
+    /// </summary>
+    public string? Sha256 { get; }
+
+    internal static PluginDeclaredFile Present(
+        string fileName,
+        string declaredPath,
+        string resolvedRelativePath,
+        PluginFileKind kind,
+        Version? declaredAssemblyVersion,
+        string sha256
+    ) =>
+        new(
+            fileName,
+            declaredPath,
+            resolvedRelativePath,
+            kind,
+            declaredAssemblyVersion,
+            declaredAssemblyVersion is null
+                ? PluginVersionSource.NotDeclared
+                : PluginVersionSource.DepsJsonDeclaration,
+            PluginFileAvailability.Present,
+            sha256
+        );
+
+    internal static PluginDeclaredFile Absent(
+        string fileName,
+        string declaredPath,
+        PluginFileKind kind,
+        Version? declaredAssemblyVersion
+    ) =>
+        new(
+            fileName,
+            declaredPath,
+            resolvedRelativePath: null,
+            kind,
+            declaredAssemblyVersion,
+            declaredAssemblyVersion is null
+                ? PluginVersionSource.NotDeclared
+                : PluginVersionSource.DepsJsonDeclaration,
+            PluginFileAvailability.Absent,
+            sha256: null
+        );
+}
+
+/// <summary>
+/// One inventory row, as it stands at the moment the caller asked for it.
+/// </summary>
+/// <param name="FileName">The file's name as it was published.</param>
+/// <param name="DeclaredPath">The path the manifest wrote.</param>
+/// <param name="ResolvedRelativePath">Where the file was found, or <see langword="null"/>.</param>
+/// <param name="Kind">What kind of asset the manifest declared.</param>
+/// <param name="DeclaredAssemblyVersion">
+/// The version the manifest declared, which stays <see langword="null"/> when it declared none. It is
+/// kept apart from <paramref name="EffectiveVersion"/> so that the absence of a declaration remains
+/// visible rather than being filled in.
+/// </param>
+/// <param name="EffectiveVersion">The version the process actually has, when that is knowable.</param>
+/// <param name="EffectiveVersionSource">Where <paramref name="EffectiveVersion"/> came from.</param>
+/// <param name="Availability">Whether the declared file is in the plugin directory.</param>
+/// <param name="Sha256">The digest of the file, non-null exactly when it is present.</param>
+/// <param name="LoadState">
+/// Whether this file's own bytes were loaded in the plugin's context when the row was produced. Read
+/// at that moment rather than frozen when loading finished, because an assembly first touched inside a
+/// contribution hook loads long after the loader's work is over.
+/// </param>
+public sealed record PluginInventoryRow(
+    string FileName,
+    string DeclaredPath,
+    string? ResolvedRelativePath,
+    PluginFileKind Kind,
+    Version? DeclaredAssemblyVersion,
+    Version? EffectiveVersion,
+    PluginVersionSource EffectiveVersionSource,
+    PluginFileAvailability Availability,
+    string? Sha256,
+    PluginFileLoadState LoadState
+);
+
+/// <summary>
+/// An assembly the host served to a plugin in place of the plugin's own.
+/// </summary>
+/// <remarks>
+/// Host-first substitution is silent and almost always correct, which is exactly why it needs a
+/// record: it is the diagnostic for the one report that would otherwise arrive with no evidence behind
+/// it, that a plugin works on its author's machine and not in the host.
+/// </remarks>
+/// <param name="AssemblyName">The simple name the plugin asked for.</param>
+/// <param name="RequestedVersion">
+/// The version the requesting assembly's reference carried, which is what the runtime asked for rather
+/// than what the manifest declared. The two can differ, and neither stands in for the other.
+/// </param>
+/// <param name="HostVersion">The version the host served.</param>
+/// <param name="DeclaredVersion">
+/// The version the plugin's manifest declared for that assembly, or <see langword="null"/> when the
+/// manifest declares none. A shared-framework assembly has no declaration, and inventing one would be
+/// a claim the manifest never made.
+/// </param>
+public sealed record HostFirstSubstitution(
+    string AssemblyName,
+    Version? RequestedVersion,
+    Version HostVersion,
+    Version? DeclaredVersion
+);

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadContext.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadContext.cs
@@ -23,10 +23,44 @@ namespace EdFi.Api.Plugins.Hosting;
 /// Non-collectible because nothing unloads a plugin.
 /// </para>
 /// </remarks>
-internal sealed class PluginLoadContext(string pluginName, string entryAssemblyPath)
-    : AssemblyLoadContext(pluginName, isCollectible: false)
+internal sealed class PluginLoadContext : AssemblyLoadContext
 {
-    private readonly AssemblyDependencyResolver _resolver = new(entryAssemblyPath);
+    private readonly AssemblyDependencyResolver _resolver;
+    private readonly IReadOnlyDictionary<string, Version> _declaredVersions;
+    private readonly Lock _substitutionsLock = new();
+    private readonly Dictionary<string, HostFirstSubstitution> _substitutions = new(StringComparer.Ordinal);
+
+    internal PluginLoadContext(string pluginName, string entryAssemblyPath)
+        : this(pluginName, entryAssemblyPath, new Dictionary<string, Version>(StringComparer.Ordinal)) { }
+
+    internal PluginLoadContext(
+        string pluginName,
+        string entryAssemblyPath,
+        IReadOnlyDictionary<string, Version> declaredVersions
+    )
+        : base(pluginName, isCollectible: false)
+    {
+        _resolver = new AssemblyDependencyResolver(entryAssemblyPath);
+        _declaredVersions = declaredVersions;
+    }
+
+    /// <summary>
+    /// Every assembly this context has actually served from the host in place of the plugin's own,
+    /// where what the host carries is not what the plugin's manifest declared.
+    /// </summary>
+    /// <remarks>
+    /// Read when the caller asks rather than frozen when loading finished: <c>Load</c> is called when a
+    /// type resolution first needs an assembly, so an assembly first touched inside a contribution hook
+    /// is served long after the loader's own work is over. These are resolutions that happened, not
+    /// predictions about resolutions that might.
+    /// </remarks>
+    internal IReadOnlyList<HostFirstSubstitution> MaterializeSubstitutions()
+    {
+        lock (_substitutionsLock)
+        {
+            return [.. _substitutions.Values];
+        }
+    }
 
     protected override Assembly? Load(AssemblyName assemblyName)
     {
@@ -45,16 +79,19 @@ internal sealed class PluginLoadContext(string pluginName, string entryAssemblyP
             return path is null ? null : LoadFromAssemblyPath(path);
         }
 
-        if (
-            assemblyName.Version is { } requested
-            && hostAssembly.GetName().Version is { } hostVersion
-            && hostVersion < requested
-        )
+        Version? hostVersion = hostAssembly.GetName().Version;
+
+        if (assemblyName.Version is { } requested && hostVersion is not null && hostVersion < requested)
         {
-            // Name is the base class's own copy of pluginName. Reading the primary-constructor
-            // parameter here instead would capture it a second time, which is CS9107 and therefore an
-            // error under this repository's TreatWarningsAsErrors.
+            // Name is the base class's own copy of pluginName. Reading a constructor parameter here
+            // instead would capture it a second time, which is CS9107 and therefore an error under this
+            // repository's TreatWarningsAsErrors.
             throw new PluginVersionSkewException(Name!, simpleName, requested, hostVersion);
+        }
+
+        if (hostVersion is not null)
+        {
+            RecordSubstitution(simpleName, assemblyName.Version, hostVersion);
         }
 
         return hostAssembly;
@@ -67,5 +104,35 @@ internal sealed class PluginLoadContext(string pluginName, string entryAssemblyP
         // default probing", which is what happens for a library the plugin did not ship.
         string? path = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
         return path is null ? IntPtr.Zero : LoadUnmanagedDllFromPath(path);
+    }
+
+    /// <summary>
+    /// Records a resolution the host answered, when what it served differs from what the plugin
+    /// declared or, absent a declaration, from what the reference asked for.
+    /// </summary>
+    private void RecordSubstitution(string simpleName, Version? requestedVersion, Version hostVersion)
+    {
+        Version? declaredVersion = _declaredVersions.GetValueOrDefault(simpleName);
+
+        // The manifest declaration is the comparison that matters, because it is what the plugin
+        // shipped and therefore what its author tested against. The reference version is a different
+        // fact and is carried separately rather than standing in for the declaration: they can differ,
+        // and a shared-framework assembly has no declaration at all.
+        bool substituted = declaredVersion is not null
+            ? declaredVersion != hostVersion
+            : requestedVersion is not null && requestedVersion != hostVersion;
+
+        if (!substituted)
+        {
+            return;
+        }
+
+        lock (_substitutionsLock)
+        {
+            _substitutions.TryAdd(
+                simpleName,
+                new HostFirstSubstitution(simpleName, requestedVersion, hostVersion, declaredVersion)
+            );
+        }
     }
 }

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadContext.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadContext.cs
@@ -29,6 +29,7 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
     private readonly IReadOnlyDictionary<string, Version> _declaredVersions;
     private readonly Lock _substitutionsLock = new();
     private readonly Dictionary<string, HostFirstSubstitution> _substitutions = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _servedFromHost = new(StringComparer.Ordinal);
 
     internal PluginLoadContext(string pluginName, string entryAssemblyPath)
         : this(pluginName, entryAssemblyPath, new Dictionary<string, Version>(StringComparer.Ordinal)) { }
@@ -62,6 +63,33 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
         }
     }
 
+    /// <summary>
+    /// Whether this context has actually served <paramref name="simpleName"/> from the host.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The substitution record answers a narrower question: it carries only the resolutions where what
+    /// the host served differs from what the plugin declared or asked for. An assembly the host serves
+    /// at exactly the expected version leaves no row there, so nothing else can say whether this
+    /// override was the thing that resolved it. That distinction matters for the assemblies a
+    /// framework-dependent publish does not declare at all, where the manifest cannot say and the
+    /// preflight never looked.
+    /// </para>
+    /// <para>
+    /// Deliberately a set of distinct simple names and not a request log: no ordering, no repeat
+    /// history, no per-call record. Its bound is one name per host assembly this plugin resolves,
+    /// which is the same bound the substitution dictionary beside it already carries. It records only
+    /// the serving path, so a refusal is never counted as a resolution.
+    /// </para>
+    /// </remarks>
+    internal bool HasServedFromHost(string simpleName)
+    {
+        lock (_substitutionsLock)
+        {
+            return _servedFromHost.Contains(simpleName);
+        }
+    }
+
     protected override Assembly? Load(AssemblyName assemblyName)
     {
         if (assemblyName.Name is not { } simpleName)
@@ -87,6 +115,13 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
             // instead would capture it a second time, which is CS9107 and therefore an error under this
             // repository's TreatWarningsAsErrors.
             throw new PluginVersionSkewException(Name!, simpleName, requested, hostVersion);
+        }
+
+        // Recorded here, past the refusal above, so what is recorded is a resolution this override
+        // actually answered rather than one it was merely asked about.
+        lock (_substitutionsLock)
+        {
+            _servedFromHost.Add(simpleName);
         }
 
         if (hostVersion is not null)

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadContext.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadContext.cs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// One plugin's assembly load context: named for the plugin, non-collectible, resolving host-first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Host-first means any assembly the host itself carries is served from the default context, and the
+/// plugin's own copy is used only for assemblies the host does not have. That is what keeps every type
+/// the host and a plugin exchange to one identity, and it is why a plugin cannot silently displace a
+/// host assembly. What a plugin still gets its own copy of is anything the host does not carry, which
+/// is where real collisions live.
+/// </para>
+/// <para>
+/// Non-collectible because nothing unloads a plugin.
+/// </para>
+/// </remarks>
+internal sealed class PluginLoadContext(string pluginName, string entryAssemblyPath)
+    : AssemblyLoadContext(pluginName, isCollectible: false)
+{
+    private readonly AssemblyDependencyResolver _resolver = new(entryAssemblyPath);
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        if (assemblyName.Name is not { } simpleName)
+        {
+            return null;
+        }
+
+        // Asked by simple name so that the default binder's own version check cannot turn "the host
+        // carries an older copy" into "the host does not have it": those two throw the same exception
+        // and need opposite treatment.
+        if (!HostAssemblies.TryLoad(simpleName, out Assembly hostAssembly))
+        {
+            // Genuinely plugin-private: the host carries nothing by this name.
+            string? path = _resolver.ResolveAssemblyToPath(assemblyName);
+            return path is null ? null : LoadFromAssemblyPath(path);
+        }
+
+        if (
+            assemblyName.Version is { } requested
+            && hostAssembly.GetName().Version is { } hostVersion
+            && hostVersion < requested
+        )
+        {
+            // Name is the base class's own copy of pluginName. Reading the primary-constructor
+            // parameter here instead would capture it a second time, which is CS9107 and therefore an
+            // error under this repository's TreatWarningsAsErrors.
+            throw new PluginVersionSkewException(Name!, simpleName, requested, hostVersion);
+        }
+
+        return hostAssembly;
+    }
+
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {
+        // The resolver answers with a path and the override has to return a handle, so the path goes
+        // through LoadUnmanagedDllFromPath. Returning zero is how the override says "fall back to the
+        // default probing", which is what happens for a library the plugin did not ship.
+        string? path = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        return path is null ? IntPtr.Zero : LoadUnmanagedDllFromPath(path);
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadContext.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadContext.cs
@@ -29,7 +29,7 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
     private readonly IReadOnlyDictionary<string, Version> _declaredVersions;
     private readonly Lock _substitutionsLock = new();
     private readonly Dictionary<string, HostFirstSubstitution> _substitutions = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _servedFromHost = new(StringComparer.Ordinal);
+    private readonly HostResolutionObserver? _observer;
 
     internal PluginLoadContext(string pluginName, string entryAssemblyPath)
         : this(pluginName, entryAssemblyPath, new Dictionary<string, Version>(StringComparer.Ordinal)) { }
@@ -37,12 +37,17 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
     internal PluginLoadContext(
         string pluginName,
         string entryAssemblyPath,
-        IReadOnlyDictionary<string, Version> declaredVersions
+        IReadOnlyDictionary<string, Version> declaredVersions,
+        HostResolutionObserver? observer = null
     )
         : base(pluginName, isCollectible: false)
     {
         _resolver = new AssemblyDependencyResolver(entryAssemblyPath);
         _declaredVersions = declaredVersions;
+
+        // Null on the public loader path, which is what keeps an ordinary host run free of any
+        // observation state. Only a caller that names the assemblies it wants to know about gets one.
+        _observer = observer;
     }
 
     /// <summary>
@@ -60,33 +65,6 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
         lock (_substitutionsLock)
         {
             return [.. _substitutions.Values];
-        }
-    }
-
-    /// <summary>
-    /// Whether this context has actually served <paramref name="simpleName"/> from the host.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The substitution record answers a narrower question: it carries only the resolutions where what
-    /// the host served differs from what the plugin declared or asked for. An assembly the host serves
-    /// at exactly the expected version leaves no row there, so nothing else can say whether this
-    /// override was the thing that resolved it. That distinction matters for the assemblies a
-    /// framework-dependent publish does not declare at all, where the manifest cannot say and the
-    /// preflight never looked.
-    /// </para>
-    /// <para>
-    /// Deliberately a set of distinct simple names and not a request log: no ordering, no repeat
-    /// history, no per-call record. Its bound is one name per host assembly this plugin resolves,
-    /// which is the same bound the substitution dictionary beside it already carries. It records only
-    /// the serving path, so a refusal is never counted as a resolution.
-    /// </para>
-    /// </remarks>
-    internal bool HasServedFromHost(string simpleName)
-    {
-        lock (_substitutionsLock)
-        {
-            return _servedFromHost.Contains(simpleName);
         }
     }
 
@@ -117,12 +95,9 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
             throw new PluginVersionSkewException(Name!, simpleName, requested, hostVersion);
         }
 
-        // Recorded here, past the refusal above, so what is recorded is a resolution this override
-        // actually answered rather than one it was merely asked about.
-        lock (_substitutionsLock)
-        {
-            _servedFromHost.Add(simpleName);
-        }
+        // Told past the refusal above, so what an observer sees is a resolution this override actually
+        // answered rather than one it was merely asked about. Nothing is retained here.
+        _observer?.Record(simpleName);
 
         if (hostVersion is not null)
         {

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadException.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadException.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Thrown when an allowlisted plugin cannot be loaded. Every plugin failure is fatal, so this is the
+/// single exception a host sees from the loader.
+/// </summary>
+/// <remarks>
+/// The message is what an operator reads and always names the entry and the rule that refused it. The
+/// <see cref="Reason"/> is what code reads, so a caller does not have to match on message text, and
+/// the original failure is preserved as the inner exception wherever the runtime produced one.
+/// </remarks>
+public sealed class PluginLoadException(
+    PluginLoadFailure reason,
+    string? pluginName,
+    string message,
+    Exception? innerException = null
+) : Exception(message, innerException)
+{
+    /// <summary>The rule that refused the plugin.</summary>
+    public PluginLoadFailure Reason { get; } = reason;
+
+    /// <summary>
+    /// The allowlist entry the failure belongs to, or <see langword="null"/> for a failure of the
+    /// configuration or the plugin root, which belongs to no single entry.
+    /// </summary>
+    public string? PluginName { get; } = pluginName;
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadFailure.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoadFailure.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// The structured reason a plugin failed to load, one value per fatal row the plugin design defines.
+/// </summary>
+/// <remarks>
+/// The reason travels on <see cref="PluginLoadException"/> beside the human-readable message so that
+/// a caller, and a test, can tell which rule fired without matching on message text. Every value is a
+/// fatal: the design refuses skip-and-continue, because an allowlisted plugin that silently does not
+/// load takes correctness or security posture with it.
+/// </remarks>
+public enum PluginLoadFailure
+{
+    /// <summary>A name appears more than once in the allowlist, before or after trimming.</summary>
+    DuplicateAllowlistEntry,
+
+    /// <summary>An allowlist entry is not a single path segment of the permitted shape.</summary>
+    InvalidAllowlistName,
+
+    /// <summary>The configured plugin directory could not be turned into a full path.</summary>
+    PluginPathUnresolvable,
+
+    /// <summary>The plugin root does not exist and the allowlist is not empty.</summary>
+    PluginRootMissing,
+
+    /// <summary>An allowlisted directory does not exist under the plugin root.</summary>
+    PluginDirectoryMissing,
+
+    /// <summary>An allowlisted directory resolves outside the plugin root once links are followed.</summary>
+    EscapesPluginRoot,
+
+    /// <summary>The entry assembly named for the plugin directory is not present.</summary>
+    EntryAssemblyMissing,
+
+    /// <summary>The dependency manifest named for the plugin directory is not present.</summary>
+    DepsJsonMissing,
+
+    /// <summary>The dependency manifest is not readable as the shape a publish produces.</summary>
+    DepsJsonUnreadable,
+
+    /// <summary>The dependency manifest declares a runtime pack, which a self-contained publish produces.</summary>
+    SelfContainedPublish,
+
+    /// <summary>The entry assembly references a newer version of a declared contract than the host carries.</summary>
+    ContractVersionSkew,
+
+    /// <summary>The entry assembly references a declared contract assembly the host cannot resolve.</summary>
+    ContractAssemblyMissing,
+
+    /// <summary>The manifest declares a higher version of an assembly the host also carries.</summary>
+    DependencyVersionSkew,
+
+    /// <summary>The entry assembly is not a readable managed assembly.</summary>
+    EntryAssemblyUnreadable,
+
+    /// <summary>The entry assembly could not be loaded into the plugin's context.</summary>
+    EntryAssemblyLoadFailed,
+
+    /// <summary>The entry assembly's exported types could not be enumerated.</summary>
+    PluginTypesUnloadable,
+
+    /// <summary>The entry assembly exposes no constructible plugin type.</summary>
+    NoPluginType,
+
+    /// <summary>The entry assembly exposes more than one constructible plugin type.</summary>
+    MultiplePluginTypes,
+
+    /// <summary>The entry assembly's own name does not equal the plugin directory name.</summary>
+    AssemblyNameMismatch,
+
+    /// <summary>The plugin type could not be constructed.</summary>
+    PluginActivationFailed,
+
+    /// <summary>The plugin's name could not be read.</summary>
+    PluginNameUnavailable,
+
+    /// <summary>The plugin's name does not equal the plugin directory name.</summary>
+    PluginNameMismatch,
+
+    /// <summary>A file the manifest declares is present but could not be read.</summary>
+    PluginFileUnreadable,
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
@@ -575,17 +575,34 @@ public static class PluginLoader
     /// The version the manifest declares for each simple assembly name, for the substitution record.
     /// </summary>
     /// <remarks>
-    /// A manifest can declare one simple name more than once, as a top-level runtime entry and again as
-    /// a RID-specific row. Those agree in every publish measured here; where they did not, the first
+    /// <para>
+    /// Read from every managed declaration the manifest makes, and deliberately not from the skew
+    /// preflight's set. The preflight reads top-level <c>runtime</c> entries only, which is a policy
+    /// about what to refuse and is documented as such. The record is a different question: it says what
+    /// the plugin declared for an assembly the host actually served, and an assembly declared only in a
+    /// RID-specific row is declared just as much as one declared at the top level. Narrowing the
+    /// record's source to the preflight's would report no declaration for a version the manifest plainly
+    /// states.
+    /// </para>
+    /// <para>
+    /// A manifest can declare one simple name more than once, as a top-level entry and again as a
+    /// RID-specific row. Those agree in every publish measured here; where they did not, the first
     /// declaration wins and the record still says what a declaration said rather than inventing one.
+    /// </para>
     /// </remarks>
     private static IReadOnlyDictionary<string, Version> DeclaredVersionsOf(PluginDepsManifest manifest)
     {
         Dictionary<string, Version> declared = new(StringComparer.Ordinal);
 
-        foreach (PluginDeclaredAssembly assembly in manifest.DeclaredAssemblies)
+        foreach (PluginDeclaredAsset asset in manifest.DeclaredAssets)
         {
-            declared.TryAdd(assembly.SimpleName, assembly.DeclaredVersion);
+            // A native asset has no version to declare, and nothing resolves one by assembly name.
+            if (asset.Kind == PluginFileKind.Native || asset.DeclaredVersion is not { } version)
+            {
+                continue;
+            }
+
+            declared.TryAdd(Path.GetFileNameWithoutExtension(asset.DeclaredPath), version);
         }
 
         return declared;

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
@@ -422,11 +422,60 @@ public static class PluginLoader
     /// </summary>
     private static Type FindPluginType(string name, Assembly entryAssembly)
     {
-        Type[] exported;
-
         try
         {
-            exported = entryAssembly.GetExportedTypes();
+            // Every step here is reflection over a third party's assembly, and every step of it can
+            // bind another assembly. Enumerating the exported types is the obvious one; resolving a
+            // constructor is the one that is easy to miss, because asking for the parameterless
+            // constructor makes the runtime resolve the parameter types of the type's *other*
+            // constructors, and an overload naming a type from a skewed or absent assembly fails
+            // there. The whole discovery therefore sits inside one classified handler, so the
+            // first-use backstop applies to all of it rather than only to enumeration.
+            Type[] exported = entryAssembly.GetExportedTypes();
+
+            // A candidate has to be something the host can actually construct and call. An abstract
+            // type, an open generic and a type with no public parameterless constructor are each
+            // impossible to construct, so counting them would turn "your plugin type is not
+            // constructible" into "your assembly exposes two plugins".
+            List<Type> candidates = exported
+                .Where(type =>
+                    type.IsClass
+                    && !type.IsAbstract
+                    && !type.ContainsGenericParameters
+                    && typeof(EdFiApiPlugin).IsAssignableFrom(type)
+                    && type.GetConstructor(Type.EmptyTypes) is not null
+                )
+                .ToList();
+
+            if (candidates.Count == 1)
+            {
+                return candidates[0];
+            }
+
+            IEnumerable<Type> nearMisses = exported.Where(type =>
+                typeof(EdFiApiPlugin).IsAssignableFrom(type) && !candidates.Contains(type)
+            );
+
+            string found =
+                candidates.Count == 0 ? "none" : string.Join(", ", candidates.Select(type => type.FullName));
+            string excluded = string.Join(", ", nearMisses.Select(type => type.FullName));
+
+            // Thrown from inside the try deliberately: it is a PluginLoadException, and neither handler
+            // below catches one, so the zero and multiple classifications survive intact.
+            throw new PluginLoadException(
+                candidates.Count == 0
+                    ? PluginLoadFailure.NoPluginType
+                    : PluginLoadFailure.MultiplePluginTypes,
+                name,
+                $"plugin '{PluginDiagnosticText.Quote(name)}' has to expose exactly one public, "
+                    + "non-abstract, non-generic EdFiApiPlugin subclass with a public parameterless "
+                    + $"constructor. Constructible: {PluginDiagnosticText.Quote(found)}."
+                    + (
+                        excluded.Length == 0
+                            ? string.Empty
+                            : $" Exposed but not constructible: {PluginDiagnosticText.Quote(excluded)}."
+                    )
+            );
         }
         catch (ReflectionTypeLoadException exception)
         {
@@ -448,57 +497,22 @@ public static class PluginLoader
                 );
         }
         catch (Exception exception)
-            when (exception is FileNotFoundException or FileLoadException or TypeLoadException)
+            when (exception
+                    is FileNotFoundException
+                        or FileLoadException
+                        or TypeLoadException
+                        or BadImageFormatException
+            )
         {
             throw Unwrap(name, exception)
                 ?? new PluginLoadException(
                     PluginLoadFailure.PluginTypesUnloadable,
                     name,
-                    $"plugin '{PluginDiagnosticText.Quote(name)}' has exported types that could not be "
-                        + $"loaded: {PluginDiagnosticText.Quote(exception.Message)}",
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' exposes types the runtime could not "
+                        + $"resolve: {PluginDiagnosticText.Quote(exception.Message)}",
                     exception
                 );
         }
-
-        // A candidate has to be something the host can actually construct and call. An abstract type,
-        // an open generic and a type with no public parameterless constructor are each impossible to
-        // construct, so counting them would turn "your plugin type is not constructible" into "your
-        // assembly exposes two plugins".
-        List<Type> candidates = exported
-            .Where(type =>
-                type.IsClass
-                && !type.IsAbstract
-                && !type.ContainsGenericParameters
-                && typeof(EdFiApiPlugin).IsAssignableFrom(type)
-                && type.GetConstructor(Type.EmptyTypes) is not null
-            )
-            .ToList();
-
-        if (candidates.Count == 1)
-        {
-            return candidates[0];
-        }
-
-        IEnumerable<Type> nearMisses = exported.Where(type =>
-            typeof(EdFiApiPlugin).IsAssignableFrom(type) && !candidates.Contains(type)
-        );
-
-        string found =
-            candidates.Count == 0 ? "none" : string.Join(", ", candidates.Select(type => type.FullName));
-        string excluded = string.Join(", ", nearMisses.Select(type => type.FullName));
-
-        throw new PluginLoadException(
-            candidates.Count == 0 ? PluginLoadFailure.NoPluginType : PluginLoadFailure.MultiplePluginTypes,
-            name,
-            $"plugin '{PluginDiagnosticText.Quote(name)}' has to expose exactly one public, "
-                + "non-abstract, non-generic EdFiApiPlugin subclass with a public parameterless "
-                + $"constructor. Constructible: {PluginDiagnosticText.Quote(found)}."
-                + (
-                    excluded.Length == 0
-                        ? string.Empty
-                        : $" Exposed but not constructible: {PluginDiagnosticText.Quote(excluded)}."
-                )
-        );
     }
 
     private static EdFiApiPlugin Activate(string name, Type pluginType)

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
@@ -46,10 +46,15 @@ public static class PluginLoader
     /// The overload the public one calls with <see cref="Console.Error"/>, so that a test can read the
     /// channel without redirecting the process's own.
     /// </summary>
+    /// <param name="observer">
+    /// Watches a finite set of assembly names a caller wants to know the override actually served.
+    /// Omitted by the public overload, so an ordinary host run creates contexts that observe nothing.
+    /// </param>
     internal static LoadedPlugins Load(
         IConfiguration configuration,
         IReadOnlyCollection<string> contractAssemblyNames,
-        TextWriter diagnostics
+        TextWriter diagnostics,
+        HostResolutionObserver? observer = null
     )
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -89,7 +94,7 @@ public static class PluginLoader
 
         foreach (string name in plugins.AllowedNames)
         {
-            loaded.Add(LoadPlugin(name, resolvedRoot, contractAssemblyNames, diagnostics));
+            loaded.Add(LoadPlugin(name, resolvedRoot, contractAssemblyNames, diagnostics, observer));
         }
 
         ReportDirectoriesNobodyAskedFor(resolvedRoot, plugins.AllowedNames, diagnostics);
@@ -113,7 +118,8 @@ public static class PluginLoader
         string name,
         string resolvedRoot,
         IReadOnlyCollection<string> contractAssemblyNames,
-        TextWriter diagnostics
+        TextWriter diagnostics,
+        HostResolutionObserver? observer
     )
     {
         try
@@ -190,7 +196,7 @@ public static class PluginLoader
             CheckContractReferences(name, entryAssemblyPath, contractAssemblyNames);
             CheckDeclaredDependencies(name, manifest);
 
-            PluginLoadContext context = CreateLoadContext(name, entryAssemblyPath, manifest);
+            PluginLoadContext context = CreateLoadContext(name, entryAssemblyPath, manifest, observer);
             Assembly entryAssembly = LoadEntryAssembly(name, entryAssemblyPath, context);
 
             if (entryAssembly.GetName().Name is not { } entryAssemblyName)
@@ -544,7 +550,8 @@ public static class PluginLoader
     private static PluginLoadContext CreateLoadContext(
         string name,
         string entryAssemblyPath,
-        PluginDepsManifest manifest
+        PluginDepsManifest manifest,
+        HostResolutionObserver? observer
     )
     {
         try
@@ -552,7 +559,7 @@ public static class PluginLoader
             // The declared versions go to the context so that a substitution it records can say what the
             // plugin's manifest declared, rather than only what the reference asked for. The two differ,
             // and the declaration is the one the plugin shipped and its author tested against.
-            return new PluginLoadContext(name, entryAssemblyPath, DeclaredVersionsOf(manifest));
+            return new PluginLoadContext(name, entryAssemblyPath, DeclaredVersionsOf(manifest), observer);
         }
         catch (Exception exception)
             when (exception is ArgumentException or InvalidOperationException or IOException)

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
@@ -138,6 +138,16 @@ public static class PluginLoader
                 );
             }
 
+            // Before resolution, and against the plugin root rather than a link target, so that what is
+            // checked is the allowlisted entry as the root spells it.
+            RequireExactSpelling(
+                resolvedRoot,
+                name,
+                name,
+                PluginLoadFailure.PluginDirectoryMissing,
+                directory: true
+            );
+
             string resolvedPlugin = ResolveDirectory(candidate, name, diagnostics);
 
             // The containment check resolves symbolic links rather than normalizing lexically, because
@@ -170,11 +180,25 @@ public static class PluginLoader
                 PluginLoadFailure.EntryAssemblyMissing,
                 "its entry assembly"
             );
+            RequireExactSpelling(
+                resolvedPlugin,
+                $"{name}.dll",
+                name,
+                PluginLoadFailure.EntryAssemblyMissing,
+                directory: false
+            );
             RequireFile(
                 manifestPath,
                 name,
                 PluginLoadFailure.DepsJsonMissing,
                 "its dependency manifest, without which its private closure would not resolve"
+            );
+            RequireExactSpelling(
+                resolvedPlugin,
+                $"{name}.deps.json",
+                name,
+                PluginLoadFailure.DepsJsonMissing,
+                directory: false
             );
 
             PluginDepsManifest manifest = PluginDepsManifest.Read(name, manifestPath);
@@ -287,6 +311,83 @@ public static class PluginLoader
 
             throw pluginName is null ? Report(diagnostics, null, failure) : failure;
         }
+    }
+
+    /// <summary>
+    /// Requires that <paramref name="expected"/> is present in <paramref name="parent"/> under exactly
+    /// that spelling, reading the name back from the directory rather than asking whether a path exists.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Directory.Exists"/> and <see cref="File.Exists"/> are answered by the filesystem, and
+    /// a case-insensitive one answers true for a name that is not the name it was asked about. Every
+    /// identity comparison this loader makes is ordinal so that a plugin's identity does not depend on
+    /// which filesystem the image was built on, and trusting those probes made the plugin directory, the
+    /// entry assembly and the manifest the three places where it did: one plugin root would load here
+    /// and be a missing-path fatal in a Linux image.
+    /// </para>
+    /// <para>
+    /// The expected name is safe to pass as a search pattern. An allowlist entry has already been held
+    /// to a single path segment carrying no wildcard character, and the two file names are composed from
+    /// it. Every returned match is inspected rather than the first, so a match the platform adds cannot
+    /// hide the real one.
+    /// </para>
+    /// </remarks>
+    private static void RequireExactSpelling(
+        string parent,
+        string expected,
+        string pluginName,
+        PluginLoadFailure reason,
+        bool directory
+    )
+    {
+        string[] present;
+
+        try
+        {
+            present =
+            [
+                .. (
+                    directory
+                        ? Directory.EnumerateDirectories(parent, expected)
+                        : Directory.EnumerateFiles(parent, expected)
+                ).Select(path => Path.GetFileName(path) ?? string.Empty),
+            ];
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw new PluginLoadException(
+                PluginLoadFailure.PluginPathUnresolvable,
+                pluginName,
+                $"'{PluginDiagnosticText.Quote(parent)}' could not be listed to read how "
+                    + $"'{PluginDiagnosticText.Quote(expected)}' is spelled in it. The name has to come "
+                    + "from the directory to be compared ordinally with the one that was asked for.",
+                exception
+            );
+        }
+
+        if (Array.Exists(present, name => string.Equals(name, expected, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        string? actual = present.Length == 0 ? null : present[0];
+
+        throw new PluginLoadException(
+            reason,
+            pluginName,
+            $"plugin '{PluginDiagnosticText.Quote(pluginName)}' needs "
+                + $"'{PluginDiagnosticText.Quote(expected)}' in "
+                + $"'{PluginDiagnosticText.Quote(parent)}', "
+                + (
+                    actual is null
+                        ? "and nothing there is spelled that way."
+                        : $"and what is there is '{PluginDiagnosticText.Quote(actual)}', which differs "
+                            + "only in case."
+                )
+                + " Names are compared ordinally, so a plugin's identity does not depend on which "
+                + "filesystem the image was built on."
+        );
     }
 
     private static void RequireFile(

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
@@ -190,7 +190,7 @@ public static class PluginLoader
             CheckContractReferences(name, entryAssemblyPath, contractAssemblyNames);
             CheckDeclaredDependencies(name, manifest);
 
-            PluginLoadContext context = CreateLoadContext(name, entryAssemblyPath);
+            PluginLoadContext context = CreateLoadContext(name, entryAssemblyPath, manifest);
             Assembly entryAssembly = LoadEntryAssembly(name, entryAssemblyPath, context);
 
             if (entryAssembly.GetName().Name is not { } entryAssemblyName)
@@ -240,6 +240,8 @@ public static class PluginLoader
                 instance,
                 resolvedPlugin,
                 entryAssembly.GetName().Version ?? new Version(0, 0, 0, 0),
+                $"{name}.dll",
+                PluginFileInventory.Build(name, resolvedPlugin, manifest),
                 context
             );
 
@@ -539,11 +541,18 @@ public static class PluginLoader
         }
     }
 
-    private static PluginLoadContext CreateLoadContext(string name, string entryAssemblyPath)
+    private static PluginLoadContext CreateLoadContext(
+        string name,
+        string entryAssemblyPath,
+        PluginDepsManifest manifest
+    )
     {
         try
         {
-            return new PluginLoadContext(name, entryAssemblyPath);
+            // The declared versions go to the context so that a substitution it records can say what the
+            // plugin's manifest declared, rather than only what the reference asked for. The two differ,
+            // and the declaration is the one the plugin shipped and its author tested against.
+            return new PluginLoadContext(name, entryAssemblyPath, DeclaredVersionsOf(manifest));
         }
         catch (Exception exception)
             when (exception is ArgumentException or InvalidOperationException or IOException)
@@ -560,6 +569,26 @@ public static class PluginLoader
                 exception
             );
         }
+    }
+
+    /// <summary>
+    /// The version the manifest declares for each simple assembly name, for the substitution record.
+    /// </summary>
+    /// <remarks>
+    /// A manifest can declare one simple name more than once, as a top-level runtime entry and again as
+    /// a RID-specific row. Those agree in every publish measured here; where they did not, the first
+    /// declaration wins and the record still says what a declaration said rather than inventing one.
+    /// </remarks>
+    private static IReadOnlyDictionary<string, Version> DeclaredVersionsOf(PluginDepsManifest manifest)
+    {
+        Dictionary<string, Version> declared = new(StringComparer.Ordinal);
+
+        foreach (PluginDeclaredAssembly assembly in manifest.DeclaredAssemblies)
+        {
+            declared.TryAdd(assembly.SimpleName, assembly.DeclaredVersion);
+        }
+
+        return declared;
     }
 
     private static string? ReadName(string name, EdFiApiPlugin instance)

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
@@ -190,7 +190,7 @@ public static class PluginLoader
             CheckContractReferences(name, entryAssemblyPath, contractAssemblyNames);
             CheckDeclaredDependencies(name, manifest);
 
-            PluginLoadContext context = new(name, entryAssemblyPath);
+            PluginLoadContext context = CreateLoadContext(name, entryAssemblyPath);
             Assembly entryAssembly = LoadEntryAssembly(name, entryAssemblyPath, context);
 
             if (entryAssembly.GetName().Name is not { } entryAssemblyName)
@@ -219,7 +219,10 @@ public static class PluginLoader
 
             EdFiApiPlugin instance = Activate(name, FindPluginType(name, entryAssembly));
 
-            string declaredName = ReadName(name, instance);
+            // A plugin can return null from Name: it is a non-nullable property on the contract, and a
+            // third-party assembly is not constrained by that at runtime. A null is simply a name that
+            // is not the directory name, so it takes the same refusal and renders as <null>.
+            string? declaredName = ReadName(name, instance);
 
             if (!string.Equals(declaredName, name, StringComparison.Ordinal))
             {
@@ -522,7 +525,30 @@ public static class PluginLoader
         }
     }
 
-    private static string ReadName(string name, EdFiApiPlugin instance)
+    private static PluginLoadContext CreateLoadContext(string name, string entryAssemblyPath)
+    {
+        try
+        {
+            return new PluginLoadContext(name, entryAssemblyPath);
+        }
+        catch (Exception exception)
+            when (exception is ArgumentException or InvalidOperationException or IOException)
+        {
+            // AssemblyDependencyResolver reads the manifest itself, and it is stricter about parts of
+            // it than the loader's own reader needs to be. Its refusal is still a refusal of the
+            // plugin's manifest, so it arrives as one rather than as a raw argument exception.
+            throw new PluginLoadException(
+                PluginLoadFailure.DepsJsonUnreadable,
+                name,
+                $"plugin '{PluginDiagnosticText.Quote(name)}' could not be given a dependency resolver "
+                    + $"over '{PluginDiagnosticText.Quote(entryAssemblyPath)}': "
+                    + PluginDiagnosticText.Quote(exception.Message),
+                exception
+            );
+        }
+    }
+
+    private static string? ReadName(string name, EdFiApiPlugin instance)
     {
         try
         {

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginLoader.cs
@@ -1,0 +1,665 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Loads the plugins an operator allowlisted, one isolated load context each.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The loader is host-agnostic. It takes an <see cref="IConfiguration"/> and the assembly names of the
+/// contracts the caller declares, returns the plugin instances in allowlist order, writes its own
+/// outcomes to <see cref="Console.Error"/>, and throws <see cref="PluginLoadException"/> on any fatal.
+/// It knows nothing about either host's startup, its logging, or the hooks it will later invoke.
+/// </para>
+/// <para>
+/// An allowlisted plugin that does not load is fatal. Skip-and-continue would degrade a broken plugin
+/// to silently absent, and for the plugin types this exists for, absence is invisible: what goes quiet
+/// is correctness or security posture rather than a capability an operator can see.
+/// </para>
+/// </remarks>
+public static class PluginLoader
+{
+    /// <summary>
+    /// Loads every plugin named in <c>Plugins:Allowed</c>, in order.
+    /// </summary>
+    /// <param name="configuration">The host's configuration, which the <c>Plugins</c> section is read from.</param>
+    /// <param name="contractAssemblyNames">
+    /// The simple <em>assembly</em> names of the contracts this host declares, which the entry
+    /// assembly's references are checked against. They are assembly names and never package ids: an
+    /// assembly reference carries a simple assembly name, so a package id in this set matches nothing
+    /// and silently checks nothing.
+    /// </param>
+    /// <exception cref="PluginLoadException">Any allowlisted plugin could not be loaded.</exception>
+    public static LoadedPlugins Load(
+        IConfiguration configuration,
+        IReadOnlyCollection<string> contractAssemblyNames
+    ) => Load(configuration, contractAssemblyNames, Console.Error);
+
+    /// <summary>
+    /// The overload the public one calls with <see cref="Console.Error"/>, so that a test can read the
+    /// channel without redirecting the process's own.
+    /// </summary>
+    internal static LoadedPlugins Load(
+        IConfiguration configuration,
+        IReadOnlyCollection<string> contractAssemblyNames,
+        TextWriter diagnostics
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(contractAssemblyNames);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        PluginsConfiguration plugins = Bind(configuration, diagnostics);
+
+        // No name survived the allowlist, so nothing is read and nothing is written. This is the
+        // shipped default and the reason a plugin-free deployment boots exactly as it did before.
+        if (!plugins.TryGetResolvedRoot(out string? configuredRoot))
+        {
+            return LoadedPlugins.Empty;
+        }
+
+        // Existence before resolution. ResolveLinkTarget throws for a path that does not exist, so
+        // resolving first would turn a missing root into a raw DirectoryNotFoundException instead of
+        // the fatal that names the path an operator has to create.
+        if (!Directory.Exists(configuredRoot))
+        {
+            throw Report(
+                diagnostics,
+                pluginName: null,
+                new PluginLoadException(
+                    PluginLoadFailure.PluginRootMissing,
+                    null,
+                    $"the plugin root '{PluginDiagnosticText.Quote(configuredRoot)}' does not exist, "
+                        + $"and Plugins:Allowed asks for {plugins.AllowedNames.Count} plugin(s). "
+                        + "Either create the root and place the plugins in it, or clear Plugins:Allowed."
+                )
+            );
+        }
+
+        string resolvedRoot = ResolveDirectory(configuredRoot, pluginName: null, diagnostics);
+
+        List<LoadedPlugin> loaded = [];
+
+        foreach (string name in plugins.AllowedNames)
+        {
+            loaded.Add(LoadPlugin(name, resolvedRoot, contractAssemblyNames, diagnostics));
+        }
+
+        ReportDirectoriesNobodyAskedFor(resolvedRoot, plugins.AllowedNames, diagnostics);
+
+        return new LoadedPlugins(loaded);
+    }
+
+    private static PluginsConfiguration Bind(IConfiguration configuration, TextWriter diagnostics)
+    {
+        try
+        {
+            return PluginsConfigurationBinder.Bind(configuration);
+        }
+        catch (PluginLoadException exception)
+        {
+            throw Report(diagnostics, pluginName: null, exception);
+        }
+    }
+
+    private static LoadedPlugin LoadPlugin(
+        string name,
+        string resolvedRoot,
+        IReadOnlyCollection<string> contractAssemblyNames,
+        TextWriter diagnostics
+    )
+    {
+        try
+        {
+            string candidate = Path.Combine(resolvedRoot, name);
+
+            // Existence before resolution again, and the order is the criterion: a misspelled entry has
+            // to fail with the missing-path fatal rather than with a raw exception out of resolution.
+            if (!Directory.Exists(candidate))
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.PluginDirectoryMissing,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' is allowlisted but "
+                        + $"'{PluginDiagnosticText.Quote(candidate)}' does not exist."
+                );
+            }
+
+            string resolvedPlugin = ResolveDirectory(candidate, name, diagnostics);
+
+            // The containment check resolves symbolic links rather than normalizing lexically, because
+            // Path.GetFullPath never reads the filesystem: a directory link out of the root passes it
+            // while the assembly actually loaded is the one outside. The plugin path is composed
+            // against the *resolved* root, because composing against the configured one rejects every
+            // plugin under a root that is itself a link.
+            string rootPrefix = resolvedRoot.EndsWith(Path.DirectorySeparatorChar)
+                ? resolvedRoot
+                : resolvedRoot + Path.DirectorySeparatorChar;
+
+            if (!resolvedPlugin.StartsWith(rootPrefix, StringComparison.Ordinal))
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.EscapesPluginRoot,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' resolves to "
+                        + $"'{PluginDiagnosticText.Quote(resolvedPlugin)}', which is not under the "
+                        + $"plugin root '{PluginDiagnosticText.Quote(resolvedRoot)}'. The check follows "
+                        + "symbolic links, and it covers the plugin directory rather than the files in it."
+                );
+            }
+
+            string entryAssemblyPath = Path.Combine(resolvedPlugin, $"{name}.dll");
+            string manifestPath = Path.Combine(resolvedPlugin, $"{name}.deps.json");
+
+            RequireFile(
+                entryAssemblyPath,
+                name,
+                PluginLoadFailure.EntryAssemblyMissing,
+                "its entry assembly"
+            );
+            RequireFile(
+                manifestPath,
+                name,
+                PluginLoadFailure.DepsJsonMissing,
+                "its dependency manifest, without which its private closure would not resolve"
+            );
+
+            PluginDepsManifest manifest = PluginDepsManifest.Read(name, manifestPath);
+
+            if (manifest.DeclaresRuntimePack)
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.SelfContainedPublish,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' was published self-contained, which "
+                        + "its manifest shows by declaring a runtime pack. Publish it with "
+                        + "--no-self-contained, so that it carries its own closure and not a copy of the "
+                        + "shared framework."
+                );
+            }
+
+            // Both version checks run before any type is loaded, so neither can surface as a raw
+            // type-load error from somewhere the operator cannot act on.
+            CheckContractReferences(name, entryAssemblyPath, contractAssemblyNames);
+            CheckDeclaredDependencies(name, manifest);
+
+            PluginLoadContext context = new(name, entryAssemblyPath);
+            Assembly entryAssembly = LoadEntryAssembly(name, entryAssemblyPath, context);
+
+            if (entryAssembly.GetName().Name is not { } entryAssemblyName)
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.AssemblyNameMismatch,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' has an entry assembly with no name."
+                );
+            }
+
+            // The fourth of the four equalities, and the one the file name does not prove: a csproj can
+            // declare an AssemblyName and be published under a different file name, and such a plugin
+            // satisfies every other check.
+            if (!string.Equals(entryAssemblyName, name, StringComparison.Ordinal))
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.AssemblyNameMismatch,
+                    name,
+                    $"plugin directory '{PluginDiagnosticText.Quote(name)}' holds an entry assembly "
+                        + $"whose own name is '{PluginDiagnosticText.Quote(entryAssemblyName)}'. The "
+                        + "directory, the file name, the assembly name and the plugin's Name all have to "
+                        + "be the same string."
+                );
+            }
+
+            EdFiApiPlugin instance = Activate(name, FindPluginType(name, entryAssembly));
+
+            string declaredName = ReadName(name, instance);
+
+            if (!string.Equals(declaredName, name, StringComparison.Ordinal))
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.PluginNameMismatch,
+                    name,
+                    $"plugin directory '{PluginDiagnosticText.Quote(name)}' holds a plugin whose Name is "
+                        + $"'{PluginDiagnosticText.Quote(declaredName)}'. They are compared ordinally, so "
+                        + "a plugin's identity does not depend on which filesystem the image was built on."
+                );
+            }
+
+            LoadedPlugin plugin = new(
+                name,
+                instance,
+                resolvedPlugin,
+                entryAssembly.GetName().Version ?? new Version(0, 0, 0, 0),
+                context
+            );
+
+            diagnostics.WriteLine(
+                $"plugin '{PluginDiagnosticText.Quote(name)}' loaded from "
+                    + $"'{PluginDiagnosticText.Quote(resolvedPlugin)}'"
+            );
+
+            return plugin;
+        }
+        catch (PluginLoadException exception)
+        {
+            throw Report(diagnostics, name, exception);
+        }
+    }
+
+    /// <summary>
+    /// Resolves a directory's final component through symbolic links, falling back to the path itself
+    /// when it is not a link.
+    /// </summary>
+    private static string ResolveDirectory(string path, string? pluginName, TextWriter diagnostics)
+    {
+        try
+        {
+            return Directory.ResolveLinkTarget(path, returnFinalTarget: true)?.FullName ?? path;
+        }
+        catch (Exception exception)
+            when (exception is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            PluginLoadException failure = new(
+                PluginLoadFailure.PluginPathUnresolvable,
+                pluginName,
+                $"'{PluginDiagnosticText.Quote(path)}' could not be resolved. The containment check "
+                    + "follows symbolic links, so the path has to be readable to be checked.",
+                exception
+            );
+
+            throw pluginName is null ? Report(diagnostics, null, failure) : failure;
+        }
+    }
+
+    private static void RequireFile(
+        string path,
+        string pluginName,
+        PluginLoadFailure reason,
+        string description
+    )
+    {
+        if (!File.Exists(path))
+        {
+            throw new PluginLoadException(
+                reason,
+                pluginName,
+                $"plugin '{PluginDiagnosticText.Quote(pluginName)}' is missing {description}: "
+                    + $"'{PluginDiagnosticText.Quote(path)}' does not exist."
+            );
+        }
+    }
+
+    /// <summary>
+    /// Compares the entry assembly's references against the contracts the caller declares, reading
+    /// metadata rather than loading a type, so the refusal never arrives as a type-load error.
+    /// </summary>
+    private static void CheckContractReferences(
+        string name,
+        string entryAssemblyPath,
+        IReadOnlyCollection<string> contractAssemblyNames
+    )
+    {
+        if (contractAssemblyNames.Count == 0)
+        {
+            return;
+        }
+
+        HashSet<string> contracts = new(contractAssemblyNames, StringComparer.Ordinal);
+
+        foreach (
+            (string referenceName, Version referenceVersion) in EntryAssemblyReferences.Read(
+                name,
+                entryAssemblyPath
+            )
+        )
+        {
+            if (!contracts.Contains(referenceName))
+            {
+                continue;
+            }
+
+            if (!HostAssemblies.TryGetVersion(referenceName, out Version hostVersion))
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.ContractAssemblyMissing,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' references the declared contract "
+                        + $"'{PluginDiagnosticText.Quote(referenceName)}', which this host cannot "
+                        + "resolve. The host has to carry every contract it declares."
+                );
+            }
+
+            if (hostVersion < referenceVersion)
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.ContractVersionSkew,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' requires contract "
+                        + $"'{PluginDiagnosticText.Quote(referenceName)}' {referenceVersion}, and this "
+                        + $"host carries {hostVersion}. A plugin built against a newer contract than the "
+                        + "host is refused at load rather than failing later inside a hook."
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Applies the host-first comparison to every assembly the manifest declares a version for, before
+    /// the plugin is constructed.
+    /// </summary>
+    /// <remarks>
+    /// The <c>Load</c> override alone would discover a skewed dependency only when a code path first
+    /// needed it, so a dependency no hook happens to touch would be found on a request rather than at
+    /// startup, and "fatal at load" would be a promise this design does not keep.
+    /// </remarks>
+    private static void CheckDeclaredDependencies(string name, PluginDepsManifest manifest)
+    {
+        foreach (PluginDeclaredAssembly declared in manifest.DeclaredAssemblies)
+        {
+            if (
+                HostAssemblies.TryGetVersion(declared.SimpleName, out Version hostVersion)
+                && hostVersion < declared.DeclaredVersion
+            )
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.DependencyVersionSkew,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' declares "
+                        + $"'{PluginDiagnosticText.Quote(declared.SimpleName)}' "
+                        + $"{declared.DeclaredVersion}, and this host carries {hostVersion}. Serving the "
+                        + "plugin's own copy would split the type identity that host-first resolution "
+                        + "exists to keep."
+                );
+            }
+        }
+    }
+
+    private static Assembly LoadEntryAssembly(
+        string name,
+        string entryAssemblyPath,
+        PluginLoadContext context
+    )
+    {
+        try
+        {
+            return context.LoadFromAssemblyPath(entryAssemblyPath);
+        }
+        catch (BadImageFormatException exception)
+        {
+            throw new PluginLoadException(
+                PluginLoadFailure.EntryAssemblyUnreadable,
+                name,
+                $"plugin '{PluginDiagnosticText.Quote(name)}' has an entry assembly at "
+                    + $"'{PluginDiagnosticText.Quote(entryAssemblyPath)}' that is not a managed assembly.",
+                exception
+            );
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw Unwrap(name, exception)
+                ?? new PluginLoadException(
+                    PluginLoadFailure.EntryAssemblyLoadFailed,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' could not be loaded from "
+                        + $"'{PluginDiagnosticText.Quote(entryAssemblyPath)}'.",
+                    exception
+                );
+        }
+    }
+
+    /// <summary>
+    /// Finds the one type the entry assembly exposes that the host can construct and call.
+    /// </summary>
+    private static Type FindPluginType(string name, Assembly entryAssembly)
+    {
+        Type[] exported;
+
+        try
+        {
+            exported = entryAssembly.GetExportedTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            throw Unwrap(name, exception)
+                ?? new PluginLoadException(
+                    PluginLoadFailure.PluginTypesUnloadable,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' has exported types that could not be "
+                        + "loaded: "
+                        + string.Join(
+                            "; ",
+                            exception
+                                .LoaderExceptions.OfType<Exception>()
+                                .Select(loaderException =>
+                                    PluginDiagnosticText.Quote(loaderException.Message)
+                                )
+                        ),
+                    exception
+                );
+        }
+        catch (Exception exception)
+            when (exception is FileNotFoundException or FileLoadException or TypeLoadException)
+        {
+            throw Unwrap(name, exception)
+                ?? new PluginLoadException(
+                    PluginLoadFailure.PluginTypesUnloadable,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' has exported types that could not be "
+                        + $"loaded: {PluginDiagnosticText.Quote(exception.Message)}",
+                    exception
+                );
+        }
+
+        // A candidate has to be something the host can actually construct and call. An abstract type,
+        // an open generic and a type with no public parameterless constructor are each impossible to
+        // construct, so counting them would turn "your plugin type is not constructible" into "your
+        // assembly exposes two plugins".
+        List<Type> candidates = exported
+            .Where(type =>
+                type.IsClass
+                && !type.IsAbstract
+                && !type.ContainsGenericParameters
+                && typeof(EdFiApiPlugin).IsAssignableFrom(type)
+                && type.GetConstructor(Type.EmptyTypes) is not null
+            )
+            .ToList();
+
+        if (candidates.Count == 1)
+        {
+            return candidates[0];
+        }
+
+        IEnumerable<Type> nearMisses = exported.Where(type =>
+            typeof(EdFiApiPlugin).IsAssignableFrom(type) && !candidates.Contains(type)
+        );
+
+        string found =
+            candidates.Count == 0 ? "none" : string.Join(", ", candidates.Select(type => type.FullName));
+        string excluded = string.Join(", ", nearMisses.Select(type => type.FullName));
+
+        throw new PluginLoadException(
+            candidates.Count == 0 ? PluginLoadFailure.NoPluginType : PluginLoadFailure.MultiplePluginTypes,
+            name,
+            $"plugin '{PluginDiagnosticText.Quote(name)}' has to expose exactly one public, "
+                + "non-abstract, non-generic EdFiApiPlugin subclass with a public parameterless "
+                + $"constructor. Constructible: {PluginDiagnosticText.Quote(found)}."
+                + (
+                    excluded.Length == 0
+                        ? string.Empty
+                        : $" Exposed but not constructible: {PluginDiagnosticText.Quote(excluded)}."
+                )
+        );
+    }
+
+    private static EdFiApiPlugin Activate(string name, Type pluginType)
+    {
+        try
+        {
+            return (EdFiApiPlugin)Activator.CreateInstance(pluginType)!;
+        }
+        catch (Exception exception)
+        {
+            Exception cause = exception is TargetInvocationException { InnerException: { } inner }
+                ? inner
+                : exception;
+
+            throw Unwrap(name, cause)
+                ?? new PluginLoadException(
+                    PluginLoadFailure.PluginActivationFailed,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' exposes "
+                        + $"'{PluginDiagnosticText.Quote(pluginType.FullName ?? pluginType.Name)}', which "
+                        + $"could not be constructed: {PluginDiagnosticText.Quote(cause.Message)}",
+                    cause
+                );
+        }
+    }
+
+    private static string ReadName(string name, EdFiApiPlugin instance)
+    {
+        try
+        {
+            return instance.Name;
+        }
+        catch (Exception exception)
+        {
+            throw Unwrap(name, exception)
+                ?? new PluginLoadException(
+                    PluginLoadFailure.PluginNameUnavailable,
+                    name,
+                    $"plugin '{PluginDiagnosticText.Quote(name)}' threw when its Name was read: "
+                        + PluginDiagnosticText.Quote(exception.Message),
+                    exception
+                );
+        }
+    }
+
+    /// <summary>
+    /// Finds a version skew the runtime wrapped, and turns it back into the message an operator can act
+    /// on.
+    /// </summary>
+    /// <remarks>
+    /// The runtime wraps anything thrown from inside a load context's resolution callback in a
+    /// <see cref="FileLoadException"/> whose own message names only the version the host carries and
+    /// says nothing about the version the plugin asked for. Reflection wraps failures again in
+    /// <see cref="ReflectionTypeLoadException.LoaderExceptions"/>, which is not on the inner-exception
+    /// chain at all, so both are searched.
+    /// </remarks>
+    private static PluginLoadException? Unwrap(string name, Exception exception)
+    {
+        if (FindSkew(exception) is not { } skew)
+        {
+            return null;
+        }
+
+        return new PluginLoadException(
+            PluginLoadFailure.DependencyVersionSkew,
+            name,
+            skew.Message,
+            exception
+        );
+    }
+
+    private static PluginVersionSkewException? FindSkew(Exception? exception)
+    {
+        while (exception is not null)
+        {
+            if (exception is PluginVersionSkewException skew)
+            {
+                return skew;
+            }
+
+            if (exception is ReflectionTypeLoadException reflection)
+            {
+                foreach (Exception? loaderException in reflection.LoaderExceptions)
+                {
+                    if (FindSkew(loaderException) is { } nested)
+                    {
+                        return nested;
+                    }
+                }
+            }
+
+            exception = exception.InnerException;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Names the directories under the plugin root that nobody allowlisted.
+    /// </summary>
+    /// <remarks>
+    /// Only names are read. Nothing inside such a directory is opened, probed, or has its metadata
+    /// read, which is what keeps discovery allowlist-driven: a directory nobody asked for is never
+    /// touched, and the warning exists so that an operator who expected it to load finds out why it did
+    /// not.
+    /// </remarks>
+    private static void ReportDirectoriesNobodyAskedFor(
+        string resolvedRoot,
+        IReadOnlyList<string> allowedNames,
+        TextWriter diagnostics
+    )
+    {
+        string[] ignored;
+
+        try
+        {
+            HashSet<string> allowed = new(allowedNames, StringComparer.Ordinal);
+
+            ignored = Directory
+                .EnumerateDirectories(resolvedRoot)
+                .Select(directory => Path.GetFileName(directory))
+                .Where(directory => directory.Length > 0 && !allowed.Contains(directory))
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // A warning is not worth failing a boot that has otherwise succeeded, and every plugin the
+            // operator asked for has already loaded by this point.
+            diagnostics.WriteLine(
+                "plugins: the plugin root could not be listed for unallowlisted directories: "
+                    + PluginDiagnosticText.Quote(exception.Message)
+            );
+            return;
+        }
+
+        if (ignored.Length > 0)
+        {
+            diagnostics.WriteLine(
+                "plugins: ignoring directories not in the allowlist: "
+                    + string.Join(
+                        ", ",
+                        ignored.Select(directory => $"'{PluginDiagnosticText.Quote(directory)}'")
+                    )
+            );
+        }
+    }
+
+    /// <summary>
+    /// Writes the outcome line for an allowlist entry, or for the configuration when no entry owns the
+    /// failure, and hands the exception back so the caller throws it.
+    /// </summary>
+    private static PluginLoadException Report(
+        TextWriter diagnostics,
+        string? pluginName,
+        PluginLoadException exception
+    )
+    {
+        diagnostics.WriteLine(
+            pluginName is null
+                ? $"plugins: {exception.Message}"
+                : $"plugin '{PluginDiagnosticText.Quote(pluginName)}' failed: {exception.Message}"
+        );
+
+        return exception;
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginVersionSkewException.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginVersionSkewException.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Thrown from inside a plugin's load context when the host carries an older version of an assembly
+/// than the plugin's reference declares.
+/// </summary>
+/// <remarks>
+/// Internal because a caller never sees it. The runtime wraps anything thrown from inside an
+/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> resolution callback in a
+/// <see cref="FileLoadException"/> whose message names only the version the host has, so the loader
+/// unwraps that chain and reports this exception's four values as a <see cref="PluginLoadException"/>
+/// instead. Falling back to the plugin's private copy rather than throwing is what would split the type
+/// identity that host-first resolution exists to keep.
+/// </remarks>
+#pragma warning disable S3871 // Exception types should be public - deliberate: this one never leaves
+// the assembly. The runtime wraps it, PluginLoader unwraps it, and a caller only ever sees the
+// PluginLoadException built from its four values. Making it public would publish a type no host can
+// observe and invite someone to catch what never escapes.
+internal sealed class PluginVersionSkewException(
+    string pluginName,
+    string assemblyName,
+    Version requestedVersion,
+    Version hostVersion
+)
+    : Exception(
+        $"plugin '{PluginDiagnosticText.Quote(pluginName)}' requires "
+            + $"{PluginDiagnosticText.Quote(assemblyName)} >= {requestedVersion}, "
+            + $"host carries {hostVersion}"
+    )
+{
+    internal string PluginName { get; } = pluginName;
+
+    internal string AssemblyName { get; } = assemblyName;
+
+    internal Version RequestedVersion { get; } = requestedVersion;
+
+    internal Version HostVersion { get; } = hostVersion;
+}
+#pragma warning restore S3871

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginsConfiguration.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginsConfiguration.cs
@@ -3,17 +3,54 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace EdFi.Api.Plugins.Hosting;
 
 /// <summary>
-/// The validated result of binding the <c>Plugins</c> section: a fully qualified plugin root and the
-/// allowlist in the order it was written.
+/// The validated result of binding the <c>Plugins</c> section: either an allowlist naming at least one
+/// plugin together with the root they are read from, or a statement that no plugins were asked for.
 /// </summary>
 /// <remarks>
-/// Every name in <paramref name="AllowedNames"/> has already been trimmed, checked for ambiguity
-/// against the rest of the list, and checked against the single-path-segment rule, so a caller may
-/// compose a path from one without validating it again. Nothing here has touched the filesystem.
+/// <para>
+/// The two cases are separate because the shipped default is the second one and it must not depend on
+/// the first one's inputs. A deployment that adopts no plugins boots exactly as it does today, whatever
+/// <c>Plugins:Directory</c> happens to say, so an allowlist with no names never resolves, validates or
+/// probes a root. Carrying a placeholder path for that case would make the absence of a root
+/// indistinguishable from a root that happens to be wrong.
+/// </para>
+/// <para>
+/// Every name in <see cref="AllowedNames"/> has been trimmed, checked for ambiguity against the rest of
+/// the list, and checked against the single-path-segment rule, so a caller may compose a path from one
+/// without validating it again. Nothing here has touched the filesystem.
+/// </para>
 /// </remarks>
-/// <param name="ResolvedRoot">The plugin root as a fully qualified path.</param>
-/// <param name="AllowedNames">The allowlisted plugin names, in the order the operator wrote them.</param>
-internal sealed record PluginsConfiguration(string ResolvedRoot, IReadOnlyList<string> AllowedNames);
+internal sealed record PluginsConfiguration
+{
+    private readonly string? _resolvedRoot;
+
+    private PluginsConfiguration(string? resolvedRoot, IReadOnlyList<string> allowedNames)
+    {
+        _resolvedRoot = resolvedRoot;
+        AllowedNames = allowedNames;
+    }
+
+    /// <summary>No plugin was asked for, so there is no root and nothing to read.</summary>
+    internal static PluginsConfiguration NoPluginsRequested { get; } = new(null, []);
+
+    /// <summary>At least one plugin was asked for, from the given fully qualified root.</summary>
+    internal static PluginsConfiguration Rooted(string resolvedRoot, IReadOnlyList<string> allowedNames) =>
+        new(resolvedRoot, allowedNames);
+
+    /// <summary>The allowlisted plugin names, in the order the operator wrote them.</summary>
+    internal IReadOnlyList<string> AllowedNames { get; }
+
+    /// <summary>
+    /// Gets the plugin root, which exists only when the allowlist named at least one plugin.
+    /// </summary>
+    internal bool TryGetResolvedRoot([NotNullWhen(true)] out string? resolvedRoot)
+    {
+        resolvedRoot = _resolvedRoot;
+        return resolvedRoot is not null;
+    }
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginsConfiguration.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginsConfiguration.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// The validated result of binding the <c>Plugins</c> section: a fully qualified plugin root and the
+/// allowlist in the order it was written.
+/// </summary>
+/// <remarks>
+/// Every name in <paramref name="AllowedNames"/> has already been trimmed, checked for ambiguity
+/// against the rest of the list, and checked against the single-path-segment rule, so a caller may
+/// compose a path from one without validating it again. Nothing here has touched the filesystem.
+/// </remarks>
+/// <param name="ResolvedRoot">The plugin root as a fully qualified path.</param>
+/// <param name="AllowedNames">The allowlisted plugin names, in the order the operator wrote them.</param>
+internal sealed record PluginsConfiguration(string ResolvedRoot, IReadOnlyList<string> AllowedNames);

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginsConfigurationBinder.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginsConfigurationBinder.cs
@@ -36,21 +36,38 @@ internal static partial class PluginsConfigurationBinder
         PluginsOptions options =
             configuration.GetSection(SectionName).Get<PluginsOptions>() ?? new PluginsOptions();
 
+        // A null Allowed is an absent allowlist rather than a malformed one: binding assigns a JSON
+        // null straight over the property initializer, and an operator who wrote null asked for no
+        // plugins just as surely as one who omitted the key.
+        IReadOnlyList<string> allowedNames = ParseAllowed(options.Allowed);
+
+        if (allowedNames.Count == 0)
+        {
+            // The shipped default. No plugin was asked for, so the configured directory is neither
+            // resolved nor validated: a deployment that adopts nothing boots the same way whatever
+            // Plugins:Directory says, and refusing it here would turn an unused setting into a startup
+            // failure.
+            return PluginsConfiguration.NoPluginsRequested;
+        }
+
         // The allowlist is validated in full before the root is resolved, and the root is resolved
         // before anything asks the filesystem a question. An operator who wrote a bad entry learns
         // about the entry rather than about a path that could never have been composed from it.
-        IReadOnlyList<string> allowedNames = ParseAllowed(options.Allowed);
-
-        return new PluginsConfiguration(ResolveRoot(options.Directory), allowedNames);
+        return PluginsConfiguration.Rooted(ResolveRoot(options.Directory), allowedNames);
     }
 
     /// <summary>
     /// Splits the delimited allowlist once, trims each entry, drops empty entries, and refuses an
     /// ambiguous or malformed list.
     /// </summary>
-    private static IReadOnlyList<string> ParseAllowed(string allowed)
+    private static IReadOnlyList<string> ParseAllowed(string? allowed)
     {
         List<string> names = [];
+
+        if (allowed is null)
+        {
+            return names;
+        }
 
         // Ambiguity is settled case-insensitively, because two entries differing only in case would
         // resolve to one directory on a case-insensitive filesystem and to two on the image's, so the
@@ -106,14 +123,14 @@ internal static partial class PluginsConfigurationBinder
     /// Turns the configured directory into a fully qualified path, resolving a relative one against
     /// the application's base directory.
     /// </summary>
-    private static string ResolveRoot(string directory)
+    private static string ResolveRoot(string? directory)
     {
         if (string.IsNullOrWhiteSpace(directory))
         {
             throw new PluginLoadException(
                 PluginLoadFailure.PluginPathUnresolvable,
                 null,
-                "Plugins:Directory is present but empty. Remove the setting to use the default "
+                "Plugins:Directory is present but carries no path. Remove the setting to use the default "
                     + "'/app/plugins', or give it a path. An empty value is refused rather than treated "
                     + "as the default, because an operator who cleared the setting did not ask for the "
                     + "default root to be read."

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginsConfigurationBinder.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginsConfigurationBinder.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// Binds the <c>Plugins</c> section and validates the allowlist, before anything composes a path or
+/// opens a file.
+/// </summary>
+internal static partial class PluginsConfigurationBinder
+{
+    /// <summary>The host-owned configuration section, which is the only one plugins have.</summary>
+    internal const string SectionName = "Plugins";
+
+    /// <summary>
+    /// The single-path-segment rule, as it is written in messages so that an operator reading a
+    /// refusal sees the same text the design states.
+    /// </summary>
+    internal const string AllowedNameRule = "^[A-Za-z0-9][A-Za-z0-9._-]*$";
+
+    /// <summary>
+    /// Binds and validates the section. The result is safe to compose paths from; nothing here has
+    /// touched the filesystem.
+    /// </summary>
+    /// <exception cref="PluginLoadException">
+    /// The allowlist is ambiguous, an entry is not a single path segment, or the configured directory
+    /// cannot be turned into a full path.
+    /// </exception>
+    internal static PluginsConfiguration Bind(IConfiguration configuration)
+    {
+        PluginsOptions options =
+            configuration.GetSection(SectionName).Get<PluginsOptions>() ?? new PluginsOptions();
+
+        // The allowlist is validated in full before the root is resolved, and the root is resolved
+        // before anything asks the filesystem a question. An operator who wrote a bad entry learns
+        // about the entry rather than about a path that could never have been composed from it.
+        IReadOnlyList<string> allowedNames = ParseAllowed(options.Allowed);
+
+        return new PluginsConfiguration(ResolveRoot(options.Directory), allowedNames);
+    }
+
+    /// <summary>
+    /// Splits the delimited allowlist once, trims each entry, drops empty entries, and refuses an
+    /// ambiguous or malformed list.
+    /// </summary>
+    private static IReadOnlyList<string> ParseAllowed(string allowed)
+    {
+        List<string> names = [];
+
+        // Ambiguity is settled case-insensitively, because two entries differing only in case would
+        // resolve to one directory on a case-insensitive filesystem and to two on the image's, so the
+        // operator's intent cannot be recovered from the list. Every other comparison the loader makes
+        // is ordinal.
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string entry in allowed.Split(','))
+        {
+            string name = entry.Trim();
+
+            if (name.Length == 0)
+            {
+                continue;
+            }
+
+            if (!seen.Add(name))
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.DuplicateAllowlistEntry,
+                    name,
+                    $"Plugins:Allowed names '{PluginDiagnosticText.Quote(name)}' more than once. "
+                        + "The allowlist has to be unambiguous about what the operator approved, and "
+                        + "entries are compared case-insensitively so that two spellings of one name "
+                        + "cannot mean one directory on one filesystem and two on another."
+                );
+            }
+
+            names.Add(name);
+        }
+
+        // Shape is checked over the whole list rather than as each entry is read, so that a list whose
+        // first entry is well formed and whose third is not still refuses the third rather than acting
+        // on the first.
+        foreach (string name in names)
+        {
+            if (!AllowedNamePattern().IsMatch(name))
+            {
+                throw new PluginLoadException(
+                    PluginLoadFailure.InvalidAllowlistName,
+                    name,
+                    $"Plugins:Allowed entry '{PluginDiagnosticText.Quote(name)}' is not a plugin name. "
+                        + $"Each entry has to be a single path segment matching {AllowedNameRule}, "
+                        + "because a rooted or traversing entry would compose a path outside the plugin root."
+                );
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Turns the configured directory into a fully qualified path, resolving a relative one against
+    /// the application's base directory.
+    /// </summary>
+    private static string ResolveRoot(string directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            throw new PluginLoadException(
+                PluginLoadFailure.PluginPathUnresolvable,
+                null,
+                "Plugins:Directory is present but empty. Remove the setting to use the default "
+                    + "'/app/plugins', or give it a path. An empty value is refused rather than treated "
+                    + "as the default, because an operator who cleared the setting did not ask for the "
+                    + "default root to be read."
+            );
+        }
+
+        try
+        {
+            // Fully qualified rather than merely rooted: on Windows a path such as "/app/plugins" is
+            // rooted and still needs a drive, and resolving it against the base directory is what
+            // supplies one.
+            return Path.IsPathFullyQualified(directory)
+                ? Path.GetFullPath(directory)
+                : Path.GetFullPath(directory, AppContext.BaseDirectory);
+        }
+        catch (Exception exception)
+            when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            throw new PluginLoadException(
+                PluginLoadFailure.PluginPathUnresolvable,
+                null,
+                $"Plugins:Directory '{PluginDiagnosticText.Quote(directory)}' could not be resolved "
+                    + "to a full path.",
+                exception
+            );
+        }
+    }
+
+    // \z rather than $ closes the one hole the written rule has: $ also matches before a trailing
+    // newline, so "Acme\n" would satisfy the rule as written. Trimming already removes that character,
+    // which makes the hole unreachable here, and the anchor is exact anyway so that the pattern stays
+    // correct if the trim ever moves.
+    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9._-]*\z", RegexOptions.CultureInvariant)]
+    private static partial Regex AllowedNamePattern();
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginsOptions.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginsOptions.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Api.Plugins.Hosting;
+
+/// <summary>
+/// The bindable shape of the host-owned <c>Plugins</c> configuration section, which is the only
+/// configuration surface plugins have.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A mutable class with a public parameterless constructor is what configuration binding requires, so
+/// this is deliberately not a record. The property defaults are the shipped defaults: an absent
+/// section binds to exactly the same values as a section that writes them out.
+/// </para>
+/// <para>
+/// The whole section binds from environment variables in the standard way, so
+/// <c>Plugins__Allowed=A,B</c> is equivalent to the JSON form, which is how a container deployment
+/// sets it.
+/// </para>
+/// </remarks>
+public sealed class PluginsOptions
+{
+    /// <summary>
+    /// The plugin root, defaulting to <c>/app/plugins</c> and resolved against
+    /// <see cref="AppContext.BaseDirectory"/> when it is not fully qualified.
+    /// </summary>
+    public string Directory { get; set; } = "/app/plugins";
+
+    /// <summary>
+    /// The comma-delimited list of plugin directory names that may load, defaulting to the empty
+    /// string, which asks for no plugins at all.
+    /// </summary>
+    /// <remarks>
+    /// The written order is the invocation order for the composition phases, so the list is never
+    /// sorted. A delimited string rather than an array follows the convention
+    /// <c>AppSettings:AllowIdentityUpdateOverrides</c> already sets for a list with no entries.
+    /// </remarks>
+    public string Allowed { get; set; } = string.Empty;
+}

--- a/src/plugins/EdFi.Api.Plugins.Hosting/PluginsOptions.cs
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/PluginsOptions.cs
@@ -27,16 +27,29 @@ public sealed class PluginsOptions
     /// The plugin root, defaulting to <c>/app/plugins</c> and resolved against
     /// <see cref="AppContext.BaseDirectory"/> when it is not fully qualified.
     /// </summary>
-    public string Directory { get; set; } = "/app/plugins";
+    /// <remarks>
+    /// Nullable because binding says so rather than because a null is meaningful: configuration
+    /// binding assigns a JSON null straight over a property initializer, so a section that writes
+    /// <c>"Directory": null</c> leaves this null while an absent key leaves the default. The two are
+    /// therefore distinguishable, and a null is treated as a value that is not a path rather than as an
+    /// absent key.
+    /// </remarks>
+    public string? Directory { get; set; } = "/app/plugins";
 
     /// <summary>
     /// The comma-delimited list of plugin directory names that may load, defaulting to the empty
     /// string, which asks for no plugins at all.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The written order is the invocation order for the composition phases, so the list is never
     /// sorted. A delimited string rather than an array follows the convention
     /// <c>AppSettings:AllowIdentityUpdateOverrides</c> already sets for a list with no entries.
+    /// </para>
+    /// <para>
+    /// Nullable for the same binding reason as <see cref="Directory"/>. Here a null and an absent key
+    /// do mean the same thing, because both say the operator asked for no plugins.
+    /// </para>
     /// </remarks>
-    public string Allowed { get; set; } = string.Empty;
+    public string? Allowed { get; set; } = string.Empty;
 }

--- a/src/plugins/EdFi.Api.Plugins.Hosting/packages.lock.json
+++ b/src/plugins/EdFi.Api.Plugins.Hosting/packages.lock.json
@@ -8,6 +8,16 @@
         "resolved": "4.12.0",
         "contentHash": "5S+LHLhm0am4MWQQMN0O3VyKA/St5JCqH1yv+1YGZl2klIJlLlmNA/KTLCVJSC1kZPIKR1MFF/3g9FqsyzIyCQ=="
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Lp4CZIuTVXtlvkAnTq6QvMSW7+H62gX2cU2vdFxHQUxvrWTpi7LwYI3X+YAyIS0r12/p7gaosco7efIxL4yFNw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
         "requested": "[9.32.0.97167, )",
@@ -24,6 +34,16 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "[10.0.1, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {


### PR DESCRIPTION
Implements the shared plugin loader for DMS-1497. Hosts can load plugins explicitly named in `Plugins:Allowed`, in allowlist order, with a separate assembly load context for each plugin. An empty allowlist performs no plugin discovery; an allowlisted plugin that cannot load produces a fatal diagnostic.

- Bind and validate plugin configuration, discover plugin entry types, and enforce directory containment and file naming rules.
- Validate dependency manifests and declared managed/resource assets, resolve shared assemblies from the host first, isolate private dependencies, and reject incompatible contract or host assembly versions.
- Expose loaded plugin inventory and observed host substitutions, with diagnostics for malformed plugins and manifests.
- Add fixture-backed tests for configuration, discovery, compatibility, isolation, native dependencies, runtime targets, containment, and fixture staging/freshness; include the hosting test project in both DMS and CMS solutions.

Validation: `git diff --check origin/main...HEAD` passed. Automated tests were not run during PR creation.
