### PR TITLE
chore: Bump two action pins to currently approved SHAs

### DIFF
--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -27,13 +27,13 @@ jobs:
       # issues: read
     steps:
       - name: Download and Extract Artifacts
-        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6 # v2.20.0
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.24.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json

--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -33,7 +33,7 @@ jobs:
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.24.0
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json


### PR DESCRIPTION
Unblocks CI for every open pull request. No ticket; this is a two-line pin bump.

`Ed-Fi-Actions` commit [`8a2a78d6d`](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Actions/commit/8a2a78d6d) ("Approve security-reviewed Node 24 action pins") landed 2026-09-10 at 13:24 UTC and replaced the approved entries for two actions this repository pins. The `action-allowedlist` check reads `approved.json` from that repository at run time, and nothing here pins the allowlist version, so from that moment every pull request fails with:

```
The following 2 actions/versions were denied:
  dawidd6/action-download-artifact           ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
  EnricoMi/publish-unit-test-result-action   3a74b2957438d0b6e2e61d67b05318aa25c9e6c6
```

`Config CI Gate` and the DMS gate then fail transitively: their logs list every other required job as `success` and only `scan-actions-bidi: failure`. Pull requests whose last run predates the allowlist commit still show green, which makes this look branch-specific when it is repository-wide.

Both pins live in `.github/workflows/after-pullrequest.yml` and had not changed since `b3c9b49c9` in February 2026. This moves them to the non-deprecated approved entries:

| Action | Was | Now |
| --- | --- | --- |
| `dawidd6/action-download-artifact` | `ac66b43f` (v11) | `d63b86af` (v24) |
| `EnricoMi/publish-unit-test-result-action` | `3a74b295` (v2.20.0) | `c950f6fb` (v2.23.0) |

Compatibility was checked against each action's `action.yml` at the new SHA rather than assumed, because the first is a major-version jump:

- `action-download-artifact` v24 still declares both inputs this workflow passes, `run_id` and `path`. It runs on `node24`.
- `publish-unit-test-result-action` at `c950f6fb` still declares all four inputs passed here: `commit`, `event_file`, `event_name`, `files`. It is a Docker action, so the Node runtime change does not apply to it.

No step arguments change, and no other workflow references either action.

Reviewer note on the test-results pin, worth a look because the allowlist is self-inconsistent here. `approved.json` lists one commit, `c950f6fb`, under **both** `v2.23.0` (flagged `deprecated`) and `v2.24.0`. Upstream, that commit is `v2.23.0`; the real `v2.24.0` is `d0a4676d`, which does not appear on the allowlist at all and would therefore be denied. So `c950f6fb` is the only approved SHA for this action, and the trailing comment reads `# v2.23.0` because that is the tag it actually resolves to. The scanner matches the first entry for a SHA, so this pin logs a non-fatal "deprecated" warning; that is unavoidable until the allowlist either fixes its `v2.24.0` entry or approves `d0a4676d`.

For `action-download-artifact` there is no such ambiguity: `d63b86af` resolves to `v24` upstream, and the allowlist's other entry, `v19`, is flagged `deprecated`, so `v24` is the right target.

Verified by reimplementing the scanner's own logic (`Ed-Fi-Actions/action-allowedlist/action_allowedlist/actions_parser.py`) against `approved.json` and running it over both trees: `origin/main` gives 419 step-level pins with exactly these **2 denied**, reproducing the CI verdict, and this branch gives **0 denied**. So these are the only bumps required.

Two properties of that scanner explain why the blast radius is not larger, and are worth knowing before reading the numbers above: it auto-approves every `actions/*` and `github/*` action without consulting the list, and it inspects only step-level `uses:` in `*.yml`, so job-level reusable-workflow calls such as `Ed-Fi-Alliance-OSS/slsa-github-generator` are never checked.

Separately, and **not** addressed here: that same run reports 105 pins on entries the allowlist flags `deprecated`. Those pass today with only a warning, but deprecation is the state our two pins were in before they were dropped, so they are the next wave of this same failure. Worth a scheduled sweep rather than folding into this fix.

Note on cost, corrected after observing the first two runs: the DMS lanes do **not** skip for a `.github/`-only change. `on-dms-pullrequest.yml` carries no `paths:` filter by design, because the merge queue needs `dms-ci-gate` to report on every pull request, and `detect-fresh-build-changes` treated this change as DMS-relevant — of 46 jobs only 2 skipped, and the full E2E and integration lanes ran. So each push here costs a full suite on shared runners. Please avoid re-running this one needlessly; the `action-allowedlist` result is the only check that has to be read.


