### PR TITLE
[DMS-1528] Isolate the representation-restamp E2E scenarios and attribute drain timeouts to a phase

### DIFF
--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -29,7 +29,22 @@ internal sealed record RepresentationRestampE2EProviderSql(
     string SetLifecycle,
     string ReadCanonicalContentVersion,
     string ReadRequiredWorkVersion,
-    string IsProjected
+    string IsProjected,
+    string ReadResidualWork
+);
+
+/// <summary>
+/// One durable <c>dms.DocumentProjectionWork</c> row joined to its canonical document and, when
+/// present, its cache row. Read only for diagnostics: it tells a reader which rows kept a drain
+/// alive and whether they belong to the scenario under test.
+/// </summary>
+internal sealed record RepresentationRestampE2EResidualWorkRow(
+    long DocumentId,
+    Guid DocumentUuid,
+    long RequiredContentVersion,
+    long CanonicalContentVersion,
+    long? CacheContentVersion,
+    DateTimeOffset FirstEnqueuedAt
 );
 
 internal interface IRepresentationRestampE2EProviderOperations
@@ -61,6 +76,11 @@ internal interface IRepresentationRestampE2EProviderOperations
     Task<bool> IsProjectedAsync(
         DbConnection connection,
         Guid documentUuid,
+        CancellationToken cancellationToken
+    );
+
+    Task<IReadOnlyList<RepresentationRestampE2EResidualWorkRow>> ReadResidualWorkAsync(
+        DbConnection connection,
         CancellationToken cancellationToken
     );
 }
@@ -127,6 +147,50 @@ internal abstract class RepresentationRestampE2EProviderOperations(Representatio
         return Convert.ToBoolean(await command.ExecuteScalarAsync(cancellationToken));
     }
 
+    public async Task<IReadOnlyList<RepresentationRestampE2EResidualWorkRow>> ReadResidualWorkAsync(
+        DbConnection connection,
+        CancellationToken cancellationToken
+    )
+    {
+        await using DbCommand command = connection.CreateCommand();
+        command.CommandText = Sql.ReadResidualWork;
+        await using DbDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        List<RepresentationRestampE2EResidualWorkRow> rows = [];
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(
+                new RepresentationRestampE2EResidualWorkRow(
+                    reader.GetInt64(0),
+                    reader.GetGuid(1),
+                    reader.GetInt64(2),
+                    reader.GetInt64(3),
+                    await reader.IsDBNullAsync(4, cancellationToken) ? null : reader.GetInt64(4),
+                    ToUtcTimestamp(reader.GetValue(5))
+                )
+            );
+        }
+
+        return rows;
+    }
+
+    private static DateTimeOffset ToUtcTimestamp(object value) =>
+        value switch
+        {
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToUniversalTime(),
+            DateTime dateTime => new DateTimeOffset(
+                dateTime.Kind == DateTimeKind.Unspecified
+                    ? DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+                    : dateTime.ToUniversalTime()
+            ),
+            _ => DateTimeOffset
+                .Parse(
+                    Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture)
+                        ?? throw new InvalidOperationException("DocumentProjectionWork timestamp was null."),
+                    System.Globalization.CultureInfo.InvariantCulture
+                )
+                .ToUniversalTime(),
+        };
+
     private static DbCommand CreateDocumentCommand(
         DbConnection connection,
         string commandText,
@@ -182,6 +246,19 @@ internal sealed class PostgresqlRepresentationRestampE2EProviderOperations()
                       WHERE work."DocumentId" = document."DocumentId"
                   )
             );
+            """,
+            """
+            SELECT work."DocumentId",
+                   document."DocumentUuid",
+                   work."RequiredContentVersion",
+                   document."ContentVersion",
+                   cache."ContentVersion",
+                   work."FirstEnqueuedAt"
+            FROM dms."DocumentProjectionWork" AS work
+            INNER JOIN dms."Document" AS document ON document."DocumentId" = work."DocumentId"
+            LEFT JOIN dms."DocumentCache" AS cache ON cache."DocumentId" = work."DocumentId"
+            ORDER BY work."FirstEnqueuedAt", work."DocumentId"
+            LIMIT 50;
             """
         )
     )
@@ -227,6 +304,19 @@ internal sealed class MssqlRepresentationRestampE2EProviderOperations()
                 ) THEN 1 ELSE 0 END
                 AS bit
             );
+            """,
+            """
+            SELECT TOP (50)
+                   work.[DocumentId],
+                   document.[DocumentUuid],
+                   work.[RequiredContentVersion],
+                   document.[ContentVersion],
+                   cache.[ContentVersion],
+                   work.[FirstEnqueuedAt]
+            FROM [dms].[DocumentProjectionWork] AS work
+            INNER JOIN [dms].[Document] AS document ON document.[DocumentId] = work.[DocumentId]
+            LEFT JOIN [dms].[DocumentCache] AS cache ON cache.[DocumentId] = work.[DocumentId]
+            ORDER BY work.[FirstEnqueuedAt], work.[DocumentId];
             """
         )
     )
@@ -373,7 +463,7 @@ internal static class RepresentationRestampE2EHarness
                             },
                             async () =>
                             {
-                                await DrainOrdinaryProjectorAsync(target);
+                                await DrainOrdinaryProjectorAsync(target, documentUuid);
                                 projectionExpected = true;
                             }
                         );
@@ -555,9 +645,15 @@ internal static class RepresentationRestampE2EHarness
         DocumentCacheProjectionTargetRuntimeContext Context
     );
 
-    private static async Task DrainOrdinaryProjectorAsync(DocumentCacheAdminCliTarget target)
+    private static async Task DrainOrdinaryProjectorAsync(
+        DocumentCacheAdminCliTarget target,
+        Guid documentUuid
+    )
     {
         string targetDescription = TargetDescription(target);
+        IRepresentationRestampE2EProviderOperations providerOperations = ProviderOperationsFor(
+            target.ProviderToken
+        );
         ProjectionRuntime runtime = await RunPhaseAsync(
             ProjectorSetupPhase,
             ProjectorSetupBudget,
@@ -569,6 +665,17 @@ internal static class RepresentationRestampE2EHarness
         IDocumentCacheProjectionDrainPageProcessor processor =
             serviceProvider.GetRequiredService<IDocumentCacheProjectionDrainPageProcessor>();
 
+        IReadOnlyList<RepresentationRestampE2EResidualWorkRow> queuedBeforeDrain =
+            await ReadResidualWorkAsync(providerOperations, target.ConnectionString, CancellationToken.None);
+        Log.Information(
+            "Representation-restamp ordinary drain for target {Target} and document {DocumentUuid} starts with {QueuedRowCount} queued work row(s): {QueuedRows}",
+            targetDescription,
+            documentUuid,
+            queuedBeforeDrain.Count,
+            DescribeResidualWork(queuedBeforeDrain, documentUuid)
+        );
+
+        var tally = new RepresentationRestampDrainTally();
         await RunPhaseAsync(
             OrdinaryDrainPhase,
             OrdinaryDrainBudget,
@@ -584,15 +691,94 @@ internal static class RepresentationRestampE2EHarness
                         ),
                         cancellationToken
                     );
+                    tally.Record(result);
                     if (result.Outcome == DocumentCacheProjectionDrainPageOutcome.NoEligibleWork)
                     {
                         return;
                     }
 
-                    result.Outcome.Should().Be(DocumentCacheProjectionDrainPageOutcome.PageProcessed);
+                    result
+                        .Outcome.Should()
+                        .Be(DocumentCacheProjectionDrainPageOutcome.PageProcessed, tally.Describe());
                 }
-            }
+            },
+            () =>
+                DescribeDrainAsync(tally, context, providerOperations, target.ConnectionString, documentUuid)
         );
+    }
+
+    /// <summary>
+    /// Builds the drain diagnostics attached to a drain failure: the page tallies, the projector's own
+    /// per-document failure snapshot, and a fresh read of the work rows still queued. The residual read
+    /// gets its own short budget because the drain budget has already been spent when this runs.
+    /// </summary>
+    private static async Task<string> DescribeDrainAsync(
+        RepresentationRestampDrainTally tally,
+        DocumentCacheProjectionTargetRuntimeContext context,
+        IRepresentationRestampE2EProviderOperations providerOperations,
+        string connectionString,
+        Guid documentUuid
+    )
+    {
+        using var readBudget = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        IReadOnlyList<RepresentationRestampE2EResidualWorkRow> residualWork = await ReadResidualWorkAsync(
+            providerOperations,
+            connectionString,
+            readBudget.Token
+        );
+        return FormatDrainDiagnostics(
+            tally,
+            residualWork,
+            DescribeProjectorFailures(context.FailureBackoffState.CreateFailureDiagnosticsSnapshot()),
+            documentUuid
+        );
+    }
+
+    internal static string FormatDrainDiagnostics(
+        RepresentationRestampDrainTally tally,
+        IReadOnlyList<RepresentationRestampE2EResidualWorkRow> residualWork,
+        IReadOnlyList<string> projectorFailures,
+        Guid documentUuid
+    ) =>
+        $"{tally.Describe()} Residual work rows ({residualWork.Count}, own document {documentUuid}): "
+        + $"{DescribeResidualWork(residualWork, documentUuid)}. Projector failure diagnostics ({projectorFailures.Count}): "
+        + $"{(projectorFailures.Count == 0 ? "none" : string.Join("; ", projectorFailures))}.";
+
+    internal static string DescribeResidualWork(
+        IReadOnlyList<RepresentationRestampE2EResidualWorkRow> residualWork,
+        Guid documentUuid
+    ) =>
+        residualWork.Count == 0
+            ? "none"
+            : string.Join(
+                "; ",
+                residualWork.Select(row =>
+                    $"[{(row.DocumentUuid == documentUuid ? "own" : "foreign")} DocumentId={row.DocumentId} "
+                    + $"DocumentUuid={row.DocumentUuid} RequiredContentVersion={row.RequiredContentVersion} "
+                    + $"CanonicalContentVersion={row.CanonicalContentVersion} "
+                    + $"CacheContentVersion={(row.CacheContentVersion is null ? "absent" : row.CacheContentVersion.Value.ToString())} "
+                    + $"FirstEnqueuedAt={row.FirstEnqueuedAt:O}]"
+                )
+            );
+
+    internal static IReadOnlyList<string> DescribeProjectorFailures(
+        DocumentCacheProjectionFailureDiagnostics diagnostics
+    ) =>
+        diagnostics
+            .DocumentDiagnostics.Select(diagnostic =>
+                $"DocumentId={diagnostic.DocumentId} {diagnostic.Category}: {diagnostic.Message}"
+            )
+            .ToList();
+
+    private static async Task<IReadOnlyList<RepresentationRestampE2EResidualWorkRow>> ReadResidualWorkAsync(
+        IRepresentationRestampE2EProviderOperations providerOperations,
+        string connectionString,
+        CancellationToken cancellationToken
+    )
+    {
+        await using DbConnection connection = providerOperations.OpenConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        return await providerOperations.ReadResidualWorkAsync(connection, cancellationToken);
     }
 
     private static async Task<ProjectionRuntime> CreateProjectionRuntimeAsync(
@@ -665,7 +851,8 @@ internal static class RepresentationRestampE2EHarness
         string phaseName,
         TimeSpan budget,
         string targetDescription,
-        Func<CancellationToken, Task<T>> action
+        Func<CancellationToken, Task<T>> action,
+        Func<Task<string>>? describeTimeoutAsync = null
     )
     {
         using var budgetSource = new CancellationTokenSource(budget);
@@ -677,7 +864,13 @@ internal static class RepresentationRestampE2EHarness
         catch (OperationCanceledException exception) when (budgetSource.IsCancellationRequested)
         {
             throw new TimeoutException(
-                PhaseTimeoutMessage(phaseName, stopwatch.Elapsed, budget, targetDescription),
+                PhaseTimeoutMessage(
+                    phaseName,
+                    stopwatch.Elapsed,
+                    budget,
+                    targetDescription,
+                    await DescribeTimeoutAsync(describeTimeoutAsync)
+                ),
                 exception
             );
         }
@@ -687,7 +880,8 @@ internal static class RepresentationRestampE2EHarness
         string phaseName,
         TimeSpan budget,
         string targetDescription,
-        Func<CancellationToken, Task> action
+        Func<CancellationToken, Task> action,
+        Func<Task<string>>? describeTimeoutAsync = null
     ) =>
         await RunPhaseAsync(
             phaseName,
@@ -697,17 +891,41 @@ internal static class RepresentationRestampE2EHarness
             {
                 await action(cancellationToken);
                 return true;
-            }
+            },
+            describeTimeoutAsync
         );
+
+    /// <summary>
+    /// Diagnostics must never hide the timeout they describe: a failing describer is reported inline
+    /// instead of replacing the <see cref="TimeoutException"/>.
+    /// </summary>
+    private static async Task<string?> DescribeTimeoutAsync(Func<Task<string>>? describeTimeoutAsync)
+    {
+        if (describeTimeoutAsync is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await describeTimeoutAsync();
+        }
+        catch (Exception exception)
+        {
+            return $"Drain diagnostics unavailable: {exception.GetType().Name}: {exception.Message}";
+        }
+    }
 
     internal static string PhaseTimeoutMessage(
         string phaseName,
         TimeSpan elapsed,
         TimeSpan budget,
-        string targetDescription
+        string targetDescription,
+        string? detail = null
     ) =>
         $"Timed out in representation-restamp phase '{phaseName}' after {elapsed} (budget {budget}) "
-        + $"for target {targetDescription}.";
+        + $"for target {targetDescription}."
+        + (string.IsNullOrWhiteSpace(detail) ? string.Empty : $" {detail}");
 
     internal static async Task<ServiceProvider> CreateProjectionServiceProviderAsync(
         RelationalProviderToken providerToken,
@@ -1170,4 +1388,44 @@ internal static class RepresentationRestampE2EHarness
     }
 
     private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
+}
+
+/// <summary>
+/// Running totals for one ordinary drain, kept by the harness so a drain failure can say how many
+/// pages ran and whether any of them acknowledged work. Consecutive pages without an acknowledgement
+/// are counted because a residual row the projector cannot acknowledge produces exactly that pattern.
+/// </summary>
+internal sealed class RepresentationRestampDrainTally
+{
+    public int Pages { get; private set; }
+
+    public int ProcessedItems { get; private set; }
+
+    public int AcknowledgedOrRemovedItems { get; private set; }
+
+    public int DocumentScopedFailures { get; private set; }
+
+    public int ConsecutivePagesWithoutAcknowledgement { get; private set; }
+
+    public DocumentCacheProjectionDrainPageOutcome? LastOutcome { get; private set; }
+
+    public void Record(DocumentCacheProjectionDrainPageResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        Pages++;
+        ProcessedItems += result.ProcessedItemCount;
+        AcknowledgedOrRemovedItems += result.AcknowledgedOrRemovedItemCount;
+        DocumentScopedFailures += result.DocumentScopedFailureCount;
+        LastOutcome = result.Outcome;
+        ConsecutivePagesWithoutAcknowledgement =
+            result.Outcome == DocumentCacheProjectionDrainPageOutcome.PageProcessed
+            && result.AcknowledgedOrRemovedItemCount == 0
+                ? ConsecutivePagesWithoutAcknowledgement + 1
+                : 0;
+    }
+
+    public string Describe() =>
+        $"Drain pages={Pages} processed={ProcessedItems} acknowledgedOrRemoved={AcknowledgedOrRemovedItems} "
+        + $"documentScopedFailures={DocumentScopedFailures} consecutivePagesWithoutAcknowledgement={ConsecutivePagesWithoutAcknowledgement} "
+        + $"lastOutcome={(LastOutcome is null ? "none" : LastOutcome.Value.ToString())}.";
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -64,8 +64,6 @@ internal interface IRepresentationRestampE2EProviderOperations
 
     DbConnection OpenConnection(string connectionString);
 
-    Task SetTrackingLifecycleAsync(DbConnection connection, CancellationToken cancellationToken);
-
     Task SetLifecycleAsync(
         DbConnection connection,
         DocumentCacheLifecycleState lifecycleState,
@@ -109,9 +107,6 @@ internal abstract class RepresentationRestampE2EProviderOperations(Representatio
     public RepresentationRestampE2EProviderSql Sql { get; } = sql;
 
     public abstract DbConnection OpenConnection(string connectionString);
-
-    public Task SetTrackingLifecycleAsync(DbConnection connection, CancellationToken cancellationToken) =>
-        SetLifecycleAsync(connection, DocumentCacheLifecycleState.Tracking, cancellationToken);
 
     public async Task SetLifecycleAsync(
         DbConnection connection,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -538,77 +538,176 @@ internal static class RepresentationRestampE2EHarness
         await providerOperations.SetLifecycleAsync(connection, lifecycleState, cancellationToken);
     }
 
+    /// <summary>
+    /// Phase names reported when a representation-restamp harness phase exceeds its budget. Setup
+    /// (service provider, effective schema bootstrap, runtime mapping-set compilation) and the drain
+    /// loop have separate budgets so a timeout says which one ran out instead of one undifferentiated
+    /// two-minute failure.
+    /// </summary>
+    internal const string ProjectorSetupPhase = "ProjectorSetup";
+    internal const string OrdinaryDrainPhase = "OrdinaryDrain";
+
+    internal static readonly TimeSpan ProjectorSetupBudget = TimeSpan.FromMinutes(2);
+    internal static readonly TimeSpan OrdinaryDrainBudget = TimeSpan.FromMinutes(2);
+
+    private sealed record ProjectionRuntime(
+        ServiceProvider ServiceProvider,
+        DocumentCacheProjectionTargetRuntimeContext Context
+    );
+
     private static async Task DrainOrdinaryProjectorAsync(DocumentCacheAdminCliTarget target)
     {
-        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        string targetDescription = TargetDescription(target);
+        ProjectionRuntime runtime = await RunPhaseAsync(
+            ProjectorSetupPhase,
+            ProjectorSetupBudget,
+            targetDescription,
+            cancellationToken => CreateProjectionRuntimeAsync(target, cancellationToken)
+        );
+        await using ServiceProvider serviceProvider = runtime.ServiceProvider;
+        await using DocumentCacheProjectionTargetRuntimeContext context = runtime.Context;
+        IDocumentCacheProjectionDrainPageProcessor processor =
+            serviceProvider.GetRequiredService<IDocumentCacheProjectionDrainPageProcessor>();
+
+        await RunPhaseAsync(
+            OrdinaryDrainPhase,
+            OrdinaryDrainBudget,
+            targetDescription,
+            async cancellationToken =>
+            {
+                while (true)
+                {
+                    DocumentCacheProjectionDrainPageResult result = await processor.ProcessPageAsync(
+                        new DocumentCacheProjectionDrainPageRequest(
+                            context,
+                            DocumentCacheProjectionDrainInvocationKind.Ordinary
+                        ),
+                        cancellationToken
+                    );
+                    if (result.Outcome == DocumentCacheProjectionDrainPageOutcome.NoEligibleWork)
+                    {
+                        return;
+                    }
+
+                    result.Outcome.Should().Be(DocumentCacheProjectionDrainPageOutcome.PageProcessed);
+                }
+            }
+        );
+    }
+
+    private static async Task<ProjectionRuntime> CreateProjectionRuntimeAsync(
+        DocumentCacheAdminCliTarget target,
+        CancellationToken cancellationToken
+    )
+    {
+        ServiceProvider serviceProvider = await CreateProjectionServiceProviderAsync(
+            target.ProviderToken,
+            target.AppSettingsDatastore,
+            target.ApiSchemaDirectory,
+            cancellationToken
+        );
         try
         {
-            await using ServiceProvider serviceProvider = await CreateProjectionServiceProviderAsync(
-                target.ProviderToken,
-                target.AppSettingsDatastore,
-                target.ApiSchemaDirectory,
-                timeoutSource.Token
-            );
-            DocumentCacheTargetExecutionContext executionContext = new(
-                DocumentCacheTargetKey.Create(target.TenantKey, target.DataStoreId),
-                new DocumentCacheTargetContextGeneration(1),
-                new DocumentCacheTargetEffectiveSettings(
-                    true,
-                    TimeSpan.FromMilliseconds(250),
-                    TimeSpan.FromMilliseconds(10),
-                    10,
-                    1,
-                    TimeSpan.FromSeconds(1),
-                    1000,
-                    TimeSpan.FromMinutes(1)
-                ),
-                new DocumentCacheTargetDataStoreMetadata(target.DataStoreId, target.AppSettingsDatastore),
-                new DocumentCacheTargetConnectionInput(target.ProviderToken, target.ConnectionString),
-                new DocumentCachePhysicalSourceFingerprint(
-                    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-                ),
-                new DocumentCacheLifecycleObservation(DocumentCacheLifecycleState.Tracking, false),
-                new DocumentCacheInventoryValidationResult(
-                    DocumentCacheInventoryStatus.Satisfied,
-                    "Inventory satisfied."
-                ),
-                new DocumentCacheEnqueueTriggerValidationResult(
-                    DocumentCacheEnqueueTriggerStatus.Satisfied,
-                    "Enqueue trigger satisfied."
-                ),
-                DocumentCacheSqlServerPrerequisiteDetails.NotApplicable()
-            );
-            await using DocumentCacheProjectionTargetRuntimeContext context = await serviceProvider
+            DocumentCacheProjectionTargetRuntimeContext context = await serviceProvider
                 .GetRequiredService<IDocumentCacheProjectionTargetRuntimeContextFactory>()
-                .CreateAsync(executionContext, timeoutSource.Token);
-            IDocumentCacheProjectionDrainPageProcessor processor =
-                serviceProvider.GetRequiredService<IDocumentCacheProjectionDrainPageProcessor>();
-
-            while (true)
-            {
-                DocumentCacheProjectionDrainPageResult result = await processor.ProcessPageAsync(
-                    new DocumentCacheProjectionDrainPageRequest(
-                        context,
-                        DocumentCacheProjectionDrainInvocationKind.Ordinary
-                    ),
-                    timeoutSource.Token
-                );
-                if (result.Outcome == DocumentCacheProjectionDrainPageOutcome.NoEligibleWork)
-                {
-                    return;
-                }
-
-                result.Outcome.Should().Be(DocumentCacheProjectionDrainPageOutcome.PageProcessed);
-            }
+                .CreateAsync(CreateExecutionContext(target), cancellationToken);
+            return new ProjectionRuntime(serviceProvider, context);
         }
-        catch (OperationCanceledException exception) when (timeoutSource.IsCancellationRequested)
+        catch
+        {
+            await serviceProvider.DisposeAsync();
+            throw;
+        }
+    }
+
+    private static DocumentCacheTargetExecutionContext CreateExecutionContext(
+        DocumentCacheAdminCliTarget target
+    ) =>
+        new(
+            DocumentCacheTargetKey.Create(target.TenantKey, target.DataStoreId),
+            new DocumentCacheTargetContextGeneration(1),
+            new DocumentCacheTargetEffectiveSettings(
+                true,
+                TimeSpan.FromMilliseconds(250),
+                TimeSpan.FromMilliseconds(10),
+                10,
+                1,
+                TimeSpan.FromSeconds(1),
+                1000,
+                TimeSpan.FromMinutes(1)
+            ),
+            new DocumentCacheTargetDataStoreMetadata(target.DataStoreId, target.AppSettingsDatastore),
+            new DocumentCacheTargetConnectionInput(target.ProviderToken, target.ConnectionString),
+            new DocumentCachePhysicalSourceFingerprint(
+                "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ),
+            new DocumentCacheLifecycleObservation(DocumentCacheLifecycleState.Tracking, false),
+            new DocumentCacheInventoryValidationResult(
+                DocumentCacheInventoryStatus.Satisfied,
+                "Inventory satisfied."
+            ),
+            new DocumentCacheEnqueueTriggerValidationResult(
+                DocumentCacheEnqueueTriggerStatus.Satisfied,
+                "Enqueue trigger satisfied."
+            ),
+            DocumentCacheSqlServerPrerequisiteDetails.NotApplicable()
+        );
+
+    private static string TargetDescription(DocumentCacheAdminCliTarget target) =>
+        $"'{target.TenantKey}':{target.DataStoreId}";
+
+    /// <summary>
+    /// Runs one harness phase under its own budget. Only a cancellation caused by this phase's budget
+    /// becomes a <see cref="TimeoutException"/> that names the phase, the elapsed time, and the budget;
+    /// cancellation from another token and every other failure propagate unchanged.
+    /// </summary>
+    internal static async Task<T> RunPhaseAsync<T>(
+        string phaseName,
+        TimeSpan budget,
+        string targetDescription,
+        Func<CancellationToken, Task<T>> action
+    )
+    {
+        using var budgetSource = new CancellationTokenSource(budget);
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            return await action(budgetSource.Token);
+        }
+        catch (OperationCanceledException exception) when (budgetSource.IsCancellationRequested)
         {
             throw new TimeoutException(
-                $"Timed out draining the ordinary projector for target '{target.TenantKey}':{target.DataStoreId}.",
+                PhaseTimeoutMessage(phaseName, stopwatch.Elapsed, budget, targetDescription),
                 exception
             );
         }
     }
+
+    internal static async Task RunPhaseAsync(
+        string phaseName,
+        TimeSpan budget,
+        string targetDescription,
+        Func<CancellationToken, Task> action
+    ) =>
+        await RunPhaseAsync(
+            phaseName,
+            budget,
+            targetDescription,
+            async cancellationToken =>
+            {
+                await action(cancellationToken);
+                return true;
+            }
+        );
+
+    internal static string PhaseTimeoutMessage(
+        string phaseName,
+        TimeSpan elapsed,
+        TimeSpan budget,
+        string targetDescription
+    ) =>
+        $"Timed out in representation-restamp phase '{phaseName}' after {elapsed} (budget {budget}) "
+        + $"for target {targetDescription}.";
 
     internal static async Task<ServiceProvider> CreateProjectionServiceProviderAsync(
         RelationalProviderToken providerToken,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -777,6 +777,21 @@ internal static class RepresentationRestampE2EHarness
     internal static readonly TimeSpan ProjectorSetupBudget = TimeSpan.FromMinutes(2);
     internal static readonly TimeSpan OrdinaryDrainBudget = TimeSpan.FromMinutes(2);
 
+    /// <summary>
+    /// Diagnostic reads of the queued work rows are bounded separately from the phase budgets: the
+    /// pre-drain snapshot must not eat into the drain, and the failure snapshot runs after the drain
+    /// budget is already spent.
+    /// </summary>
+    internal static readonly TimeSpan ResidualWorkReadBudget = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// A residual row the projector cannot acknowledge (for example a WorkVersionMismatch anomaly left
+    /// by a Disabled restamp) makes every page report PageProcessed with nothing acknowledged. The drain
+    /// stops after this many such pages in a row and reports the residual rows instead of spinning
+    /// until the budget expires.
+    /// </summary>
+    internal const int MaxConsecutivePagesWithoutAcknowledgement = 20;
+
     private sealed record ProjectionRuntime(
         ServiceProvider ServiceProvider,
         DocumentCacheProjectionTargetRuntimeContext Context
@@ -803,7 +818,7 @@ internal static class RepresentationRestampE2EHarness
             serviceProvider.GetRequiredService<IDocumentCacheProjectionDrainPageProcessor>();
 
         IReadOnlyList<RepresentationRestampE2EResidualWorkRow> queuedBeforeDrain =
-            await ReadResidualWorkAsync(providerOperations, target.ConnectionString, CancellationToken.None);
+            await ReadResidualWorkBoundedAsync(providerOperations, target.ConnectionString);
         Log.Information(
             "Representation-restamp ordinary drain for target {Target} and document {DocumentUuid} starts with {QueuedRowCount} queued work row(s): {QueuedRows}",
             targetDescription,
@@ -813,35 +828,141 @@ internal static class RepresentationRestampE2EHarness
         );
 
         var tally = new RepresentationRestampDrainTally();
+        Func<Task<string>> describeDiagnosticsAsync = () =>
+            DescribeDrainAsync(tally, context, providerOperations, target.ConnectionString, documentUuid);
         await RunPhaseAsync(
             OrdinaryDrainPhase,
             OrdinaryDrainBudget,
             targetDescription,
-            async cancellationToken =>
-            {
-                while (true)
-                {
-                    DocumentCacheProjectionDrainPageResult result = await processor.ProcessPageAsync(
-                        new DocumentCacheProjectionDrainPageRequest(
-                            context,
-                            DocumentCacheProjectionDrainInvocationKind.Ordinary
+            cancellationToken =>
+                DrainUntilOwnWorkProjectedAsync(
+                    tally,
+                    token =>
+                        processor.ProcessPageAsync(
+                            new DocumentCacheProjectionDrainPageRequest(
+                                context,
+                                DocumentCacheProjectionDrainInvocationKind.Ordinary
+                            ),
+                            token
                         ),
-                        cancellationToken
-                    );
-                    tally.Record(result);
-                    if (result.Outcome == DocumentCacheProjectionDrainPageOutcome.NoEligibleWork)
+                    token =>
+                        IsProjectedAsync(providerOperations, target.ConnectionString, documentUuid, token),
+                    describeDiagnosticsAsync,
+                    targetDescription,
+                    MaxConsecutivePagesWithoutAcknowledgement,
+                    cancellationToken
+                ),
+            describeDiagnosticsAsync
+        );
+        Log.Information(
+            "Representation-restamp ordinary drain for target {Target} projected document {DocumentUuid}. {Tally}",
+            targetDescription,
+            documentUuid,
+            tally.Describe()
+        );
+    }
+
+    /// <summary>
+    /// The ordinary drain loop, isolated from other scenarios' work. The scenario's obligation is that
+    /// its own Tracking restamp work gets projected, so the drain completes as soon as the own document
+    /// is projected and merely reports any foreign rows still queued. NoEligibleWork without the own
+    /// document projected, any outcome other than PageProcessed, and a run of pages that acknowledge
+    /// nothing all fail with the drain diagnostics instead of waiting for the budget.
+    /// </summary>
+    internal static async Task DrainUntilOwnWorkProjectedAsync(
+        RepresentationRestampDrainTally tally,
+        Func<CancellationToken, Task<DocumentCacheProjectionDrainPageResult>> processPageAsync,
+        Func<CancellationToken, Task<bool>> isOwnDocumentProjectedAsync,
+        Func<Task<string>> describeDiagnosticsAsync,
+        string targetDescription,
+        int maxConsecutivePagesWithoutAcknowledgement,
+        CancellationToken cancellationToken
+    )
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxConsecutivePagesWithoutAcknowledgement);
+        while (true)
+        {
+            DocumentCacheProjectionDrainPageResult result = await processPageAsync(cancellationToken);
+            tally.Record(result);
+            switch (result.Outcome)
+            {
+                case DocumentCacheProjectionDrainPageOutcome.PageProcessed:
+                    if (await isOwnDocumentProjectedAsync(cancellationToken))
                     {
                         return;
                     }
 
-                    result
-                        .Outcome.Should()
-                        .Be(DocumentCacheProjectionDrainPageOutcome.PageProcessed, tally.Describe());
-                }
-            },
-            () =>
-                DescribeDrainAsync(tally, context, providerOperations, target.ConnectionString, documentUuid)
-        );
+                    if (
+                        tally.ConsecutivePagesWithoutAcknowledgement
+                        >= maxConsecutivePagesWithoutAcknowledgement
+                    )
+                    {
+                        throw new InvalidOperationException(
+                            await DrainFailureMessageAsync(
+                                targetDescription,
+                                $"made no progress: {maxConsecutivePagesWithoutAcknowledgement} consecutive page(s) acknowledged no work while the own document is still not projected",
+                                describeDiagnosticsAsync
+                            )
+                        );
+                    }
+
+                    continue;
+
+                case DocumentCacheProjectionDrainPageOutcome.NoEligibleWork:
+                    if (await isOwnDocumentProjectedAsync(cancellationToken))
+                    {
+                        return;
+                    }
+
+                    throw new InvalidOperationException(
+                        await DrainFailureMessageAsync(
+                            targetDescription,
+                            "reported NoEligibleWork but the Tracking restamp's own document is not projected, so its enqueued work was never acknowledged",
+                            describeDiagnosticsAsync
+                        )
+                    );
+
+                default:
+                    throw new InvalidOperationException(
+                        await DrainFailureMessageAsync(
+                            targetDescription,
+                            $"ended with outcome '{result.Outcome}' instead of PageProcessed or NoEligibleWork",
+                            describeDiagnosticsAsync
+                        )
+                    );
+            }
+        }
+    }
+
+    private static async Task<string> DrainFailureMessageAsync(
+        string targetDescription,
+        string reason,
+        Func<Task<string>> describeDiagnosticsAsync
+    ) =>
+        $"Representation-restamp phase '{OrdinaryDrainPhase}' failed for target {targetDescription}: "
+        + $"the ordinary drain {reason}. {await DescribeSafelyAsync(describeDiagnosticsAsync)}";
+
+    private static async Task<bool> IsProjectedAsync(
+        IRepresentationRestampE2EProviderOperations providerOperations,
+        string connectionString,
+        Guid documentUuid,
+        CancellationToken cancellationToken
+    )
+    {
+        await using DbConnection connection = providerOperations.OpenConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        return await providerOperations.IsProjectedAsync(connection, documentUuid, cancellationToken);
+    }
+
+    private static async Task<
+        IReadOnlyList<RepresentationRestampE2EResidualWorkRow>
+    > ReadResidualWorkBoundedAsync(
+        IRepresentationRestampE2EProviderOperations providerOperations,
+        string connectionString
+    )
+    {
+        using var readBudget = new CancellationTokenSource(ResidualWorkReadBudget);
+        return await ReadResidualWorkAsync(providerOperations, connectionString, readBudget.Token);
     }
 
     /// <summary>
@@ -857,12 +978,8 @@ internal static class RepresentationRestampE2EHarness
         Guid documentUuid
     )
     {
-        using var readBudget = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-        IReadOnlyList<RepresentationRestampE2EResidualWorkRow> residualWork = await ReadResidualWorkAsync(
-            providerOperations,
-            connectionString,
-            readBudget.Token
-        );
+        IReadOnlyList<RepresentationRestampE2EResidualWorkRow> residualWork =
+            await ReadResidualWorkBoundedAsync(providerOperations, connectionString);
         return FormatDrainDiagnostics(
             tally,
             residualWork,
@@ -1006,7 +1123,7 @@ internal static class RepresentationRestampE2EHarness
                     stopwatch.Elapsed,
                     budget,
                     targetDescription,
-                    await DescribeTimeoutAsync(describeTimeoutAsync)
+                    await DescribeSafelyAsync(describeTimeoutAsync)
                 ),
                 exception
             );
@@ -1033,19 +1150,19 @@ internal static class RepresentationRestampE2EHarness
         );
 
     /// <summary>
-    /// Diagnostics must never hide the timeout they describe: a failing describer is reported inline
-    /// instead of replacing the <see cref="TimeoutException"/>.
+    /// Diagnostics must never hide the failure they describe: a failing describer is reported inline
+    /// instead of replacing the timeout or drain failure.
     /// </summary>
-    private static async Task<string?> DescribeTimeoutAsync(Func<Task<string>>? describeTimeoutAsync)
+    private static async Task<string?> DescribeSafelyAsync(Func<Task<string>>? describeAsync)
     {
-        if (describeTimeoutAsync is null)
+        if (describeAsync is null)
         {
             return null;
         }
 
         try
         {
-            return await describeTimeoutAsync();
+            return await describeAsync();
         }
         catch (Exception exception)
         {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -819,12 +819,9 @@ internal static class RepresentationRestampE2EHarness
 
         IReadOnlyList<RepresentationRestampE2EResidualWorkRow> queuedBeforeDrain =
             await ReadResidualWorkBoundedAsync(providerOperations, target.ConnectionString);
-        Log.Information(
-            "Representation-restamp ordinary drain for target {Target} and document {DocumentUuid} starts with {QueuedRowCount} queued work row(s): {QueuedRows}",
-            targetDescription,
-            documentUuid,
-            queuedBeforeDrain.Count,
-            DescribeResidualWork(queuedBeforeDrain, documentUuid)
+        WriteHarnessOutput(
+            $"Ordinary drain for target {targetDescription} and document {documentUuid} starts with "
+                + $"{queuedBeforeDrain.Count} queued work row(s): {DescribeResidualWork(queuedBeforeDrain, documentUuid)}"
         );
 
         var tally = new RepresentationRestampDrainTally();
@@ -854,13 +851,19 @@ internal static class RepresentationRestampE2EHarness
                 ),
             describeDiagnosticsAsync
         );
-        Log.Information(
-            "Representation-restamp ordinary drain for target {Target} projected document {DocumentUuid}. {Tally}",
-            targetDescription,
-            documentUuid,
-            tally.Describe()
+        WriteHarnessOutput(
+            $"Ordinary drain for target {targetDescription} projected document {documentUuid}. {tally.Describe()}"
         );
     }
+
+    /// <summary>
+    /// Harness diagnostics go to NUnit's captured test output, which lands in the TRX for the scenario
+    /// and in the console for failed tests. The E2E project's Serilog <c>TestLogger</c> is an instance
+    /// the static harness cannot reach, and nothing assigns Serilog's static logger, so writing there
+    /// would be silently dropped.
+    /// </summary>
+    private static void WriteHarnessOutput(string message) =>
+        TestContext.Out.WriteLine($"[RepresentationRestamp] {message}");
 
     /// <summary>
     /// The ordinary drain loop, isolated from other scenarios' work. The scenario's obligation is that

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/RepresentationRestampE2eHarness.cs
@@ -30,7 +30,18 @@ internal sealed record RepresentationRestampE2EProviderSql(
     string ReadCanonicalContentVersion,
     string ReadRequiredWorkVersion,
     string IsProjected,
-    string ReadResidualWork
+    string ReadResidualWork,
+    string ReadDocumentCacheState
+);
+
+/// <summary>
+/// The <c>dms.DocumentCacheState</c> singleton as observed before a scenario mutates it. Both
+/// columns are captured so cleanup restores the exact pre-scenario state: <c>SetLifecycleAsync</c>
+/// also writes the cache-ahead latch, so restoring the lifecycle alone would clobber a set latch.
+/// </summary>
+internal sealed record RepresentationRestampE2EDocumentCacheStateObservation(
+    DocumentCacheLifecycleState LifecycleState,
+    bool CacheAheadRecoveryRequired
 );
 
 /// <summary>
@@ -58,6 +69,13 @@ internal interface IRepresentationRestampE2EProviderOperations
     Task SetLifecycleAsync(
         DbConnection connection,
         DocumentCacheLifecycleState lifecycleState,
+        CancellationToken cancellationToken,
+        bool cacheAheadRecoveryRequired = false
+    );
+
+    Task<RepresentationRestampE2EDocumentCacheStateObservation> ReadDocumentCacheStateAsync(
+        DbConnection connection,
+        string targetDescription,
         CancellationToken cancellationToken
     );
 
@@ -98,14 +116,36 @@ internal abstract class RepresentationRestampE2EProviderOperations(Representatio
     public async Task SetLifecycleAsync(
         DbConnection connection,
         DocumentCacheLifecycleState lifecycleState,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        bool cacheAheadRecoveryRequired = false
     )
     {
         await using DbCommand command = connection.CreateCommand();
         command.CommandText = Sql.SetLifecycle;
         AddParameter(command, "projectionLifecycleState", lifecycleState.ToString());
-        AddParameter(command, "cacheAheadRecoveryRequired", false);
+        AddParameter(command, "cacheAheadRecoveryRequired", cacheAheadRecoveryRequired);
         await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task<RepresentationRestampE2EDocumentCacheStateObservation> ReadDocumentCacheStateAsync(
+        DbConnection connection,
+        string targetDescription,
+        CancellationToken cancellationToken
+    )
+    {
+        await using DbCommand command = connection.CreateCommand();
+        command.CommandText = Sql.ReadDocumentCacheState;
+        await using DbDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return RepresentationRestampE2EHarness.ParseDocumentCacheState(null, null, targetDescription);
+        }
+
+        return RepresentationRestampE2EHarness.ParseDocumentCacheState(
+            reader.GetValue(0),
+            reader.GetValue(1),
+            targetDescription
+        );
     }
 
     public async Task<long> ReadCanonicalContentVersionAsync(
@@ -259,6 +299,11 @@ internal sealed class PostgresqlRepresentationRestampE2EProviderOperations()
             LEFT JOIN dms."DocumentCache" AS cache ON cache."DocumentId" = work."DocumentId"
             ORDER BY work."FirstEnqueuedAt", work."DocumentId"
             LIMIT 50;
+            """,
+            """
+            SELECT "ProjectionLifecycleState", "CacheAheadRecoveryRequired"
+            FROM dms."DocumentCacheState"
+            WHERE "StateId" = 1;
             """
         )
     )
@@ -317,6 +362,11 @@ internal sealed class MssqlRepresentationRestampE2EProviderOperations()
             INNER JOIN [dms].[Document] AS document ON document.[DocumentId] = work.[DocumentId]
             LEFT JOIN [dms].[DocumentCache] AS cache ON cache.[DocumentId] = work.[DocumentId]
             ORDER BY work.[FirstEnqueuedAt], work.[DocumentId];
+            """,
+            """
+            SELECT [ProjectionLifecycleState], [CacheAheadRecoveryRequired]
+            FROM [dms].[DocumentCacheState]
+            WHERE [StateId] = 1;
             """
         )
     )
@@ -356,12 +406,12 @@ internal static class RepresentationRestampE2EHarness
             async () =>
             {
                 var projectionExpected = false;
-                // Cleanup undoes only what this run could have changed: the container is restarted
-                // only after a stop that succeeded, and the Disabled lifecycle reset is armed once
-                // the write is about to be attempted. A wrong container name fails on the copy
-                // below, before DMS is touched, so neither cleanup runs.
+                // Cleanup undoes only what actually happened: the container is restarted only after a
+                // stop that succeeded, and DocumentCacheState is restored only after it was observed,
+                // which happens before any mutation. A wrong container name fails on the copy below,
+                // before DMS is touched; an unreadable state row fails before the lifecycle is changed.
                 var dmsStopped = false;
-                var disabledLifecycleResetRequired = false;
+                RepresentationRestampE2EDocumentCacheStateObservation? observedState = null;
                 IRepresentationRestampE2EProviderOperations providerOperations = ProviderOperationsFor(
                     ProviderFor(AppSettings.DatabaseEngine)
                 );
@@ -384,11 +434,17 @@ internal static class RepresentationRestampE2EHarness
                         );
                         providerOperations = ProviderOperationsFor(target.ProviderToken);
                         connectionString = target.ConnectionString;
-                        // Arm the reset before the write is attempted, not after it returns: a write
-                        // that fails partway can still have moved the lifecycle, and cleanup has to
-                        // try to restore Tracking either way. Safe to arm here because the provider
-                        // and connection now address the external target the reset will use.
-                        disabledLifecycleResetRequired = RequiresDisabledLifecycleReset(mode);
+                        // Capture the pre-scenario state before the first mutation so cleanup can put the
+                        // shared E2E database back exactly. Without this the first restamp scenario left
+                        // the database in Tracking for the rest of the run, every later write enqueued
+                        // work nobody drained, and a later Disabled restamp orphaned a work row that kept
+                        // the next Tracking drain spinning (DMS-1528).
+                        observedState = await ReadDocumentCacheStateAsync(
+                            providerOperations,
+                            connectionString,
+                            TargetDescription(target),
+                            CancellationToken.None
+                        );
                         await SetLifecycleAsync(
                             providerOperations,
                             connectionString,
@@ -468,23 +524,23 @@ internal static class RepresentationRestampE2EHarness
                             }
                         );
                     },
-                    // Nested so a failed lifecycle reset cannot skip the restart: the reset is the
+                    // Nested so a failed state restore cannot skip the restart: the restore is the
                     // inner action and the restart is its cleanup, which runs either way.
                     () =>
                         RunWithCleanupAsync(
                             $"cleanup after representation restamp ({mode}) for DMS container '{containerName}'",
-                            async () =>
-                            {
-                                if (disabledLifecycleResetRequired)
-                                {
-                                    await SetLifecycleAsync(
-                                        providerOperations,
-                                        connectionString,
-                                        DocumentCacheLifecycleState.Tracking,
-                                        CancellationToken.None
-                                    );
-                                }
-                            },
+                            () =>
+                                RestoreDocumentCacheStateAsync(
+                                    observedState,
+                                    (lifecycleState, cacheAheadRecoveryRequired) =>
+                                        SetLifecycleAsync(
+                                            providerOperations,
+                                            connectionString,
+                                            lifecycleState,
+                                            CancellationToken.None,
+                                            cacheAheadRecoveryRequired
+                                        )
+                                ),
                             async () =>
                             {
                                 if (!dmsStopped)
@@ -566,14 +622,6 @@ internal static class RepresentationRestampE2EHarness
         }
     }
 
-    /// <summary>
-    /// Whether cleanup has to restore the Tracking lifecycle. True for a Disabled restamp, which is
-    /// the only mode that writes a different lifecycle. Callers arm this before attempting that
-    /// write rather than after it succeeds, so a write that fails partway is still reset.
-    /// </summary>
-    internal static bool RequiresDisabledLifecycleReset(DocumentCacheRepresentationRestampMode mode) =>
-        mode == DocumentCacheRepresentationRestampMode.Disabled;
-
     internal static RelationalProviderToken ProviderFor(string databaseEngine)
     {
         if (string.Equals(databaseEngine, "mssql", StringComparison.OrdinalIgnoreCase))
@@ -620,13 +668,101 @@ internal static class RepresentationRestampE2EHarness
         IRepresentationRestampE2EProviderOperations providerOperations,
         string connectionString,
         DocumentCacheLifecycleState lifecycleState,
+        CancellationToken cancellationToken,
+        bool cacheAheadRecoveryRequired = false
+    )
+    {
+        await using DbConnection connection = providerOperations.OpenConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await providerOperations.SetLifecycleAsync(
+            connection,
+            lifecycleState,
+            cancellationToken,
+            cacheAheadRecoveryRequired
+        );
+    }
+
+    private static async Task<RepresentationRestampE2EDocumentCacheStateObservation> ReadDocumentCacheStateAsync(
+        IRepresentationRestampE2EProviderOperations providerOperations,
+        string connectionString,
+        string targetDescription,
         CancellationToken cancellationToken
     )
     {
         await using DbConnection connection = providerOperations.OpenConnection(connectionString);
         await connection.OpenAsync(cancellationToken);
-        await providerOperations.SetLifecycleAsync(connection, lifecycleState, cancellationToken);
+        return await providerOperations.ReadDocumentCacheStateAsync(
+            connection,
+            targetDescription,
+            cancellationToken
+        );
     }
+
+    /// <summary>
+    /// Interprets the <c>dms.DocumentCacheState</c> row strictly. A missing row, an unknown lifecycle
+    /// value, or an unreadable latch fails the <see cref="LifecycleCapturePhase"/> before anything is
+    /// mutated; guessing here would silently reintroduce the cross-scenario coupling this guards against.
+    /// </summary>
+    internal static RepresentationRestampE2EDocumentCacheStateObservation ParseDocumentCacheState(
+        object? lifecycleValue,
+        object? cacheAheadRecoveryRequiredValue,
+        string targetDescription
+    )
+    {
+        if (lifecycleValue is null || lifecycleValue is DBNull)
+        {
+            throw new InvalidOperationException(
+                $"Representation-restamp phase '{LifecycleCapturePhase}' failed for target {targetDescription}: "
+                    + "dms.DocumentCacheState has no readable singleton row (StateId = 1)."
+            );
+        }
+
+        string lifecycleText = Convert.ToString(
+            lifecycleValue,
+            System.Globalization.CultureInfo.InvariantCulture
+        )!;
+        // Enum.TryParse also accepts numeric text such as "1"; only the exact member name is a valid
+        // column value, matching the DDL CHECK constraint.
+        if (
+            !Enum.TryParse(lifecycleText, ignoreCase: false, out DocumentCacheLifecycleState lifecycleState)
+            || !Enum.IsDefined(lifecycleState)
+            || !string.Equals(lifecycleState.ToString(), lifecycleText, StringComparison.Ordinal)
+        )
+        {
+            throw new InvalidOperationException(
+                $"Representation-restamp phase '{LifecycleCapturePhase}' failed for target {targetDescription}: "
+                    + $"dms.DocumentCacheState.ProjectionLifecycleState has unsupported value '{lifecycleText}'."
+            );
+        }
+
+        if (cacheAheadRecoveryRequiredValue is null || cacheAheadRecoveryRequiredValue is DBNull)
+        {
+            throw new InvalidOperationException(
+                $"Representation-restamp phase '{LifecycleCapturePhase}' failed for target {targetDescription}: "
+                    + "dms.DocumentCacheState.CacheAheadRecoveryRequired is unreadable."
+            );
+        }
+
+        return new RepresentationRestampE2EDocumentCacheStateObservation(
+            lifecycleState,
+            Convert.ToBoolean(
+                cacheAheadRecoveryRequiredValue,
+                System.Globalization.CultureInfo.InvariantCulture
+            )
+        );
+    }
+
+    /// <summary>
+    /// Restores the observed <c>dms.DocumentCacheState</c> for both restamp modes. Nothing is written
+    /// when nothing was observed, because then nothing was mutated either.
+    /// </summary>
+    internal static Task RestoreDocumentCacheStateAsync(
+        RepresentationRestampE2EDocumentCacheStateObservation? observedState,
+        Func<DocumentCacheLifecycleState, bool, Task> setStateAsync
+    ) =>
+        observedState is null
+            ? Task.CompletedTask
+            : setStateAsync(observedState.LifecycleState, observedState.CacheAheadRecoveryRequired);
 
     /// <summary>
     /// Phase names reported when a representation-restamp harness phase exceeds its budget. Setup
@@ -636,6 +772,7 @@ internal static class RepresentationRestampE2EHarness
     /// </summary>
     internal const string ProjectorSetupPhase = "ProjectorSetup";
     internal const string OrdinaryDrainPhase = "OrdinaryDrain";
+    internal const string LifecycleCapturePhase = "LifecycleCapture";
 
     internal static readonly TimeSpan ProjectorSetupBudget = TimeSpan.FromMinutes(2);
     internal static readonly TimeSpan OrdinaryDrainBudget = TimeSpan.FromMinutes(2);

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -162,6 +162,17 @@ variables — **names only; never commit or echo credential values**) are:
   scenario immediately on `docker cp`, reporting the operation, the name, the exit code, and both
   Docker streams.
 
+The representation-restamp scenarios share one database and the E2E DMS container runs no
+DocumentCache projector, so the harness keeps them isolated from each other: each scenario reads
+`dms.DocumentCacheState` (lifecycle and cache-ahead latch) after stopping DMS and before changing
+it, and cleanup restores both values, so the database returns to the seeded `Disabled` state and a
+Disabled restamp never orphans a work row for the next Tracking drain. The Tracking drain completes
+as soon as the scenario's own document is projected and only reports any foreign work rows still
+queued. Setup (`ProjectorSetup`) and the drain (`OrdinaryDrain`) run under separate two-minute
+budgets; a timeout names the phase, and a drain failure carries the page tallies, the queued rows
+marked own or foreign, and the projector's per-document failure diagnostics. A drain that pages
+twenty times in a row without acknowledging anything fails fast with the same diagnostics.
+
 If the engine or database name does not match the provisioned stack, the run fails fast at
 setup (an engine/schema mismatch surfaces as an `EffectiveSchemaHash` mismatch and all
 data-plane requests return 503).

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
@@ -1110,3 +1110,310 @@ public sealed class Given_Representation_Restamp_E2E_Harness_Lifecycle_Restore
         wrote.Should().BeFalse();
     }
 }
+
+[TestFixture]
+public sealed class Given_Representation_Restamp_E2E_Harness_Drain_Loop
+{
+    private const string TargetDescription = "'':1";
+    private const string Diagnostics = "Drain pages=1. Residual work rows (1): [foreign DocumentId=1].";
+
+    private static Func<CancellationToken, Task<DocumentCacheProjectionDrainPageResult>> Pages(
+        params DocumentCacheProjectionDrainPageResult[] results
+    )
+    {
+        var index = 0;
+        return _ =>
+        {
+            DocumentCacheProjectionDrainPageResult result = results[Math.Min(index, results.Length - 1)];
+            index++;
+            return Task.FromResult(result);
+        };
+    }
+
+    private static Func<CancellationToken, Task<bool>> OwnDocumentProjected(params bool[] answers)
+    {
+        var index = 0;
+        return _ =>
+        {
+            bool answer = answers[Math.Min(index, answers.Length - 1)];
+            index++;
+            return Task.FromResult(answer);
+        };
+    }
+
+    private static Task<string> DescribeDiagnostics() => Task.FromResult(Diagnostics);
+
+    private static Task Drain(
+        RepresentationRestampDrainTally tally,
+        Func<CancellationToken, Task<DocumentCacheProjectionDrainPageResult>> processPageAsync,
+        Func<CancellationToken, Task<bool>> isOwnDocumentProjectedAsync,
+        int maxConsecutivePagesWithoutAcknowledgement = 20,
+        Func<Task<string>>? describeDiagnosticsAsync = null
+    ) =>
+        RepresentationRestampE2EHarness.DrainUntilOwnWorkProjectedAsync(
+            tally,
+            processPageAsync,
+            isOwnDocumentProjectedAsync,
+            describeDiagnosticsAsync ?? DescribeDiagnostics,
+            TargetDescription,
+            maxConsecutivePagesWithoutAcknowledgement,
+            CancellationToken.None
+        );
+
+    [Test]
+    public void It_uses_a_fixed_named_stall_threshold_of_twenty_pages()
+    {
+        RepresentationRestampE2EHarness.MaxConsecutivePagesWithoutAcknowledgement.Should().Be(20);
+        RepresentationRestampE2EHarness.ResidualWorkReadBudget.Should().Be(TimeSpan.FromSeconds(15));
+    }
+
+    [Test]
+    public async Task It_completes_when_the_own_document_is_projected_even_if_foreign_work_remains()
+    {
+        // The page acknowledged the own row and left a foreign row behind; the drain must not wait
+        // for that foreign row.
+        var tally = new RepresentationRestampDrainTally();
+        var describeCalls = 0;
+
+        await Drain(
+            tally,
+            Pages(DocumentCacheProjectionDrainPageResult.PageProcessed(2, 1, 1, [1])),
+            OwnDocumentProjected(true),
+            describeDiagnosticsAsync: () =>
+            {
+                describeCalls++;
+                return DescribeDiagnostics();
+            }
+        );
+
+        tally.Pages.Should().Be(1);
+        describeCalls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_keeps_paging_until_the_own_document_is_projected()
+    {
+        var tally = new RepresentationRestampDrainTally();
+
+        await Drain(
+            tally,
+            Pages(
+                DocumentCacheProjectionDrainPageResult.PageProcessed(1, 1),
+                DocumentCacheProjectionDrainPageResult.PageProcessed(1, 1)
+            ),
+            OwnDocumentProjected(false, true)
+        );
+
+        tally.Pages.Should().Be(2);
+    }
+
+    [Test]
+    public async Task It_completes_on_no_eligible_work_when_the_own_document_is_projected()
+    {
+        var tally = new RepresentationRestampDrainTally();
+
+        await Drain(
+            tally,
+            Pages(DocumentCacheProjectionDrainPageResult.NoEligibleWork),
+            OwnDocumentProjected(true)
+        );
+
+        tally.LastOutcome.Should().Be(DocumentCacheProjectionDrainPageOutcome.NoEligibleWork);
+    }
+
+    [Test]
+    public async Task It_fails_with_diagnostics_on_no_eligible_work_when_the_own_document_is_not_projected()
+    {
+        Func<Task> act = () =>
+            Drain(
+                new RepresentationRestampDrainTally(),
+                Pages(
+                    DocumentCacheProjectionDrainPageResult.NoEligibleWorkWithRetry(
+                        DateTimeOffset.UtcNow.AddSeconds(1)
+                    )
+                ),
+                OwnDocumentProjected(false)
+            );
+
+        InvalidOperationException exception = (
+            await act.Should().ThrowAsync<InvalidOperationException>()
+        ).Which;
+        exception
+            .Message.Should()
+            .StartWith(
+                $"Representation-restamp phase 'OrdinaryDrain' failed for target {TargetDescription}: "
+            );
+        exception
+            .Message.Should()
+            .Contain("reported NoEligibleWork but the Tracking restamp's own document is not projected");
+        exception.Message.Should().EndWith(Diagnostics);
+    }
+
+    [Test]
+    public async Task It_fails_fast_after_the_stall_threshold_without_acknowledgements()
+    {
+        var tally = new RepresentationRestampDrainTally();
+
+        Func<Task> act = () =>
+            Drain(
+                tally,
+                Pages(DocumentCacheProjectionDrainPageResult.PageProcessed(1)),
+                OwnDocumentProjected(false),
+                maxConsecutivePagesWithoutAcknowledgement: 3
+            );
+
+        InvalidOperationException exception = (
+            await act.Should().ThrowAsync<InvalidOperationException>()
+        ).Which;
+        exception.Message.Should().Contain("made no progress: 3 consecutive page(s) acknowledged no work");
+        exception.Message.Should().EndWith(Diagnostics);
+        tally.Pages.Should().Be(3);
+    }
+
+    [Test]
+    public async Task It_resets_the_stall_count_when_a_page_acknowledges_work()
+    {
+        // Two idle pages, one page that acknowledges foreign work, then two more idle pages: the
+        // threshold of three is never reached consecutively, so the own-document check decides.
+        var tally = new RepresentationRestampDrainTally();
+
+        await Drain(
+            tally,
+            Pages(
+                DocumentCacheProjectionDrainPageResult.PageProcessed(1),
+                DocumentCacheProjectionDrainPageResult.PageProcessed(1),
+                DocumentCacheProjectionDrainPageResult.PageProcessed(1, 1),
+                DocumentCacheProjectionDrainPageResult.PageProcessed(1),
+                DocumentCacheProjectionDrainPageResult.PageProcessed(1)
+            ),
+            OwnDocumentProjected(false, false, false, false, true),
+            maxConsecutivePagesWithoutAcknowledgement: 3
+        );
+
+        tally.Pages.Should().Be(5);
+    }
+
+    private static IEnumerable<TestCaseData> NonPageOutcomes()
+    {
+        yield return new TestCaseData(
+            DocumentCacheProjectionDrainPageResult.TargetBackoff(
+                new DateTimeOffset(2026, 9, 11, 16, 0, 0, TimeSpan.Zero)
+            )
+        ).SetName("It_fails_naming_a_non_page_outcome(TargetBackoff)");
+        yield return new TestCaseData(DocumentCacheProjectionDrainPageResult.LifecycleFenced).SetName(
+            "It_fails_naming_a_non_page_outcome(LifecycleFenced)"
+        );
+        yield return new TestCaseData(DocumentCacheProjectionDrainPageResult.TargetPaused(1)).SetName(
+            "It_fails_naming_a_non_page_outcome(TargetPaused)"
+        );
+        yield return new TestCaseData(
+            DocumentCacheProjectionDrainPageResult.AdministrativeFailureResult(
+                0,
+                0,
+                0,
+                [],
+                new DocumentCacheAdministrativeDrainFailure(
+                    DocumentCacheAdministrativeCommandStatus.RejectedNoMutation,
+                    DocumentCacheAdministrativeCommandClassification.TargetNotConfigured,
+                    DocumentCacheAdministrativeDiagnosticCategory.TargetNotConfigured,
+                    "target not configured",
+                    retryable: false
+                )
+            )
+        ).SetName("It_fails_naming_a_non_page_outcome(AdministrativeFailure)");
+    }
+
+    [TestCaseSource(nameof(NonPageOutcomes))]
+    public async Task It_fails_naming_a_non_page_outcome(DocumentCacheProjectionDrainPageResult result)
+    {
+        var ownDocumentChecks = 0;
+
+        Func<Task> act = () =>
+            Drain(
+                new RepresentationRestampDrainTally(),
+                Pages(result),
+                _ =>
+                {
+                    ownDocumentChecks++;
+                    return Task.FromResult(true);
+                }
+            );
+
+        InvalidOperationException exception = (
+            await act.Should().ThrowAsync<InvalidOperationException>()
+        ).Which;
+        exception
+            .Message.Should()
+            .Contain($"ended with outcome '{result.Outcome}' instead of PageProcessed or NoEligibleWork");
+        exception.Message.Should().EndWith(Diagnostics);
+        ownDocumentChecks.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_reports_a_failing_describer_inside_the_drain_failure()
+    {
+        Func<Task> act = () =>
+            Drain(
+                new RepresentationRestampDrainTally(),
+                Pages(DocumentCacheProjectionDrainPageResult.LifecycleFenced),
+                OwnDocumentProjected(true),
+                describeDiagnosticsAsync: () =>
+                    Task.FromException<string>(new TimeoutException("residual read timed out"))
+            );
+
+        InvalidOperationException exception = (
+            await act.Should().ThrowAsync<InvalidOperationException>()
+        ).Which;
+        exception.Message.Should().Contain("ended with outcome 'LifecycleFenced'");
+        exception
+            .Message.Should()
+            .EndWith("Drain diagnostics unavailable: TimeoutException: residual read timed out");
+    }
+
+    [Test]
+    public async Task It_reports_the_drain_phase_when_the_budget_expires_mid_page()
+    {
+        var tally = new RepresentationRestampDrainTally();
+
+        Func<Task> act = () =>
+            RepresentationRestampE2EHarness.RunPhaseAsync(
+                RepresentationRestampE2EHarness.OrdinaryDrainPhase,
+                TimeSpan.FromMilliseconds(25),
+                TargetDescription,
+                cancellationToken =>
+                    RepresentationRestampE2EHarness.DrainUntilOwnWorkProjectedAsync(
+                        tally,
+                        async token =>
+                        {
+                            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                            return DocumentCacheProjectionDrainPageResult.NoEligibleWork;
+                        },
+                        OwnDocumentProjected(false),
+                        DescribeDiagnostics,
+                        TargetDescription,
+                        20,
+                        cancellationToken
+                    ),
+                DescribeDiagnostics
+            );
+
+        TimeoutException exception = (await act.Should().ThrowAsync<TimeoutException>()).Which;
+        exception.Message.Should().Contain("phase 'OrdinaryDrain'");
+        exception.Message.Should().EndWith($"for target {TargetDescription}. {Diagnostics}");
+        tally.Pages.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_rejects_a_non_positive_stall_threshold()
+    {
+        Func<Task> act = () =>
+            Drain(
+                new RepresentationRestampDrainTally(),
+                Pages(DocumentCacheProjectionDrainPageResult.NoEligibleWork),
+                OwnDocumentProjected(true),
+                maxConsecutivePagesWithoutAcknowledgement: 0
+            );
+
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
@@ -682,3 +682,127 @@ public sealed class Given_Representation_Restamp_E2E_Harness_Cleanup
         restartRan.Should().BeTrue();
     }
 }
+
+[TestFixture]
+public sealed class Given_Representation_Restamp_E2E_Harness_Phase_Budgets
+{
+    private const string TargetDescription = "'':1";
+
+    [Test]
+    public async Task It_names_the_phase_elapsed_and_budget_when_a_phase_times_out()
+    {
+        TimeSpan budget = TimeSpan.FromMilliseconds(25);
+
+        Func<Task> act = async () =>
+            await RepresentationRestampE2EHarness.RunPhaseAsync(
+                RepresentationRestampE2EHarness.OrdinaryDrainPhase,
+                budget,
+                TargetDescription,
+                async cancellationToken =>
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    return 0;
+                }
+            );
+
+        TimeoutException exception = (await act.Should().ThrowAsync<TimeoutException>()).Which;
+        exception.Message.Should().Contain("phase 'OrdinaryDrain'");
+        exception.Message.Should().Contain($"budget {budget}");
+        exception.Message.Should().Contain($"for target {TargetDescription}.");
+        exception.Message.Should().MatchRegex(@"after \d\d:\d\d:\d\d");
+        exception.InnerException.Should().BeOfType<TaskCanceledException>();
+    }
+
+    [Test]
+    public async Task It_returns_the_phase_result_when_the_phase_completes()
+    {
+        int result = await RepresentationRestampE2EHarness.RunPhaseAsync(
+            RepresentationRestampE2EHarness.ProjectorSetupPhase,
+            TimeSpan.FromMinutes(1),
+            TargetDescription,
+            _ => Task.FromResult(42)
+        );
+
+        result.Should().Be(42);
+    }
+
+    [Test]
+    public async Task It_completes_a_result_free_phase()
+    {
+        var ran = false;
+
+        await RepresentationRestampE2EHarness.RunPhaseAsync(
+            RepresentationRestampE2EHarness.OrdinaryDrainPhase,
+            TimeSpan.FromMinutes(1),
+            TargetDescription,
+            _ =>
+            {
+                ran = true;
+                return Task.CompletedTask;
+            }
+        );
+
+        ran.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task It_rethrows_cancellation_that_is_not_the_phase_budget()
+    {
+        using var externalSource = new CancellationTokenSource();
+        await externalSource.CancelAsync();
+
+        Func<Task> act = async () =>
+            await RepresentationRestampE2EHarness.RunPhaseAsync(
+                RepresentationRestampE2EHarness.OrdinaryDrainPhase,
+                TimeSpan.FromMinutes(1),
+                TargetDescription,
+                _ => Task.FromCanceled<int>(externalSource.Token)
+            );
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await act.Should().NotThrowAsync<TimeoutException>();
+    }
+
+    [Test]
+    public async Task It_rethrows_non_cancellation_failures_unchanged()
+    {
+        var expected = new InvalidOperationException("provider failure");
+
+        Func<Task> act = async () =>
+            await RepresentationRestampE2EHarness.RunPhaseAsync(
+                RepresentationRestampE2EHarness.ProjectorSetupPhase,
+                TimeSpan.FromMinutes(1),
+                TargetDescription,
+                _ => Task.FromException<int>(expected)
+            );
+
+        InvalidOperationException exception = (
+            await act.Should().ThrowAsync<InvalidOperationException>()
+        ).Which;
+        exception.Should().BeSameAs(expected);
+    }
+
+    [Test]
+    public void It_formats_the_phase_timeout_message()
+    {
+        string message = RepresentationRestampE2EHarness.PhaseTimeoutMessage(
+            RepresentationRestampE2EHarness.ProjectorSetupPhase,
+            TimeSpan.FromSeconds(125),
+            TimeSpan.FromMinutes(2),
+            TargetDescription
+        );
+
+        message
+            .Should()
+            .Be(
+                "Timed out in representation-restamp phase 'ProjectorSetup' after 00:02:05 (budget 00:02:00) for target '':1."
+            );
+    }
+
+    [Test]
+    public void It_keeps_separate_two_minute_budgets_for_setup_and_drain()
+    {
+        RepresentationRestampE2EHarness.ProjectorSetupBudget.Should().Be(TimeSpan.FromMinutes(2));
+        RepresentationRestampE2EHarness.OrdinaryDrainBudget.Should().Be(TimeSpan.FromMinutes(2));
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
@@ -6,6 +6,7 @@
 using System.Data.Common;
 using System.Reflection;
 using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.DocumentCache;
 using EdFi.DataManagementService.Core.Startup;
@@ -250,6 +251,9 @@ public sealed class Given_Representation_Restamp_E2E_Harness
         operations.Sql.ReadRequiredWorkVersion.Should().Contain("dms.\"DocumentProjectionWork\"");
         operations.Sql.IsProjected.Should().Contain("dms.\"DocumentCache\"");
         operations.Sql.IsProjected.Should().Contain("dms.\"DocumentProjectionWork\"");
+        operations.Sql.ReadResidualWork.Should().Contain("dms.\"DocumentProjectionWork\"");
+        operations.Sql.ReadResidualWork.Should().Contain("LEFT JOIN dms.\"DocumentCache\"");
+        operations.Sql.ReadResidualWork.Should().Contain("LIMIT 50");
     }
 
     [Test]
@@ -268,6 +272,9 @@ public sealed class Given_Representation_Restamp_E2E_Harness
         operations.Sql.ReadRequiredWorkVersion.Should().Contain("[dms].[DocumentProjectionWork]");
         operations.Sql.IsProjected.Should().Contain("[dms].[DocumentCache]");
         operations.Sql.IsProjected.Should().Contain("[dms].[DocumentProjectionWork]");
+        operations.Sql.ReadResidualWork.Should().Contain("[dms].[DocumentProjectionWork]");
+        operations.Sql.ReadResidualWork.Should().Contain("LEFT JOIN [dms].[DocumentCache]");
+        operations.Sql.ReadResidualWork.Should().Contain("SELECT TOP (50)");
     }
 
     [Test]
@@ -804,5 +811,181 @@ public sealed class Given_Representation_Restamp_E2E_Harness_Phase_Budgets
     {
         RepresentationRestampE2EHarness.ProjectorSetupBudget.Should().Be(TimeSpan.FromMinutes(2));
         RepresentationRestampE2EHarness.OrdinaryDrainBudget.Should().Be(TimeSpan.FromMinutes(2));
+    }
+}
+
+[TestFixture]
+public sealed class Given_Representation_Restamp_E2E_Harness_Drain_Diagnostics
+{
+    private static readonly Guid _ownDocument = Guid.Parse("9622f938-2c1a-4f99-9bc4-10970b1c2649");
+    private static readonly Guid _foreignDocument = Guid.Parse("3f1d2a6c-0d3f-4d1e-9c2b-7a5e0f1b2c3d");
+    private static readonly DateTimeOffset _enqueuedAt = new(2026, 9, 11, 15, 53, 45, TimeSpan.Zero);
+
+    [Test]
+    public void It_counts_pages_items_failures_and_consecutive_pages_without_acknowledgement()
+    {
+        var tally = new RepresentationRestampDrainTally();
+
+        tally.Record(DocumentCacheProjectionDrainPageResult.PageProcessed(2, 1, 1, [7]));
+        tally.Record(DocumentCacheProjectionDrainPageResult.PageProcessed(1));
+        tally.Record(DocumentCacheProjectionDrainPageResult.PageProcessed(1));
+
+        tally.Pages.Should().Be(3);
+        tally.ProcessedItems.Should().Be(4);
+        tally.AcknowledgedOrRemovedItems.Should().Be(1);
+        tally.DocumentScopedFailures.Should().Be(1);
+        tally.ConsecutivePagesWithoutAcknowledgement.Should().Be(2);
+        tally.LastOutcome.Should().Be(DocumentCacheProjectionDrainPageOutcome.PageProcessed);
+    }
+
+    [Test]
+    public void It_resets_the_consecutive_count_when_a_page_acknowledges_work()
+    {
+        var tally = new RepresentationRestampDrainTally();
+
+        tally.Record(DocumentCacheProjectionDrainPageResult.PageProcessed(1));
+        tally.Record(DocumentCacheProjectionDrainPageResult.PageProcessed(1, 1));
+
+        tally.ConsecutivePagesWithoutAcknowledgement.Should().Be(0);
+    }
+
+    [Test]
+    public void It_describes_an_empty_tally()
+    {
+        new RepresentationRestampDrainTally()
+            .Describe()
+            .Should()
+            .Be(
+                "Drain pages=0 processed=0 acknowledgedOrRemoved=0 documentScopedFailures=0 consecutivePagesWithoutAcknowledgement=0 lastOutcome=none."
+            );
+    }
+
+    [Test]
+    public void It_formats_drain_diagnostics_with_tallies_and_marks_the_own_document()
+    {
+        var tally = new RepresentationRestampDrainTally();
+        tally.Record(DocumentCacheProjectionDrainPageResult.PageProcessed(2, 1, 1, [1]));
+        RepresentationRestampE2EResidualWorkRow[] residualWork =
+        [
+            new(1, _foreignDocument, 1, 2, null, _enqueuedAt),
+            new(2, _ownDocument, 4, 4, 4, _enqueuedAt.AddSeconds(45)),
+        ];
+
+        string diagnostics = RepresentationRestampE2EHarness.FormatDrainDiagnostics(
+            tally,
+            residualWork,
+            ["DocumentId=1 WorkAnomaly: Cache writer observed work anomaly."],
+            _ownDocument
+        );
+
+        diagnostics
+            .Should()
+            .StartWith("Drain pages=1 processed=2 acknowledgedOrRemoved=1 documentScopedFailures=1");
+        diagnostics.Should().Contain($"Residual work rows (2, own document {_ownDocument})");
+        diagnostics
+            .Should()
+            .Contain(
+                $"[foreign DocumentId=1 DocumentUuid={_foreignDocument} RequiredContentVersion=1 CanonicalContentVersion=2 CacheContentVersion=absent FirstEnqueuedAt=2026-09-11T15:53:45.0000000+00:00]"
+            );
+        diagnostics
+            .Should()
+            .Contain(
+                $"[own DocumentId=2 DocumentUuid={_ownDocument} RequiredContentVersion=4 CanonicalContentVersion=4 CacheContentVersion=4"
+            );
+        diagnostics
+            .Should()
+            .EndWith(
+                "Projector failure diagnostics (1): DocumentId=1 WorkAnomaly: Cache writer observed work anomaly.."
+            );
+    }
+
+    [Test]
+    public void It_formats_an_empty_residual_snapshot()
+    {
+        string diagnostics = RepresentationRestampE2EHarness.FormatDrainDiagnostics(
+            new RepresentationRestampDrainTally(),
+            [],
+            [],
+            _ownDocument
+        );
+
+        diagnostics.Should().Contain($"Residual work rows (0, own document {_ownDocument}): none.");
+        diagnostics.Should().EndWith("Projector failure diagnostics (0): none.");
+    }
+
+    [Test]
+    public void It_describes_projector_failures_per_document()
+    {
+        DocumentCacheProjectionDocumentDiagnostic diagnostic = new(
+            17,
+            DocumentCacheProjectionDocumentDiagnosticCategory.WorkAnomaly,
+            "Cache writer observed work anomaly.",
+            _enqueuedAt,
+            _enqueuedAt.AddSeconds(1)
+        );
+        DocumentCacheProjectionFailureDiagnostics diagnostics = new(
+            effectiveProjectorPageSize: 10,
+            failureCount: 1,
+            earliestRetryAt: _enqueuedAt.AddSeconds(1),
+            evictionCount: 0,
+            documentDiagnostics: [diagnostic]
+        );
+
+        RepresentationRestampE2EHarness
+            .DescribeProjectorFailures(diagnostics)
+            .Should()
+            .Equal("DocumentId=17 WorkAnomaly: Cache writer observed work anomaly.");
+    }
+
+    [Test]
+    public async Task It_appends_the_drain_diagnostics_to_the_phase_timeout()
+    {
+        Func<Task> act = async () =>
+            await RepresentationRestampE2EHarness.RunPhaseAsync(
+                RepresentationRestampE2EHarness.OrdinaryDrainPhase,
+                TimeSpan.FromMilliseconds(25),
+                "'':1",
+                cancellationToken => Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken),
+                () => Task.FromResult("Drain pages=3 acknowledgedOrRemoved=0.")
+            );
+
+        TimeoutException exception = (await act.Should().ThrowAsync<TimeoutException>()).Which;
+        exception.Message.Should().Contain("phase 'OrdinaryDrain'");
+        exception.Message.Should().EndWith("for target '':1. Drain pages=3 acknowledgedOrRemoved=0.");
+    }
+
+    [Test]
+    public async Task It_reports_a_failing_describer_without_hiding_the_timeout()
+    {
+        Func<Task> act = async () =>
+            await RepresentationRestampE2EHarness.RunPhaseAsync(
+                RepresentationRestampE2EHarness.OrdinaryDrainPhase,
+                TimeSpan.FromMilliseconds(25),
+                "'':1",
+                cancellationToken => Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken),
+                () => Task.FromException<string>(new InvalidOperationException("database unreachable"))
+            );
+
+        TimeoutException exception = (await act.Should().ThrowAsync<TimeoutException>()).Which;
+        exception
+            .Message.Should()
+            .EndWith("Drain diagnostics unavailable: InvalidOperationException: database unreachable");
+    }
+
+    [Test]
+    public void It_leaves_the_phase_timeout_message_unchanged_without_detail()
+    {
+        RepresentationRestampE2EHarness
+            .PhaseTimeoutMessage(
+                RepresentationRestampE2EHarness.OrdinaryDrainPhase,
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                "'':1",
+                detail: "   "
+            )
+            .Should()
+            .Be(
+                "Timed out in representation-restamp phase 'OrdinaryDrain' after 00:00:01 (budget 00:00:02) for target '':1."
+            );
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Management/Given_Representation_Restamp_E2E_Harness.cs
@@ -175,16 +175,6 @@ public sealed class Given_Representation_Restamp_E2E_Harness
         RepresentationRestampE2EHarness.ProviderFor("mssql").Should().Be(RelationalProviderToken.SqlServer);
     }
 
-    [TestCase(DocumentCacheRepresentationRestampMode.Disabled, true)]
-    [TestCase(DocumentCacheRepresentationRestampMode.Tracking, false)]
-    public void It_requires_a_lifecycle_reset_only_for_the_disabled_mode(
-        DocumentCacheRepresentationRestampMode mode,
-        bool expected
-    )
-    {
-        RepresentationRestampE2EHarness.RequiresDisabledLifecycleReset(mode).Should().Be(expected);
-    }
-
     [Test]
     public void It_rejects_an_unsupported_database_engine()
     {
@@ -254,6 +244,8 @@ public sealed class Given_Representation_Restamp_E2E_Harness
         operations.Sql.ReadResidualWork.Should().Contain("dms.\"DocumentProjectionWork\"");
         operations.Sql.ReadResidualWork.Should().Contain("LEFT JOIN dms.\"DocumentCache\"");
         operations.Sql.ReadResidualWork.Should().Contain("LIMIT 50");
+        operations.Sql.ReadDocumentCacheState.Should().Contain("dms.\"DocumentCacheState\"");
+        operations.Sql.ReadDocumentCacheState.Should().Contain("\"CacheAheadRecoveryRequired\"");
     }
 
     [Test]
@@ -275,6 +267,8 @@ public sealed class Given_Representation_Restamp_E2E_Harness
         operations.Sql.ReadResidualWork.Should().Contain("[dms].[DocumentProjectionWork]");
         operations.Sql.ReadResidualWork.Should().Contain("LEFT JOIN [dms].[DocumentCache]");
         operations.Sql.ReadResidualWork.Should().Contain("SELECT TOP (50)");
+        operations.Sql.ReadDocumentCacheState.Should().Contain("[dms].[DocumentCacheState]");
+        operations.Sql.ReadDocumentCacheState.Should().Contain("[CacheAheadRecoveryRequired]");
     }
 
     [Test]
@@ -987,5 +981,132 @@ public sealed class Given_Representation_Restamp_E2E_Harness_Drain_Diagnostics
             .Be(
                 "Timed out in representation-restamp phase 'OrdinaryDrain' after 00:00:01 (budget 00:00:02) for target '':1."
             );
+    }
+}
+
+[TestFixture]
+public sealed class Given_Representation_Restamp_E2E_Harness_Lifecycle_Restore
+{
+    private const string TargetDescription = "'':1";
+
+    [TestCase("Disabled", DocumentCacheLifecycleState.Disabled)]
+    [TestCase("Resetting", DocumentCacheLifecycleState.Resetting)]
+    [TestCase("Rebuilding", DocumentCacheLifecycleState.Rebuilding)]
+    [TestCase("Tracking", DocumentCacheLifecycleState.Tracking)]
+    public void It_parses_each_supported_lifecycle_state_strictly(
+        string lifecycleValue,
+        DocumentCacheLifecycleState expected
+    )
+    {
+        RepresentationRestampE2EDocumentCacheStateObservation observation =
+            RepresentationRestampE2EHarness.ParseDocumentCacheState(lifecycleValue, true, TargetDescription);
+
+        observation.LifecycleState.Should().Be(expected);
+        observation.CacheAheadRecoveryRequired.Should().BeTrue();
+    }
+
+    [TestCase("tracking")]
+    [TestCase("Paused")]
+    [TestCase("")]
+    [TestCase("1")]
+    public void It_rejects_an_unknown_or_blank_lifecycle_value_with_the_capture_phase_named(
+        string lifecycleValue
+    )
+    {
+        Action act = () =>
+            RepresentationRestampE2EHarness.ParseDocumentCacheState(lifecycleValue, false, TargetDescription);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*phase 'LifecycleCapture'*")
+            .WithMessage($"*for target {TargetDescription}*")
+            .WithMessage($"*unsupported value '{lifecycleValue}'*");
+    }
+
+    [Test]
+    public void It_rejects_a_missing_state_row_with_the_capture_phase_named()
+    {
+        Action act = () =>
+            RepresentationRestampE2EHarness.ParseDocumentCacheState(null, null, TargetDescription);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*phase 'LifecycleCapture'*")
+            .WithMessage("*no readable singleton row*");
+    }
+
+    [Test]
+    public void It_rejects_an_unreadable_latch_with_the_capture_phase_named()
+    {
+        Action act = () =>
+            RepresentationRestampE2EHarness.ParseDocumentCacheState(
+                "Tracking",
+                DBNull.Value,
+                TargetDescription
+            );
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*phase 'LifecycleCapture'*")
+            .WithMessage("*CacheAheadRecoveryRequired is unreadable*");
+    }
+
+    [Test]
+    public void It_reads_the_latch_from_a_database_boolean()
+    {
+        RepresentationRestampE2EHarness
+            .ParseDocumentCacheState("Disabled", false, TargetDescription)
+            .Should()
+            .Be(
+                new RepresentationRestampE2EDocumentCacheStateObservation(
+                    DocumentCacheLifecycleState.Disabled,
+                    false
+                )
+            );
+    }
+
+    [TestCase(DocumentCacheLifecycleState.Disabled, false)]
+    [TestCase(DocumentCacheLifecycleState.Tracking, false)]
+    [TestCase(DocumentCacheLifecycleState.Tracking, true)]
+    [TestCase(DocumentCacheLifecycleState.Rebuilding, true)]
+    public async Task It_restores_the_observed_lifecycle_and_latch_for_both_modes(
+        DocumentCacheLifecycleState lifecycleState,
+        bool cacheAheadRecoveryRequired
+    )
+    {
+        // The restore does not depend on the restamp mode: whatever was observed before the first
+        // mutation is written back, latch included, so a set latch is never clobbered to false.
+        List<(DocumentCacheLifecycleState LifecycleState, bool Latch)> writes = [];
+
+        await RepresentationRestampE2EHarness.RestoreDocumentCacheStateAsync(
+            new RepresentationRestampE2EDocumentCacheStateObservation(
+                lifecycleState,
+                cacheAheadRecoveryRequired
+            ),
+            (state, latch) =>
+            {
+                writes.Add((state, latch));
+                return Task.CompletedTask;
+            }
+        );
+
+        writes.Should().Equal((lifecycleState, cacheAheadRecoveryRequired));
+    }
+
+    [Test]
+    public async Task It_skips_restore_when_nothing_was_observed()
+    {
+        var wrote = false;
+
+        await RepresentationRestampE2EHarness.RestoreDocumentCacheStateAsync(
+            null,
+            (_, _) =>
+            {
+                wrote = true;
+                return Task.CompletedTask;
+            }
+        );
+
+        wrote.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary

The four representation-restamp E2E scenarios pass alone but, run together, the Tracking ETag scenario timed out in `DrainOrdinaryProjectorAsync` after two minutes on a slower Windows Docker Desktop host (3 passed / 1 failed). The cause was cross-scenario coupling in the E2E harness, not the projector:

- The E2E DMS container runs no DocumentCache projector (no compose overlay), so only the harness's own drain ever removes `dms.DocumentProjectionWork` rows.
- The seeded lifecycle is `Disabled` and the enqueue trigger inserts nothing in that state, but the harness flipped the shared database to `Tracking` and never restored it. The after-feature reset truncates data tables and preserves `DocumentCacheState`, so the lifecycle leaked across features while the rows did not.
- Within a feature the Disabled scenario runs first (`ADisabled…` sorts before `ARepresentation…`). Its POST enqueued a row under the leaked `Tracking`; the Disabled restamp bumped the canonical version and, by design, left the row behind. That orphan row is a permanent `WorkVersionMismatch` anomaly.
- The harness drain loop only stopped on `NoEligibleWork`, which the processor returns only if a cursor pass finishes while the anomaly's one-second failure suppression is still active. On a slow host it never did, so the loop spun until the single shared budget expired.

## What changed (E2E harness and its unit tests only)

1. **Phase budgets and attribution** (`07e63a34a`): `ProjectorSetup` (service provider, schema bootstrap, runtime mapping-set compilation) and `OrdinaryDrain` run under separate two-minute budgets through `RunPhaseAsync`; a timeout names the phase, elapsed time, budget, and target.
2. **Drain diagnostics** (`f352f8c3e`): a capped, read-only snapshot of queued work rows joined to canonical and cache versions, per-page tallies, and the projector's per-document failure diagnostics are attached to drain failures; a failing describer is reported inline and never hides the failure.
3. **Producer-side isolation** (`398d5816d`): each scenario captures `ProjectionLifecycleState` and `CacheAheadRecoveryRequired` after `docker stop` and before the first mutation, and the nested cleanup restores both for either mode. An unreadable or unknown state fails fast in a named `LifecycleCapture` phase before anything is mutated; the container restart still runs.
4. **Consumer-side isolation** (`b5a06505e`): the drain completes as soon as the scenario's own document is projected and only reports foreign rows. `NoEligibleWork` without the own document projected, any non-page outcome, and 20 consecutive pages acknowledging nothing (`MaxConsecutivePagesWithoutAcknowledgement`) fail with the diagnostics instead of waiting for the budget.
5. **Output and docs** (`f2141d9f5`): harness output goes to NUnit's captured test output; the E2E README documents the isolation, budgets, and diagnostics.

`Tracking` versus `Disabled` semantics are unchanged: Tracking still asserts `projectionWorkQueued`, a work row at the new version, and projection of that row; Disabled still asserts `canonicalOnlyComplete` and no projection work, with no drain and no cache or Kafka publication claim. No production projector code, DDL, CLI, or `RelationalMappingVersion` change.

## Base

Developed on `origin/DMS-1527` (`fba0bb9f8`, PR #1247) by explicit approval because both tickets edit the same harness and unit-test files, then replayed onto `main` after #1247 squash-merged as `7d3f31c7b`. #1247's final commit (`957ec7579`) had introduced a `disabledLifecycleResetRequired` flag armed before the lifecycle write, with a `RequiresDisabledLifecycleReset` helper and one unit test; this PR's `DocumentCacheState` capture-and-restore supersedes that flag (it is likewise captured before the write and restores both columns for both modes), so the conflict was resolved by taking this PR's side and removing the now-unused helper and its test. The resulting tree is byte-identical to the tree verified before the rebase.

## Evidence (2026-09-11, local image, PostgreSQL, Windows Docker Desktop)

Before the fix on the #1247 base: 3 passed / 1 failed; the Tracking ETag scenario failed at 2m43s with `Timed out draining the ordinary projector for target '':1`. Polling the work table every 3 seconds during a re-run showed the orphan row (`RequiredContentVersion` 1, canonical 2) planted by the Disabled ETag scenario and the Tracking scenario's own row acknowledged about 16 seconds after its restamp while the loop kept running.

After the fix, on the pre-rebase tip `3e80bff6e` (byte-identical to `f2141d9f5` for the changed files) after a full teardown:

| Run | Result |
|---|---|
| Exact ticket repro (`E2ETest -Configuration Release -IdentityProvider self-contained -EnvironmentFile './.env.e2e' -TestFilter 'Name~RepresentationRestamp'`, image rebuilt) | 4 passed / 0 failed (Change Query Disabled 42s, Change Query Tracking 48s, ETag Disabled 34s, ETag Tracking 47s) |
| `-TestFilter 'Name~ARepresentationRestampInvalidates'` | passed, 52s |
| Both whole features (`ETagValidationsFeature`, `LiveResourceEndpointsFilterByChangeVersion_Feature`) | 33 passed / 0 failed |
| Published image (`-UsePublishedImage`, `edfialliance/ed-fi-api:pre`, container `dms-published-dms-1`, schema hashes matched) | 4 passed / 0 failed (34s, 43s, 37s, 49s) |

A 3-second poll of `dms.DocumentCacheState` and `dms.DocumentProjectionWork` during the batch showed the seeded `Disabled,false` restored after every scenario, Disabled scenarios enqueuing nothing, and each Tracking drain seeing only its own row. The published-image batch is the all-four run that DMS-1527 lists as blocked by this ticket.

## Verification

- `dotnet csharpier check` on the two touched C# files: clean.
- `./build-dms.ps1 Build -Configuration Release`: clean.
- `dotnet test …Tests.Unit.csproj -c Release --filter "FullyQualifiedName~Given_Representation_Restamp_E2E_Harness"`: 80 passed (34 pre-existing including #1247's fixtures, 46 added here).
- E2E results as tabled above. No production code, DDL, CLI, or `RelationalMappingVersion` changes; the `Tests.Unit/packages.lock.json` line the Release build rewrites is not part of this change.
- Re-verified after the rebase onto `main` (`f2141d9f5` on `7d3f31c7b`, full teardown): CSharpier clean, Release build clean, harness unit filter 80 passed, exact ticket repro 4 passed / 0 failed (36s, 46s, 35s, 44s), single Tracking ETag scenario passed (52s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
