### PR TITLE
[DMS-1343] Resolve the apiClient GET key-first on one route

### DIFF
--- a/docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md
+++ b/docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md
@@ -104,10 +104,13 @@ today. Two different identifiers are involved:
 - the **`clientId`** (returned as `key` when credentials are issued) is the
   OAuth client identifier.
 
-The single-item `GET` accepts either one, and the path segment itself decides
-which lookup runs: a segment that is a valid 32-bit integer is read as the
-numeric `id`, and any other segment is read as the OAuth `clientId` key. The
-two values remain distinct, because a client's `id` and its `key` are different
+The single-item `GET` accepts either one and resolves them key-first. The
+segment is matched against the OAuth `clientId` key, and that match wins
+whenever it exists. Only when no client key matches, and the segment is a valid
+32-bit integer, is it read as the numeric `id`. Key-first is deliberate: a
+`clientId` has no enforced format, so a key made only of digits is possible, and
+reading the numeric `id` first could hand back an unrelated client. The two
+values remain distinct, because a client's `id` and its `key` are different
 values resolved through different columns. You just do not have to convert one
 into the other to read a client.
 

--- a/docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md
+++ b/docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md
@@ -97,12 +97,19 @@ an absent one, depending on the deployment's identity provider.
 #### Provisioning a Client With No Data Store Assignment
 
 The sequence below is the whole lifecycle, using only endpoints that exist
-today. Two different identifiers are involved and they are not interchangeable:
+today. Two different identifiers are involved:
 
 - the **numeric `id`** returned in the API-client response body is the
   management identifier used in `PUT`, `DELETE` and `reset-credential` routes;
 - the **`clientId`** (returned as `key` when credentials are issued) is the
-  OAuth client identifier, and it is what `GET /v3/apiClients/{clientId}` takes.
+  OAuth client identifier.
+
+The single-item `GET` accepts either one, and the path segment itself decides
+which lookup runs: a segment that is a valid 32-bit integer is read as the
+numeric `id`, and any other segment is read as the OAuth `clientId` key. The
+two values remain distinct, because a client's `id` and its `key` are different
+values resolved through different columns. You just do not have to convert one
+into the other to read a client.
 
 `POST /v3/applications` returns the **application's** id in `id`, not the
 initial client's. To act on that client, read it with
@@ -139,7 +146,8 @@ initial client's. To act on that client, read it with
    parameter, so omitting it sends an empty scope, which the self-contained
    provider ignores but Keycloak rejects with `invalid_scope`.
 8. **Delete a client** — `DELETE /v3/apiClients/{numeric id}`, after which
-   `GET /v3/apiClients/{key}` reports `404`.
+   both `GET /v3/apiClients/{numeric id}` and `GET /v3/apiClients/{key}` report
+   `404`.
 
 What the resulting token can *do* with a DMS identity API is out of scope here:
 **the DMS identity routes do not exist yet.** This section documents only how to

--- a/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
+++ b/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
@@ -249,6 +249,8 @@ Files deliberately **not** changed: every `IApiClientRepository` implementation,
 
 ## 7. Test plan
 
+> **Superseded by §1.2 (R2).** This section records the R1 test plan and is kept as history. Its numeric-first expectations are inverted under R2, where the client-key lookup runs first on every request and the OpenAPI `id` parameter is a `string`. The tests the R2 patch actually carries are listed in §12.3.
+
 ### 7.1 Unit — `ApiClientModuleTests.cs` (NUnit, FluentAssertions, FakeItEasy)
 
 New fixtures follow the file's `Given_…` / `It_…` style and reuse `SetUpClient()`.
@@ -358,6 +360,8 @@ Each step ends with a local commit, the SHA, an exact file list, and an approve/
 
 ## 9. Backwards compatibility
 
+> **Superseded by §1.2 (R2).** This table assesses the R1 two-route design and is kept as history; it reasons about `:int` route selection and a separately documented `/v3/apiClients/{clientId}` path item, neither of which exists under R2. The R2 assessment is in §1.2: the client key is resolved first, so every case that worked before this branch returns the same row, and the residual is recorded there.
+
 | Concern | Assessment |
 |---|---|
 | Existing key-based callers (`GET /v3/apiClients/{guid}`) | Unaffected: GUID keys contain hyphens and letters, never satisfy `:int`, and continue to select the string route. Response body and status codes unchanged. |
@@ -370,6 +374,8 @@ Each step ends with a local commit, the SHA, an exact file list, and an approve/
 ---
 
 ## 10. Risks
+
+> **Superseded by §1.2 (R2) except §10.5.** These entries assess the R1 two-route design and are kept as history. Two are now inverted: R2 has no route constraint and therefore no precedence question (§10.1), and a numeric-looking client key is no longer shadowed but deliberately wins (§10.2). §10.5, the missing uniqueness constraint, still stands and is tracked as DMS-1529.
 
 ### 10.1 Route precedence **[INFER → tested]**
 ASP.NET Core ranks constrained parameter segments above unconstrained ones, so the two templates are not ambiguous. If this assumption were wrong, the app would throw `AmbiguousMatchException` on the first matching request; the Phase 1 unit tests exercise both templates against a numeric and a string value in the same host and would fail immediately.

--- a/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
+++ b/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
@@ -14,7 +14,7 @@
 | Branch | `DMS-1343` (created from `main` at `ab140a4d5`) |
 | Author | Samuel Lugo (with repository audit) |
 | Date | 2026-09-09 |
-| **Status** | **Implemented — 2026-09-09.** Phases 1–4 committed (§12); Phase 5 verification and push are human-gated. Approved 2026-09-09 with reviewer answers to Q1–Q4 in §11 and guardrails in §1.1 |
+| **Status** | **Implemented, amended 2026-09-10.** Phases 1-5 landed as PR #1242; review of that PR superseded the dispatch design, and §1.2 records the key-first replacement. Approved 2026-09-09 with reviewer answers to Q1-Q4 in §11 and guardrails in §1.1 |
 | Jira decision | Option 1 (replace) is struck through in the ticket. Option 2 (support both identifier styles) is the active direction. |
 | Jira comment (2026-08-18) | `dmscs.ApiClient` has no DB-level unique constraint on `ClientId` or `ClientUuid`; recommends the authoritative external identifier receive a unique index. Tracked as follow-up **DMS-1529** (under DMS-1072). |
 | Pre-existing design doc | None found for DMS-1343 in `reference/` or `docs/` (verified). |
@@ -23,12 +23,36 @@
 
 ### 1.1 Review guardrails (binding, 2026-09-09)
 
-- **Identifier rule wording.** Documentation must state the exact rule, never "GET accepts either identifier": *a path segment that is a valid `int32` is the numeric ApiClient `id`; any other segment is the OAuth `clientId` key.*
+- **Identifier rule wording.** Documentation must state the exact rule, never a bare "GET accepts either identifier". The rule is the key-first contract in §1.2, which supersedes the int32-first wording this bullet originally carried.
 - **E2E hygiene.** Tear down the CMS E2E stack before setup and again after the scoped E2E run.
 - **Scope lock.** `ConfigurationServiceApplicationProvider.cs`, all repositories, DDL, and response DTOs stay untouched unless a later review explicitly approves expanding scope.
 - **Gates.** The approved spec is committed alone first (SHA and files reported), then work stops for approval before Phase 1. Every implementation commit is a focused behavior slice with its tests; each gate reports SHA, files edited, and test results, and waits for approval before the next phase.
-- **OpenAPI ambiguity note.** The two single-item GET path items (`{id}` and `{clientId}`) remain documented side by side as a deliberate compatibility compromise, because the final runtime behavior includes both routes (§5.2).
+- **OpenAPI ambiguity note.** Superseded by §1.2. There is now one single-item GET path item, `/v3/apiClients/{id}`, so the collision this bullet accepted no longer exists.
 
+### 1.2 Amendment R2 (2026-09-10) — key-first dispatch on a single route
+
+Team review of PR #1242 rejected the two-route `:int` design. This amendment supersedes §4.1–§4.3, §5.1–§5.2, §11 Q2, and the Jira Implementation Decisions block **on dispatch and OpenAPI shape only**. Scope, non-goals, authorization, tenant scoping, and response shape are unchanged.
+
+**Findings.** (1) `{id:int}` made a numeric-looking `ClientId` unreachable. `ClientId` is `VARCHAR/NVARCHAR(36)` with no format constraint, so a stored key of `"12345"` was shadowed by the unrelated row whose primary key is `12345`. (2) Documenting `get` on both `/v3/apiClients/{id}` and `/v3/apiClients/{clientId}` is a real OpenAPI collision once both path items carry the same operation, because templated paths differing only by parameter name are the same path and a generator may deduplicate either one. (3) The DMS application-context lookup could receive a numeric-id row for a numeric `client_id`, converting its previous `NotFound` into `Unavailable`.
+
+**Resolution.** One registration, `MapLimitedAccess("/v3/apiClients/{id}", GetByIdentifier)`, with a `string` parameter and this contract:
+
+| Client-key lookup | Segment parses as int32 | Numeric lookup | Response |
+|---|---|---|---|
+| Success | not attempted | not called | 200, key-matched row |
+| FailureUnknown | not attempted | not called | 500, sanitized |
+| FailureNotFound | no | not called | 404, `ApiClient not found` |
+| FailureNotFound | yes | Success | 200, id-matched row |
+| FailureNotFound | yes | FailureNotFound | 404, `ApiClient with ID {parsed} not found.` |
+| FailureNotFound | yes | FailureUnknown | 500, sanitized |
+
+Those six rows are the whole contract. Parsing uses `NumberStyles.Integer` with `CultureInfo.InvariantCulture`, the rules `IntRouteConstraint` applied, so the segments treated as numeric are unchanged from R1. The numeric 404 interpolates the parsed integer rather than the raw segment: it matches the message the other numeric routes emit and keeps caller-supplied text out of the response body, at the cost of reporting `007` as `ID 7`.
+
+**Why key-first rather than the review's id-first fallback.** Under id-first, a caller passing the key `"12345"` still receives the row whose primary key is `12345` whenever that row exists, because the first lookup succeeds and the fallback never runs. Finding 1 would stay open verbatim and finding 3 would worsen, since that mismatch is exactly what turns a DMS `NotFound` into `Unavailable`. Key-first inverts the loss onto the new, additive, management-only numeric surface and leaves the security-relevant key path byte-identical to its pre-branch behavior. Gating the fallback on the caller's scope was considered and rejected: making a lookup result depend on authorization would be a worse defect than the one it fixes.
+
+**Consequences accepted.** A numeric-id read costs two queries when no key matches; the DMS path still costs one. The remaining path item declares `id` as a string for `get` and as int32 for `put` and `delete`, which is legal per-operation OpenAPI and describes the runtime honestly.
+
+**Residual risk.** A token whose `client_id` is numeric, matches no stored `ClientId`, and collides with some row's primary key yields a mismatched 200 that DMS converts to `Unavailable` rather than the `NotFound` it returned before this branch. It requires an externally provisioned numeric key, since CMS issues GUID keys. DMS-1529's unique index does not remove this; a format constraint on `ClientId` would, and that note is recorded on DMS-1529.
 **Evidence tags:** **[JIRA]** ticket fact · **[SPEC]** verified in the published Management API 3.0.0 YAML · **[REPO]** verified in the repository at `ab140a4d5` · **[INFER]** inference about framework behavior, verified by a test in the plan · **[REC]** author recommendation.
 
 ---

--- a/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
+++ b/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
@@ -1,0 +1,385 @@
+# DMS-1343 — Align `GET /v3/apiClients/{id}` identifier semantics with the Management API 3.0.0 spec
+
+**Implementation specification (Configuration Service / CMS)**
+
+---
+
+## 1. Document control
+
+| Field | Value |
+|---|---|
+| Spec file | `reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md` |
+| Jira ticket | [DMS-1343](https://edfi.atlassian.net/browse/DMS-1343) — *Decide and align GET /v3/apiClients/{id} identifier semantics with spec/Admin API* (In Progress) |
+| Parent epic | DMS-1072 — Admin API v2.3 / CMS Gap Remediation |
+| Branch | `DMS-1343` (created from `main` at `ab140a4d5`) |
+| Author | Samuel Lugo (with repository audit) |
+| Date | 2026-09-09 |
+| **Status** | **Approved — 2026-09-09** (reviewer answers to Q1–Q4 recorded in §11; guardrails in §1.1) |
+| Jira decision | Option 1 (replace) is struck through in the ticket. Option 2 (support both identifier styles) is the active direction. |
+| Jira comment (2026-08-18) | `dmscs.ApiClient` has no DB-level unique constraint on `ClientId` or `ClientUuid`; recommends the authoritative external identifier receive a unique index. Tracked as follow-up **DMS-1529** (under DMS-1072). |
+| Pre-existing design doc | None found for DMS-1343 in `reference/` or `docs/` (verified). |
+
+> **Control document.** No production code is written and no commit is made (including this spec) until the spec is marked **Approved**. After approval, the spec is committed first, then implementation proceeds phase-by-phase with a local commit, SHA, and file summary at every gate.
+
+### 1.1 Review guardrails (binding, 2026-09-09)
+
+- **Identifier rule wording.** Documentation must state the exact rule, never "GET accepts either identifier": *a path segment that is a valid `int32` is the numeric ApiClient `id`; any other segment is the OAuth `clientId` key.*
+- **E2E hygiene.** Tear down the CMS E2E stack before setup and again after the scoped E2E run.
+- **Scope lock.** `ConfigurationServiceApplicationProvider.cs`, all repositories, DDL, and response DTOs stay untouched unless a later review explicitly approves expanding scope.
+- **Gates.** The approved spec is committed alone first (SHA and files reported), then work stops for approval before Phase 1. Every implementation commit is a focused behavior slice with its tests; each gate reports SHA, files edited, and test results, and waits for approval before the next phase.
+- **OpenAPI ambiguity note.** The two single-item GET path items (`{id}` and `{clientId}`) remain documented side by side as a deliberate compatibility compromise, because the final runtime behavior includes both routes (§5.2).
+
+**Evidence tags:** **[JIRA]** ticket fact · **[SPEC]** verified in the published Management API 3.0.0 YAML · **[REPO]** verified in the repository at `ab140a4d5` · **[INFER]** inference about framework behavior, verified by a test in the plan · **[REC]** author recommendation.
+
+---
+
+## 2. Problem statement
+
+**[SPEC]** The published Management API 3.0.0 specification (`api-specifications/management/management-api-3.0.0.yaml` in `Ed-Fi-Alliance-OSS/Ed-Fi-API-Specifications`) defines:
+
+```yaml
+'/v3/apiClients/{id}':
+  get:
+    summary: Retrieves a specific apiClient based on the identifier.
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+    responses: 200 (apiClientModel), 401, 403, 404, 500
+```
+
+and `apiClientModel` carries **two** identifiers: `id` (`integer/int32`, the primary key) and `clientId` (`string`, the external OAuth client key).
+
+**[REPO]** CMS today registers only a string route for the single-item GET:
+
+```csharp
+// ApiClientModule.cs:73-76
+endpoints.MapLimitedAccess("/v3/apiClients/", GetAll).Produces<List<ApiClientResponse>>(200);
+endpoints
+    .MapLimitedAccess("/v3/apiClients/{clientId}", GetByClientId)
+    .Produces<ApiClientResponse>(200);
+```
+
+`GetByClientId` (`ApiClientModule.cs:296-313`) calls `IApiClientRepository.GetApiClientByClientId(string)`, which queries `WHERE ac."ClientId" = @ClientId AND <tenant scope>`. A request such as `GET /v3/apiClients/1` therefore looks for a client whose OAuth key is the literal string `"1"` and returns `404`. An Admin-API-conformant caller that passes the numeric `id` cannot read a client.
+
+**[REPO]** The numeric lookup already exists: `GetApiClientById(int id)` is implemented in both the PostgreSQL and MSSQL `ApiClientRepository` with identical tenant scoping (`WHERE ac."Id" = @Id AND <tenant scope>`), and is used by `UpdateApiClient`, `DeleteApiClient`, and `ResetCredential` via `AcquireApiClientLocksAsync` (`ApiClientModule.cs:809, 861`). Nothing new is needed in the backend.
+
+**[REPO]** The client-key route has real consumers that must keep working:
+
+- DMS: `ConfigurationServiceApplicationProvider.FetchApplicationByClientIdAsync` issues `GET /v3/apiClients/{clientId}` with the OAuth key from the bearer token (`src/dms/core/EdFi.DataManagementService.Core/Configuration/ConfigurationServiceApplicationProvider.cs:59`), using a service account with the limited-access `AuthMetadataReadOnlyAccess` scope. Its unit test pins the path `/v3/apiClients/client-id`.
+- CMS E2E: `ApiClients.feature` (scenarios 02, 03, 05, 09, 12, 14, 20, 23), `Applications.feature:960`, `OwnershipTokens.feature:84, 304`, `Tenants.feature:249, 276, 335, 353, 376` all read by key.
+- Operator docs: `docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md` §"Provisioning a Client With No Data Store Assignment" tells operators to read the initial client with `GET /v3/apiClients/{key}` to discover its numeric `id`.
+
+---
+
+## 3. Scope
+
+### 3.1 In scope
+
+1. Add a numeric-id single-item GET at `/v3/apiClients/{id:int}` that resolves against `ApiClient.Id` through the existing `GetApiClientById(int)` repository method, tenant scoping included.
+2. Keep the existing client-key GET at `/v3/apiClients/{clientId}` unchanged in path, handler semantics, authorization policy, and response shape.
+3. Make the served OpenAPI document describe both operations accurately: `GET /v3/apiClients/{id}` with an `int32` `id` parameter (Admin API alignment) and `GET /v3/apiClients/{clientId}` with a `string` parameter, each with a summary/description that names the identifier it takes.
+4. Tests at unit (module), OpenAPI-contract, and CMS E2E levels that prove the resolved identifier semantics, including `404` for a well-formed but non-existent numeric id, `404` for a missing client key, and that non-numeric values never reach the numeric path.
+5. Update the operator documentation that currently states the numeric id cannot be used with GET.
+
+### 3.2 Non-goals (explicit)
+
+- **No change to DMS.** The DMS application-context lookup keeps calling `GET /v3/apiClients/{clientId}` with the OAuth key. No DMS file is touched.
+- **No repository or DDL change.** Both repository methods already exist with tenant scoping; no SQL is edited, so backend integration tests are not re-run as part of the gate (they are unaffected).
+- **No unique index on `ClientId`/`ClientUuid`.** Recorded as a follow-up risk (§10.5) and filed as DMS-1529 under DMS-1072, including duplicate-data/migration handling for PostgreSQL and MSSQL.
+- **No route relocation.** The key lookup is not moved to `/v3/apiClients/byClientId/{clientId}` or to a query parameter. The ticket allows this only "if the approved spec explicitly moves it … and handles compatibility"; the recommendation is not to move it (§4.2).
+- **No response-shape change.** `ApiClientResponse` is returned unchanged by both GETs. Aligning field names with `apiClientModel` (`keyStatus`, `educationOrganizationIds`) is a separate gap in `reference/DMS-1039/AdminApi-CMS GAP Analysis.md`.
+- **No change to PUT/DELETE/reset-credential/ownership routes**, which already use `{id}` bound to `int`.
+
+---
+
+## 4. Route design
+
+### 4.1 Final registration **[REC]**
+
+```csharp
+// Limited access endpoints - accessible by service accounts for internal DMS operations
+endpoints.MapLimitedAccess("/v3/apiClients/", GetAll).Produces<List<ApiClientResponse>>(200);
+
+// Numeric primary-key lookup, the Management API 3.0.0 / Admin API contract.
+// The :int constraint gives this route precedence over the string route below
+// whenever the segment parses as an Int32; anything else falls through.
+endpoints
+    .MapLimitedAccess("/v3/apiClients/{id:int}", GetById)
+    .Produces<ApiClientResponse>(200)
+    .WithSummary("Retrieves a specific apiClient based on its numeric identifier.")
+    .WithDescription("… `id` is the numeric ApiClient identifier returned as `id` in responses. To look up a client by its OAuth client key (`clientId`), request GET /v3/apiClients/{clientId} with a non-numeric value.");
+
+// OAuth client-key lookup, retained for DMS application-context resolution and existing callers.
+endpoints
+    .MapLimitedAccess("/v3/apiClients/{clientId}", GetByClientId)
+    .Produces<ApiClientResponse>(200)
+    .WithSummary("Retrieves a specific apiClient based on its OAuth client key.")
+    .WithDescription("… `clientId` is the OAuth client key (returned as `key` when credentials are issued). A purely numeric value is interpreted as the numeric identifier instead and served by GET /v3/apiClients/{id}.");
+```
+
+Handler shape (new, minimal, mirrors `GetByClientId`):
+
+```csharp
+private static async Task<IResult> GetById(
+    int id,
+    HttpContext httpContext,
+    IApiClientRepository apiClientRepository
+)
+{
+    ApiClientGetResult getResult = await apiClientRepository.GetApiClientById(id);
+    return getResult switch
+    {
+        ApiClientGetResult.Success success => Results.Ok(success.ApiClientResponse),
+        ApiClientGetResult.FailureNotFound => FailureResults.NotFound(
+            $"ApiClient with ID {id} not found.",
+            httpContext.TraceIdentifier
+        ),
+        _ => FailureResults.Unknown(httpContext.TraceIdentifier),
+    };
+}
+```
+
+`GetByClientId` is untouched, including its `"ApiClient not found"` message.
+
+### 4.2 Why two routes on the same segment rather than a relocated key route
+
+| Option | Verdict |
+|---|---|
+| **A. `{id:int}` + `{clientId}` on the same segment (recommended)** | Zero change for DMS, E2E, and operators. ASP.NET Core endpoint routing ranks a constrained parameter segment above an unconstrained one, so `/v3/apiClients/7` selects the `int` route and `/v3/apiClients/c86b44f2-…` selects the string route without an `AmbiguousMatchException` **[INFER, verified by unit test in Phase 1]**. The served OpenAPI document gains `get` under the already-present `/v3/apiClients/{id}` path item. |
+| B. Single `{id}` string route that branches on `int.TryParse` inside the handler | One OpenAPI path, but the documented parameter would have to be `string` (contradicting the spec) or `int32` (contradicting behavior). Also less explicit than a route constraint. Rejected. |
+| C. Move the key lookup to `/v3/apiClients/byClientId/{clientId}` (or `?clientId=`) and make `{id}` numeric-only | Breaks DMS's application-context lookup and every key-based E2E step unless a compatibility shim keeps the old string route anyway, which collapses back to A plus an extra route. Rejected for this ticket; can be revisited if the spec ever adds such a path. |
+
+### 4.3 Route-matching edge cases (defensive behavior)
+
+| Request segment | Route selected | Repository call | Result |
+|---|---|---|---|
+| `1` | `{id:int}` | `GetApiClientById(1)` | 200 if the row exists in the caller's tenant, else 404 |
+| `999999` (well-formed, absent) | `{id:int}` | `GetApiClientById(999999)` | 404 `"ApiClient with ID 999999 not found."` |
+| `c86b44f2-a80b-450d-be0c-4ecf43397e03` (GUID key) | `{clientId}` | `GetApiClientByClientId(...)` | unchanged |
+| `12abc`, `abc`, `1.5`, `1e3` | `{clientId}` | `GetApiClientByClientId(...)` | 404 unless such a key exists |
+| `99999999999` (exceeds Int32) | `{clientId}` (int constraint fails) | `GetApiClientByClientId("99999999999")` | 404 |
+| `-1`, `+1`, `0` | `{id:int}` (`IntRouteConstraint` accepts `NumberStyles.Integer`) | `GetApiClientById(-1 / 1 / 0)` | 404 (no such id); `+1` resolves as 1 |
+| empty (`/v3/apiClients/`) | collection route | `QueryApiClient` | unchanged |
+
+**[REPO]** CMS generates every OAuth client key with `Guid.NewGuid().ToString()` (`ApiClientModule.cs:183`, `ApplicationModule.cs:63`), so a CMS-issued key is never all-digits and can never be shadowed by the numeric route. Only a key inserted by an external process could be; that is an accepted residual risk (§10.2).
+
+### 4.4 Authorization policy **[REC]**
+
+Both GETs use `MapLimitedAccess` (`ServicePolicy` + `AdminOrAuthMetadataReadOnlyAccessScopePolicyOrReadOnly`). Rationale: the numeric GET exposes exactly the `ApiClientResponse` that the limited-access collection GET `/v3/apiClients/` already returns for every client, so a narrower policy would add no protection while making the two single-item reads behave differently for the same scope. Management reads (`ReadOnly`/`Admin`) are a subset of that policy, so they remain permitted. See Q1.
+
+---
+
+## 5. OpenAPI representation
+
+### 5.1 Resulting document shape
+
+The generator (`Microsoft.AspNetCore.OpenApi`) keys path items by the route template with constraints stripped **[INFER, verified in Phase 2 tests]**, so:
+
+| Path item | Operations after this change | `id`/`clientId` parameter schema |
+|---|---|---|
+| `/v3/apiClients/{id}` | **`get` (new)**, `put`, `delete` | `integer` / `int32` (inferred from the `int id` handler parameter, as PUT/DELETE already are) |
+| `/v3/apiClients/{clientId}` | `get` (unchanged) | `string` |
+| `/v3/apiClients/{id}/reset-credential`, `/v3/apiClients/{id}/ownership` | unchanged | `int32` |
+
+No `/v3/apiClients/{id:int}` key may appear in the document; a test asserts this.
+
+### 5.2 Ambiguous templated paths
+
+OpenAPI 3.x states that templated paths with the same hierarchy but different parameter names must not coexist. **[REPO]** The served CMS document **already** contains both `/v3/apiClients/{id}` (PUT, DELETE) and `/v3/apiClients/{clientId}` (GET), so this condition pre-exists and no CI tooling lints for it (no spectral/redocly/swagger-cli usage found in `.github/` or `eng/`). This change does not introduce a new conflicting path item; it adds an operation to an existing one. The operation summaries/descriptions in §4.1 disambiguate the two for human readers and Swagger UI.
+
+Alternative considered: hide the `{clientId}` GET with `.ExcludeFromDescription()` to produce a strictly valid document. Rejected (Q2, reviewer-confirmed) because the ticket requires metadata to "accurately reflect the final behavior" and the operator docs direct users to that route. **Keeping both path items is a deliberate compatibility compromise:** the document is knowingly non-conformant on this one point so that it describes every route the service actually serves.
+
+### 5.3 Metadata endpoint
+
+`/metadata/specifications` (`MetadataModule.cs`) re-serves `/openapi/v1.json` with hand-written `components.parameters.id` (`int32`). No change is needed there; the existing `MetadataSpecifications_Declares_Id_Parameter_As_Int32` test keeps passing.
+
+---
+
+## 6. Affected files
+
+| Area | File | Change |
+|---|---|---|
+| CMS frontend | `src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs` | Register `GET /v3/apiClients/{id:int}`; add `GetById` handler; add `WithSummary`/`WithDescription` to both single-item GETs. |
+| CMS unit tests | `src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientModuleTests.cs` | New fixtures for numeric lookup, numeric 404, string fallthrough, and repository-call exclusivity. |
+| CMS OpenAPI tests | `.../Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs` | Add `"GET /v3/apiClients/{id} int32"` to `ExpectedIdPathParameters`; update the XML doc comment that describes the set. |
+| CMS OpenAPI tests | `.../Frontend.AspNetCore.Tests.Unit/Modules/ApiClientOpenApiContractTests.cs` | New tests: `{id}` GET parameter is int32 with the numeric description; `{clientId}` GET parameter is string with the key description; no constraint-bearing path key. |
+| CMS E2E | `src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ApiClients.feature` | New scenarios 25–27 (numeric GET 200, numeric 404, digits-plus-letters 404). |
+| CMS E2E | `src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Tenants.feature` | One added step pair in the existing cross-tenant scenario: tenant B `GET /v3/apiClients/{tenantAClientId}` → 404. |
+| Docs | `docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md` | State that GET accepts either identifier; keep the key-based discovery step. |
+| Docs | `reference/design/configuration-service/README.md` | Link this spec. |
+| Spec | this file | Status/progress updates at each gate. |
+
+Files deliberately **not** changed: every `IApiClientRepository` implementation, DDL scripts, `ConfigurationServiceApplicationProvider.cs` and its tests, `EndpointBuilderExtensions.cs`, `MetadataModule.cs`, the GAP analysis.
+
+---
+
+## 7. Test plan
+
+### 7.1 Unit — `ApiClientModuleTests.cs` (NUnit, FluentAssertions, FakeItEasy)
+
+New fixtures follow the file's `Given_…` / `It_…` style and reuse `SetUpClient()`.
+
+| Fixture | Arrangement | Assertions |
+|---|---|---|
+| `Given_Get_By_Numeric_Id` | `GetApiClientById(7)` returns `Success(response with Id = 7, ClientId = "test-client-id")`; `GetApiClientByClientId` returns `FailureNotFound` | `GET /v3/apiClients/7` → 200; body `id == 7`; `GetApiClientById(7)` `MustHaveHappenedOnceExactly`; `GetApiClientByClientId(any)` `MustNotHaveHappened` |
+| `Given_Get_By_Numeric_Id_That_Does_Not_Exist` | `GetApiClientById(999)` returns `FailureNotFound` | `GET /v3/apiClients/999` → 404 with `application/problem+json`; `GetApiClientByClientId` never called (this is the ticket's explicit AC) |
+| `Given_Get_By_Client_Key` (extends existing coverage) | as today | `GET /v3/apiClients/test-client-id` → 200; `GetApiClientById(any)` `MustNotHaveHappened` |
+| `Given_Get_With_Non_Numeric_Identifier_Values` (TestCases `12abc`, `1.5`, `99999999999`, `abc`) | `GetApiClientByClientId(value)` returns `FailureNotFound` | 404; `GetApiClientByClientId(value)` called once; `GetApiClientById(any)` never called |
+| `Given_Get_By_Numeric_Id_Repository_Failure` | `GetApiClientById` returns `FailureUnknown` | 500 (`FailureResults.Unknown`) |
+| Existing `Given_Nonexistent_Resources.It_returns_not_found_for_get_by_client_id` | unchanged | still passes |
+
+Also update `Given_Valid_ApiClient_Operations.It_returns_success_responses_for_all_operations` to add a `GET /v3/apiClients/1` call asserting 200, so the "all operations" sweep covers the new route.
+
+### 7.2 OpenAPI / metadata contract
+
+- `MetadataModuleTests.OpenApi_Declares_Resource_Identifiers_As_Int32`: exact-set gains `"GET /v3/apiClients/{id} int32"` (the test fails without it and fails if the route were mis-typed).
+- `ApiClientOpenApiContractTests` (`Given_the_served_openapi_document`):
+  - `It_declares_the_numeric_api_client_get_id_parameter_as_int32` — `paths["/v3/apiClients/{id}"]["get"].parameters[name=id]` has `in: path`, `type: integer`, `format: int32`.
+  - `It_declares_the_client_key_api_client_get_parameter_as_string` — `paths["/v3/apiClients/{clientId}"]["get"].parameters[name=clientId]` has `type: string`.
+  - `It_describes_which_identifier_each_api_client_get_takes` — the numeric GET's description contains "numeric" and the key GET's description contains "OAuth client key".
+  - `It_does_not_leak_route_constraints_into_path_keys` — no path key contains `:` .
+
+### 7.3 Backend integration
+
+None added. **[REPO]** `ApiClientTests` (PostgreSQL and MSSQL) already cover `GetApiClientById` happy path (`:319`), cross-tenant not-found (`:534`/`:632`), and `GetApiClientByClientId` cross-tenant not-found (`:551`/`:649`). No SQL changes, so these lanes are not part of the gate.
+
+### 7.4 CMS E2E — `ApiClients.feature`
+
+Appended after scenario 24 (no renumbering of existing scenarios):
+
+- **25 Ensure clients can GET apiClient by numeric id** — POST `/v3/apiClients` for the background application, capture `apiClientId` and credentials; `GET /v3/apiClients/{apiClientId}` → 200 with the full body (`id`, `applicationId`, `clientId`, `clientUuid`, `name`, `isApproved`, `creatorOwnershipTokenId`, `ownershipTokenIds`, `dataStoreIds`) equal to the same client read via `GET /v3/apiClients/{clientId}`.
+- **26 Verify a well-formed but non-existent numeric id returns 404** — `GET /v3/apiClients/99999` → 404.
+- **27 Verify a mixed value is treated as a client key** — `GET /v3/apiClients/12abc-not-a-key` → 404.
+
+Tag 25 with `@MssqlRepresentative` so the MSSQL smoke subset also exercises the numeric route (CI runs `TestCategory=MssqlRepresentative` against MSSQL).
+
+### 7.5 CMS E2E — `Tenants.feature`
+
+In the existing "Tenant B can neither read, update, reset nor delete tenant A's unassigned client" block (line ~353), add immediately after the key-based 404:
+
+```gherkin
+When a GET request is made to "/v3/apiClients/{tenantAClientId}" with header "Tenant" value "TenantB_{scenarioRunId}"
+Then it should respond with 404
+```
+
+This proves tenant scoping on the numeric path end-to-end using the already-captured `tenantAClientId`.
+
+### 7.6 Verification commands (run before push)
+
+```powershell
+# Format only what was edited
+dotnet csharpier format src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
+dotnet csharpier format src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules
+dotnet csharpier check src/config
+
+# Focused unit + OpenAPI contract tests
+dotnet test src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit --filter "FullyQualifiedName~ApiClientModuleTests|FullyQualifiedName~MetadataModuleTests|FullyQualifiedName~Given_the_served_openapi_document"
+
+# Full CMS unit lane as the final local gate
+./build-config.ps1 UnitTest -Configuration Release
+
+# CMS E2E (PostgreSQL, self-contained IdP), scoped to the two edited features.
+# Teardown first so no stale stack or image from another branch is reused, and again afterwards.
+pwsh src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/teardown-local-cms.ps1
+pwsh src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/setup-local-cms.ps1
+dotnet test src/config/tests/EdFi.DmsConfigurationService.Tests.E2E --filter "FullyQualifiedName~ApiClients|FullyQualifiedName~Tenants"
+pwsh src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/teardown-local-cms.ps1
+```
+
+---
+
+## 8. Implementation phases and steps
+
+Each step ends with a local commit, the SHA, an exact file list, and an approve/reject gate.
+
+### Phase 0 — Spec approval
+- **0.1** Reviewer resolved Q1–Q4 (§11) on 2026-09-09. Follow-up DMS-1529 filed and linked from a DMS-1343 comment. Spec status set to Approved; commit spec only (`[DMS-1343] Add implementation spec for apiClient GET identifier semantics`), report SHA, stop for approval.
+
+### Phase 1 — Numeric route and handler
+- **1.1** `ApiClientModule.cs`: register `MapLimitedAccess("/v3/apiClients/{id:int}", GetById)` *before* the `{clientId}` registration (order is not required for precedence but keeps the intent readable); add the `GetById` handler. No OpenAPI text yet.
+- **1.2** `ApiClientModuleTests.cs`: add the fixtures in §7.1; extend the all-operations sweep. Run the focused unit filter; all green. Commit.
+
+### Phase 2 — OpenAPI metadata
+- **2.1** `ApiClientModule.cs`: add `WithSummary`/`WithDescription` to both single-item GETs (§4.1 wording).
+- **2.2** `MetadataModuleTests.cs`: add `"GET /v3/apiClients/{id} int32"` to the expected set; reword the XML doc comment ("nine item routes … five secondary routes" and the `{clientId}` remark) to reflect the new count and that `{clientId}` is intentionally string.
+- **2.3** `ApiClientOpenApiContractTests.cs`: add the four tests in §7.2. Run focused filter; commit.
+
+### Phase 3 — CMS E2E
+- **3.1** `ApiClients.feature`: scenarios 25–27.
+- **3.2** `Tenants.feature`: the two-line cross-tenant numeric step.
+- **3.3** Run `teardown-local-cms.ps1`, then `setup-local-cms.ps1`, execute the two features, report totals (passed/failed/skipped), then `teardown-local-cms.ps1` again. Commit.
+
+### Phase 4 — Documentation
+- **4.1** `docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md`: revise the "two identifiers … not interchangeable" paragraph and steps 3/8 to state the exact rule from §1.1 (a valid `int32` segment is the numeric `id`; any other segment is the OAuth `clientId` key), while the key remains the way to *discover* the id after `POST /v3/applications`.
+- **4.2** `reference/design/configuration-service/README.md`: add a link to this spec.
+- **4.3** This spec: status → Implemented, progress table filled with SHAs. Commit.
+
+### Phase 5 — Final verification and push (human-gated)
+- **5.1** `dotnet csharpier check src/config`; full `./build-config.ps1 UnitTest`; E2E result from 3.3 recorded.
+- **5.2** Push `DMS-1343` and open the PR only after explicit approval; PR body via the `pr-description` skill.
+
+---
+
+## 9. Backwards compatibility
+
+| Concern | Assessment |
+|---|---|
+| Existing key-based callers (`GET /v3/apiClients/{guid}`) | Unaffected: GUID keys contain hyphens and letters, never satisfy `:int`, and continue to select the string route. Response body and status codes unchanged. |
+| DMS application-context lookup | Unchanged path, unchanged policy, unchanged payload; DMS's post-read check `applicationContext.ClientId == requested clientId` continues to hold. No DMS code or test changes. |
+| Callers that previously received 404 for `GET /v3/apiClients/<digits>` | Now receive 200 when a client with that primary key exists in their tenant. This is the intended new capability, not a regression; no known caller depends on the old 404. |
+| PUT/DELETE/reset-credential/ownership | Untouched. |
+| OpenAPI consumers | `/v3/apiClients/{id}` gains a `get`; `/v3/apiClients/{clientId}` unchanged. Code generators keyed on operation ids may see one new operation. |
+| Release notes | Additive change; suggest a "CMS: `GET /v3/apiClients/{id}` now accepts the numeric ApiClient id (Admin API alignment); key-based lookup unchanged" line. |
+
+---
+
+## 10. Risks
+
+### 10.1 Route precedence **[INFER → tested]**
+ASP.NET Core ranks constrained parameter segments above unconstrained ones, so the two templates are not ambiguous. If this assumption were wrong, the app would throw `AmbiguousMatchException` on the first matching request; the Phase 1 unit tests exercise both templates against a numeric and a string value in the same host and would fail immediately.
+
+### 10.2 Numeric client keys
+A client key that is a pure Int32 literal would be shadowed by the numeric route. CMS never issues such keys (§4.3). Mitigation for externally seeded rows: none in this ticket; documented in the route description.
+
+### 10.3 OpenAPI templated-path ambiguity (pre-existing)
+Described in §5.2. Not introduced by this change. If a future lint gate is adopted, the remedy would be to move or hide the key route under a separate ticket.
+
+### 10.4 Message-shape difference between the two 404s
+Numeric 404 uses `"ApiClient with ID {id} not found."` (matching the reset-credential message in the same module); key 404 keeps `"ApiClient not found"`. Both are `application/problem+json` through `FailureResults.NotFound`. No consumer parses the detail text (DMS checks only the status).
+
+### 10.5 No unique constraint on `ClientId` / `ClientUuid` **[JIRA]**
+`GetApiClientByClientId` uses `SingleOrDefault()`, so duplicate keys would surface as a 500 (`FailureUnknown`) rather than an arbitrary row. The numeric route is immune (primary key). Adding a unique index is a schema migration for both PostgreSQL and MSSQL and belongs in a follow-up ticket (Q3).
+
+### 10.6 Test-set brittleness
+`ExpectedIdPathParameters` is an exact set by design; forgetting to add the new GET fails the build loudly, which is the intended guard.
+
+---
+
+## 11. Decisions (resolved 2026-09-09) and assumptions
+
+| # | Question | Decision |
+|---|---|---|
+| **Q1** | Authorization for `GET /v3/apiClients/{id:int}`: `MapLimitedAccess` (same as the sibling reads) or `MapSecuredGet` (ReadOnly/Admin only)? | **`MapLimitedAccess`** (§4.4). Matches the existing collection and key-based reads and exposes nothing the limited-access collection route does not already expose. |
+| **Q2** | OpenAPI: keep documenting the `{clientId}` GET as its own path item (accurate, but the pre-existing "same hierarchy, different name" condition remains), or hide it? | **Keep it documented.** Do not hide it. The ambiguity note in §5.2 stays explicit as a deliberate compatibility compromise. |
+| **Q3** | Should a follow-up Jira ticket be filed now for a unique index on `dmscs.ApiClient.ClientId` (and possibly `ClientUuid`) in both DDL sets, or is a comment on DMS-1343 sufficient? | **Filed as DMS-1529** under DMS-1072, covering `ClientId` and `ClientUuid` with duplicate-data/migration handling for PostgreSQL and MSSQL. No DDL or repository change in DMS-1343. |
+| **Q4** | Numeric 404 detail text: `"ApiClient with ID {id} not found."` (module-consistent) vs. reusing the existing `"ApiClient not found"`? | **`"ApiClient with ID {id} not found."`** for numeric-id 404s. The key-based 404 message is unchanged. |
+| **A1** | Assumption: the constraint-stripped path key `/v3/apiClients/{id}` is what the generator emits for `{id:int}`. | Verified by `It_does_not_leak_route_constraints_into_path_keys` and by the exact-set test. |
+| **A2** | Assumption: no caller relies on `GET /v3/apiClients/<digits>` returning 404. | No such caller found in DMS, CMS, E2E, or docs. |
+| **A3** | Assumption: the spec's `description` text for the GET ("Get search pattern…") is boilerplate and need not be copied verbatim; CMS wording that names the identifier is preferable. | Confirm or supply preferred wording. |
+
+---
+
+## 12. Progress (filled during implementation)
+
+| Step | Commit | Files | Status |
+|---|---|---|---|
+| 0.1 | — | this spec | pending approval |
+| 1.1–1.2 | — | | |
+| 2.1–2.3 | — | | |
+| 3.1–3.3 | — | | |
+| 4.1–4.3 | — | | |
+| 5.1–5.2 | — | | |

--- a/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
+++ b/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
@@ -103,9 +103,9 @@ endpoints
 
 ### 3.1 In scope
 
-1. Add a numeric-id single-item GET at `/v3/apiClients/{id:int}` that resolves against `ApiClient.Id` through the existing `GetApiClientById(int)` repository method, tenant scoping included.
-2. Keep the existing client-key GET at `/v3/apiClients/{clientId}` unchanged in path, handler semantics, authorization policy, and response shape.
-3. Make the served OpenAPI document describe both operations accurately: `GET /v3/apiClients/{id}` with an `int32` `id` parameter (Admin API alignment) and `GET /v3/apiClients/{clientId}` with a `string` parameter, each with a summary/description that names the identifier it takes.
+1. Serve both identifier forms from one single-item GET, `/v3/apiClients/{id}`, resolving the OAuth client key first and falling back to `ApiClient.Id` through the existing `GetApiClientById(int)` only when no key matches. Tenant scoping is unchanged. (R2; the R1 wording specified a separate `{id:int}` route.)
+2. Keep client-key resolution reachable at its existing path with unchanged handler semantics, authorization policy, and response shape. Under R2 that path is the same one segment, resolved key-first.
+3. Publish exactly one single-item GET path item, `/v3/apiClients/{id}`, with a `string` parameter and a summary and description stating the key-first rule. (R2; the R1 wording published two path items.)
 4. Tests at unit (module), OpenAPI-contract, and CMS E2E levels that prove the resolved identifier semantics, including `404` for a well-formed but non-existent numeric id, `404` for a missing client key, and that non-numeric values never reach the numeric path.
 5. Update the operator documentation that currently states the numeric id cannot be used with GET.
 
@@ -121,6 +121,8 @@ endpoints
 ---
 
 ## 4. Route design
+
+> **Superseded by §1.2 (R2).** This section records the R1 two-route plan and is kept as history. The binding route contract is the key-first single route in §1.2.
 
 ### 4.1 Final registration **[REC]**
 
@@ -199,6 +201,8 @@ Both GETs use `MapLimitedAccess` (`ServicePolicy` + `AdminOrAuthMetadataReadOnly
 
 ## 5. OpenAPI representation
 
+> **Superseded by §1.2 (R2).** This section records the R1 two-path-item plan and is kept as history. The published document now carries one single-item GET with a `string` parameter.
+
 ### 5.1 Resulting document shape
 
 The generator (`Microsoft.AspNetCore.OpenApi`) keys path items by the route template with constraints stripped **[INFER, verified in Phase 2 tests]**, so:
@@ -224,6 +228,8 @@ Alternative considered: hide the `{clientId}` GET with `.ExcludeFromDescription(
 ---
 
 ## 6. Affected files
+
+> **Superseded by §1.2 (R2).** This table records the R1 file set as planned. The R2 patch's actual file set is in §12.3.
 
 | Area | File | Change |
 |---|---|---|
@@ -318,6 +324,8 @@ pwsh src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/teardown-local-cms.
 
 ## 8. Implementation phases and steps
 
+> **Superseded by §1.2 (R2) for route and OpenAPI content.** This section records the R1 phase plan as executed and is kept as history; §12 carries the outcomes. The R2 patch is a single commit recorded in §12.3.
+
 Each step ends with a local commit, the SHA, an exact file list, and an approve/reject gate.
 
 ### Phase 0 — Spec approval
@@ -385,13 +393,15 @@ Numeric 404 uses `"ApiClient with ID {id} not found."` (matching the reset-crede
 
 ## 11. Decisions (resolved 2026-09-09) and assumptions
 
+> Q1, Q3 and Q4 still stand. Q2 was reversed by the R2 review; see §1.2.
+
 | # | Question | Decision |
 |---|---|---|
 | **Q1** | Authorization for `GET /v3/apiClients/{id:int}`: `MapLimitedAccess` (same as the sibling reads) or `MapSecuredGet` (ReadOnly/Admin only)? | **`MapLimitedAccess`** (§4.4). Matches the existing collection and key-based reads and exposes nothing the limited-access collection route does not already expose. |
-| **Q2** | OpenAPI: keep documenting the `{clientId}` GET as its own path item (accurate, but the pre-existing "same hierarchy, different name" condition remains), or hide it? | **Keep it documented.** Do not hide it. The ambiguity note in §5.2 stays explicit as a deliberate compatibility compromise. |
+| **Q2** | OpenAPI: keep documenting the `{clientId}` GET as its own path item (accurate, but the pre-existing "same hierarchy, different name" condition remains), or hide it? | ~~**Keep it documented.**~~ **Superseded by §1.2 (R2):** review rejected the compromise. The `{clientId}` path item no longer exists, so there is nothing to document or hide. |
 | **Q3** | Should a follow-up Jira ticket be filed now for a unique index on `dmscs.ApiClient.ClientId` (and possibly `ClientUuid`) in both DDL sets, or is a comment on DMS-1343 sufficient? | **Filed as DMS-1529** under DMS-1072, covering `ClientId` and `ClientUuid` with duplicate-data/migration handling for PostgreSQL and MSSQL. No DDL or repository change in DMS-1343. |
 | **Q4** | Numeric 404 detail text: `"ApiClient with ID {id} not found."` (module-consistent) vs. reusing the existing `"ApiClient not found"`? | **`"ApiClient with ID {id} not found."`** for numeric-id 404s. The key-based 404 message is unchanged. |
-| **A1** | Assumption: the constraint-stripped path key `/v3/apiClients/{id}` is what the generator emits for `{id:int}`. | Verified by `It_does_not_leak_route_constraints_into_path_keys` and by the exact-set test. |
+| **A1** | Assumption: the constraint-stripped path key `/v3/apiClients/{id}` is what the generator emits for `{id:int}`. | Verified under R1 by the exact-set test. Moot under R2: the route carries no constraint, and `It_publishes_exactly_one_single_item_get_for_api_clients` now pins the path key. |
 | **A2** | Assumption: no caller relies on `GET /v3/apiClients/<digits>` returning 404. | No such caller found in DMS, CMS, E2E, or docs. |
 | **A3** | Assumption: the spec's `description` text for the GET ("Get search pattern…") is boilerplate and need not be copied verbatim; CMS wording that names the identifier is preferable. | Confirm or supply preferred wording. |
 
@@ -420,7 +430,25 @@ Numeric 404 uses `"ApiClient with ID {id} not found."` (matching the reset-crede
 
 | Ref | Assumption | Evidence |
 |---|---|---|
-| A1 | The generator publishes `{id:int}` under the constraint-free key `/v3/apiClients/{id}` | Confirmed twice: the exact-set failure in Phase 1 named that key, and `It_publishes_the_numeric_get_without_its_route_constraint` asserts no path key contains a colon |
+| A1 | The generator publishes `{id:int}` under the constraint-free key `/v3/apiClients/{id}` | Confirmed twice under R1: the exact-set failure in Phase 1 named that key, and a contract test asserted no path key contains a colon. R2 removed the constraint, and that test was replaced by `It_publishes_exactly_one_single_item_get_for_api_clients` |
 | §10.1 | The constrained and unconstrained templates are not ambiguous | Both routes are exercised in one host across the unit fixtures; no `AmbiguousMatchException` occurred, and each request reached exactly one repository lookup |
 | §4.3 | Non-numeric, out-of-range, zero and negative segments dispatch as the table describes | Pinned by `Given_an_api_client_get_with_a_non_numeric_identifier` and `Given_an_api_client_get_with_a_non_positive_numeric_identifier`, plus E2E scenario 27 |
 | A3 | CMS wording that names the identifier is preferable to the specification's boilerplate description | Reviewer approved the published summaries and descriptions at the Phase 2 gate |
+
+### 12.3 R2 patch (2026-09-10)
+
+Commit `36e8a4b52`, the key-first replacement described in §1.2. Seven files:
+
+| File | Change |
+|---|---|
+| `ApiClientModule.cs` | Two registrations and two handlers replaced by `MapLimitedAccess("/v3/apiClients/{id}", GetByIdentifier)` and one key-first handler |
+| `ApiClientModuleTests.cs` | Eight GET fixtures reworked for key-first, plus the collision fixture that pins a numeric-looking key over a colliding primary key |
+| `ApiClientOpenApiContractTests.cs` | String parameter, single path item, key-first description |
+| `MetadataModuleTests.cs` | Sweep exclusion for this one operation, pinned entry removed, comment rewritten, and `OpenApi_ApiClient_Response_Schemas_Expose_Story_Fields` repointed off the removed `{clientId}` path |
+| `docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md` | Dispatch paragraph restated key-first |
+| this spec | §1.2 amendment, guardrail bullets repointed, superseded banners on §4–§6, §11 Q2 reversed |
+| `ApiClients.feature` | Two comments that described the removed route constraint. No executable step changed |
+
+Verification: `dotnet csharpier check src/config` clean over 435 files; the frontend unit project filtered to `ApiClientModuleTests`, `Given_the_served_openapi_document` and `MetadataModuleTests` passed 225 of 225. Injecting numeric-first precedence into the handler failed nine assertions, including both collision assertions, then the handler was restored and the suite reran green. E2E was not rerun, because the only feature-file edits are comments.
+
+Files from the R1 plan that R2 did not touch: `Tenants.feature` and the design README, both already correct.

--- a/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
+++ b/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
@@ -14,7 +14,7 @@
 | Branch | `DMS-1343` (created from `main` at `ab140a4d5`) |
 | Author | Samuel Lugo (with repository audit) |
 | Date | 2026-09-09 |
-| **Status** | **Approved — 2026-09-09** (reviewer answers to Q1–Q4 recorded in §11; guardrails in §1.1) |
+| **Status** | **Implemented — 2026-09-09.** Phases 1–4 committed (§12); Phase 5 verification and push are human-gated. Approved 2026-09-09 with reviewer answers to Q1–Q4 in §11 and guardrails in §1.1 |
 | Jira decision | Option 1 (replace) is struck through in the ticket. Option 2 (support both identifier styles) is the active direction. |
 | Jira comment (2026-08-18) | `dmscs.ApiClient` has no DB-level unique constraint on `ClientId` or `ClientUuid`; recommends the authoritative external identifier receive a unique index. Tracked as follow-up **DMS-1529** (under DMS-1072). |
 | Pre-existing design doc | None found for DMS-1343 in `reference/` or `docs/` (verified). |
@@ -373,13 +373,30 @@ Numeric 404 uses `"ApiClient with ID {id} not found."` (matching the reset-crede
 
 ---
 
-## 12. Progress (filled during implementation)
+## 12. Progress
 
-| Step | Commit | Files | Status |
+| Step | Commit | Files | Outcome |
 |---|---|---|---|
-| 0.1 | — | this spec | pending approval |
-| 1.1–1.2 | — | | |
-| 2.1–2.3 | — | | |
-| 3.1–3.3 | — | | |
-| 4.1–4.3 | — | | |
-| 5.1–5.2 | — | | |
+| 0.1 | `f54d7f5aa`, `124c7f6fc` | this spec | Approved 2026-09-09 with the §1.1 guardrails; the second commit replaced the docs-phase wording with the exact dispatch rule |
+| 1.1–1.2 | `c6beb368f` | `ApiClientModule.cs`, `ApiClientModuleTests.cs`, `MetadataModuleTests.cs` | Numeric route, `GetById` handler, six new fixtures (19 tests). Full CMS frontend unit project: 1118 passed |
+| 2.1–2.3 | `a8fa8cbe7` | `ApiClientModule.cs`, `ApiClientOpenApiContractTests.cs`, `MetadataModuleTests.cs` | Operation summaries and descriptions, four contract tests, doc-comment rewrite. Full project: 1122 passed |
+| 3.1–3.3 | `08c0dff77` | `ApiClients.feature`, `Tenants.feature` | Scenarios 25–27 and the matched same-URL tenant pair. ApiClients 25 passed; Tenants 4 passed with multi-tenancy enabled |
+| 4.1–4.3 | this commit | `docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md`, `reference/design/configuration-service/README.md`, this spec | Documentation and closeout |
+| 5.1–5.2 | — | — | Final verification and push, human-gated |
+
+### 12.1 Deviations from the plan, and why
+
+1. **The pinned id-parameter set moved from Phase 2 into Phase 1.** Registering the route immediately adds `GET /v3/apiClients/{id}` to the served document, so `OpenApi_Declares_Resource_Identifiers_As_Int32` fails the moment the route exists. The single array entry shipped with the route to keep every commit green; the doc-comment rewrite stayed in Phase 2 as planned.
+2. **The doc comment's route counts were corrected, not just reworded.** It claimed nine item routes and five secondary routes. Enumerating the pinned array gives ten and six. The counts were already stale before this ticket, because this change adds an operation to an existing path rather than a new path. Reviewer confirmed the correction should stand.
+3. **The cross-tenant E2E step gained a positive read.** The planned step asserted only tenant B's `404`, which an unsubstituted `{tenantAClientId}` placeholder would also produce through the client-key route. Tenant A now reads the identical URL and gets `200` first, so the `404` can only come from tenant scoping.
+4. **The Tenants feature ran on PostgreSQL with multi-tenancy enabled.** Its scenarios are `@MultitenantOnly` and skip unless `DMS_CONFIG_MULTI_TENANCY=true` is set on both the stack and the test process. CI runs that lane only against MSSQL. A temporary environment file was used and deleted; no repository environment file changed.
+5. **Q3 produced DMS-1529.** Database-level uniqueness for `dmscs.ApiClient.ClientId` and `ClientUuid` is filed under DMS-1072, including duplicate-data and migration handling for both engines. No DDL or repository change was made here.
+
+### 12.2 Assumptions closed by evidence
+
+| Ref | Assumption | Evidence |
+|---|---|---|
+| A1 | The generator publishes `{id:int}` under the constraint-free key `/v3/apiClients/{id}` | Confirmed twice: the exact-set failure in Phase 1 named that key, and `It_publishes_the_numeric_get_without_its_route_constraint` asserts no path key contains a colon |
+| §10.1 | The constrained and unconstrained templates are not ambiguous | Both routes are exercised in one host across the unit fixtures; no `AmbiguousMatchException` occurred, and each request reached exactly one repository lookup |
+| §4.3 | Non-numeric, out-of-range, zero and negative segments dispatch as the table describes | Pinned by `Given_an_api_client_get_with_a_non_numeric_identifier` and `Given_an_api_client_get_with_a_non_positive_numeric_identifier`, plus E2E scenario 27 |
+| A3 | CMS wording that names the identifier is preferable to the specification's boilerplate description | Reviewer approved the published summaries and descriptions at the Phase 2 gate |

--- a/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
+++ b/reference/design/configuration-service/DMS-1343-apiclient-get-identifier-semantics.md
@@ -209,7 +209,7 @@ Alternative considered: hide the `{clientId}` GET with `.ExcludeFromDescription(
 | CMS OpenAPI tests | `.../Frontend.AspNetCore.Tests.Unit/Modules/ApiClientOpenApiContractTests.cs` | New tests: `{id}` GET parameter is int32 with the numeric description; `{clientId}` GET parameter is string with the key description; no constraint-bearing path key. |
 | CMS E2E | `src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ApiClients.feature` | New scenarios 25–27 (numeric GET 200, numeric 404, digits-plus-letters 404). |
 | CMS E2E | `src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Tenants.feature` | One added step pair in the existing cross-tenant scenario: tenant B `GET /v3/apiClients/{tenantAClientId}` → 404. |
-| Docs | `docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md` | State that GET accepts either identifier; keep the key-based discovery step. |
+| Docs | `docs/API-CLIENT-AND-INSTANCE-CONFIGURATION.md` | State the exact dispatch rule: a valid `int32` path segment is the numeric ApiClient `id`; any other segment is the OAuth `clientId` key. Keep the key-based discovery step. |
 | Docs | `reference/design/configuration-service/README.md` | Link this spec. |
 | Spec | this file | Status/progress updates at each gate. |
 

--- a/reference/design/configuration-service/README.md
+++ b/reference/design/configuration-service/README.md
@@ -6,6 +6,7 @@ API client credentials for the Data Management Service.
 
 Detailed design notes:
 
+* [API Client GET Identifier Semantics (DMS-1343)](./DMS-1343-apiclient-get-identifier-semantics.md)
 * [Authorization in the Configuration Service](./CS-AUTH.md)
 * [Claimset Management](./CLAIMSET-MGMT.md)
 * [Expired Access Token Cleanup](./TOKEN-CLEANUP.md)

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientModuleTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.Json.Nodes;
@@ -4777,123 +4778,49 @@ public class ApiClientModuleTests
     }
 
     /// <summary>
-    /// Shared arrangement for the two single-item GET routes. Both repository lookups are stubbed to
-    /// succeed unless a fixture narrows one of them, so a test asserting that a lookup was never
-    /// reached proves the route dispatch rather than merely a missing stub.
+    /// Shared arrangement for the single-item GET, which resolves one path segment key-first and
+    /// only then by numeric id. Fixtures stub the lookup they are not exercising to a value that
+    /// would change the response if the handler consulted it, so an assertion that a lookup was
+    /// never reached proves the precedence rather than a missing stub.
     /// </summary>
     public abstract class ApiClientGetByIdentifierTestBase : ApiClientModuleTests
     {
         protected const int StoredApiClientId = 7;
         protected const string StoredClientKey = "c86b44f2-a80b-450d-be0c-4ecf43397e03";
 
-        protected static ApiClientResponse StoredApiClient() =>
+        /// <summary>A key made only of digits, which the database permits because ClientId carries
+        /// no format constraint, and which is also a well-formed primary key value.</summary>
+        protected const string NumericClientKey = "12345";
+
+        /// <summary>The row that owns <see cref="NumericClientKey"/> as its client key. Its own
+        /// primary key is deliberately not 12345.</summary>
+        protected const int NumericKeyOwnerId = 42;
+
+        protected static ApiClientResponse ApiClient(int id, string clientId) =>
             new()
             {
-                Id = StoredApiClientId,
+                Id = id,
                 ApplicationId = 3,
-                ClientId = StoredClientKey,
+                ClientId = clientId,
                 ClientUuid = Guid.NewGuid(),
-                Name = "Stored API Client",
+                Name = $"API Client {id}",
                 IsApproved = true,
                 DataStoreIds = [1],
             };
 
-        protected void ArrangeBothLookupsSucceed()
-        {
-            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored))
-                .Returns(new ApiClientGetResult.Success(StoredApiClient()));
-            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
-                .Returns(new ApiClientGetResult.Success(StoredApiClient()));
-        }
+        protected void ArrangeClientKeyLookup(ApiClientGetResult result) =>
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored)).Returns(result);
+
+        protected void ArrangeNumericLookup(ApiClientGetResult result) =>
+            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored)).Returns(result);
+
+        protected void AssertNumericLookupNotReached() =>
+            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored)).MustNotHaveHappened();
     }
 
     // Instance per test case so each test gets its own fakes: NUnit otherwise shares one fixture
     // instance across the fixture, and the request issued in Setup would be recorded once per test
     // method, breaking the call-count assertions below.
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class Given_an_api_client_get_by_numeric_id : ApiClientGetByIdentifierTestBase
-    {
-        private HttpResponseMessage _response = new();
-        private JsonNode _responseBody = JsonNode.Parse("{}")!;
-
-        [SetUp]
-        public async Task Setup()
-        {
-            ArrangeBothLookupsSucceed();
-            using var client = SetUpClient();
-
-            _response = await client.GetAsync($"/v3/apiClients/{StoredApiClientId}");
-            _responseBody = JsonNode.Parse(await _response.Content.ReadAsStringAsync())!;
-        }
-
-        [TearDown]
-        public void DisposeResponse() => _response.Dispose();
-
-        [Test]
-        public void It_returns_the_api_client() => _response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        [Test]
-        public void It_returns_the_client_resolved_by_primary_key() =>
-            _responseBody["id"]!.GetValue<int>().Should().Be(StoredApiClientId);
-
-        [Test]
-        public void It_reads_through_the_numeric_lookup() =>
-            A.CallTo(() => _apiClientRepository.GetApiClientById(StoredApiClientId))
-                .MustHaveHappenedOnceExactly();
-
-        [Test]
-        public void It_does_not_read_through_the_client_key_lookup() =>
-            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
-                .MustNotHaveHappened();
-    }
-
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class Given_an_api_client_get_by_a_numeric_id_that_does_not_exist
-        : ApiClientGetByIdentifierTestBase
-    {
-        private const int MissingApiClientId = 999;
-
-        private HttpResponseMessage _response = new();
-
-        [SetUp]
-        public async Task Setup()
-        {
-            // The client-key lookup is deliberately left succeeding: if a well-formed numeric id
-            // ever fell through to it, this fixture would observe a 200 instead of the 404 below.
-            ArrangeBothLookupsSucceed();
-            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored))
-                .Returns(new ApiClientGetResult.FailureNotFound());
-
-            using var client = SetUpClient();
-            _response = await client.GetAsync($"/v3/apiClients/{MissingApiClientId}");
-        }
-
-        [TearDown]
-        public void DisposeResponse() => _response.Dispose();
-
-        [Test]
-        public async Task It_returns_the_not_found_contract() =>
-            await AssertContract(
-                _response,
-                HttpStatusCode.NotFound,
-                "urn:ed-fi:api:not-found",
-                "Not Found",
-                $"ApiClient with ID {MissingApiClientId} not found."
-            );
-
-        [Test]
-        public void It_reads_through_the_numeric_lookup() =>
-            A.CallTo(() => _apiClientRepository.GetApiClientById(MissingApiClientId))
-                .MustHaveHappenedOnceExactly();
-
-        [Test]
-        public void It_does_not_fall_back_to_the_client_key_lookup() =>
-            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
-                .MustNotHaveHappened();
-    }
-
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class Given_an_api_client_get_by_client_key : ApiClientGetByIdentifierTestBase
@@ -4904,9 +4831,12 @@ public class ApiClientModuleTests
         [SetUp]
         public async Task Setup()
         {
-            ArrangeBothLookupsSucceed();
-            using var client = SetUpClient();
+            ArrangeClientKeyLookup(
+                new ApiClientGetResult.Success(ApiClient(StoredApiClientId, StoredClientKey))
+            );
+            ArrangeNumericLookup(new ApiClientGetResult.Success(ApiClient(99, "other-client-key")));
 
+            using var client = SetUpClient();
             _response = await client.GetAsync($"/v3/apiClients/{StoredClientKey}");
             _responseBody = JsonNode.Parse(await _response.Content.ReadAsStringAsync())!;
         }
@@ -4927,33 +4857,176 @@ public class ApiClientModuleTests
                 .MustHaveHappenedOnceExactly();
 
         [Test]
-        public void It_does_not_read_through_the_numeric_lookup() =>
-            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored)).MustNotHaveHappened();
+        public void It_does_not_reach_the_numeric_lookup() => AssertNumericLookupNotReached();
+    }
+
+    /// <summary>
+    /// The collision this route has to get right: the segment is simultaneously a stored client key
+    /// and a well-formed primary key belonging to a different row. Resolving the primary key first
+    /// would return that unrelated row to a caller who supplied an OAuth client key.
+    /// </summary>
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_whose_client_key_is_also_another_rows_numeric_id
+        : ApiClientGetByIdentifierTestBase
+    {
+        private HttpResponseMessage _response = new();
+        private JsonNode _responseBody = JsonNode.Parse("{}")!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            ArrangeClientKeyLookup(
+                new ApiClientGetResult.Success(ApiClient(NumericKeyOwnerId, NumericClientKey))
+            );
+            ArrangeNumericLookup(new ApiClientGetResult.Success(ApiClient(12345, "a-different-client-key")));
+
+            using var client = SetUpClient();
+            _response = await client.GetAsync($"/v3/apiClients/{NumericClientKey}");
+            _responseBody = JsonNode.Parse(await _response.Content.ReadAsStringAsync())!;
+        }
+
+        [TearDown]
+        public void DisposeResponse() => _response.Dispose();
+
+        [Test]
+        public void It_returns_the_api_client() => _response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        [Test]
+        public void It_returns_the_row_that_owns_the_client_key()
+        {
+            _responseBody["clientId"]!.GetValue<string>().Should().Be(NumericClientKey);
+            _responseBody["id"]!.GetValue<int>().Should().Be(NumericKeyOwnerId);
+        }
+
+        [Test]
+        public void It_does_not_return_the_unrelated_row_whose_primary_key_matches() =>
+            _responseBody["id"]!.GetValue<int>().Should().NotBe(12345);
+
+        [Test]
+        public void It_does_not_reach_the_numeric_lookup() => AssertNumericLookupNotReached();
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_by_numeric_id_when_no_client_key_matches
+        : ApiClientGetByIdentifierTestBase
+    {
+        private HttpResponseMessage _response = new();
+        private JsonNode _responseBody = JsonNode.Parse("{}")!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            ArrangeClientKeyLookup(new ApiClientGetResult.FailureNotFound());
+            ArrangeNumericLookup(
+                new ApiClientGetResult.Success(ApiClient(StoredApiClientId, StoredClientKey))
+            );
+
+            using var client = SetUpClient();
+            _response = await client.GetAsync($"/v3/apiClients/{StoredApiClientId}");
+            _responseBody = JsonNode.Parse(await _response.Content.ReadAsStringAsync())!;
+        }
+
+        [TearDown]
+        public void DisposeResponse() => _response.Dispose();
+
+        [Test]
+        public void It_returns_the_api_client() => _response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        [Test]
+        public void It_returns_the_client_resolved_by_primary_key() =>
+            _responseBody["id"]!.GetValue<int>().Should().Be(StoredApiClientId);
+
+        [Test]
+        public void It_tries_the_client_key_first() =>
+            A.CallTo(() =>
+                    _apiClientRepository.GetApiClientByClientId(
+                        StoredApiClientId.ToString(CultureInfo.InvariantCulture)
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+
+        [Test]
+        public void It_falls_back_to_the_numeric_lookup() =>
+            A.CallTo(() => _apiClientRepository.GetApiClientById(StoredApiClientId))
+                .MustHaveHappenedOnceExactly();
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_by_a_numeric_id_that_does_not_exist
+        : ApiClientGetByIdentifierTestBase
+    {
+        private const int MissingApiClientId = 999;
+
+        private HttpResponseMessage _response = new();
+
+        [SetUp]
+        public async Task Setup()
+        {
+            ArrangeClientKeyLookup(new ApiClientGetResult.FailureNotFound());
+            ArrangeNumericLookup(new ApiClientGetResult.FailureNotFound());
+
+            using var client = SetUpClient();
+            _response = await client.GetAsync($"/v3/apiClients/{MissingApiClientId}");
+        }
+
+        [TearDown]
+        public void DisposeResponse() => _response.Dispose();
+
+        [Test]
+        public async Task It_returns_the_id_bearing_not_found_contract() =>
+            await AssertContract(
+                _response,
+                HttpStatusCode.NotFound,
+                "urn:ed-fi:api:not-found",
+                "Not Found",
+                $"ApiClient with ID {MissingApiClientId} not found."
+            );
+
+        [Test]
+        public void It_consulted_both_lookups()
+        {
+            A.CallTo(() =>
+                    _apiClientRepository.GetApiClientByClientId(
+                        MissingApiClientId.ToString(CultureInfo.InvariantCulture)
+                    )
+                )
+                .MustHaveHappenedOnceExactly();
+            A.CallTo(() => _apiClientRepository.GetApiClientById(MissingApiClientId))
+                .MustHaveHappenedOnceExactly();
+        }
     }
 
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class Given_an_api_client_get_with_a_non_numeric_identifier : ApiClientGetByIdentifierTestBase
     {
-        // Letters, a decimal point, and a value beyond Int32 range all fail the :int route
-        // constraint, so each is an OAuth client key and must never reach the numeric lookup.
+        // Letters, a decimal point, and a value beyond Int32 range are all client keys with no
+        // numeric reading, so the key 404 stands and the numeric lookup is never reached.
         [TestCase("abc")]
         [TestCase("12abc")]
         [TestCase("1.5")]
         [TestCase("99999999999")]
-        public async Task It_resolves_only_through_the_client_key_lookup(string identifier)
+        public async Task It_returns_the_client_key_not_found_contract(string identifier)
         {
-            ArrangeBothLookupsSucceed();
-            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
-                .Returns(new ApiClientGetResult.FailureNotFound());
+            ArrangeClientKeyLookup(new ApiClientGetResult.FailureNotFound());
+            ArrangeNumericLookup(new ApiClientGetResult.Success(ApiClient(12, "unrelated-key")));
 
             using var client = SetUpClient();
             using var response = await client.GetAsync($"/v3/apiClients/{identifier}");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            await AssertContract(
+                response,
+                HttpStatusCode.NotFound,
+                "urn:ed-fi:api:not-found",
+                "Not Found",
+                "ApiClient not found"
+            );
             A.CallTo(() => _apiClientRepository.GetApiClientByClientId(identifier))
                 .MustHaveHappenedOnceExactly();
-            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored)).MustNotHaveHappened();
+            AssertNumericLookupNotReached();
         }
     }
 
@@ -4962,39 +5035,81 @@ public class ApiClientModuleTests
     public class Given_an_api_client_get_with_a_non_positive_numeric_identifier
         : ApiClientGetByIdentifierTestBase
     {
-        // The :int constraint accepts zero and a leading sign, so these are numeric ids that simply
-        // do not exist rather than client keys. Pinning them keeps the dispatch rule unambiguous.
+        // Zero and a leading sign parse as Int32, so these reach the numeric lookup after the key
+        // lookup misses. Pinning them keeps the parse rule from silently narrowing.
         [TestCase("0", 0)]
         [TestCase("-1", -1)]
-        public async Task It_resolves_only_through_the_numeric_lookup(string identifier, int expectedId)
+        public async Task It_falls_back_to_the_numeric_lookup(string identifier, int expectedId)
         {
-            ArrangeBothLookupsSucceed();
-            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored))
-                .Returns(new ApiClientGetResult.FailureNotFound());
+            ArrangeClientKeyLookup(new ApiClientGetResult.FailureNotFound());
+            ArrangeNumericLookup(new ApiClientGetResult.FailureNotFound());
 
             using var client = SetUpClient();
             using var response = await client.GetAsync($"/v3/apiClients/{identifier}");
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(identifier))
+                .MustHaveHappenedOnceExactly();
             A.CallTo(() => _apiClientRepository.GetApiClientById(expectedId)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
-                .MustNotHaveHappened();
         }
     }
 
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class Given_an_api_client_get_by_numeric_id_whose_lookup_fails : ApiClientGetByIdentifierTestBase
+    public class Given_an_api_client_get_whose_client_key_lookup_fails : ApiClientGetByIdentifierTestBase
     {
-        private const string Sentinel = "SENTINEL_APICLIENT_GET_BY_ID_must_not_leak";
+        private const string Sentinel = "SENTINEL_APICLIENT_KEY_LOOKUP_must_not_leak";
 
         private HttpResponseMessage _response = new();
 
         [SetUp]
         public async Task Setup()
         {
-            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored))
-                .Returns(new ApiClientGetResult.FailureUnknown(Sentinel));
+            ArrangeClientKeyLookup(new ApiClientGetResult.FailureUnknown(Sentinel));
+            // Arranged to succeed: an unknown backend state must not be treated as an absent row,
+            // so a numeric-looking segment must still not fall through to this lookup.
+            ArrangeNumericLookup(
+                new ApiClientGetResult.Success(ApiClient(StoredApiClientId, StoredClientKey))
+            );
+
+            using var client = SetUpClient();
+            _response = await client.GetAsync($"/v3/apiClients/{StoredApiClientId}");
+        }
+
+        [TearDown]
+        public void DisposeResponse() => _response.Dispose();
+
+        [Test]
+        public async Task It_returns_the_internal_server_error_contract() =>
+            await AssertContract(
+                _response,
+                HttpStatusCode.InternalServerError,
+                "urn:ed-fi:api:internal-server-error",
+                "Internal Server Error",
+                ""
+            );
+
+        [Test]
+        public async Task It_does_not_leak_the_repository_failure_message() =>
+            (await _response.Content.ReadAsStringAsync()).Should().NotContain(Sentinel);
+
+        [Test]
+        public void It_does_not_fall_through_to_the_numeric_lookup() => AssertNumericLookupNotReached();
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_whose_numeric_lookup_fails : ApiClientGetByIdentifierTestBase
+    {
+        private const string Sentinel = "SENTINEL_APICLIENT_ID_LOOKUP_must_not_leak";
+
+        private HttpResponseMessage _response = new();
+
+        [SetUp]
+        public async Task Setup()
+        {
+            ArrangeClientKeyLookup(new ApiClientGetResult.FailureNotFound());
+            ArrangeNumericLookup(new ApiClientGetResult.FailureUnknown(Sentinel));
 
             using var client = SetUpClient();
             _response = await client.GetAsync($"/v3/apiClients/{StoredApiClientId}");

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientModuleTests.cs
@@ -294,6 +294,7 @@ public class ApiClientModuleTests
 
             var getAllResponse = await client.GetAsync("/v3/apiClients?offset=0&limit=25");
             var getByClientIdResponse = await client.GetAsync("/v3/apiClients/test-client-id");
+            var getByIdResponse = await client.GetAsync("/v3/apiClients/1");
 
             var updateResponse = await client.PutAsync(
                 "/v3/apiClients/1",
@@ -318,6 +319,7 @@ public class ApiClientModuleTests
             insertResponse.StatusCode.Should().Be(HttpStatusCode.Created);
             getAllResponse.StatusCode.Should().Be(HttpStatusCode.OK);
             getByClientIdResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            getByIdResponse.StatusCode.Should().Be(HttpStatusCode.OK);
             updateResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
             deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
         }
@@ -4772,5 +4774,247 @@ public class ApiClientModuleTests
             A.CallTo(() => _apiClientRepository.UpdateApiClient(A<ApiClientUpdateCommand>.Ignored))
                 .MustNotHaveHappened();
         }
+    }
+
+    /// <summary>
+    /// Shared arrangement for the two single-item GET routes. Both repository lookups are stubbed to
+    /// succeed unless a fixture narrows one of them, so a test asserting that a lookup was never
+    /// reached proves the route dispatch rather than merely a missing stub.
+    /// </summary>
+    public abstract class ApiClientGetByIdentifierTestBase : ApiClientModuleTests
+    {
+        protected const int StoredApiClientId = 7;
+        protected const string StoredClientKey = "c86b44f2-a80b-450d-be0c-4ecf43397e03";
+
+        protected static ApiClientResponse StoredApiClient() =>
+            new()
+            {
+                Id = StoredApiClientId,
+                ApplicationId = 3,
+                ClientId = StoredClientKey,
+                ClientUuid = Guid.NewGuid(),
+                Name = "Stored API Client",
+                IsApproved = true,
+                DataStoreIds = [1],
+            };
+
+        protected void ArrangeBothLookupsSucceed()
+        {
+            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored))
+                .Returns(new ApiClientGetResult.Success(StoredApiClient()));
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
+                .Returns(new ApiClientGetResult.Success(StoredApiClient()));
+        }
+    }
+
+    // Instance per test case so each test gets its own fakes: NUnit otherwise shares one fixture
+    // instance across the fixture, and the request issued in Setup would be recorded once per test
+    // method, breaking the call-count assertions below.
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_by_numeric_id : ApiClientGetByIdentifierTestBase
+    {
+        private HttpResponseMessage _response = new();
+        private JsonNode _responseBody = JsonNode.Parse("{}")!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            ArrangeBothLookupsSucceed();
+            using var client = SetUpClient();
+
+            _response = await client.GetAsync($"/v3/apiClients/{StoredApiClientId}");
+            _responseBody = JsonNode.Parse(await _response.Content.ReadAsStringAsync())!;
+        }
+
+        [TearDown]
+        public void DisposeResponse() => _response.Dispose();
+
+        [Test]
+        public void It_returns_the_api_client() => _response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        [Test]
+        public void It_returns_the_client_resolved_by_primary_key() =>
+            _responseBody["id"]!.GetValue<int>().Should().Be(StoredApiClientId);
+
+        [Test]
+        public void It_reads_through_the_numeric_lookup() =>
+            A.CallTo(() => _apiClientRepository.GetApiClientById(StoredApiClientId))
+                .MustHaveHappenedOnceExactly();
+
+        [Test]
+        public void It_does_not_read_through_the_client_key_lookup() =>
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
+                .MustNotHaveHappened();
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_by_a_numeric_id_that_does_not_exist
+        : ApiClientGetByIdentifierTestBase
+    {
+        private const int MissingApiClientId = 999;
+
+        private HttpResponseMessage _response = new();
+
+        [SetUp]
+        public async Task Setup()
+        {
+            // The client-key lookup is deliberately left succeeding: if a well-formed numeric id
+            // ever fell through to it, this fixture would observe a 200 instead of the 404 below.
+            ArrangeBothLookupsSucceed();
+            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored))
+                .Returns(new ApiClientGetResult.FailureNotFound());
+
+            using var client = SetUpClient();
+            _response = await client.GetAsync($"/v3/apiClients/{MissingApiClientId}");
+        }
+
+        [TearDown]
+        public void DisposeResponse() => _response.Dispose();
+
+        [Test]
+        public async Task It_returns_the_not_found_contract() =>
+            await AssertContract(
+                _response,
+                HttpStatusCode.NotFound,
+                "urn:ed-fi:api:not-found",
+                "Not Found",
+                $"ApiClient with ID {MissingApiClientId} not found."
+            );
+
+        [Test]
+        public void It_reads_through_the_numeric_lookup() =>
+            A.CallTo(() => _apiClientRepository.GetApiClientById(MissingApiClientId))
+                .MustHaveHappenedOnceExactly();
+
+        [Test]
+        public void It_does_not_fall_back_to_the_client_key_lookup() =>
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
+                .MustNotHaveHappened();
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_by_client_key : ApiClientGetByIdentifierTestBase
+    {
+        private HttpResponseMessage _response = new();
+        private JsonNode _responseBody = JsonNode.Parse("{}")!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            ArrangeBothLookupsSucceed();
+            using var client = SetUpClient();
+
+            _response = await client.GetAsync($"/v3/apiClients/{StoredClientKey}");
+            _responseBody = JsonNode.Parse(await _response.Content.ReadAsStringAsync())!;
+        }
+
+        [TearDown]
+        public void DisposeResponse() => _response.Dispose();
+
+        [Test]
+        public void It_returns_the_api_client() => _response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        [Test]
+        public void It_returns_the_client_resolved_by_client_key() =>
+            _responseBody["clientId"]!.GetValue<string>().Should().Be(StoredClientKey);
+
+        [Test]
+        public void It_reads_through_the_client_key_lookup() =>
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(StoredClientKey))
+                .MustHaveHappenedOnceExactly();
+
+        [Test]
+        public void It_does_not_read_through_the_numeric_lookup() =>
+            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored)).MustNotHaveHappened();
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_with_a_non_numeric_identifier : ApiClientGetByIdentifierTestBase
+    {
+        // Letters, a decimal point, and a value beyond Int32 range all fail the :int route
+        // constraint, so each is an OAuth client key and must never reach the numeric lookup.
+        [TestCase("abc")]
+        [TestCase("12abc")]
+        [TestCase("1.5")]
+        [TestCase("99999999999")]
+        public async Task It_resolves_only_through_the_client_key_lookup(string identifier)
+        {
+            ArrangeBothLookupsSucceed();
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
+                .Returns(new ApiClientGetResult.FailureNotFound());
+
+            using var client = SetUpClient();
+            using var response = await client.GetAsync($"/v3/apiClients/{identifier}");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(identifier))
+                .MustHaveHappenedOnceExactly();
+            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored)).MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_with_a_non_positive_numeric_identifier
+        : ApiClientGetByIdentifierTestBase
+    {
+        // The :int constraint accepts zero and a leading sign, so these are numeric ids that simply
+        // do not exist rather than client keys. Pinning them keeps the dispatch rule unambiguous.
+        [TestCase("0", 0)]
+        [TestCase("-1", -1)]
+        public async Task It_resolves_only_through_the_numeric_lookup(string identifier, int expectedId)
+        {
+            ArrangeBothLookupsSucceed();
+            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored))
+                .Returns(new ApiClientGetResult.FailureNotFound());
+
+            using var client = SetUpClient();
+            using var response = await client.GetAsync($"/v3/apiClients/{identifier}");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            A.CallTo(() => _apiClientRepository.GetApiClientById(expectedId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _apiClientRepository.GetApiClientByClientId(A<string>.Ignored))
+                .MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class Given_an_api_client_get_by_numeric_id_whose_lookup_fails : ApiClientGetByIdentifierTestBase
+    {
+        private const string Sentinel = "SENTINEL_APICLIENT_GET_BY_ID_must_not_leak";
+
+        private HttpResponseMessage _response = new();
+
+        [SetUp]
+        public async Task Setup()
+        {
+            A.CallTo(() => _apiClientRepository.GetApiClientById(A<int>.Ignored))
+                .Returns(new ApiClientGetResult.FailureUnknown(Sentinel));
+
+            using var client = SetUpClient();
+            _response = await client.GetAsync($"/v3/apiClients/{StoredApiClientId}");
+        }
+
+        [TearDown]
+        public void DisposeResponse() => _response.Dispose();
+
+        [Test]
+        public async Task It_returns_the_internal_server_error_contract() =>
+            await AssertContract(
+                _response,
+                HttpStatusCode.InternalServerError,
+                "urn:ed-fi:api:internal-server-error",
+                "Internal Server Error",
+                ""
+            );
+
+        [Test]
+        public async Task It_does_not_leak_the_repository_failure_message() =>
+            (await _response.Content.ReadAsStringAsync()).Should().NotContain(Sentinel);
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientOpenApiContractTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientOpenApiContractTests.cs
@@ -60,6 +60,13 @@ public class Given_the_served_openapi_document
                 && parameter["in"]!.GetValue<string>() == "path"
             )!;
 
+    /// <summary>True for the single-item apiClient path itself, excluding sub-resource paths such
+    /// as the ownership and reset-credential routes.</summary>
+    private static bool IsApiClientItemPath(string path) =>
+        path.StartsWith("/v3/apiClients/", StringComparison.Ordinal)
+        && path.EndsWith('}')
+        && !path["/v3/apiClients/".Length..].Contains('/');
+
     [Test]
     public void It_documents_the_insert_data_store_ids_as_optional_with_empty_allowed()
     {
@@ -130,48 +137,47 @@ public class Given_the_served_openapi_document
     }
 
     [Test]
-    public void It_declares_the_numeric_api_client_get_id_parameter_as_int32()
+    public void It_declares_the_api_client_get_id_parameter_as_a_string()
     {
-        // The Management API specification models this route's identifier as integer/int32. The
-        // generator infers that from the int handler parameter behind the {id:int} constraint.
+        // One route now carries both identifier forms, so the published parameter is the raw
+        // segment. PUT and DELETE on this same path keep their int32 id, which is deliberate:
+        // they accept only the numeric identifier.
         JsonNode parameter = GetPathParameter("/v3/apiClients/{id}", "id");
-
-        parameter["required"]!.GetValue<bool>().Should().BeTrue();
-        parameter["schema"]!["type"]!.GetValue<string>().Should().Be("integer");
-        parameter["schema"]!["format"]!.GetValue<string>().Should().Be("int32");
-    }
-
-    [Test]
-    public void It_declares_the_client_key_api_client_get_parameter_as_a_string()
-    {
-        JsonNode parameter = GetPathParameter("/v3/apiClients/{clientId}", "clientId");
 
         parameter["required"]!.GetValue<bool>().Should().BeTrue();
         parameter["schema"]!["type"]!.GetValue<string>().Should().Be("string");
     }
 
     [Test]
-    public void It_describes_which_identifier_each_api_client_get_takes()
+    public void It_publishes_exactly_one_single_item_get_for_api_clients()
     {
-        // The two single-item GETs share a path hierarchy and differ only by parameter name, so the
-        // published text is what tells a reader which identifier each one resolves.
-        JsonNode numericGet = SingleItemGetOperation("/v3/apiClients/{id}");
-        JsonNode clientKeyGet = SingleItemGetOperation("/v3/apiClients/{clientId}");
+        // Two templated paths that differ only by parameter name are the same path to OpenAPI, and
+        // a generator may deduplicate them arbitrarily. Only one item path may carry a get.
+        List<string> singleItemGetPaths =
+        [
+            .. _document["paths"]!
+                .AsObject()
+                .Where(path => path.Value!["get"] is not null && IsApiClientItemPath(path.Key))
+                .Select(path => path.Key),
+        ];
 
-        numericGet["summary"]!.GetValue<string>().Should().Contain("numeric identifier");
-        numericGet["description"]!.GetValue<string>().Should().Contain("not a valid 32-bit integer");
-        clientKeyGet["summary"]!.GetValue<string>().Should().Contain("OAuth client key");
-        clientKeyGet["description"]!.GetValue<string>().Should().Contain("is a valid 32-bit integer");
+        singleItemGetPaths.Should().Equal("/v3/apiClients/{id}");
     }
 
     [Test]
-    public void It_publishes_the_numeric_get_without_its_route_constraint()
+    public void It_documents_the_key_first_identifier_dispatch()
     {
-        // The route is registered as {id:int}. The document must key the operation under the
-        // constraint-free path the specification names, with no separate /v3/apiClients/{id:int}.
-        List<string> pathKeys = [.. _document["paths"]!.AsObject().Select(path => path.Key)];
+        // The segment is ambiguous by construction, so the published text is the only place a
+        // reader learns which identifier wins when both could match.
+        JsonNode operation = SingleItemGetOperation("/v3/apiClients/{id}");
+        string summary = operation["summary"]!.GetValue<string>();
+        string description = operation["description"]!.GetValue<string>();
 
-        pathKeys.Should().Contain("/v3/apiClients/{id}");
-        pathKeys.Should().OnlyContain(key => !key.Contains(':'));
+        summary.Should().Contain("OAuth client key");
+        summary.Should().Contain("numeric identifier");
+        description.Should().Contain("key-first");
+        description.Should().Contain("wins whenever it exists");
+        description.Should().Contain("Only when no client key matches");
+        description.Should().Contain("32-bit integer");
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientOpenApiContractTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientOpenApiContractTests.cs
@@ -50,6 +50,16 @@ public class Given_the_served_openapi_document
     private JsonNode RequestBodyExample(string path, string method) =>
         _document["paths"]![path]![method]!["requestBody"]!["content"]!["application/json"]!["example"]!;
 
+    private JsonNode SingleItemGetOperation(string path) => _document["paths"]![path]!["get"]!;
+
+    private JsonNode GetPathParameter(string path, string parameterName) =>
+        SingleItemGetOperation(path)["parameters"]!
+            .AsArray()
+            .Single(parameter =>
+                parameter!["name"]!.GetValue<string>() == parameterName
+                && parameter["in"]!.GetValue<string>() == "path"
+            )!;
+
     [Test]
     public void It_documents_the_insert_data_store_ids_as_optional_with_empty_allowed()
     {
@@ -117,5 +127,51 @@ public class Given_the_served_openapi_document
     public void It_publishes_an_empty_data_store_assignment_example(string path, string method)
     {
         RequestBodyExample(path, method)["dataStoreIds"]!.AsArray().Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_declares_the_numeric_api_client_get_id_parameter_as_int32()
+    {
+        // The Management API specification models this route's identifier as integer/int32. The
+        // generator infers that from the int handler parameter behind the {id:int} constraint.
+        JsonNode parameter = GetPathParameter("/v3/apiClients/{id}", "id");
+
+        parameter["required"]!.GetValue<bool>().Should().BeTrue();
+        parameter["schema"]!["type"]!.GetValue<string>().Should().Be("integer");
+        parameter["schema"]!["format"]!.GetValue<string>().Should().Be("int32");
+    }
+
+    [Test]
+    public void It_declares_the_client_key_api_client_get_parameter_as_a_string()
+    {
+        JsonNode parameter = GetPathParameter("/v3/apiClients/{clientId}", "clientId");
+
+        parameter["required"]!.GetValue<bool>().Should().BeTrue();
+        parameter["schema"]!["type"]!.GetValue<string>().Should().Be("string");
+    }
+
+    [Test]
+    public void It_describes_which_identifier_each_api_client_get_takes()
+    {
+        // The two single-item GETs share a path hierarchy and differ only by parameter name, so the
+        // published text is what tells a reader which identifier each one resolves.
+        JsonNode numericGet = SingleItemGetOperation("/v3/apiClients/{id}");
+        JsonNode clientKeyGet = SingleItemGetOperation("/v3/apiClients/{clientId}");
+
+        numericGet["summary"]!.GetValue<string>().Should().Contain("numeric identifier");
+        numericGet["description"]!.GetValue<string>().Should().Contain("not a valid 32-bit integer");
+        clientKeyGet["summary"]!.GetValue<string>().Should().Contain("OAuth client key");
+        clientKeyGet["description"]!.GetValue<string>().Should().Contain("is a valid 32-bit integer");
+    }
+
+    [Test]
+    public void It_publishes_the_numeric_get_without_its_route_constraint()
+    {
+        // The route is registered as {id:int}. The document must key the operation under the
+        // constraint-free path the specification names, with no separate /v3/apiClients/{id:int}.
+        List<string> pathKeys = [.. _document["paths"]!.AsObject().Select(path => path.Key)];
+
+        pathKeys.Should().Contain("/v3/apiClients/{id}");
+        pathKeys.Should().OnlyContain(key => !key.Contains(':'));
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
@@ -42,10 +42,10 @@ public class MetadataModuleTests
     /// operation regressing to int64 fails it as well.
     /// The entries span ten item routes and the six secondary routes that carry the same identifier;
     /// a path contributes one entry per operation, so several paths appear more than once.
-    /// DMS-1343 added GET /v3/apiClients/{id}, which the generator publishes as a further operation
-    /// on the existing item path rather than as a new path, because it strips the :int route
-    /// constraint from the key. The separate /v3/apiClients/{clientId} GET resolves the OAuth client
-    /// key, declares a string parameter, and is excluded by the "id" name filter.
+    /// One operation is deliberately absent. GET /v3/apiClients/{id} accepts either identifier and
+    /// resolves the OAuth client key first, so its id parameter is a string and the sweep skips it;
+    /// ApiClientOpenApiContractTests pins that parameter as a string instead. PUT and DELETE on the
+    /// same path keep their int32 id, which is why the path still appears below.
     /// /v3/tenants/{id} is out of scope and only appears when multi-tenancy is enabled - it is pinned
     /// as int64 by It_should_declare_the_out_of_scope_tenant_id_path_parameter_as_int64.
     /// </summary>
@@ -59,7 +59,6 @@ public class MetadataModuleTests
         "PUT /v3/applications/{id} int32",
         "DELETE /v3/applications/{id} int32",
         "PUT /v3/applications/{id}/reset-credential int32",
-        "GET /v3/apiClients/{id} int32",
         "PUT /v3/apiClients/{id} int32",
         "DELETE /v3/apiClients/{id} int32",
         "PUT /v3/apiClients/{id}/reset-credential int32",
@@ -211,6 +210,13 @@ public class MetadataModuleTests
             foreach (var operation in path.Value.EnumerateObject())
             {
                 if (!HttpMethodNames.Contains(operation.Name))
+                {
+                    continue;
+                }
+
+                // DMS-1343: this GET takes either identifier and resolves the client key first, so
+                // its id parameter is a string by design rather than a regression to be caught here.
+                if (operation.Name == "get" && path.Name.TrimEnd('/') == "/v3/apiClients/{id}")
                 {
                     continue;
                 }
@@ -645,10 +651,10 @@ public class MetadataModuleTests
         var postProperties = ResolveJsonResponseSchemaProperties(doc, pathItem, "post", "201");
         postProperties.Should().ContainKeys("applicationId", "name", "key", "secret");
 
-        var apiClientByIdPath = "/v3/apiClients/{clientId}".TrimEnd('/').ToLowerInvariant();
+        var apiClientByIdPath = "/v3/apiClients/{id}".TrimEnd('/').ToLowerInvariant();
         pathMap
             .Should()
-            .ContainKey(apiClientByIdPath, "path /v3/apiClients/{clientId} should exist in OpenAPI spec");
+            .ContainKey(apiClientByIdPath, "path /v3/apiClients/{id} should exist in OpenAPI spec");
         var pathItemById = pathMap[apiClientByIdPath];
 
         var getByIdProperties = ResolveJsonResponseSchemaProperties(doc, pathItemById, "get", "200");

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
@@ -55,6 +55,7 @@ public class MetadataModuleTests
         "PUT /v3/applications/{id} int32",
         "DELETE /v3/applications/{id} int32",
         "PUT /v3/applications/{id}/reset-credential int32",
+        "GET /v3/apiClients/{id} int32",
         "PUT /v3/apiClients/{id} int32",
         "DELETE /v3/apiClients/{id} int32",
         "PUT /v3/apiClients/{id}/reset-credential int32",

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
@@ -40,8 +40,12 @@ public class MetadataModuleTests
     /// int32, so all of them are int32. Asserted as an exact set: the sweep cannot pass trivially on
     /// an empty document, a route disappearing from the document fails the test, and a single
     /// operation regressing to int64 fails it as well.
-    /// The nine item routes are joined by five secondary routes that carry the same identifier.
-    /// /v3/apiClients/{clientId} is a string parameter and is excluded by the "id" name filter.
+    /// The entries span ten item routes and the six secondary routes that carry the same identifier;
+    /// a path contributes one entry per operation, so several paths appear more than once.
+    /// DMS-1343 added GET /v3/apiClients/{id}, which the generator publishes as a further operation
+    /// on the existing item path rather than as a new path, because it strips the :int route
+    /// constraint from the key. The separate /v3/apiClients/{clientId} GET resolves the OAuth client
+    /// key, declares a string parameter, and is excluded by the "id" name filter.
     /// /v3/tenants/{id} is out of scope and only appears when multi-tenancy is enabled - it is pinned
     /// as int64 by It_should_declare_the_out_of_scope_tenant_id_path_parameter_as_int64.
     /// </summary>

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
@@ -71,6 +71,10 @@ public class ApiClientModule : IEndpointModule
             .Produces<ApiClientCredentialsResponse>(200);
         // Limited access endpoints - accessible by service accounts for internal DMS operations
         endpoints.MapLimitedAccess("/v3/apiClients/", GetAll).Produces<List<ApiClientResponse>>(200);
+        // A path segment that parses as an Int32 is the numeric ApiClient id. The route constraint
+        // gives this registration precedence over the client-key route below, so any other segment
+        // (letters, decimals, or digits outside Int32 range) still resolves as an OAuth client key.
+        endpoints.MapLimitedAccess("/v3/apiClients/{id:int}", GetById).Produces<ApiClientResponse>(200);
         endpoints
             .MapLimitedAccess("/v3/apiClients/{clientId}", GetByClientId)
             .Produces<ApiClientResponse>(200);
@@ -289,6 +293,30 @@ public class ApiClientModule : IEndpointModule
         return getResult switch
         {
             ApiClientQueryResult.Success success => Results.Ok(success.ApiClientResponses),
+            _ => FailureResults.Unknown(httpContext.TraceIdentifier),
+        };
+    }
+
+    /// <summary>
+    /// Resolves an ApiClient by its numeric primary key, which is the identifier the Management API
+    /// specification models for this route. Reuses the same tenant-scoped repository read that the
+    /// update, delete, and reset-credential workflows already perform. A path segment that is not a
+    /// valid Int32 never reaches here; it is routed to <see cref="GetByClientId"/> instead.
+    /// </summary>
+    private static async Task<IResult> GetById(
+        int id,
+        HttpContext httpContext,
+        IApiClientRepository apiClientRepository
+    )
+    {
+        ApiClientGetResult getResult = await apiClientRepository.GetApiClientById(id);
+        return getResult switch
+        {
+            ApiClientGetResult.Success success => Results.Ok(success.ApiClientResponse),
+            ApiClientGetResult.FailureNotFound => FailureResults.NotFound(
+                $"ApiClient with ID {id} not found.",
+                httpContext.TraceIdentifier
+            ),
             _ => FailureResults.Unknown(httpContext.TraceIdentifier),
         };
     }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Globalization;
 using System.Net;
 using System.Text.Json.Nodes;
 using EdFi.DmsConfigurationService.Backend;
@@ -71,27 +72,21 @@ public class ApiClientModule : IEndpointModule
             .Produces<ApiClientCredentialsResponse>(200);
         // Limited access endpoints - accessible by service accounts for internal DMS operations
         endpoints.MapLimitedAccess("/v3/apiClients/", GetAll).Produces<List<ApiClientResponse>>(200);
-        // A path segment that parses as an Int32 is the numeric ApiClient id. The route constraint
-        // gives this registration precedence over the client-key route below, so any other segment
-        // (letters, decimals, or digits outside Int32 range) still resolves as an OAuth client key.
+        // One route carries both identifier forms. The OAuth client key is resolved first and wins
+        // outright, because ClientId has no format constraint: a stored key of "12345" is possible
+        // and must never be shadowed by the unrelated row whose primary key is 12345. Registering a
+        // second templated path here would also collide in OpenAPI, where two paths differing only
+        // by parameter name are the same path.
         endpoints
-            .MapLimitedAccess("/v3/apiClients/{id:int}", GetById)
+            .MapLimitedAccess("/v3/apiClients/{id}", GetByIdentifier)
             .Produces<ApiClientResponse>(200)
-            .WithSummary("Retrieves a specific apiClient based on its numeric identifier.")
+            .WithSummary("Retrieves a specific apiClient by OAuth client key or by numeric identifier.")
             .WithDescription(
-                "The path segment is the numeric ApiClient identifier, the value returned as 'id' in "
-                    + "apiClient responses. A segment that is not a valid 32-bit integer is treated as "
-                    + "an OAuth client key and is served by GET /v3/apiClients/{clientId} instead."
-            );
-        endpoints
-            .MapLimitedAccess("/v3/apiClients/{clientId}", GetByClientId)
-            .Produces<ApiClientResponse>(200)
-            .WithSummary("Retrieves a specific apiClient based on its OAuth client key.")
-            .WithDescription(
-                "The path segment is the OAuth client key, the value returned as 'clientId' in "
-                    + "apiClient responses and as 'key' when credentials are issued. A segment that is "
-                    + "a valid 32-bit integer is treated as the numeric identifier and is served by "
-                    + "GET /v3/apiClients/{id} instead."
+                "The path segment is resolved key-first. It is matched against the OAuth client key "
+                    + "('clientId' in responses, 'key' when credentials are issued), and that match "
+                    + "wins whenever it exists. Only when no client key matches, and the segment is a "
+                    + "valid 32-bit integer, is it resolved as the numeric ApiClient identifier ('id' "
+                    + "in responses)."
             );
     }
 
@@ -313,41 +308,51 @@ public class ApiClientModule : IEndpointModule
     }
 
     /// <summary>
-    /// Resolves an ApiClient by its numeric primary key, which is the identifier the Management API
-    /// specification models for this route. Reuses the same tenant-scoped repository read that the
-    /// update, delete, and reset-credential workflows already perform. A path segment that is not a
-    /// valid Int32 never reaches here; it is routed to <see cref="GetByClientId"/> instead.
+    /// Resolves an ApiClient from a single path segment that may carry either identifier the
+    /// Management API models: the OAuth client key or the numeric primary key.
+    ///
+    /// The client key is resolved first and wins outright. ClientId is stored as a variable-length
+    /// string with no format constraint, so a key such as "12345" is possible even though CMS issues
+    /// GUID keys, and resolving the numeric primary key first would hand that caller an unrelated
+    /// row. The numeric lookup runs only after the key lookup reports the row absent, and reuses the
+    /// same tenant-scoped read that update, delete, and reset-credential perform.
+    ///
+    /// A failed lookup at either stage is an unknown backend state rather than an absent row, so it
+    /// is reported as a sanitized 500 and never falls through to the other lookup.
     /// </summary>
-    private static async Task<IResult> GetById(
-        int id,
+    private static async Task<IResult> GetByIdentifier(
+        string id,
         HttpContext httpContext,
         IApiClientRepository apiClientRepository
     )
     {
-        ApiClientGetResult getResult = await apiClientRepository.GetApiClientById(id);
-        return getResult switch
-        {
-            ApiClientGetResult.Success success => Results.Ok(success.ApiClientResponse),
-            ApiClientGetResult.FailureNotFound => FailureResults.NotFound(
-                $"ApiClient with ID {id} not found.",
-                httpContext.TraceIdentifier
-            ),
-            _ => FailureResults.Unknown(httpContext.TraceIdentifier),
-        };
-    }
+        ApiClientGetResult byClientId = await apiClientRepository.GetApiClientByClientId(id);
 
-    private static async Task<IResult> GetByClientId(
-        string clientId,
-        HttpContext httpContext,
-        IApiClientRepository apiClientRepository
-    )
-    {
-        ApiClientGetResult getResult = await apiClientRepository.GetApiClientByClientId(clientId);
-        return getResult switch
+        if (byClientId is ApiClientGetResult.Success clientKeyMatch)
         {
-            ApiClientGetResult.Success success => Results.Ok(success.ApiClientResponse),
+            return Results.Ok(clientKeyMatch.ApiClientResponse);
+        }
+
+        if (byClientId is not ApiClientGetResult.FailureNotFound)
+        {
+            return FailureResults.Unknown(httpContext.TraceIdentifier);
+        }
+
+        // IntRouteConstraint's parse rules, so the segments treated as numeric are exactly those the
+        // separate {id:int} route accepted before the two routes became one.
+        if (!int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out int numericId))
+        {
+            return FailureResults.NotFound("ApiClient not found", httpContext.TraceIdentifier);
+        }
+
+        ApiClientGetResult byId = await apiClientRepository.GetApiClientById(numericId);
+        return byId switch
+        {
+            ApiClientGetResult.Success primaryKeyMatch => Results.Ok(primaryKeyMatch.ApiClientResponse),
+            // The parsed value rather than the raw segment: it matches the message the other numeric
+            // routes emit and keeps caller-supplied text out of the response body.
             ApiClientGetResult.FailureNotFound => FailureResults.NotFound(
-                "ApiClient not found",
+                $"ApiClient with ID {numericId} not found.",
                 httpContext.TraceIdentifier
             ),
             _ => FailureResults.Unknown(httpContext.TraceIdentifier),

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
@@ -74,10 +74,25 @@ public class ApiClientModule : IEndpointModule
         // A path segment that parses as an Int32 is the numeric ApiClient id. The route constraint
         // gives this registration precedence over the client-key route below, so any other segment
         // (letters, decimals, or digits outside Int32 range) still resolves as an OAuth client key.
-        endpoints.MapLimitedAccess("/v3/apiClients/{id:int}", GetById).Produces<ApiClientResponse>(200);
+        endpoints
+            .MapLimitedAccess("/v3/apiClients/{id:int}", GetById)
+            .Produces<ApiClientResponse>(200)
+            .WithSummary("Retrieves a specific apiClient based on its numeric identifier.")
+            .WithDescription(
+                "The path segment is the numeric ApiClient identifier, the value returned as 'id' in "
+                    + "apiClient responses. A segment that is not a valid 32-bit integer is treated as "
+                    + "an OAuth client key and is served by GET /v3/apiClients/{clientId} instead."
+            );
         endpoints
             .MapLimitedAccess("/v3/apiClients/{clientId}", GetByClientId)
-            .Produces<ApiClientResponse>(200);
+            .Produces<ApiClientResponse>(200)
+            .WithSummary("Retrieves a specific apiClient based on its OAuth client key.")
+            .WithDescription(
+                "The path segment is the OAuth client key, the value returned as 'clientId' in "
+                    + "apiClient responses and as 'key' when credentials are issued. A segment that is "
+                    + "a valid 32-bit integer is treated as the numeric identifier and is served by "
+                    + "GET /v3/apiClients/{id} instead."
+            );
     }
 
     /// <summary>

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ApiClients.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ApiClients.feature
@@ -1074,9 +1074,9 @@ Feature: ApiClients endpoints
                   }
                   """
 
-        # Scenarios 25 onward cover the numeric-id lookup added by DMS-1343. A path segment that is
-        # a valid 32-bit integer resolves the ApiClient primary key; any other segment stays on the
-        # OAuth client-key lookup.
+        # Scenarios 25 onward cover the numeric-id lookup added by DMS-1343. The single-item GET
+        # resolves the OAuth client key first; only when no key matches and the segment is a valid
+        # 32-bit integer does it fall back to the ApiClient primary key.
         @MssqlRepresentative
         Scenario: 25 Ensure clients can GET apiClient by numeric id
             Given a POST request is made to "/v3/applications" with
@@ -1139,7 +1139,7 @@ Feature: ApiClients endpoints
              Then it should respond with 404
 
         Scenario: 27 Verify an identifier that is not a valid integer stays on the client-key lookup
-              # Digits followed by letters fail the route constraint, so this is read as a client
-              # key that does not exist rather than as the numeric id 12.
+              # The value is resolved as a client key first and does not exist. It is not a valid
+              # 32-bit integer either, so there is no numeric fallback and the key 404 stands.
              When a GET request is made to "/v3/apiClients/12abc-not-a-client-key"
              Then it should respond with 404

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ApiClients.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ApiClients.feature
@@ -1073,3 +1073,73 @@ Feature: ApiClients endpoints
                     "dataStoreIds": [{dataStoreId}]
                   }
                   """
+
+        # Scenarios 25 onward cover the numeric-id lookup added by DMS-1343. A path segment that is
+        # a valid 32-bit integer resolves the ApiClient primary key; any other segment stays on the
+        # OAuth client-key lookup.
+        @MssqlRepresentative
+        Scenario: 25 Ensure clients can GET apiClient by numeric id
+            Given a POST request is made to "/v3/applications" with
+                  """
+                  {
+                   "vendorId": {vendorId},
+                   "applicationName": "Test Application 25",
+                   "claimSetName": "TestClaim01",
+                   "dataStoreIds": [{dataStoreId}]
+                  }
+                  """
+             When a POST request is made to "/v3/apiClients" with
+                  """
+                  {
+                   "applicationId": {applicationId},
+                   "name": "Client 25",
+                   "isApproved": true,
+                   "dataStoreIds": [{dataStoreId}]
+                  }
+                  """
+             Then it should respond with 201
+              And the response body credentials are captured as "client25"
+              And the response body id is captured as "client25Id"
+             When a GET request is made to "/v3/apiClients/{client25Id}"
+             Then it should respond with 200
+              And the response body is
+                  """
+                  {
+                    "id": {client25Id},
+                    "applicationId": {applicationId},
+                    "clientId": "{client25Key}",
+                    "clientUuid": "{clientUuid}",
+                    "name": "Client 25",
+                    "isApproved": true,
+                    "creatorOwnershipTokenId": null,
+                    "ownershipTokenIds": [],
+                    "dataStoreIds": [{dataStoreId}]
+                  }
+                  """
+              # The OAuth client key resolves the same client, so neither lookup was repurposed.
+             When a GET request is made to "/v3/apiClients/{client25Key}"
+             Then it should respond with 200
+              And the response body is
+                  """
+                  {
+                    "id": {client25Id},
+                    "applicationId": {applicationId},
+                    "clientId": "{client25Key}",
+                    "clientUuid": "{clientUuid}",
+                    "name": "Client 25",
+                    "isApproved": true,
+                    "creatorOwnershipTokenId": null,
+                    "ownershipTokenIds": [],
+                    "dataStoreIds": [{dataStoreId}]
+                  }
+                  """
+
+        Scenario: 26 Verify error handling when getting a well-formed but non-existent numeric id
+             When a GET request is made to "/v3/apiClients/99999"
+             Then it should respond with 404
+
+        Scenario: 27 Verify an identifier that is not a valid integer stays on the client-key lookup
+              # Digits followed by letters fail the route constraint, so this is read as a client
+              # key that does not exist rather than as the numeric id 12.
+             When a GET request is made to "/v3/apiClients/12abc-not-a-client-key"
+             Then it should respond with 404

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Tenants.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Tenants.feature
@@ -349,8 +349,16 @@ Feature: Tenants endpoints
                         "dataStoreIds": []
                     }
                   """
+              # The same client is readable by its numeric id inside its own tenant, which is what
+              # makes tenant B's 404 on the identical URL below a scoping result.
+             When a GET request is made to "/v3/apiClients/{tenantAClientId}" with header "Tenant" value "TenantA_{scenarioRunId}"
+             Then it should respond with 200
               # Tenant B can neither read, update, reset nor delete tenant A's unassigned client.
              When a GET request is made to "/v3/apiClients/{tenantAEmptyKey}" with header "Tenant" value "TenantB_{scenarioRunId}"
+             Then it should respond with 404
+              # Same URL, different tenant header: the numeric-id lookup is tenant scoped exactly
+              # like the client-key lookup above.
+             When a GET request is made to "/v3/apiClients/{tenantAClientId}" with header "Tenant" value "TenantB_{scenarioRunId}"
              Then it should respond with 404
              When a PUT request is made to "/v3/apiClients/{tenantAClientId}" with header "Tenant" value "TenantB_{scenarioRunId}" and
                   """


### PR DESCRIPTION
## What

Adds numeric-id lookup to the single-item API-client GET while preserving the existing OAuth client-key lookup, using one route that resolves client keys first and falls back to the numeric primary key only when no key matches.

## Why

The published Management API 3.0.0 specification models `GET /v3/apiClients/{id}` with `id` as `integer/int32`, and `apiClientModel` carries `id` and `clientId` as separate fields. CMS previously bound the route segment as a string and looked up only by OAuth `clientId`, so a spec-conformant caller could not read an API client by numeric id.

The OAuth client-key lookup must keep working because it is used by the DMS application-context lookup, CMS E2E flows, and the operator guide.

## Implementation Decisions

DMS-1343's Jira description is the source of truth for these decisions. This PR implements the same contract.

### Option chosen

Support both identifier styles on the existing single-item GET route. CMS serves both the OAuth client key and the numeric ApiClient id through `GET /v3/apiClients/{id}`. No `byId` route, query parameter, or relocated client-key route is introduced.

### Runtime route and authorization

CMS registers one GET route: `MapLimitedAccess("/v3/apiClients/{id}", GetByIdentifier)`. The limited-access read policy is unchanged and matches the collection and existing service-account read behavior.

### Identifier resolution contract

| Client-key lookup | Segment parses as int32 | Numeric lookup | Response |
|---|---|---|---|
| Success | not attempted | not called | 200, key-matched row |
| FailureUnknown | not attempted | not called | 500, sanitized |
| FailureNotFound | no | not called | 404, `ApiClient not found` |
| FailureNotFound | yes | Success | 200, id-matched row |
| FailureNotFound | yes | FailureNotFound | 404, `ApiClient with ID {parsedId} not found.` |
| FailureNotFound | yes | FailureUnknown | 500, sanitized |

Parsing uses `NumberStyles.Integer` with `CultureInfo.InvariantCulture`. The id-bearing 404 interpolates the parsed integer rather than the raw path segment.

### OpenAPI and metadata

The served OpenAPI document contains one single-item GET path item for apiClients: `/v3/apiClients/{id}`. The GET parameter is documented as string, because the runtime accepts the raw path segment and resolves it key-first with numeric fallback. `PUT`, `DELETE`, `reset-credential`, and ownership routes continue to use the numeric `int32` id and are unchanged.

### Scope exclusions

- No DMS change and no file under `src/dms/` is touched.
- No repository, DDL, response DTO, identity provider, ownership module, or application module change.
- No change to `PUT`, `DELETE`, `reset-credential`, or ownership behavior.

## Changes

- Replaced the API-client single-item GET handling with one key-first route and handler in `ApiClientModule.cs`.
- Added unit coverage for the six runtime outcomes, including the collision case where a path segment is both a stored `ClientId` and another row's numeric primary key.
- Updated OpenAPI contract tests and metadata expectations for one GET path item with a string parameter.
- Added CMS E2E coverage for numeric-id lookup, key lookup, numeric 404, non-numeric 404, and tenant scoping.
- Updated the operator guide and added the DMS-1343 design record to the configuration-service design index.

## Verification

| Gate | Result |
|---|---|
| `dotnet csharpier check src/config` | 435 files checked, clean |
| `build-config.ps1 Build -Configuration Release` | Build succeeded, 0 warnings, 0 errors |
| `build-config.ps1 UnitTest -Configuration Release` | 1780 passed, 0 failed, 0 skipped |
| Frontend unit project filtered to the affected test classes | 225 passed, 0 failed, 0 skipped |

The Release unit lane predates the key-first patch. The filtered unit run was executed after the key-first patch and covers the affected fixtures. CI is the full current-head gate.

E2E, with teardown before setup and again after each run:

| Feature | Environment | Passed | Failed | Skipped |
|---|---|---|---|---|
| ApiClients | PostgreSQL, self-contained identity, single tenant | 25 | 0 | 1 |
| Tenants | PostgreSQL with multi-tenancy enabled | 4 | 0 | 0 |

The E2E runs predate the key-first handler patch. After that patch, the feature-file edits were comments only; no executable E2E steps changed. The current-head CI run provides the authoritative E2E gate.

## Known Residual Behavior

A token whose `client_id` is numeric, matches no stored `ClientId`, and collides with an ApiClient primary key can still produce a CMS 200 for the numeric row; DMS then rejects the mismatch as `Unavailable`. CMS-issued keys are GUID strings, so this requires external provisioning.

## Follow-Up

Database-level uniqueness for `dmscs.ApiClient.ClientId` and `ClientUuid` is tracked separately as DMS-1529 under DMS-1072. A uniqueness constraint does not prevent a client key from looking numeric; a future format constraint on `ClientId` would remove that remaining ambiguity.