### PR TITLE
[DMS-1526] Launch the DocumentCacheAdmin CLI in the current build configuration

### DIFF
--- a/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Integration/DocumentCacheAdminCliIntegrationHarness.cs
+++ b/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Integration/DocumentCacheAdminCliIntegrationHarness.cs
@@ -1606,6 +1606,8 @@ internal sealed class DocumentCacheAdminCliProcessHarness : IAsyncDisposable
         process.StartInfo.ArgumentList.Add("run");
         process.StartInfo.ArgumentList.Add("--project");
         process.StartInfo.ArgumentList.Add(ToolProjectPath());
+        process.StartInfo.ArgumentList.Add("--configuration");
+        process.StartInfo.ArgumentList.Add(CurrentBuildConfiguration());
         process.StartInfo.ArgumentList.Add("--no-build");
         process.StartInfo.ArgumentList.Add("--");
         foreach (string argument in arguments)
@@ -1718,6 +1720,26 @@ internal sealed class DocumentCacheAdminCliProcessHarness : IAsyncDisposable
             "EdFi.DataManagementService.DocumentCacheAdmin",
             "EdFi.DataManagementService.DocumentCacheAdmin.csproj"
         );
+
+    // `dotnet run` defaults to Debug, so a Release test run would otherwise start the CLI out of
+    // an unbuilt bin/Debug. The test assembly's own output directory names the configuration the
+    // CLI was built into alongside it.
+    private static string CurrentBuildConfiguration()
+    {
+        DirectoryInfo? currentDirectory = new(AppContext.BaseDirectory);
+
+        while (currentDirectory is not null)
+        {
+            if (currentDirectory.Name is "Debug" or "Release")
+            {
+                return currentDirectory.Name;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        return "Debug";
+    }
 
     private static string RepositoryRoot() =>
         FixturePathResolver.FindRepositoryRoot(AppContext.BaseDirectory);

--- a/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Integration/Given_DocumentCacheAdminStatusCommand.cs
+++ b/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin.Tests.Integration/Given_DocumentCacheAdminStatusCommand.cs
@@ -44,6 +44,8 @@ public sealed class Given_DocumentCacheAdminStatusCommand
         process.StartInfo.ArgumentList.Add("run");
         process.StartInfo.ArgumentList.Add("--project");
         process.StartInfo.ArgumentList.Add(ToolProjectPath());
+        process.StartInfo.ArgumentList.Add("--configuration");
+        process.StartInfo.ArgumentList.Add(CurrentBuildConfiguration());
         process.StartInfo.ArgumentList.Add("--no-build");
         process.StartInfo.ArgumentList.Add("--");
         foreach (string argument in arguments)
@@ -71,6 +73,26 @@ public sealed class Given_DocumentCacheAdminStatusCommand
             "EdFi.DataManagementService.DocumentCacheAdmin",
             "EdFi.DataManagementService.DocumentCacheAdmin.csproj"
         );
+
+    // `dotnet run` defaults to Debug, so a Release test run would otherwise start the CLI out of
+    // an unbuilt bin/Debug. The test assembly's own output directory names the configuration the
+    // CLI was built into alongside it.
+    private static string CurrentBuildConfiguration()
+    {
+        DirectoryInfo? currentDirectory = new(AppContext.BaseDirectory);
+
+        while (currentDirectory is not null)
+        {
+            if (currentDirectory.Name is "Debug" or "Release")
+            {
+                return currentDirectory.Name;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        return "Debug";
+    }
 
     private static string RepositoryRoot()
     {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -641,24 +641,13 @@ internal static class RepresentationRestampE2EHarness
         IReadOnlyList<string> commandArguments
     )
     {
-        List<string> arguments =
-        [
-            "run",
-            "--project",
+        IReadOnlyList<string> arguments = BuildCliProcessArguments(
             ToolProjectPath(),
-            "--no-build",
-            "--",
+            BuildConfiguration(),
             command,
-            "--data-store-id",
-            dataStoreId.ToString(),
-        ];
-
-        foreach (string commandArgument in commandArguments)
-        {
-            arguments.Add(commandArgument);
-        }
-
-        arguments.Add("--json");
+            dataStoreId,
+            commandArguments
+        );
 
         ProcessResult result = await RunProcessAsync(
             "dotnet",
@@ -843,6 +832,33 @@ internal static class RepresentationRestampE2EHarness
         return new(process.ExitCode, await standardOutput, await standardError);
     }
 
+    /// <summary>
+    /// Builds the <c>dotnet</c> argument list that launches the DocumentCacheAdmin CLI. The
+    /// configuration is passed explicitly because <c>dotnet run</c> defaults to Debug, so a
+    /// Release test run would otherwise try to start the CLI out of an unbuilt bin/Debug.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildCliProcessArguments(
+        string toolProjectPath,
+        string buildConfiguration,
+        string command,
+        long dataStoreId,
+        IReadOnlyList<string> commandArguments
+    ) =>
+        [
+            "run",
+            "--project",
+            toolProjectPath,
+            "--configuration",
+            buildConfiguration,
+            "--no-build",
+            "--",
+            command,
+            "--data-store-id",
+            dataStoreId.ToString(),
+            .. commandArguments,
+            "--json",
+        ];
+
     private static string ToolProjectPath() =>
         Path.Combine(
             RepositoryRoot(),
@@ -852,6 +868,32 @@ internal static class RepresentationRestampE2EHarness
             "EdFi.DataManagementService.DocumentCacheAdmin",
             "EdFi.DataManagementService.DocumentCacheAdmin.csproj"
         );
+
+    private static string BuildConfiguration() =>
+        BuildConfiguration(new DirectoryInfo(AppContext.BaseDirectory));
+
+    /// <summary>
+    /// Resolves the build configuration the CLI has to be launched from. The test assembly's own
+    /// output directory is the only reliable signal: it is written to bin/&lt;configuration&gt;, and
+    /// the CLI is built into the matching directory by the E2E project's build-order reference to
+    /// it. Falls back to Debug, which is what <c>dotnet run</c> would have used anyway, so a
+    /// layout without a configuration segment behaves exactly as it does today.
+    /// </summary>
+    internal static string BuildConfiguration(DirectoryInfo startDirectory)
+    {
+        DirectoryInfo? directory = startDirectory;
+        while (directory is not null)
+        {
+            if (directory.Name is "Debug" or "Release")
+            {
+                return directory.Name;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return "Debug";
+    }
 
     private static string RepositoryRoot() => RepositoryRoot(new DirectoryInfo(AppContext.BaseDirectory));
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
@@ -69,6 +69,96 @@ public sealed class Given_Representation_Restamp_E2E_Harness
             .Be(repositoryRoot);
     }
 
+    [TestCase("Debug")]
+    [TestCase("Release")]
+    public void It_reads_the_build_configuration_from_the_test_assembly_output_directory(
+        string buildConfiguration
+    )
+    {
+        string outputDirectory = Path.Combine(
+            _temporaryDirectory,
+            "EdFi.DataManagementService.Tests.E2E",
+            "bin",
+            buildConfiguration,
+            "net10.0"
+        );
+        Directory.CreateDirectory(outputDirectory);
+
+        RepresentationRestampE2EHarness
+            .BuildConfiguration(new DirectoryInfo(outputDirectory))
+            .Should()
+            .Be(buildConfiguration);
+    }
+
+    [Test]
+    public void It_reads_the_nearest_configuration_segment_when_an_ancestor_directory_also_matches()
+    {
+        // A repository checked out under a path segment named Release must not outrank the
+        // configuration segment of the output directory itself.
+        string outputDirectory = Path.Combine(
+            _temporaryDirectory,
+            "Release",
+            "EdFi.DataManagementService.Tests.E2E",
+            "bin",
+            "Debug",
+            "net10.0"
+        );
+        Directory.CreateDirectory(outputDirectory);
+
+        RepresentationRestampE2EHarness
+            .BuildConfiguration(new DirectoryInfo(outputDirectory))
+            .Should()
+            .Be("Debug");
+    }
+
+    [Test]
+    public void It_falls_back_to_debug_when_the_output_directory_has_no_configuration_segment()
+    {
+        string outputDirectory = Path.Combine(_temporaryDirectory, "artifacts", "net10.0");
+        Directory.CreateDirectory(outputDirectory);
+
+        RepresentationRestampE2EHarness
+            .BuildConfiguration(new DirectoryInfo(outputDirectory))
+            .Should()
+            .Be("Debug");
+    }
+
+    [Test]
+    public void It_launches_the_document_cache_admin_cli_in_the_current_build_configuration()
+    {
+        const string toolProjectPath =
+            "/repository/src/dms/clis/EdFi.DataManagementService.DocumentCacheAdmin/EdFi.DataManagementService.DocumentCacheAdmin.csproj";
+        const string documentUuid = "9622f938-2c1a-4f99-9bc4-10970b1c2649";
+
+        IReadOnlyList<string> arguments = RepresentationRestampE2EHarness.BuildCliProcessArguments(
+            toolProjectPath,
+            "Release",
+            "restamp-preview",
+            1,
+            ["--mode", "tracking", "--document-uuid", documentUuid]
+        );
+
+        arguments
+            .Should()
+            .Equal(
+                "run",
+                "--project",
+                toolProjectPath,
+                "--configuration",
+                "Release",
+                "--no-build",
+                "--",
+                "restamp-preview",
+                "--data-store-id",
+                "1",
+                "--mode",
+                "tracking",
+                "--document-uuid",
+                documentUuid,
+                "--json"
+            );
+    }
+
     [Test]
     public void It_selects_postgresql_for_the_postgresql_database_engine()
     {


### PR DESCRIPTION
## What

Passes the current build configuration explicitly when the DMS test harnesses launch the DocumentCacheAdmin CLI, so a Release test run no longer tries to start the CLI out of an unbuilt `bin/Debug`.

## Why

The four representation-restamp E2E scenarios failed in both identity-provider legs of the Scheduled pre Image Tests lane:

```
An error occurred trying to start process
'.../DocumentCacheAdmin/bin/Debug/net10.0/dms-document-cache'. No such file or directory
```

while the CLI had been built to `bin/Release/net10.0`.

`RepresentationRestampE2eHarness.RunCliAsync` ran `dotnet run --project <csproj> --no-build` with no `--configuration`, and `dotnet run` defaults to Debug.

The invocation has never been configuration-correct. It is accidentally correct in every lane that declares a workflow-level `CONFIGURATION` environment variable - `on-dms-pullrequest.yml` and `scheduled-build.yml` both do - because MSBuild imports environment variables as properties and matches property names case-insensitively, so `CONFIGURATION=Release` silently supplies `Configuration=Release` to `dotnet run`. `scheduled-pre-image-test.yml` declares no environment block and passes Release only as a `build-dms.ps1` parameter, which is why that lane, and any local Release run, is the one that fails.

## Changes

- `RepresentationRestampE2eHarness`: added `BuildConfiguration(DirectoryInfo)` (with an `AppContext.BaseDirectory` wrapper), mirroring the file's existing `RepositoryRoot()`/`RepositoryRoot(DirectoryInfo)` pair. It walks up and returns the first `Debug`/`Release` segment - the configuration the running test assembly was written to - and falls back to `Debug`, which is what `dotnet run` would have used anyway, so an unusual output layout behaves exactly as before rather than becoming a new hard failure. Release is not hardcoded, so local Debug runs are unaffected.
- `RepresentationRestampE2eHarness`: extracted `BuildCliProcessArguments`, which composes the argument list with `--configuration <resolved>` between `--project <path>` and `--no-build`. `--no-build` is kept: the E2E project's build-order `ProjectReference` to the CLI guarantees it was built into the matching directory. Everything after `--` is unchanged, so the CLI command contracts and the JSON the harness parses are untouched.
- `Given_Representation_Restamp_E2E_Harness`: four tests covering the full argument sequence, Debug/Release resolution, nearest-segment-wins, and the Debug fallback.
- `DocumentCacheAdminCliProcessHarness.Start` and `Given_DocumentCacheAdminStatusCommand`: the same two-line fix. Neither was failing in CI, because every workflow that runs them declares `CONFIGURATION`; both break on the first lane that does not, and both break today for anyone running the suite locally with `-Configuration Release`. They now match `Given_DocumentCacheAdminStartupExitCodes` in the same folder, which has always launched the CLI this way. Behaviour is unchanged in every existing lane.

No production code, workflow, scenario tag, CLI command contract, schema, or doc changes.

## Verification

Every new test was confirmed load-bearing by breaking the code it covers and watching only that test fail: dropping the `--configuration` pair, and moving it after `--no-build`, each fail the argument-shape test; renaming the segments the walk matches fails the Release resolution case; preferring the outermost match instead of the nearest fails the ancestor-directory case.

- `dotnet csharpier check` on all four touched files: clean.
- `build-dms.ps1 Build -Configuration Release`: 0 warnings, 0 errors.
- `EdFi.DataManagementService.Tests.Unit`: 91/91.
- DocumentCacheAdmin integration, DB-free subset, Release: 20/20. On a machine with no `bin/Debug` present, forcing the status-command test to resolve Debug makes `dotnet run --no-build` exit 1 without starting the CLI; restoring the resolution makes it pass.
- Published-image E2E (`-UsePublishedImage`, Release, `CONFIGURATION` absent), after refreshing `:pre` images that were two months stale: the `bin/Debug` symptom does not occur at all. The CLI starts and returns its own diagnostics.
- Local-image E2E (Release, `CONFIGURATION` absent): all four restamp scenarios pass on this branch; three pass in a single four-scenario process and the fourth passes on its own.

## Known limitations - please read before expecting the scheduled lane to go green

**This PR does not make the Scheduled pre Image Tests lane green.** It fixes the CLI launch defect that lane reported, and two further defects remain in front of it. Both are pre-existing, both are filed separately, and neither is touched here:

1. The restamp harness assumes the DMS container is named `ed-fi-api`, which is only true for the local-image compose stack. Under `-UsePublishedImage` the four scenarios still fail.
2. The four restamp scenarios are not isolated from each other; run in one process on a slower host, one of them times out draining the ordinary projector.

`DocumentCacheAdminCliProcessHarness.Start` is unverified at runtime - its fixtures need database targets that were not available - but it compiles and is the identical two-line pattern proven on the sibling caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
