### PR TITLE
[DMS-1524] Exclude partition sizing scenarios from scheduled E2E runs

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -163,10 +163,14 @@ jobs:
         id: e2e
         if: success()
         continue-on-error: true
-        # This lane runs against the default DS 5.2 stack, so exclude the DS 6.1 version-coupled
-        # scenarios and the DocumentCache fixture. The latter runs below with its explicit overlay.
+        # This lane runs against the default DS 5.2 stack at the shipped MAXIMUM_PAGE_SIZE of 500,
+        # so exclude the DS 6.1 version-coupled scenarios, the DocumentCache fixture, and the
+        # partition sizing scenarios. DocumentCache runs below with its explicit overlay; partition
+        # sizing needs .env.cursorpartitions.e2e, whose MAXIMUM_PAGE_SIZE of 2 is the only setting
+        # under which a collection an E2E scenario can seed over HTTP is cut into more than one
+        # partition, and runs per-PR in run-e2e-tests-partition-sizing.
         # The non-empty filter writes the filtered TRX uploaded by the following step.
-        run: ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter '(Category!=@StandardVersion-6_1)&(Category!=@DocumentCacheHostedHappyPath)'
+        run: ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter '(Category!=@StandardVersion-6_1)&(Category!=@DocumentCacheHostedHappyPath)&(Category!=@CursorPartitionSizing)'
 
       - name: Export DMS E2E Docker Logs
         if: always() && steps.e2e.outcome == 'failure'

--- a/.github/workflows/scheduled-pre-image-test.yml
+++ b/.github/workflows/scheduled-pre-image-test.yml
@@ -48,10 +48,14 @@ jobs:
         id: e2e
         if: success()
         continue-on-error: true
-        # This lane runs against the default DS 5.2 stack, so exclude the DS 6.1 version-coupled
-        # scenarios and the local-compose-only DocumentCache fixture. DocumentCache runs with its
-        # explicit overlay in scheduled-build.yml. The non-empty filter writes the filtered TRX.
-        run: ./build-dms.ps1 E2ETest -UsePublishedImage -Configuration Release -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter '(Category!=@StandardVersion-6_1)&(Category!=@DocumentCacheHostedHappyPath)'
+        # This lane runs against the default DS 5.2 stack at the shipped MAXIMUM_PAGE_SIZE of 500,
+        # so exclude the DS 6.1 version-coupled scenarios, the local-compose-only DocumentCache
+        # fixture, and the partition sizing scenarios. DocumentCache runs with its explicit overlay
+        # in scheduled-build.yml; partition sizing needs .env.cursorpartitions.e2e, whose
+        # MAXIMUM_PAGE_SIZE of 2 is the only setting under which a collection an E2E scenario can
+        # seed over HTTP is cut into more than one partition, and runs per-PR in
+        # run-e2e-tests-partition-sizing. The non-empty filter writes the filtered TRX.
+        run: ./build-dms.ps1 E2ETest -UsePublishedImage -Configuration Release -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter '(Category!=@StandardVersion-6_1)&(Category!=@DocumentCacheHostedHappyPath)&(Category!=@CursorPartitionSizing)'
 
       - name: Export DMS E2E Docker Logs
         if: always() && steps.e2e.outcome == 'failure'


### PR DESCRIPTION
## Summary

Both scheduled workflows invoke the DMS E2E suite with a **denylist** `-TestFilter`, so every scenario *not* named in that filter runs against the default `.env.e2e` stack. Since DMS-1390 that has included the `@CursorPartitionSizing` scenario, which is only meaningful against `.env.cursorpartitions.e2e`.

At `.env.e2e`'s `MAXIMUM_PAGE_SIZE` of 500 the mandatory minimum partition size is `5 * 500 = 2500`, so the 21 schools the scenario seeds collapse into a single range and its multi-partition assertions fail. The feature file predicts exactly this: *"against the ordinary stack every request here would return a single unbounded range, and the feature would fail rather than pass vacuously."*

Jira: [DMS-1524](https://edfi.atlassian.net/browse/DMS-1524)

## Change

Adds `&(Category!=@CursorPartitionSizing)` to the E2E `-TestFilter` in `scheduled-build.yml` and `scheduled-pre-image-test.yml`, matching the existing `@DocumentCacheHostedHappyPath` exclusion in the same filter.

The comment above each filter is also rewritten. Both enumerated the exclusions by name, so leaving them would have made them false; they now name the sizing exclusion and say where those scenarios do run.

Unlike the equivalent DMS-1261 fix, no TRX-suffix change is needed: both lanes already upload `EdFi.DataManagementService.Tests.E2E.filtered.trx`, and the filter remains non-empty.

## Evidence of the failure

| | |
|---|---|
| Result | 1 failed / 915 passed / 13 skipped / 929 total — identical in **all four jobs**, both workflows x both identity providers |
| Scenario | `_01SeveralRealPartitionsAreConsumedBothSequentiallyAndConcurrently` (`PartitionSizingWalk.feature`) |
| Assertion | `Expected collection to contain at least 3 item(s) ... but found 1` |
| Failing runs | [33955874260](https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service/actions/runs/33955874260) (pre-image), [33954090644](https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service/actions/runs/33954090644) (scheduled-build) |
| Onset | First red run 2026-08-29, the first Saturday after DMS-1390 merged 2026-08-25. The 2026-08-22 run was green. |

Both lanes fail identically even though `scheduled-build` builds locally and `scheduled-pre-image-test` uses `-UsePublishedImage`, which rules out image skew as the cause.

## No coverage is lost

The sizing scenarios are gated on **every** PR to `main` by `run-e2e-tests-partition-sizing`, which deploys `.env.cursorpartitions.e2e`. That job has no `if:` condition, and the scheduled lanes run the same commit, so their weekly re-run of this scenario was never adding information it could actually produce.

Per-PR CI was never affected: the DS 5.2 shards filter *positively* on `@e2e-ci-shard-N` and the sizing scenarios carry no shard tag.

## Verification

Both workflows were dispatched manually on this branch, so they exercise the new filter:

- Scheduled Build — [34392252678](https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service/actions/runs/34392252678)
- Scheduled pre Image Tests — [34392255462](https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service/actions/runs/34392255462)

**Both were still `in_progress` when this PR was opened — please confirm they went green before merging.** A green result there confirms the sizing scenario is no longer executed against the wrong stack; it does not re-verify the scenario itself, which is what `run-e2e-tests-partition-sizing` does on this PR.

## Deliberately not done

A dedicated `@CursorPartitionSizing` lane in the scheduled workflows, mirroring the DocumentCache job in `scheduled-build.yml`. The scenarios are already gated on every PR to `main`, the scheduled lanes run that same commit, and each extra lane costs a full stack deploy per workflow per week. The residual gap is that partition sizing stays unverified against the *published* image; nothing observed here suggests sizing is image-sensitive, since the locally built lane failed identically.

A guardrail unit test was also considered and rejected. `Given_E2E_Feature_File_Guardrails.cs` already pins that sizing scenarios carry no shard or version tag, and it still did not catch this — structurally it cannot, because it reasons about tags a scenario *has*, whereas these lanes fail on a tag nobody *excludes*. Catching it in a test would mean asserting over workflow YAML contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DMS-1524]: https://edfi.atlassian.net/browse/DMS-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ