### PR TITLE
[DMS-1527] Target the configured DMS container in the representation restamp E2E harness

### DIFF
--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -390,7 +390,13 @@ function Get-E2ETestEnvironmentContext {
         # Database engine backing the E2E stack. "postgresql" (default) or "mssql". An empty value
         # is normalized to postgresql so an omitted top-level -DatabaseEngine is behavior-compatible.
         [string]
-        $DatabaseEngine = "postgresql"
+        $DatabaseEngine = "postgresql",
+
+        # Selects the DMS container name the test process targets, via Get-E2EStartupPhasePlan.
+        # Compose names the container from the project and service unless a compose file sets
+        # container_name, which only the local one does.
+        [switch]
+        $UsePublishedImage
     )
 
     $resolvedDatabaseEngine =
@@ -475,6 +481,13 @@ function Get-E2ETestEnvironmentContext {
         -EnvironmentValues $environmentValues `
         -DatabaseName $e2eSnapshotDatabaseName
 
+    # One decision point for the DMS container name, shared with the Docker phases: the restamp
+    # harness copies the API schema out of that container and stops/starts it, so the name the test
+    # process gets has to be the one Compose actually created.
+    $startupPhasePlan = Get-E2EStartupPhasePlan `
+        -DatabaseEngine $resolvedDatabaseEngine `
+        -UsePublishedImage:$UsePublishedImage
+
     return [pscustomobject]@{
         EnvironmentFile = $environmentFilePath
         ShouldProvisionE2EDatabase = $true
@@ -484,6 +497,7 @@ function Get-E2ETestEnvironmentContext {
         DataStoreAdminConnectionString = $connectionStrings.AdminConnectionString
         DataStoreConnectionString = $connectionStrings.RegistrationConnectionString
         DataStoreSnapshotConnectionString = $snapshotConnectionStrings.RegistrationConnectionString
+        DmsContainerName = $startupPhasePlan.DmsContainerName
         TestResultSuffix = Get-E2ETestResultSuffix -TestFilter $TestFilter
     }
 }
@@ -511,6 +525,8 @@ function Invoke-WithE2ETestProcessContext {
     $previousDataStoreConnectionString = $env:AppSettings__DataStoreConnectionString
     $previousDataStoreSnapshotConnectionStringExists = Test-Path Env:AppSettings__DataStoreSnapshotConnectionString
     $previousDataStoreSnapshotConnectionString = $env:AppSettings__DataStoreSnapshotConnectionString
+    $previousDmsContainerNameExists = Test-Path Env:AppSettings__DmsContainerName
+    $previousDmsContainerName = $env:AppSettings__DmsContainerName
     $previousE2EEnvironmentFileExists = Test-Path Env:DMS_E2E_ENVIRONMENT_FILE
     $previousE2EEnvironmentFile = $env:DMS_E2E_ENVIRONMENT_FILE
     $previousNodeOptionsExists = Test-Path Env:NODE_OPTIONS
@@ -521,7 +537,15 @@ function Invoke-WithE2ETestProcessContext {
             throw "AppSettings__DataStoreDatabaseName must be set for the DMS E2E test process."
         }
 
+        # The representation-restamp harness copies the API schema out of the DMS container and
+        # stops/starts it by name, and the name differs by image mode. Fail here rather than let the
+        # harness fall back to its local-image default and target a container that does not exist.
+        if ([string]::IsNullOrWhiteSpace($E2ETestSettings.DmsContainerName)) {
+            throw "AppSettings__DmsContainerName must be set for the DMS E2E test process."
+        }
+
         $env:AppSettings__DataStoreDatabaseName = $E2ETestSettings.DataStoreDatabaseName
+        $env:AppSettings__DmsContainerName = $E2ETestSettings.DmsContainerName
         # Engine and the two opaque connection strings for the C# harness (host-side admin/reset
         # access and the Docker-network registration string). The values contain secrets and are set
         # into the environment only; they are never written to host output.
@@ -568,6 +592,13 @@ function Invoke-WithE2ETestProcessContext {
         }
         else {
             Remove-Item Env:AppSettings__DataStoreConnectionString -ErrorAction SilentlyContinue
+        }
+
+        if ($previousDmsContainerNameExists) {
+            $env:AppSettings__DmsContainerName = $previousDmsContainerName
+        }
+        else {
+            Remove-Item Env:AppSettings__DmsContainerName -ErrorAction SilentlyContinue
         }
 
         if ($previousE2EEnvironmentFileExists) {
@@ -1295,7 +1326,8 @@ function E2ETests {
         -EnvironmentFile $EnvironmentFile `
         -EnvironmentOverlayFile $EnvironmentOverlayFile `
         -TestFilter $TestFilter `
-        -DatabaseEngine $DatabaseEngine
+        -DatabaseEngine $DatabaseEngine `
+        -UsePublishedImage:$UsePublishedImage
 
     # Resolve the startup phase plan once (single decision point, unit-tested in
     # E2EEngineForwarding.Tests.ps1). SQL Server requires the generated relational DDL to exist before

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -1251,13 +1251,9 @@ function Initialize-E2EDatabase {
         $StartDmsAfterProvisioning
     )
 
-    $dmsContainerName =
-        if ($UsePublishedImage) {
-            "dms-published-dms-1"
-        }
-        else {
-            "ed-fi-api"
-        }
+    # Resolved once by Get-E2EStartupPhasePlan and carried on the context, so the restart target
+    # here, the schema assertion below, and the name the test process exports cannot drift apart.
+    $dmsContainerName = $E2ETestSettings.DmsContainerName
 
     $provisionedEffectiveSchemaHash = Invoke-E2EDatabaseProvisioning -E2ETestSettings $E2ETestSettings
     $dmsStartedAtUtc = [DateTime]::UtcNow.AddSeconds(-2)

--- a/eng/docker-compose/tests/E2EEngineForwarding.Tests.ps1
+++ b/eng/docker-compose/tests/E2EEngineForwarding.Tests.ps1
@@ -290,6 +290,61 @@ Describe "Get-E2ETestEnvironmentContext resolves the E2E database name with Comp
         { Get-E2ETestEnvironmentContext -EnvironmentFile "./.env.e2e" -DatabaseEngine "postgresql" } |
             Should -Throw "*E2E_DATABASE_NAME*"
     }
+
+    # DMS-1527: the restamp harness copies the API schema out of the DMS container and stops/starts
+    # it by name, so the context has to hand the test process the name Compose actually created.
+    # Taking it from Get-E2EStartupPhasePlan keeps one decision point for the Docker phases and the
+    # test process; published-dms.yml sets no container_name, so the two modes disagree.
+    It "carries the <Label> DMS container name from the startup phase plan" -ForEach @(
+        @{ Label = "local-image"; Published = $false; Expected = "ed-fi-api" }
+        @{ Label = "published-image"; Published = $true; Expected = "dms-published-dms-1" }
+    ) {
+        $context = Get-E2ETestEnvironmentContext `
+            -EnvironmentFile "./.env.e2e" `
+            -DatabaseEngine "postgresql" `
+            -UsePublishedImage:$Published
+
+        $context.DmsContainerName | Should -Be $Expected
+    }
+
+    It "defaults to the local-image DMS container name when the image mode is not specified" {
+        $context = Get-E2ETestEnvironmentContext -EnvironmentFile "./.env.e2e" -DatabaseEngine "postgresql"
+
+        $context.DmsContainerName | Should -Be "ed-fi-api"
+    }
+
+    # The two functions are only ever used together, and each one's own tests pass even when the
+    # field one produces is not the field the other requires. Run the real pair so a context that
+    # stops satisfying the process context's guard fails here instead of in an E2E run.
+    It "produces a context the test process accepts, exporting the <Label> container name" -ForEach @(
+        @{ Label = "local-image"; Published = $false; Expected = "ed-fi-api" }
+        @{ Label = "published-image"; Published = $true; Expected = "dms-published-dms-1" }
+    ) {
+        . ([scriptblock]::Create((Get-BuildScriptFunctionText -ScriptPath $script:buildScript -FunctionName "Invoke-WithE2ETestProcessContext")))
+
+        $context = Get-E2ETestEnvironmentContext `
+            -EnvironmentFile "./.env.e2e" `
+            -DatabaseEngine "postgresql" `
+            -UsePublishedImage:$Published
+
+        $observed = $null
+        try {
+            Invoke-WithE2ETestProcessContext -E2ETestSettings $context -Action {
+                $script:observed = $env:AppSettings__DmsContainerName
+            }
+        }
+        finally {
+            foreach ($name in @(
+                    "AppSettings__DataStoreDatabaseName", "AppSettings__DatabaseEngine",
+                    "AppSettings__DataStoreAdminConnectionString", "AppSettings__DataStoreConnectionString",
+                    "AppSettings__DataStoreSnapshotConnectionString", "AppSettings__DmsContainerName",
+                    "DMS_E2E_ENVIRONMENT_FILE")) {
+                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+            }
+        }
+
+        $script:observed | Should -Be $Expected
+    }
 }
 
 Describe "DocumentCache hosted E2E environment isolation" {

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -179,6 +179,7 @@ Describe "Invoke-WithE2ETestProcessContext restores prior environment state exac
             "AppSettings__DataStoreAdminConnectionString"
             "AppSettings__DataStoreConnectionString"
             "AppSettings__DataStoreSnapshotConnectionString"
+            "AppSettings__DmsContainerName"
             "DMS_E2E_ENVIRONMENT_FILE"
             "NODE_OPTIONS"
         )
@@ -187,6 +188,8 @@ Describe "Invoke-WithE2ETestProcessContext restores prior environment state exac
             EnvironmentFile                   = "/repo/eng/docker-compose/.derived/.env.e2e.document-cache.e2e.mssql"
             DataStoreDatabaseName             = "edfi_datamanagementservice_e2e"
             DatabaseEngine                    = "mssql"
+            # The published-image name, which is the one the restamp harness cannot guess (DMS-1527).
+            DmsContainerName                  = "dms-published-dms-1"
             DataStoreAdminConnectionString    = "Server=127.0.0.1,1435;Database=edfi_datamanagementservice_e2e;User Id=sa;Password=secret;TrustServerCertificate=true;"
             DataStoreConnectionString         = "Server=dms-mssql,1433;Database=edfi_datamanagementservice_e2e;User Id=sa;Password=secret;TrustServerCertificate=true;"
             DataStoreSnapshotConnectionString = "Server=dms-mssql,1433;Database=edfi_datamanagementservice_e2e_snapshot;User Id=sa;Password=secret;TrustServerCertificate=true;"
@@ -221,6 +224,7 @@ Describe "Invoke-WithE2ETestProcessContext restores prior environment state exac
         Remove-Item Env:AppSettings__DataStoreAdminConnectionString -ErrorAction SilentlyContinue
         Remove-Item Env:AppSettings__DataStoreConnectionString -ErrorAction SilentlyContinue
         Remove-Item Env:AppSettings__DataStoreSnapshotConnectionString -ErrorAction SilentlyContinue
+        Remove-Item Env:AppSettings__DmsContainerName -ErrorAction SilentlyContinue
         Remove-Item Env:DMS_E2E_ENVIRONMENT_FILE -ErrorAction SilentlyContinue
 
         $observed = $null
@@ -230,6 +234,7 @@ Describe "Invoke-WithE2ETestProcessContext restores prior environment state exac
                     Admin           = $env:AppSettings__DataStoreAdminConnectionString
                     Registration    = $env:AppSettings__DataStoreConnectionString
                     Snapshot        = $env:AppSettings__DataStoreSnapshotConnectionString
+                    ContainerName   = $env:AppSettings__DmsContainerName
                     EnvironmentFile = $env:DMS_E2E_ENVIRONMENT_FILE
                 }
                 throw "boom"
@@ -239,13 +244,49 @@ Describe "Invoke-WithE2ETestProcessContext restores prior environment state exac
         $script:observed.Admin | Should -Be $script:testSettings.DataStoreAdminConnectionString
         $script:observed.Registration | Should -Be $script:testSettings.DataStoreConnectionString
         $script:observed.Snapshot | Should -Be $script:testSettings.DataStoreSnapshotConnectionString
+        $script:observed.ContainerName | Should -Be "dms-published-dms-1"
         $script:observed.EnvironmentFile | Should -Be $script:testSettings.EnvironmentFile
 
         (Test-Path Env:AppSettings__DatabaseEngine) | Should -BeFalse
         (Test-Path Env:AppSettings__DataStoreAdminConnectionString) | Should -BeFalse
         (Test-Path Env:AppSettings__DataStoreConnectionString) | Should -BeFalse
         (Test-Path Env:AppSettings__DataStoreSnapshotConnectionString) | Should -BeFalse
+        (Test-Path Env:AppSettings__DmsContainerName) | Should -BeFalse
         (Test-Path Env:DMS_E2E_ENVIRONMENT_FILE) | Should -BeFalse
+    }
+
+    It "restores AppSettings__DmsContainerName to its prior <Label> state after the action throws" -ForEach @(
+        @{ Label = "absent"; Setup = { Remove-Item Env:AppSettings__DmsContainerName -ErrorAction SilentlyContinue }; ExpectExists = $false; ExpectValue = $null }
+        @{ Label = "empty"; Setup = { $env:AppSettings__DmsContainerName = "" }; ExpectExists = $true; ExpectValue = "" }
+        @{ Label = "whitespace"; Setup = { $env:AppSettings__DmsContainerName = "   " }; ExpectExists = $true; ExpectValue = "   " }
+        @{ Label = "nonempty"; Setup = { $env:AppSettings__DmsContainerName = "ed-fi-api" }; ExpectExists = $true; ExpectValue = "ed-fi-api" }
+    ) {
+        & $Setup
+
+        { Invoke-WithE2ETestProcessContext -E2ETestSettings $script:testSettings -Action { throw "boom" } } |
+            Should -Throw
+
+        (Test-Path Env:AppSettings__DmsContainerName) | Should -Be $ExpectExists
+        if ($ExpectExists) {
+            $env:AppSettings__DmsContainerName | Should -Be $ExpectValue
+        }
+    }
+
+    It "refuses to run the test process when DmsContainerName is <Label>" -ForEach @(
+        @{ Label = "missing"; Value = $null }
+        @{ Label = "empty"; Value = "" }
+        @{ Label = "whitespace"; Value = "   " }
+    ) {
+        # The harness would otherwise fall back to its local-image default and stop a container that
+        # does not exist in published-image mode, which is the DMS-1527 failure.
+        $settings = $script:testSettings.PSObject.Copy()
+        $settings.DmsContainerName = $Value
+        $actionRan = $false
+
+        { Invoke-WithE2ETestProcessContext -E2ETestSettings $settings -Action { $script:actionRan = $true } } |
+            Should -Throw -ExpectedMessage "*AppSettings__DmsContainerName must be set*"
+
+        $script:actionRan | Should -BeFalse
     }
 
     It "restores every mutated variable from a mix of absent, empty, whitespace, and valued prior states" {
@@ -254,6 +295,7 @@ Describe "Invoke-WithE2ETestProcessContext restores prior environment state exac
         $env:AppSettings__DataStoreAdminConnectionString = "   "
         $env:AppSettings__DataStoreConnectionString = "prior-registration"
         $env:AppSettings__DataStoreSnapshotConnectionString = "prior-snapshot"
+        $env:AppSettings__DmsContainerName = "prior-container"
         $env:DMS_E2E_ENVIRONMENT_FILE = "prior-environment-file"
         $env:NODE_OPTIONS = "--max-old-space-size=4096"
 
@@ -266,6 +308,7 @@ Describe "Invoke-WithE2ETestProcessContext restores prior environment state exac
         $env:AppSettings__DataStoreAdminConnectionString | Should -Be "   "
         $env:AppSettings__DataStoreConnectionString | Should -Be "prior-registration"
         $env:AppSettings__DataStoreSnapshotConnectionString | Should -Be "prior-snapshot"
+        $env:AppSettings__DmsContainerName | Should -Be "prior-container"
         $env:DMS_E2E_ENVIRONMENT_FILE | Should -Be "prior-environment-file"
         $env:NODE_OPTIONS | Should -Be "--max-old-space-size=4096"
     }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/AppSettings.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/AppSettings.cs
@@ -11,6 +11,7 @@ public static class AppSettings
 {
     public const string DefaultDataStoreDatabaseName = "edfi_datamanagementservice_e2e";
     public const string DefaultDatabaseEngine = "postgresql";
+    public const string DefaultDmsContainerName = "ed-fi-api";
     public const int BytesPerMegabyte = 1024 * 1024;
     public const int DefaultMaxRequestBodySizeMegabytes = 10;
 
@@ -40,6 +41,15 @@ public static class AppSettings
     /// </summary>
     public static string DataStoreSnapshotConnectionString => _settings.DataStoreSnapshotConnectionString;
 
+    /// <summary>
+    /// The name of the running DMS container, for the harness Docker operations that copy the API
+    /// schema out of it and stop/start it. Compose names it "ed-fi-api" for the local image
+    /// (local-dms.yml sets container_name) and "dms-published-dms-1" for the published image
+    /// (published-dms.yml sets none). build-dms.ps1's E2E process context sets this from the startup
+    /// phase plan; the default keeps direct setup and direct dotnet test runs working unchanged.
+    /// </summary>
+    public static string DmsContainerName => _settings.DmsContainerName;
+
     public static int MaxRequestBodySizeMegabytes => _settings.MaxRequestBodySizeMegabytes;
 
     internal static AppSettingsValues Create(IConfiguration configuration)
@@ -53,6 +63,7 @@ public static class AppSettings
             GetString(configuration, nameof(DataStoreAdminConnectionString), string.Empty),
             GetString(configuration, nameof(DataStoreConnectionString), string.Empty),
             GetString(configuration, nameof(DataStoreSnapshotConnectionString), string.Empty),
+            GetString(configuration, nameof(DmsContainerName), DefaultDmsContainerName),
             GetInt(configuration, nameof(MaxRequestBodySizeMegabytes), DefaultMaxRequestBodySizeMegabytes)
         );
     }
@@ -90,5 +101,6 @@ internal sealed record AppSettingsValues(
     string DataStoreAdminConnectionString,
     string DataStoreConnectionString,
     string DataStoreSnapshotConnectionString,
+    string DmsContainerName,
     int MaxRequestBodySizeMegabytes
 );

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -237,7 +237,6 @@ internal sealed class MssqlRepresentationRestampE2EProviderOperations()
 
 internal static class RepresentationRestampE2EHarness
 {
-    private const string DmsContainerName = "ed-fi-api";
     private const string ConfigurationServiceClientId = "CMSReadOnlyAccess";
     private const string ConfigurationServiceClientSecret = "ValidClientSecret1234567890!Abcd";
     private const string ConfigurationServiceScope = "edfi_admin_api/readonly_access";
@@ -254,6 +253,7 @@ internal static class RepresentationRestampE2EHarness
         DocumentCacheRepresentationRestampMode mode
     )
     {
+        string containerName = AppSettings.DmsContainerName;
         string schemaCopyDirectory = Path.Combine(
             Path.GetTempPath(),
             "dms1318-restamp-schema",
@@ -266,121 +266,150 @@ internal static class RepresentationRestampE2EHarness
             async () =>
             {
                 var projectionExpected = false;
+                // Cleanup undoes only what actually happened: the container is restarted only after a
+                // stop that succeeded, and the lifecycle is reset only after it was really set to
+                // Disabled. A wrong container name fails on the copy below, before DMS is touched.
+                var dmsStopped = false;
+                var lifecycleSetToDisabled = false;
                 IRepresentationRestampE2EProviderOperations providerOperations = ProviderOperationsFor(
                     ProviderFor(AppSettings.DatabaseEngine)
                 );
                 string connectionString = AppSettings.DataStoreAdminConnectionString;
-                await RunProcessAsync(
-                    "docker",
-                    ["cp", $"{DmsContainerName}:/app/ApiSchema", schemaCopyDirectory]
-                );
-                await RunProcessAsync("docker", ["stop", DmsContainerName]);
 
-                try
-                {
-                    await using DocumentCacheAdminCliTarget target = CreateExternalTarget(
-                        schemaCopyDirectory
-                    );
-                    providerOperations = ProviderOperationsFor(target.ProviderToken);
-                    connectionString = target.ConnectionString;
-                    await SetLifecycleAsync(
-                        providerOperations,
-                        connectionString,
-                        mode == DocumentCacheRepresentationRestampMode.Tracking
-                            ? DocumentCacheLifecycleState.Tracking
-                            : DocumentCacheLifecycleState.Disabled,
-                        CancellationToken.None
-                    );
-                    await using DocumentCacheAdminTestConfigurationService configurationService =
-                        DocumentCacheAdminTestConfigurationService.Start(
-                            target,
-                            ConfigurationServiceEncryptionKey
-                        );
-                    long originalContentVersion = await ReadCanonicalContentVersionAsync(
-                        providerOperations,
-                        connectionString,
-                        documentUuid,
-                        CancellationToken.None
-                    );
-                    long? originalRequiredWorkVersion = await ReadRequiredWorkVersionAsync(
-                        providerOperations,
-                        connectionString,
-                        documentUuid,
-                        CancellationToken.None
-                    );
-                    await ExecuteRestampCommandsAsync(
-                        documentUuid,
-                        mode,
-                        (command, arguments) =>
-                            RunCliAsync(
-                                command,
-                                target.DataStoreId,
-                                configurationService.BaseUri,
-                                target.AppSettingsDatastore,
-                                target.ApiSchemaDirectory,
-                                arguments
-                            ),
-                        async () =>
-                        {
-                            long restampedContentVersion = await ReadCanonicalContentVersionAsync(
-                                providerOperations,
-                                connectionString,
-                                documentUuid,
-                                CancellationToken.None
-                            );
-                            restampedContentVersion.Should().BeGreaterThan(originalContentVersion);
-                            if (mode == DocumentCacheRepresentationRestampMode.Tracking)
-                            {
-                                long? restampedRequiredWorkVersion = await ReadRequiredWorkVersionAsync(
-                                    providerOperations,
-                                    connectionString,
-                                    documentUuid,
-                                    CancellationToken.None
-                                );
-                                restampedRequiredWorkVersion.Should().Be(restampedContentVersion);
-                            }
-                            else
-                            {
-                                long? restampedRequiredWorkVersion = await ReadRequiredWorkVersionAsync(
-                                    providerOperations,
-                                    connectionString,
-                                    documentUuid,
-                                    CancellationToken.None
-                                );
-                                restampedRequiredWorkVersion
-                                    .Should()
-                                    .Be(
-                                        originalRequiredWorkVersion,
-                                        "Disabled restamp must not enqueue or update projection work"
-                                    );
-                            }
-                        },
-                        async () =>
-                        {
-                            await DrainOrdinaryProjectorAsync(target);
-                            projectionExpected = true;
-                        }
-                    );
-                }
-                finally
-                {
-                    if (mode == DocumentCacheRepresentationRestampMode.Disabled)
+                await RunWithCleanupAsync(
+                    $"representation restamp ({mode}) for document {documentUuid} against DMS container '{containerName}'",
+                    async () =>
                     {
+                        await RunDockerAsync(
+                            "cp",
+                            containerName,
+                            ["cp", $"{containerName}:/app/ApiSchema", schemaCopyDirectory]
+                        );
+                        await RunDockerAsync("stop", containerName, ["stop", containerName]);
+                        dmsStopped = true;
+
+                        await using DocumentCacheAdminCliTarget target = CreateExternalTarget(
+                            schemaCopyDirectory
+                        );
+                        providerOperations = ProviderOperationsFor(target.ProviderToken);
+                        connectionString = target.ConnectionString;
                         await SetLifecycleAsync(
                             providerOperations,
                             connectionString,
-                            DocumentCacheLifecycleState.Tracking,
+                            mode == DocumentCacheRepresentationRestampMode.Tracking
+                                ? DocumentCacheLifecycleState.Tracking
+                                : DocumentCacheLifecycleState.Disabled,
                             CancellationToken.None
                         );
-                    }
+                        lifecycleSetToDisabled = mode == DocumentCacheRepresentationRestampMode.Disabled;
+                        await using DocumentCacheAdminTestConfigurationService configurationService =
+                            DocumentCacheAdminTestConfigurationService.Start(
+                                target,
+                                ConfigurationServiceEncryptionKey
+                            );
+                        long originalContentVersion = await ReadCanonicalContentVersionAsync(
+                            providerOperations,
+                            connectionString,
+                            documentUuid,
+                            CancellationToken.None
+                        );
+                        long? originalRequiredWorkVersion = await ReadRequiredWorkVersionAsync(
+                            providerOperations,
+                            connectionString,
+                            documentUuid,
+                            CancellationToken.None
+                        );
+                        await ExecuteRestampCommandsAsync(
+                            documentUuid,
+                            mode,
+                            (command, arguments) =>
+                                RunCliAsync(
+                                    command,
+                                    target.DataStoreId,
+                                    configurationService.BaseUri,
+                                    target.AppSettingsDatastore,
+                                    target.ApiSchemaDirectory,
+                                    arguments
+                                ),
+                            async () =>
+                            {
+                                long restampedContentVersion = await ReadCanonicalContentVersionAsync(
+                                    providerOperations,
+                                    connectionString,
+                                    documentUuid,
+                                    CancellationToken.None
+                                );
+                                restampedContentVersion.Should().BeGreaterThan(originalContentVersion);
+                                if (mode == DocumentCacheRepresentationRestampMode.Tracking)
+                                {
+                                    long? restampedRequiredWorkVersion = await ReadRequiredWorkVersionAsync(
+                                        providerOperations,
+                                        connectionString,
+                                        documentUuid,
+                                        CancellationToken.None
+                                    );
+                                    restampedRequiredWorkVersion.Should().Be(restampedContentVersion);
+                                }
+                                else
+                                {
+                                    long? restampedRequiredWorkVersion = await ReadRequiredWorkVersionAsync(
+                                        providerOperations,
+                                        connectionString,
+                                        documentUuid,
+                                        CancellationToken.None
+                                    );
+                                    restampedRequiredWorkVersion
+                                        .Should()
+                                        .Be(
+                                            originalRequiredWorkVersion,
+                                            "Disabled restamp must not enqueue or update projection work"
+                                        );
+                                }
+                            },
+                            async () =>
+                            {
+                                await DrainOrdinaryProjectorAsync(target);
+                                projectionExpected = true;
+                            }
+                        );
+                    },
+                    // Nested so a failed lifecycle reset cannot skip the restart: the reset is the
+                    // inner action and the restart is its cleanup, which runs either way.
+                    () =>
+                        RunWithCleanupAsync(
+                            $"cleanup after representation restamp ({mode}) for DMS container '{containerName}'",
+                            async () =>
+                            {
+                                if (lifecycleSetToDisabled)
+                                {
+                                    await SetLifecycleAsync(
+                                        providerOperations,
+                                        connectionString,
+                                        DocumentCacheLifecycleState.Tracking,
+                                        CancellationToken.None
+                                    );
+                                }
+                            },
+                            async () =>
+                            {
+                                if (!dmsStopped)
+                                {
+                                    return;
+                                }
 
-                    await RunProcessAsync("docker", ["start", DmsContainerName]);
-                    await WaitForDmsAsync();
-                    if (projectionExpected)
-                    {
-                        await WaitForProjectedCacheAsync(providerOperations, connectionString, documentUuid);
-                    }
-                }
+                                await RunDockerAsync("start", containerName, ["start", containerName]);
+                                await WaitForDmsAsync();
+                                if (projectionExpected)
+                                {
+                                    await WaitForProjectedCacheAsync(
+                                        providerOperations,
+                                        connectionString,
+                                        documentUuid
+                                    );
+                                }
+                            }
+                        )
+                );
             }
         );
     }
@@ -867,6 +896,46 @@ internal static class RepresentationRestampE2EHarness
     internal static string DockerStartFailureMessage(string operation, string containerName) =>
         $"failed to start docker for operation '{operation}' on DMS container '{containerName}'; "
         + "is Docker installed and on PATH?";
+
+    /// <summary>
+    /// Runs one Docker command against the DMS container and fails immediately if it did not
+    /// succeed. Without this the discarded exit code let a wrong container name run on until the
+    /// DocumentCacheAdmin CLI failed to load an API schema that was never copied out.
+    /// </summary>
+    private static async Task RunDockerAsync(
+        string operation,
+        string containerName,
+        IReadOnlyList<string> arguments
+    )
+    {
+        ProcessResult result;
+
+        try
+        {
+            result = await RunProcessAsync("docker", arguments);
+        }
+        catch (Exception exception)
+            when (exception is System.ComponentModel.Win32Exception or InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                DockerStartFailureMessage(operation, containerName),
+                exception
+            );
+        }
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                DockerFailureMessage(
+                    operation,
+                    containerName,
+                    result.ExitCode,
+                    result.StandardOutput,
+                    result.StandardError
+                )
+            );
+        }
+    }
 
     private static async Task<ProcessResult> RunProcessAsync(
         string fileName,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -5,6 +5,7 @@
 
 using System.Data.Common;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.Mssql;
@@ -792,6 +793,80 @@ internal static class RepresentationRestampE2EHarness
             }
         }
     }
+
+    /// <summary>
+    /// Runs <paramref name="cleanup"/> after <paramref name="action"/> whether or not the action
+    /// threw, without letting a cleanup failure replace the primary failure. A single failure
+    /// propagates unchanged; when both fail the result is a flattened AggregateException whose
+    /// first inner exception is the primary one. Flattening keeps that ordering when a cleanup
+    /// delegate is itself built from this helper.
+    /// </summary>
+    internal static async Task RunWithCleanupAsync(string context, Func<Task> action, Func<Task> cleanup)
+    {
+        Exception? primaryFailure = null;
+
+        try
+        {
+            await action();
+        }
+        catch (Exception exception)
+        {
+            primaryFailure = exception;
+        }
+
+        try
+        {
+            await cleanup();
+        }
+        catch (Exception cleanupFailure)
+        {
+            if (primaryFailure is null)
+            {
+                throw;
+            }
+
+            throw new AggregateException(
+                $"{context}: the primary failure was followed by a cleanup failure",
+                primaryFailure,
+                cleanupFailure
+            ).Flatten();
+        }
+
+        if (primaryFailure is not null)
+        {
+            ExceptionDispatchInfo.Capture(primaryFailure).Throw();
+        }
+    }
+
+    /// <summary>
+    /// Describes a Docker command that ran and reported failure. The container name is the first
+    /// thing to check: it differs by image mode, and a name that does not exist otherwise surfaces
+    /// much later as an unrelated API schema loading error from the DocumentCacheAdmin CLI.
+    /// </summary>
+    internal static string DockerFailureMessage(
+        string operation,
+        string containerName,
+        int exitCode,
+        string standardOutput,
+        string standardError
+    ) =>
+        string.Join(
+            Environment.NewLine,
+            $"docker {operation} failed for DMS container '{containerName}' (exit code {exitCode}). "
+                + "Set AppSettings__DmsContainerName to the running DMS container "
+                + $"(local image: {AppSettings.DefaultDmsContainerName}; published image: dms-published-dms-1).",
+            $"stdout: {standardOutput.Trim()}",
+            $"stderr: {standardError.Trim()}"
+        );
+
+    /// <summary>
+    /// Describes a Docker command that could not be launched at all, which carries no exit code to
+    /// report. Kept distinct from <see cref="DockerFailureMessage"/> so a missing Docker CLI is not
+    /// mistaken for a container that rejected the operation.
+    /// </summary>
+    internal static string DockerStartFailureMessage(string operation, string containerName) =>
+        $"failed to start docker for operation '{operation}' on DMS container '{containerName}'; "
+        + "is Docker installed and on PATH?";
 
     private static async Task<ProcessResult> RunProcessAsync(
         string fileName,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -266,11 +266,12 @@ internal static class RepresentationRestampE2EHarness
             async () =>
             {
                 var projectionExpected = false;
-                // Cleanup undoes only what actually happened: the container is restarted only after a
-                // stop that succeeded, and the lifecycle is reset only after it was really set to
-                // Disabled. A wrong container name fails on the copy below, before DMS is touched.
+                // Cleanup undoes only what this run could have changed: the container is restarted
+                // only after a stop that succeeded, and the Disabled lifecycle reset is armed once
+                // the write is about to be attempted. A wrong container name fails on the copy
+                // below, before DMS is touched, so neither cleanup runs.
                 var dmsStopped = false;
-                var lifecycleSetToDisabled = false;
+                var disabledLifecycleResetRequired = false;
                 IRepresentationRestampE2EProviderOperations providerOperations = ProviderOperationsFor(
                     ProviderFor(AppSettings.DatabaseEngine)
                 );
@@ -293,6 +294,11 @@ internal static class RepresentationRestampE2EHarness
                         );
                         providerOperations = ProviderOperationsFor(target.ProviderToken);
                         connectionString = target.ConnectionString;
+                        // Arm the reset before the write is attempted, not after it returns: a write
+                        // that fails partway can still have moved the lifecycle, and cleanup has to
+                        // try to restore Tracking either way. Safe to arm here because the provider
+                        // and connection now address the external target the reset will use.
+                        disabledLifecycleResetRequired = RequiresDisabledLifecycleReset(mode);
                         await SetLifecycleAsync(
                             providerOperations,
                             connectionString,
@@ -301,7 +307,6 @@ internal static class RepresentationRestampE2EHarness
                                 : DocumentCacheLifecycleState.Disabled,
                             CancellationToken.None
                         );
-                        lifecycleSetToDisabled = mode == DocumentCacheRepresentationRestampMode.Disabled;
                         await using DocumentCacheAdminTestConfigurationService configurationService =
                             DocumentCacheAdminTestConfigurationService.Start(
                                 target,
@@ -380,7 +385,7 @@ internal static class RepresentationRestampE2EHarness
                             $"cleanup after representation restamp ({mode}) for DMS container '{containerName}'",
                             async () =>
                             {
-                                if (lifecycleSetToDisabled)
+                                if (disabledLifecycleResetRequired)
                                 {
                                     await SetLifecycleAsync(
                                         providerOperations,
@@ -470,6 +475,14 @@ internal static class RepresentationRestampE2EHarness
             await drainOrdinaryProjectorAsync();
         }
     }
+
+    /// <summary>
+    /// Whether cleanup has to restore the Tracking lifecycle. True for a Disabled restamp, which is
+    /// the only mode that writes a different lifecycle. Callers arm this before attempting that
+    /// write rather than after it succeeds, so a write that fails partway is still reset.
+    /// </summary>
+    internal static bool RequiresDisabledLifecycleReset(DocumentCacheRepresentationRestampMode mode) =>
+        mode == DocumentCacheRepresentationRestampMode.Disabled;
 
     internal static RelationalProviderToken ProviderFor(string databaseEngine)
     {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -155,6 +155,12 @@ variables — **names only; never commit or echo credential values**) are:
 - `AppSettings__DataStoreDatabaseName` — the provisioned E2E database (default `edfi_datamanagementservice_e2e`).
 - `AppSettings__DataStoreAdminConnectionString` — host-side admin connection used to reset the database between feature files.
 - `AppSettings__DataStoreConnectionString` — the data-store connection the registered application uses.
+- `AppSettings__DmsContainerName` — the running DMS container the representation-restamp scenarios
+  copy the API schema out of and stop/start (default `ed-fi-api`, the local-image name). Leave it
+  unset for the setup paths above; `build-dms.ps1 E2ETest` sets it from the image mode, which is
+  `dms-published-dms-1` under `-UsePublishedImage`. A name with no matching container fails the
+  scenario immediately on `docker cp`, reporting the operation, the name, the exit code, and both
+  Docker streams.
 
 If the engine or database name does not match the provisioned stack, the run fails fast at
 setup (an engine/schema mismatch surfaces as an `EffectiveSchemaHash` mismatch and all
@@ -271,6 +277,9 @@ Playwright setup/teardown.
 - **Container names/ports.** DMS `ed-fi-api` (`8080`), Configuration Service
   `ed-fi-api-config-service` (`8081`), PostgreSQL `dms-postgresql` (`5435`), SQL Server
   `dms-mssql` (`1435`), Swagger UI `ed-fi-api-swagger-ui` (`8082`), Keycloak `dms-keycloak`.
+  Those are the local-image names. Only `local-dms.yml` sets `container_name`, so under
+  `-UsePublishedImage` Compose names the DMS container after the project and service instead:
+  `dms-published-dms-1`.
 - **Custom database names.** If you override `E2E_DATABASE_NAME` (or the connection strings),
   keep the setup, provisioning, and test-process values aligned to the same database, or the
   reset/provision step targets a different database than the test run.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Given_App_Settings.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Given_App_Settings.cs
@@ -87,6 +87,34 @@ public class Given_App_Settings
     }
 
     [Test]
+    public void It_defaults_the_dms_container_name_to_the_local_image_container_when_not_configured()
+    {
+        var settings = AppSettings.Create(new ConfigurationBuilder().Build());
+
+        settings.DmsContainerName.Should().Be(AppSettings.DefaultDmsContainerName);
+        settings.DmsContainerName.Should().Be("ed-fi-api");
+    }
+
+    [Test]
+    public void It_reads_the_dms_container_name_override()
+    {
+        // The published image leaves container_name unset, so Compose names the DMS container after
+        // the project and service instead of "ed-fi-api".
+        var settings = AppSettings.Create(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection([
+                    KeyValuePair.Create<string, string?>(
+                        nameof(AppSettings.DmsContainerName),
+                        "dms-published-dms-1"
+                    ),
+                ])
+                .Build()
+        );
+
+        settings.DmsContainerName.Should().Be("dms-published-dms-1");
+    }
+
+    [Test]
     public void It_defaults_the_opaque_connection_strings_to_empty_when_not_configured()
     {
         var settings = AppSettings.Create(new ConfigurationBuilder().Build());

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
@@ -491,3 +491,184 @@ public sealed class Given_Representation_Restamp_E2E_Harness_Disabled_Command
         events.Should().Equal("restamp-preview", "restamp-execute", "verify", "drain");
     }
 }
+
+[TestFixture]
+public sealed class Given_Representation_Restamp_E2E_Harness_Docker_Failure_Messages
+{
+    [Test]
+    public void It_reports_the_operation_container_exit_code_and_both_streams()
+    {
+        string message = RepresentationRestampE2EHarness.DockerFailureMessage(
+            "cp",
+            "dms-published-dms-1",
+            1,
+            "  copied nothing  ",
+            "  Error response from daemon: No such container: dms-published-dms-1  "
+        );
+
+        message.Should().Contain("docker cp failed");
+        message.Should().Contain("dms-published-dms-1");
+        message.Should().Contain("exit code 1");
+        message.Should().Contain("stdout: copied nothing");
+        message.Should().Contain("stderr: Error response from daemon: No such container");
+    }
+
+    [Test]
+    public void It_names_the_setting_that_selects_the_container_for_each_image_mode()
+    {
+        string message = RepresentationRestampE2EHarness.DockerFailureMessage(
+            "stop",
+            "ed-fi-api",
+            125,
+            "",
+            "No such container"
+        );
+
+        message.Should().Contain("AppSettings__DmsContainerName");
+        message.Should().Contain("local image: ed-fi-api");
+        message.Should().Contain("published image: dms-published-dms-1");
+    }
+
+    [Test]
+    public void It_reports_a_launch_failure_without_inventing_an_exit_code()
+    {
+        string message = RepresentationRestampE2EHarness.DockerStartFailureMessage(
+            "cp",
+            "dms-published-dms-1"
+        );
+
+        message.Should().Contain("failed to start docker for operation 'cp'");
+        message.Should().Contain("dms-published-dms-1");
+        message.Should().NotContain("exit code");
+    }
+}
+
+[TestFixture]
+public sealed class Given_Representation_Restamp_E2E_Harness_Cleanup
+{
+    private const string Context = "representation restamp (Tracking) for document 9622f938";
+
+    [Test]
+    public async Task It_runs_cleanup_after_a_successful_action()
+    {
+        List<string> events = [];
+
+        await RepresentationRestampE2EHarness.RunWithCleanupAsync(
+            Context,
+            () =>
+            {
+                events.Add("action");
+                return Task.CompletedTask;
+            },
+            () =>
+            {
+                events.Add("cleanup");
+                return Task.CompletedTask;
+            }
+        );
+
+        events.Should().Equal("action", "cleanup");
+    }
+
+    [Test]
+    public async Task It_still_runs_cleanup_when_the_action_fails()
+    {
+        var primaryFailure = new InvalidOperationException("restamp failed");
+        var cleanupRan = false;
+
+        Func<Task> act = () =>
+            RepresentationRestampE2EHarness.RunWithCleanupAsync(
+                Context,
+                () => Task.FromException(primaryFailure),
+                () =>
+                {
+                    cleanupRan = true;
+                    return Task.CompletedTask;
+                }
+            );
+
+        InvalidOperationException thrown = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        thrown.Should().BeSameAs(primaryFailure);
+        cleanupRan.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task It_surfaces_a_cleanup_failure_when_the_action_succeeded()
+    {
+        var cleanupFailure = new InvalidOperationException("docker start failed");
+
+        Func<Task> act = () =>
+            RepresentationRestampE2EHarness.RunWithCleanupAsync(
+                Context,
+                () => Task.CompletedTask,
+                () => Task.FromException(cleanupFailure)
+            );
+
+        InvalidOperationException thrown = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        thrown.Should().BeSameAs(cleanupFailure);
+    }
+
+    [Test]
+    public async Task It_preserves_the_primary_failure_first_when_cleanup_also_fails()
+    {
+        var primaryFailure = new InvalidOperationException("restamp failed");
+        var cleanupFailure = new InvalidOperationException("docker start failed");
+
+        Func<Task> act = () =>
+            RepresentationRestampE2EHarness.RunWithCleanupAsync(
+                Context,
+                () => Task.FromException(primaryFailure),
+                () => Task.FromException(cleanupFailure)
+            );
+
+        AggregateException thrown = (await act.Should().ThrowAsync<AggregateException>()).Which;
+        thrown.Message.Should().Contain(Context);
+        thrown.InnerExceptions.Should().Equal(primaryFailure, cleanupFailure);
+    }
+
+    [Test]
+    public async Task It_flattens_a_nested_cleanup_so_the_primary_failure_stays_first()
+    {
+        // The restamp cleanup is itself a RunWithCleanupAsync: reset the lifecycle, then restart the
+        // container whether or not the reset succeeded. All three failures have to survive, in order.
+        var primaryFailure = new InvalidOperationException("restamp failed");
+        var lifecycleFailure = new InvalidOperationException("lifecycle reset failed");
+        var restartFailure = new InvalidOperationException("docker start failed");
+
+        Func<Task> act = () =>
+            RepresentationRestampE2EHarness.RunWithCleanupAsync(
+                Context,
+                () => Task.FromException(primaryFailure),
+                () =>
+                    RepresentationRestampE2EHarness.RunWithCleanupAsync(
+                        "cleanup",
+                        () => Task.FromException(lifecycleFailure),
+                        () => Task.FromException(restartFailure)
+                    )
+            );
+
+        AggregateException thrown = (await act.Should().ThrowAsync<AggregateException>()).Which;
+        thrown.InnerExceptions.Should().Equal(primaryFailure, lifecycleFailure, restartFailure);
+    }
+
+    [Test]
+    public async Task It_restarts_the_container_even_when_the_lifecycle_reset_fails()
+    {
+        // The guardrail that keeps a failed disabled-mode lifecycle reset from leaving DMS stopped.
+        var restartRan = false;
+
+        Func<Task> act = () =>
+            RepresentationRestampE2EHarness.RunWithCleanupAsync(
+                "cleanup",
+                () => Task.FromException(new InvalidOperationException("lifecycle reset failed")),
+                () =>
+                {
+                    restartRan = true;
+                    return Task.CompletedTask;
+                }
+            );
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        restartRan.Should().BeTrue();
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
@@ -174,6 +174,16 @@ public sealed class Given_Representation_Restamp_E2E_Harness
         RepresentationRestampE2EHarness.ProviderFor("mssql").Should().Be(RelationalProviderToken.SqlServer);
     }
 
+    [TestCase(DocumentCacheRepresentationRestampMode.Disabled, true)]
+    [TestCase(DocumentCacheRepresentationRestampMode.Tracking, false)]
+    public void It_requires_a_lifecycle_reset_only_for_the_disabled_mode(
+        DocumentCacheRepresentationRestampMode mode,
+        bool expected
+    )
+    {
+        RepresentationRestampE2EHarness.RequiresDisabledLifecycleReset(mode).Should().Be(expected);
+    }
+
     [Test]
     public void It_rejects_an_unsupported_database_engine()
     {


### PR DESCRIPTION
## Summary

`RepresentationRestampE2eHarness` hardcoded `DmsContainerName = "ed-fi-api"`. That name only exists because `eng/docker-compose/local-dms.yml` sets `container_name`; `published-dms.yml` sets none, so Compose names the DMS container `dms-published-dms-1` under `-UsePublishedImage`. Every `docker cp`, `docker stop`, and `docker start` in the harness therefore missed its target in the scheduled pre-image E2E run.

The Docker exit codes were discarded, so nothing failed at the point of the mistake. The run continued and the DocumentCacheAdmin CLI died on an API schema that had never been copied out, reporting `DocumentCache configuration error: API schema loading failed`. That misleading message is what the scheduled workflow surfaced.

## What changed

- **The container name is configuration, not a constant.** New `AppSettings.DmsContainerName` in the E2E test project, default `ed-fi-api`, settable as `AppSettings__DmsContainerName`. Direct `setup-local-dms.ps1` plus `dotnet test` workflows are unaffected.
- **One source of truth for the name.** `Get-E2ETestEnvironmentContext` takes the image mode and reads the name from `Get-E2EStartupPhasePlan`, which already decided it for the Docker phases. `Invoke-WithE2ETestProcessContext` exports it to the test process and restores it exactly, and throws if it is blank. `Initialize-E2EDatabase` drops its duplicate copy of the same decision.
- **Docker failures are loud and immediate.** A non-zero exit throws with the operation, the target container, the exit code, and both streams. A Docker CLI that never launched gets a distinct message with no fabricated exit code.
- **Cleanup undoes only what happened.** The container is restarted only after a stop that actually succeeded, so a wrong name now fails on the first `docker cp` before DMS is touched. The disabled-mode lifecycle reset runs only if the lifecycle was really set to Disabled, and it cannot skip the restart: reset and restart are nested so both run and both failures survive behind the primary one.

## Verification

Against a real published-image stack, Compose named the container `dms-published-dms-1` and no `ed-fi-api` container existed at any point.

All four representation-restamp scenarios pass individually under the published image:

| Scenario | Result |
|---|---|
| Tracking, ETag | Passed, 57s |
| Tracking, Change Query | Passed, 1m48s |
| Disabled, ETag | Passed, 38s |
| Disabled, Change Query | Passed, 38s |

A wrong container name now fails in 0.1s, and DMS is never stopped or restarted:

```
System.InvalidOperationException : docker cp failed for DMS container 'does-not-exist' (exit code 1).
Set AppSettings__DmsContainerName to the running DMS container
(local image: ed-fi-api; published image: dms-published-dms-1).
stdout:
stderr: Error response from daemon: No such container: does-not-exist
```

Also run: CSharpier clean on all five touched C# files; 43 focused unit tests green across `Given_App_Settings` and `Given_Representation_Restamp_E2E_Harness`; the two E2E Pester suites at 221 passed.

## Known gap: batch acceptance is blocked by DMS-1528

The canonical acceptance interpretation and A/B evidence now live in the DMS-1527 Jira description under **Implementation Decisions**: https://edfi.atlassian.net/browse/DMS-1527. Briefly, this PR is verified for the published-image container-name root cause; the literal all-four batch acceptance command remains blocked by DMS-1528.

Two pre-existing Pester failures on `main`, unrelated to this work and unchanged by it: `composes an explicit feature overlay before the data-standard and database-engine overlays` in `E2EEngineForwarding.Tests.ps1`, and `run.sh clears stale generated package output...` in `BootstrapSchemaAndSecuritySelection.Tests.ps1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
